### PR TITLE
Rethrow intellisense exceptions in IntellisenseTestBase

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
@@ -71,6 +71,11 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             var intellisense = IntellisenseProvider.GetIntellisense();
             var suggestions = intellisense.Suggest(context, binding, formula);
 
+            if (suggestions.Exception != null)
+            {
+                throw suggestions.Exception;
+            }
+
             return suggestions;
         }
     }


### PR DESCRIPTION
The Get function in StringResources.cs throws exceptions when resources are not found. Line 55 in Intellisense.cs silently ignores exceptions and returns an empty suggestion list.

This change rethrows any intellisense exceptions in the unit tests so that the error messages will be more useful in the case where those tests fail because of an exception.