### PR TITLE
Add error context declaration to math functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acos.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acos.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: acos
     internal sealed class AcosFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AcosFunction()
             : base("Acos", TexlStrings.AboutAcos, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc cosine of each item in the input table.
     internal sealed class AcosTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AcosTableFunction()
             : base("Acos", TexlStrings.AboutAcosT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acot.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acot.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Acot
     internal sealed class AcotFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AcotFunction()
             : base("Acot", TexlStrings.AboutAcot, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc cotangent of each item in the input table.
     internal sealed class AcotTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AcotTableFunction()
             : base("Acot", TexlStrings.AboutAcotT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Asin.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Asin.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Asin
     internal sealed class AsinFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AsinFunction()
             : base("Asin", TexlStrings.AboutAsin, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc sine values of each item in the input table.
     internal sealed class AsinTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AsinTableFunction()
             : base("Asin", TexlStrings.AboutAsinT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Atan
     internal sealed class AtanFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AtanFunction()
             : base("Atan", TexlStrings.AboutAtan, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc tangent of each item in the input table.
     internal sealed class AtanTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public AtanTableFunction()
             : base("Atan", TexlStrings.AboutAtanT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -13,6 +13,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class Atan2Function : BuiltinFunction
     {
         public override bool IsSelfContained => true;
+        public override bool RequiresErrorContext => true;
 
         public Atan2Function()
             : base("Atan2",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cos.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cos.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Cos
     internal sealed class CosFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public CosFunction()
             : base("Cos", TexlStrings.AboutCos, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the cosine of each item in the input table.
     internal sealed class CosTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public CosTableFunction()
             : base("Cos", TexlStrings.AboutCosT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cot.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cot.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Cot
     internal sealed class CotFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public CotFunction()
             : base("Cot", TexlStrings.AboutCot, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the cotangent of each item in the input table.
     internal sealed class CotTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public CotTableFunction()
             : base("Cot", TexlStrings.AboutCotT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Degrees.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Degrees.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Degrees
     internal sealed class DegreesFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public DegreesFunction()
             : base("Degrees", TexlStrings.AboutDegrees, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the degrees values of each item in the input table.
     internal sealed class DegreesTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public DegreesTableFunction()
             : base("Degrees", TexlStrings.AboutDegreesT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Exp.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Exp.cs
@@ -11,6 +11,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ExpFunction : MathOneArgFunction
     {
         public override bool HasPreciseErrors => true;
+        public override bool RequiresErrorContext => true;
 
         public ExpFunction()
             : base("Exp", TexlStrings.AboutExp, FunctionCategories.MathAndStat)
@@ -22,6 +23,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ExpTableFunction : MathOneArgTableFunction
     {
         public override bool HasPreciseErrors => true;
+        public override bool RequiresErrorContext => true;
 
         public ExpTableFunction()
             : base("Exp", TexlStrings.AboutExpT, FunctionCategories.Table)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Ln.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Ln.cs
@@ -11,6 +11,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LnFunction : MathOneArgFunction
     {
         public override bool HasPreciseErrors => true;
+        public override bool RequiresErrorContext => true;
+
         public LnFunction()
             : base("Ln", TexlStrings.AboutLn, FunctionCategories.MathAndStat)
         { }
@@ -21,6 +23,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LnTableFunction : MathOneArgTableFunction
     {
         public override bool HasPreciseErrors => true;
+        public override bool RequiresErrorContext => true;
+
         public LnTableFunction()
             : base("Ln", TexlStrings.AboutLnT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -18,6 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
         public override bool IsSelfContained => true;
         public override bool HasPreciseErrors => true;
+        public override bool RequiresErrorContext => true;
 
 
         public LogFunction()
@@ -37,7 +38,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool SupportsParamCoercion => true;
         public override bool IsSelfContained => true;
-
+        public override bool RequiresErrorContext => true;
 
         public LogTFunction()
             : base("Log", TexlStrings.AboutLogT, FunctionCategories.MathAndStat, DType.EmptyTable, 0, 1, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool SupportsParamCoercion => true;
         public override bool IsSelfContained => true;
-
+        public override bool RequiresErrorContext => true;
 
         public ModFunction()
             : base("Mod", TexlStrings.AboutMod, FunctionCategories.MathAndStat, DType.Number, 0, 2, 2, DType.Number, DType.Number)
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool SupportsParamCoercion => true;
         public override bool IsSelfContained => true;
-
+        public override bool RequiresErrorContext => true;
 
         public ModTFunction()
             : base("Mod", TexlStrings.AboutModT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Radians.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Radians.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Radians
     internal sealed class RadiansFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public RadiansFunction()
             : base("Radians", TexlStrings.AboutRadians, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the radians values of each item in the input table.
     internal sealed class RadiansTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public RadiansTableFunction()
             : base("Radians", TexlStrings.AboutRadiansT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sin.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sin.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Sin
     internal sealed class SinFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public SinFunction()
             : base("Sin", TexlStrings.AboutSin, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the sine values of each item in the input table.
     internal sealed class SinTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public SinTableFunction()
             : base("Sin", TexlStrings.AboutSinT, FunctionCategories.Table)
         { }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Tan.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Tan.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Tan
     internal sealed class TanFunction : MathOneArgFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public TanFunction()
             : base("Tan", TexlStrings.AboutTan, FunctionCategories.MathAndStat)
         { }
@@ -19,6 +21,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the tangent of each item in the input table.
     internal sealed class TanTableFunction : MathOneArgTableFunction
     {
+        public override bool RequiresErrorContext => true;
+
         public TanTableFunction()
             : base("Tan", TexlStrings.AboutTanT, FunctionCategories.Table)
         { }


### PR DESCRIPTION
We want to add error context to math functions in Power Apps Canvas apps, and that require those functions to be tagged with requiring error context.