### PR TITLE
Add ReferencedIdentifiers to CheckResult, all identifiers used in the…

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -28,6 +28,12 @@ namespace Microsoft.PowerFx.Core.Public
         public HashSet<string> TopLevelIdentifiers { get; set; }
 
         /// <summary>
+        /// Spans of all fields that this formula uses. 
+        /// null if unavailable.  
+        /// </summary>
+        public HashSet<Localization.Span> ReferencedIdentifiers { get; set; }
+
+        /// <summary>
         /// null on success, else contains errors. 
         /// </summary>
         public ExpressionError[] Errors { get; set; }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/AllDependencyFinder.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/AllDependencyFinder.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Syntax.Nodes;
+using Microsoft.PowerFx.Core.Syntax.Visitors;
+
+namespace Microsoft.PowerFx
+{
+    internal class AllDependencyFinder : IdentityTexlVisitor
+    {
+        public HashSet<Span> _spans = new();
+
+        public static HashSet<Span> FindAllDependencies(TexlNode node)
+        {
+            var v = new AllDependencyFinder();
+            node.Accept(v);
+
+            return v._spans;
+        }
+
+        public override void Visit(FirstNameNode node)
+        {
+            if (node.Parent?.Kind == Core.Syntax.NodeKind.DottedName)
+            {
+                TexlNode nodeT = node;
+                while (nodeT.Parent?.Kind == Core.Syntax.NodeKind.DottedName)
+                {
+                    nodeT = nodeT.Parent;
+                }
+                _spans.Add(nodeT.GetCompleteSpan());
+            }
+            else
+            {
+                _spans.Add(node.Token.Span);
+            }
+
+            base.Visit(node);
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -169,6 +169,8 @@ namespace Microsoft.PowerFx
                 if (binding.ResultType.Kind != DKind.Enum)
                     result.ReturnType = FormulaType.Build(binding.ResultType);
             }
+            // We find nexted identifiers even if there were errors in the expression.
+            result.ReferencedIdentifiers = AllDependencyFinder.FindAllDependencies(binding.Top);
 
             return result;
         }


### PR DESCRIPTION
… expression. ReferencedIdentifiers returns a HashSet<Span> instead of HashSet<string>, because creating all those strings would put a lot of load on the memory management and often code will not use the ReferencedIdentifiers. If people need the strings, it's easy enough to create from the spans, as the unit tests show.