### PR TITLE
Add a table variant of the Concatenate function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -87,6 +87,8 @@ namespace Microsoft.PowerFx.Core.Localization
 
         public static StringGetter AboutConcatenate = (b) => StringResources.Get("AboutConcatenate", b);
         public static StringGetter ConcatenateArg1 = (b) => StringResources.Get("ConcatenateArg1", b);
+        public static StringGetter AboutConcatenateT = (b) => StringResources.Get("AboutConcatenateT", b);
+        public static StringGetter ConcatenateTArg1 = (b) => StringResources.Get("ConcatenateTArg1", b);
 
         public static StringGetter AboutCoalesce = (b) => StringResources.Get("AboutCoalesce", b);
         public static StringGetter CoalesceArg1 = (b) => StringResources.Get("CoalesceArg1", b);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction ColorValue = _library.Append(new ColorValueFunction());
         public static readonly TexlFunction Concat = _library.Append(new ConcatFunction());
         public static readonly TexlFunction Concatenate = _library.Append(new ConcatenateFunction());
+        public static readonly TexlFunction ConcatenateT = _library.Append(new ConcatenateTableFunction());
         public static readonly TexlFunction Cos = _library.Append(new CosFunction());
         public static readonly TexlFunction CosT = _library.Append(new CosTableFunction());
         public static readonly TexlFunction Cot = _library.Append(new CotFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (int i = 0; i < count; i++)
             {
-                var typeChecks = CheckType(args[i], argTypes[i], DType.String, errors, SupportCoercionForArg(i), out DType coercionType);
+                var typeChecks = CheckType(args[i], argTypes[i], DType.String, errors, true, out DType coercionType);
                 if (typeChecks && coercionType != null)
                     CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], coercionType);
 
@@ -79,14 +79,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
 
         public ConcatenateTableFunction()
-            : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Table | FunctionCategories.Text, DType.EmptyTable, 0, 2, int.MaxValue)
+            : base("Concatenate", TexlStrings.AboutConcatenateT, FunctionCategories.Table | FunctionCategories.Text, DType.EmptyTable, 0, 2, int.MaxValue)
         { }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
-            yield return new[] { TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1 };
-            yield return new[] { TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1 };
-            yield return new[] { TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1 };
+            yield return new[] { TexlStrings.ConcatenateTArg1, TexlStrings.ConcatenateTArg1 };
+            yield return new[] { TexlStrings.ConcatenateTArg1, TexlStrings.ConcatenateTArg1, TexlStrings.ConcatenateTArg1 };
+            yield return new[] { TexlStrings.ConcatenateTArg1, TexlStrings.ConcatenateTArg1, TexlStrings.ConcatenateTArg1, TexlStrings.ConcatenateTArg1 };
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures(int arity)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -12,16 +12,16 @@ using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
-    // Concatenate(source1:s|*[s], source2:s|*[s], ...)
+    // Concatenate(source1:s, source2:s, ...)
     // Corresponding DAX function: Concatenate
-    // Note, this performs string/string, string/Table, table/Table concatenation.
+    // This only performs string/string concatenation.
     internal sealed class ConcatenateFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
         public override bool SupportsParamCoercion => true;
 
         public ConcatenateFunction()
-            : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Table | FunctionCategories.Text, DType.Unknown, 0, 2, int.MaxValue)
+            : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Text, DType.String, 0, 2, int.MaxValue)
         { }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
@@ -46,6 +46,69 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length >= 2);
             Contracts.AssertValue(errors);
 
+            int count = args.Length;
+            bool fArgsValid = true;
+            nodeToCoercedTypeMap = null;
+
+            for (int i = 0; i < count; i++)
+            {
+                var typeChecks = CheckType(args[i], argTypes[i], DType.String, errors, SupportCoercionForArg(i), out DType coercionType);
+                if (typeChecks && coercionType != null)
+                    CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], coercionType);
+
+                fArgsValid &= typeChecks;
+            }
+
+            if (!fArgsValid)
+                nodeToCoercedTypeMap = null;
+
+            returnType = ReturnType;
+
+            return fArgsValid;
+        }
+    }
+
+    // Concatenate(source1:s|*[s], source2:s|*[s], ...)
+    // Corresponding DAX function: Concatenate
+    // Note, this performs string/table, table/table, table/string concatenation, but not string/string
+    // Tables will be expanded to be the same size as the largest table. For each scalar, a new empty table
+    // will be created, and the scalar value will be used to fill the table to be the same size as the largest table
+    internal sealed class ConcatenateTableFunction : BuiltinFunction
+    {
+        public override bool IsSelfContained => true;
+        public override bool SupportsParamCoercion => true;
+
+        public ConcatenateTableFunction()
+            : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Table | FunctionCategories.Text, DType.EmptyTable, 0, 2, int.MaxValue)
+        { }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1 };
+            yield return new[] { TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1 };
+            yield return new[] { TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1 };
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures(int arity)
+        {
+            if (arity > 2)
+                return GetGenericSignatures(arity, TexlStrings.ConcatenateArg1, TexlStrings.ConcatenateArg1);
+            return base.GetSignatures(arity);
+        }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_T");
+        }
+
+        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.Assert(args.Length >= 2);
+            Contracts.AssertValue(errors);
+
             nodeToCoercedTypeMap = null;
 
             int count = args.Length;
@@ -53,7 +116,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             bool fArgsValid = true;
 
             // Type check the args
-            // If any one input argument is of table type, then the returnType will be table type.
             for (int i = 0; i < count; i++)
             {
                 bool isTable;
@@ -61,9 +123,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 hasTableArg |= isTable;
             }
 
-            returnType = hasTableArg ? DType.CreateTable(new TypedName(DType.String, OneColumnTableResultName)) : DType.String;
-            
-            return fArgsValid;
+            fArgsValid &= hasTableArg;
+
+            if (!fArgsValid)
+                nodeToCoercedTypeMap = null;
+
+            returnType = DType.CreateTable(new TypedName(DType.String, OneColumnTableResultName));
+
+            return hasTableArg && fArgsValid;
         }
     }
 }

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -447,7 +447,18 @@
     <comment>function_parameter - Argument to the Concatenate function - the text to be concatenated.</comment>
   </data>
   <data name="AboutConcatenate_text" xml:space="preserve">
-    <value>A text or a column of text values, to be concatenated with the rest of the arguments.</value>
+    <value>A text value, to be concatenated with the rest of the arguments.</value>
+  </data>
+  <data name="AboutConcatenateT" xml:space="preserve">
+    <value>Joins several text values or tables into one column of text values.</value>
+    <comment>Description of 'Concatenate' function.</comment>
+  </data>
+  <data name="ConcatenateTArg1" xml:space="preserve">
+    <value>value</value>
+    <comment>function_parameter - Argument to the Concatenate function - the text or table to be concatenated.</comment>
+  </data>
+  <data name="AboutConcatenateT_value" xml:space="preserve">
+    <value>A text value or a column of text values, to be concatenated with the rest of the arguments.</value>
   </data>
   <data name="AboutConcat" xml:space="preserve">
     <value>Joins all text values produced by evaluating the given expression over the given table into one text value.</value>


### PR DESCRIPTION
There is a bug in both the C# and TypeScript interpreters caused by certain inputs to the Concatenate function. The bug occurs when Concatenate expects a table (according to the type checker) but gets a Blank() value at runtime. For example:

Concatenate("a", If(1<0, ["txt"]))

The type checker expects the result of this call to be a table. However, at runtime the actual return value is the string "a". This is because the result of the call to If returns Blank() instead of a table. The Blank() is considered a scalar value equivalent to the empty string by the runtime.

This PR adds a ConcatenateT variant so that the runtime knows the return type needs to be a Table. Further changes will need to be made to the TypeScript backend to always return a table from ConcatenateT, creating an empty one if needed.