### PR TITLE
Fix crash in ExpandQueryOptions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Entities/QueryOptions/ExpandQueryOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/QueryOptions/ExpandQueryOptions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerFx.Core.Entities.QueryOptions
                 _selects.Add(select);
 
             var parentDataSource = ExpandInfo.ParentDataSource as IExternalTabularDataSource;
-            var keyColumns = parentDataSource?.GetKeyColumns(ExpandInfo);
+            var keyColumns = parentDataSource?.GetKeyColumns(ExpandInfo) ?? Enumerable.Empty<string>();
             foreach (var keyColumn in keyColumns)
                 _selects.Add(keyColumn);
 


### PR DESCRIPTION
Code had consideration for a null parentDataSource but would still crash in the scenario.