### PR TITLE
Fix a bug in string interpolation where two open curly braces appear …

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -1163,7 +1163,7 @@ namespace Microsoft.PowerFx.Core.Lexer
                 }
                 else if (IsStringDelimiter(ch))
                     return LexInterpolatedStringEnd();
-                else if (IsCurlyOpen(ch))
+                else if (IsCurlyOpen(ch) && !IsCurlyOpen(nextCh))
                     return LexIslandStart();
                 else
                     return LexInterpolatedStringBody();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -424,3 +424,21 @@ Errors: Error 0-2: Invalid number of arguments: received 0, expected 1 or more.
 
 >> $"}
 Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
+
+>> $"{1}{2}{{3{{4{{5{{6{{7"
+"12{3{4{5{6{7"
+
+>> $"{{"
+"{"
+
+>> $"{{a}}" // fail
+"{a}"
+
+>> $"-{{a}}-" // pass
+"-{a}-"
+
+>> $"-{{a}}" // pass
+"-{a}"
+
+>> $"{{a}}-" // fail
+"{a}-"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -431,14 +431,14 @@ Errors: Error 2-2: Unexpected characters. Characters are used in the formula in 
 >> $"{{"
 "{"
 
->> $"{{a}}" // fail
+>> $"{{a}}"
 "{a}"
 
->> $"-{{a}}-" // pass
+>> $"-{{a}}-"
 "-{a}-"
 
->> $"-{{a}}" // pass
+>> $"-{{a}}"
 "-{a}"
 
->> $"{{a}}-" // fail
+>> $"{{a}}-"
 "{a}-"


### PR DESCRIPTION
…as the first characters after changing modes