### PR TITLE
Remove call to ToImmutableDictionary from EnumStore

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
@@ -166,11 +166,11 @@ namespace Microsoft.PowerFx.Core.Types.Enums
 #endif
             };
 
-        protected virtual ImmutableDictionary<string, string> EnumDict
+        protected virtual IDictionary<string, string> EnumDict
         {
             get
             {
-                return _enums.ToImmutableDictionary();
+                return _enums;
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
@@ -36,8 +37,8 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
 
         private class EmptyEnumStore : EnumStore
         {
-            private ImmutableDictionary<string, string> _enumDict = ImmutableDictionary<string, string>.Empty;
-            protected override ImmutableDictionary<string, string> EnumDict => _enumDict;
+            private IDictionary<string, string> _enumDict = new Dictionary<string, string>();
+            protected override IDictionary<string, string> EnumDict => _enumDict;
         }
 
         private readonly EnumStore _defaultEnumStore = new EnumStore();


### PR DESCRIPTION
Enum storage is order sensitive. The call to ToImmutableDictionary was shuffling the order, leading to errors in some unit tests most of the time.