### PR TITLE
Add an error message that appears for unmatched curly brackets

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -1031,7 +1031,8 @@ namespace Microsoft.PowerFx.Core.Lexer
 
             private void ExitMode()
             {
-                _modeStack.Pop();
+                if(_modeStack.Count != 0)
+                    _modeStack.Pop();
             }
 
             // Whether we've hit the end of input yet. If this returns true, ChCur will be zero.

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -523,6 +523,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrBadRecordFieldType_FieldName_ExpectedType = new ErrorResourceKey("ErrBadRecordFieldType_FieldName_ExpectedType");
         public static ErrorResourceKey ErrAsTypeAndIsTypeExpectConnectedDataSource = new ErrorResourceKey("ErrAsTypeAndIsTypeExpectConnectedDataSource");
         public static ErrorResourceKey ErrInvalidControlReference = new ErrorResourceKey("ErrInvalidControlReference");
+        public static ErrorResourceKey ErrUnmatchedCurly = new ErrorResourceKey("ErrUnmatchedCurly");
 
         public static ErrorResourceKey ErrErrorIrrelevantField = new ErrorResourceKey("ErrErrorIrrelevantField");
         public static ErrorResourceKey ErrAsNotInContext = new ErrorResourceKey("ErrAsNotInContext");

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -1768,6 +1768,10 @@
     <value>Incorrect argument. This formula expects a table from a connected data source. The AsType and IsType functions require connected data sources.</value>
     <comment>{Locked=AsType}{Locked=IsType} Error message provided when the user attempts to use a non-Connected data source table as the second argument to AsType or IsType.</comment>
   </data>
+  <data name="ErrUnmatchedCurly" xml:space="preserve">
+    <value>One or more '{' or '}' characters are mismatched.</value>
+    <comment>Error message when the lexer mode stack is empty, or when lexing terminates with more than a single mode in the stack.</comment>
+  </data>
   <data name="InfoMessage" xml:space="preserve">
     <value>Message: </value>
     <comment>Message Label.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -408,22 +408,22 @@ Microsoft.PowerFx.Core.Public.Values.ErrorValue
 "123456"
 
 >> $"{"
-Errors: Error 3-4: Unexpected characters. Characters are used in the formula in an unexpected way.
+Errors: Error 3-4: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 3-4: One or more '{' or '}' characters are mismatched.
 
 >> $"}"
 Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"{" & ""
-Errors: Error 3-9: Unexpected characters. Characters are used in the formula in an unexpected way.
+Errors: Error 3-9: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 3-9: One or more '{' or '}' characters are mismatched.
 
 >> $"}" & ""
 Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"{
-Errors: Error 0-2: Invalid number of arguments: received 0, expected 1 or more.
+Errors: Error 2-3: One or more '{' or '}' characters are mismatched.
 
 >> $"}
-Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
+Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 2-3: One or more '{' or '}' characters are mismatched.
 
 >> $"{1}{2}{{3{{4{{5{{6{{7"
 "12{3{4{5{6{7"


### PR DESCRIPTION
The Lexer currently does not gracefully handle unmatched curly brackets, and has the potential to throw exceptions without useful error messages. This change removes the call to Pop on the lexer mode stack when the stack is empty, and provides error messages in the token stream when mismatched curly brackets are detected, including just before EoF is added to the token stream.