### PR TITLE
Revert "Add an error message that appears for unmatched curly bracket…

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -523,7 +523,6 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrBadRecordFieldType_FieldName_ExpectedType = new ErrorResourceKey("ErrBadRecordFieldType_FieldName_ExpectedType");
         public static ErrorResourceKey ErrAsTypeAndIsTypeExpectConnectedDataSource = new ErrorResourceKey("ErrAsTypeAndIsTypeExpectConnectedDataSource");
         public static ErrorResourceKey ErrInvalidControlReference = new ErrorResourceKey("ErrInvalidControlReference");
-        public static ErrorResourceKey ErrUnmatchedCurly = new ErrorResourceKey("ErrUnmatchedCurly");
 
         public static ErrorResourceKey ErrErrorIrrelevantField = new ErrorResourceKey("ErrErrorIrrelevantField");
         public static ErrorResourceKey ErrAsNotInContext = new ErrorResourceKey("ErrAsNotInContext");

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -1768,10 +1768,6 @@
     <value>Incorrect argument. This formula expects a table from a connected data source. The AsType and IsType functions require connected data sources.</value>
     <comment>{Locked=AsType}{Locked=IsType} Error message provided when the user attempts to use a non-Connected data source table as the second argument to AsType or IsType.</comment>
   </data>
-  <data name="ErrUnmatchedCurly" xml:space="preserve">
-    <value>One or more '{' or '}' characters are mismatched.</value>
-    <comment>Error message when the lexer mode stack is empty, or when lexing terminates with more than a single mode in the stack.</comment>
-  </data>
   <data name="InfoMessage" xml:space="preserve">
     <value>Message: </value>
     <comment>Message Label.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -408,22 +408,22 @@ Microsoft.PowerFx.Core.Public.Values.ErrorValue
 "123456"
 
 >> $"{"
-Errors: Error 3-4: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 3-4: One or more '{' or '}' characters are mismatched.
+Errors: Error 3-4: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"}"
 Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"{" & ""
-Errors: Error 3-9: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 3-9: One or more '{' or '}' characters are mismatched.
+Errors: Error 3-9: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"}" & ""
 Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"{
-Errors: Error 2-3: One or more '{' or '}' characters are mismatched.
+Errors: Error 0-2: Invalid number of arguments: received 0, expected 1 or more.
 
 >> $"}
-Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 2-3: One or more '{' or '}' characters are mismatched.
+Errors: Error 2-2: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"{1}{2}{{3{{4{{5{{6{{7"
 "12{3{4{5{6{7"


### PR DESCRIPTION
…s (#99)"

This reverts commit 2c5df2a33d0b737c6d666595f22369c57cde8ea6.

Mostly. There were conflicts caused by recent changes to code styles. I also left in the empty stack guard.

The original change was breaking Intellisense in PA client. We should move those tests into this repo.