### PR TITLE
Add new error kind enum value (canceled)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerFx.Core.Public
         QuotaExceeded = 22,
         Network = 23,
         Numeric = 24,
-        Canceled = 25
+        InvalidArgument = 25,
+        Canceled = 26
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerFx.Core.Public
         InsufficientMemory = 21,
         QuotaExceeded = 22,
         Network = 23,
-        Numeric = 24
+        Numeric = 24,
+        Canceled = 25
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
@@ -198,8 +198,10 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                 // TASK 4620228: Connect to Data: Need Final design on Error enum returned by Errors function.
                 {
                     EnumConstants.ErrorKindEnumString,
-                    "%n[None:0, Sync:1, MissingRequired:2, CreatePermission:3, EditPermission:4, DeletePermission:5, Conflict:6, NotFound:7, ConstraintViolated:8, GeneratedValue:9, ReadOnlyValue:10, Validation: 11, Unknown: 12, " +
-                    "Div0: 13, BadLanguageCode: 14, BadRegex: 15, InvalidFunctionUsage: 16, FileNotFound: 17, AnalysisError: 18, ReadPermission: 19, NotSupported: 20, InsufficientMemory: 21, QuotaExceeded: 22, Network: 23, Numeric: 24, InvalidArgument: 25]"
+                    "%n[None:0, Sync:1, MissingRequired:2, CreatePermission:3, EditPermission:4, DeletePermission:5, Conflict:6, NotFound:7, ConstraintViolated:8, " +
+                    "GeneratedValue:9, ReadOnlyValue:10, Validation: 11, Unknown: 12, Div0: 13, BadLanguageCode: 14, BadRegex: 15, InvalidFunctionUsage: 16, " +
+                    "FileNotFound: 17, AnalysisError: 18, ReadPermission: 19, NotSupported: 20, InsufficientMemory: 21, QuotaExceeded: 22, Network: 23, Numeric: 24, " +
+                    "InvalidArgument: 25, Canceled: 26]"
                 },
                 {
                     EnumConstants.ZoomEnumString,

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -3301,6 +3301,10 @@
     <value>InvalidArgument</value>
     <comment>{Locked} Enum value</comment>
   </data>
+  <data name="ErrorKind_InvalidArgument_Canceled" xml:space="preserve">
+    <value>Canceled</value>
+    <comment>{Locked} Enum value</comment>
+  </data>
   <data name="Post" xml:space="preserve">
     <value>Post</value>
     <comment>Button text to post comment</comment>

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -3301,7 +3301,7 @@
     <value>InvalidArgument</value>
     <comment>{Locked} Enum value</comment>
   </data>
-  <data name="ErrorKind_InvalidArgument_Canceled" xml:space="preserve">
+  <data name="ErrorKind_Canceled_Name" xml:space="preserve">
     <value>Canceled</value>
     <comment>{Locked} Enum value</comment>
   </data>


### PR DESCRIPTION
When a function in an app is waiting on async operation (promise), and the promise is canceled, the function returns an error - and it is currently being displayed to the user. But this is a case where we decided that the operation is not necessary anymore, so that should not be a user-visible error. Adding a new error kind for canceled operations will allow the app runtime to decide what to do with it, including not showing it to the user.