### PR TITLE
Ensure that new functions don't show up in Canvas apps:

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerFx.Core.Texl
 
         // Functions in this list are shared and may show up in other hosts by default.
         private static readonly List<TexlFunction> _library = new List<TexlFunction>(200);
-
+        
         public static readonly TexlFunction AmPm = _library.Append(new AmPmFunction());
         public static readonly TexlFunction AmPmShort = _library.Append(new AmPmShortFunction());
         public static readonly TexlFunction Abs = _library.Append(new AbsFunction());
@@ -154,7 +154,6 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction SumT = _library.Append(new SumTableFunction());
         public static readonly TexlFunction Switch = _library.Append(new SwitchFunction());
         public static readonly TexlFunction Table = _library.Append(new TableFunction());
-        public static readonly TexlFunction Table_CO = _library.Append(new TableFunction_CO());
         public static readonly TexlFunction Tan = _library.Append(new TanFunction());
         public static readonly TexlFunction TanT = _library.Append(new TanTableFunction());
         public static readonly TexlFunction Time = _library.Append(new TimeFunction());
@@ -170,11 +169,9 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Upper = _library.Append(new LowerUpperFunction(isLower: false));
         public static readonly TexlFunction UpperT = _library.Append(new LowerUpperTFunction(isLower: false));
         public static readonly TexlFunction Value = _library.Append(new ValueFunction());
-        public static readonly TexlFunction Value_CO = _library.Append(new ValueFunction_CO());
         public static readonly TexlFunction VarP = _library.Append(new VarPFunction());
         public static readonly TexlFunction VarPT = _library.Append(new VarPTableFunction());
         public static readonly TexlFunction Text = _library.Append(new TextFunction());
-        public static readonly TexlFunction Text_CO = _library.Append(new TextFunction_CO());
         public static readonly TexlFunction Weekday = _library.Append(new WeekdayFunction());
         public static readonly TexlFunction WeekdaysLong = _library.Append(new WeekdaysLongFunction());
         public static readonly TexlFunction WeekdaysShort = _library.Append(new WeekdaysShortFunction());
@@ -185,6 +182,9 @@ namespace Microsoft.PowerFx.Core.Texl
         // NOTE: These functions should not be part of the core library until they are implemented in all runtimes
         public static readonly TexlFunction Index_CO = new IndexFunction_CO();
         public static readonly TexlFunction ParseJson = new ParseJsonFunction();
+        public static readonly TexlFunction Table_CO = new TableFunction_CO();
+        public static readonly TexlFunction Text_CO = new TextFunction_CO();
+        public static readonly TexlFunction Value_CO = new ValueFunction_CO();
 
         public static readonly TexlFunction IsUTCToday = new IsUTCTodayFunction();
         public static readonly TexlFunction UTCNow = new UTCNowFunction();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerFx.Core.Texl
     {
         public static IEnumerable<TexlFunction> BuiltinFunctionsLibrary => _library;
 
+        // Functions in this list are shared and may show up in other hosts by default.
         private static readonly List<TexlFunction> _library = new List<TexlFunction>(200);
 
         public static readonly TexlFunction AmPm = _library.Append(new AmPmFunction());
@@ -72,7 +73,6 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction First = _library.Append(new FirstLastFunction(isFirst: true));
         public static readonly TexlFunction FirstN = _library.Append(new FirstLastNFunction(isFirst: true));
         public static readonly TexlFunction ForAll = _library.Append(new ForAllFunction());
-        public static readonly TexlFunction Index_CO = _library.Append(new IndexFunction_CO());
         public static readonly TexlFunction Hour = _library.Append(new HourFunction());
         public static readonly TexlFunction If = _library.Append(new IfFunction());
         public static readonly TexlFunction IfError = _library.Append(new IfErrorFunction());
@@ -112,7 +112,6 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Not = _library.Append(new NotFunction());
         public static readonly TexlFunction Now = _library.Append(new NowFunction());
         public static readonly TexlFunction Or = _library.Append(new VariadicLogicalFunction(isAnd: false));
-        public static readonly TexlFunction ParseJson = _library.Append(new ParseJsonFunction());
         public static readonly TexlFunction Power = _library.Append(new PowerFunction());
         public static readonly TexlFunction PowerT = _library.Append(new PowerTFunction());
         public static readonly TexlFunction Pi = _library.Append(new PiFunction());
@@ -184,6 +183,9 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Year = _library.Append(new YearFunction());
 
         // NOTE: These functions should not be part of the core library until they are implemented in all runtimes
+        public static readonly TexlFunction Index_CO = new IndexFunction_CO();
+        public static readonly TexlFunction ParseJson = new ParseJsonFunction();
+
         public static readonly TexlFunction IsUTCToday = new IsUTCTodayFunction();
         public static readonly TexlFunction UTCNow = new UTCNowFunction();
         public static readonly TexlFunction UTCToday = new UTCTodayFunction();

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -47,6 +47,9 @@ namespace Microsoft.PowerFx
 
             AddFunction(BuiltinFunctionsCore.Index_CO);
             AddFunction(BuiltinFunctionsCore.ParseJson);
+            AddFunction(BuiltinFunctionsCore.Table_CO);
+            AddFunction(BuiltinFunctionsCore.Text_CO);
+            AddFunction(BuiltinFunctionsCore.Value_CO);
         }
 
         // Add Builtin functions that aren't yet in the shared library. 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -18,6 +18,7 @@ using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Public.Types;
 using Microsoft.PowerFx.Core.Public.Values;
 using Microsoft.PowerFx.Core.Syntax;
+using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Core.Texl.Intellisense;
 using Microsoft.PowerFx.Core.Types;
 
@@ -43,6 +44,15 @@ namespace Microsoft.PowerFx
         public RecalcEngine(PowerFxConfig powerFxConfig = null)
         {
             _powerFxConfig = powerFxConfig ?? new PowerFxConfig();
+
+            AddFunction(BuiltinFunctionsCore.Index_CO);
+            AddFunction(BuiltinFunctionsCore.ParseJson);
+        }
+
+        // Add Builtin functions that aren't yet in the shared library. 
+        private void AddFunction(TexlFunction function)
+        {
+            _extraFunctions.Add(function.Name, function);
         }
 
         /// <summary>


### PR DESCRIPTION
Notably:
  IndexFunction_CO
  ParseJsonFunction

Just setting IsHidden=true is insufficient to hide from canvas. We can't add them to _library at all.

Still include in the interpreter by default. 

This is blocking integrating into PAClient.