### PR TITLE
Changed NamedFormulas to IEnumerable

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/NamedFormulas.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/NamedFormulas.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
@@ -15,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Syntax
     /// <summary>
     /// This encapsulates a named formula: its original script, the parsed result, and any parse errors.
     /// </summary>
-    internal class NamedFormulas
+    internal class NamedFormulas : IEnumerable<(DName name, Formula formula)>
     {
         /// <summary>
         /// A script containing one or more named formulas.
@@ -79,27 +80,26 @@ namespace Microsoft.PowerFx.Core.Syntax
             return _errors ?? Enumerable.Empty<TexlError>();
         }
 
-        /// <summary>
-        /// Returns a Tuple of a DName and Formula object for each named formula.
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<(DName name, Formula formula)> GetNamedFormulas()
-        {
-            var formulas = new List<(DName, Formula)>();
-            if (_formulasResult != null)
-            {
-                foreach (var kvp in _formulasResult)
-                {
-                    formulas.Add((kvp.Key, GetFormula(kvp.Value)));
-                }
-            }
-
-            return formulas;
-        }
-
         private Formula GetFormula(TexlNode node)
         {
             return new Formula(node.GetCompleteSpan().GetFragment(Script), node);
         }
+
+        /// <summary>
+        /// Returns a enumerator of type Tuple of a DName and Formula object that can be enumerated for each named formula.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerator<(DName name, Formula formula)> GetEnumerator()
+        {
+            if (_formulasResult != null)
+            {
+                foreach (var kvp in _formulasResult)
+                {
+                    yield return (kvp.Key, GetFormula(kvp.Value));
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/NamedFormulasTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/NamedFormulasTests.cs
@@ -59,15 +59,14 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("x=1;y=2;", "1", "2")]
         public void GetNamedFormulasTest(string script, string expectedX, string expectedY)
         {
-            var namedFormula = new NamedFormulas(script);
-            namedFormula.EnsureParsed();
-            var formulas = namedFormula.GetNamedFormulas();
-            formulas.OrderBy(formula => formula.formula.Script);
+            var namedFormulas = new NamedFormulas(script);
+            namedFormulas.EnsureParsed();
+            namedFormulas.OrderBy(formula => formula.formula.Script);
 
-            Assert.NotNull(formulas);
+            Assert.NotNull(namedFormulas);
 
-            Assert.Equal(expectedX, formulas.ElementAt(0).formula.Script);
-            Assert.Equal(expectedY, formulas.ElementAt(1).formula.Script);
+            Assert.Equal(expectedX, namedFormulas.ElementAt(0).formula.Script);
+            Assert.Equal(expectedY, namedFormulas.ElementAt(1).formula.Script);
         }
     }
 }


### PR DESCRIPTION
Changed NamedFormulas to Enumerable so the consumer can enumerate on the instance, instead of calling GetNamedFormulas().