### PR TITLE
Rename _CO functions to use the _UO suffix

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -180,11 +180,11 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Year = _library.Append(new YearFunction());
 
         // NOTE: These functions should not be part of the core library until they are implemented in all runtimes
-        public static readonly TexlFunction Index_CO = new IndexFunction_CO();
+        public static readonly TexlFunction Index_UO = new IndexFunction_UO();
         public static readonly TexlFunction ParseJson = new ParseJsonFunction();
-        public static readonly TexlFunction Table_CO = new TableFunction_CO();
-        public static readonly TexlFunction Text_CO = new TextFunction_CO();
-        public static readonly TexlFunction Value_CO = new ValueFunction_CO();
+        public static readonly TexlFunction Table_UO = new TableFunction_UO();
+        public static readonly TexlFunction Text_UO = new TextFunction_UO();
+        public static readonly TexlFunction Value_UO = new ValueFunction_UO();
 
         public static readonly TexlFunction IsUTCToday = new IsUTCTodayFunction();
         public static readonly TexlFunction UTCNow = new UTCNowFunction();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 
-    internal class TableFunction_CO : BuiltinFunction
+    internal class TableFunction_UO : BuiltinFunction
     {
         public override bool RequiresErrorContext => true;
 
@@ -94,7 +94,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public TableFunction_CO()
+        public TableFunction_UO()
             : base("Table", TexlStrings.AboutTable, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.UntypedObject)
         {
         }
@@ -117,7 +117,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {
-            return GetUniqueTexlRuntimeName(suffix: "_CO");
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -167,7 +167,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     }
 
     // Text(arg:O)
-    internal sealed class TextFunction_CO : BuiltinFunction
+    internal sealed class TextFunction_UO : BuiltinFunction
     {
         public override bool SupportsParamCoercion => false;
 
@@ -175,7 +175,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public TextFunction_CO()
+        public TextFunction_UO()
             : base("Text", TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 1, DType.UntypedObject)
         {
         }
@@ -187,7 +187,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {
-            return GetUniqueTexlRuntimeName(suffix: "_CO");
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 
-    internal sealed class IndexFunction_CO : BuiltinFunction
+    internal sealed class IndexFunction_UO : BuiltinFunction
     {
         public const string IndexInvariantFunctionName = "Index";
 
@@ -45,7 +45,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsHidden => true;
 
-        public IndexFunction_CO()
+        public IndexFunction_UO()
             : base(IndexInvariantFunctionName, TexlStrings.AboutIndex, FunctionCategories.Table, DType.UntypedObject, 0, 2, 2, DType.UntypedObject, DType.Number)
         {
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     }
 
     // Value(arg:O)
-    internal sealed class ValueFunction_CO : BuiltinFunction
+    internal sealed class ValueFunction_UO : BuiltinFunction
     {
         public override bool RequiresErrorContext => true;
 
@@ -92,7 +92,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public ValueFunction_CO()
+        public ValueFunction_UO()
             : base(ValueFunction.ValueInvariantFunctionName, TexlStrings.AboutValue, FunctionCategories.Text, DType.Number, 0, 1, 1, DType.UntypedObject)
         {
         }
@@ -104,7 +104,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {
-            return GetUniqueTexlRuntimeName(suffix: "_CO");
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -345,7 +345,7 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Hour)
             },
             {
-                BuiltinFunctionsCore.Index_CO,
+                BuiltinFunctionsCore.Index_UO,
                 StandardErrorHandling<FormulaValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
@@ -356,7 +356,7 @@ namespace Microsoft.PowerFx.Functions
                         UntypedObjectArrayChecker,
                         StrictPositiveNumberChecker),
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Index_CO)
+                    targetFunction: Index_UO)
             },
             {
                 BuiltinFunctionsCore.Last,
@@ -756,14 +756,14 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Table)
             },
             {
-                BuiltinFunctionsCore.Table_CO,
+                BuiltinFunctionsCore.Table_UO,
                 StandardErrorHandling<UntypedObjectValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
                     checkRuntimeValues: UntypedObjectArrayChecker,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Table_CO)
+                    targetFunction: Table_UO)
             },
             {
                 BuiltinFunctionsCore.Text,
@@ -776,14 +776,14 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Text)
             },
             {
-                BuiltinFunctionsCore.Text_CO,
+                BuiltinFunctionsCore.Text_UO,
                 StandardErrorHandling<UntypedObjectValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
                     checkRuntimeValues: UntypedObjectPrimitiveChecker,
                     returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
-                    targetFunction: Text_CO)
+                    targetFunction: Text_UO)
             },
             {
                 BuiltinFunctionsCore.Time,
@@ -867,14 +867,14 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Value)
             },
             {
-                BuiltinFunctionsCore.Value_CO,
+                BuiltinFunctionsCore.Value_UO,
                 StandardErrorHandling<UntypedObjectValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
                     checkRuntimeValues: UntypedObjectPrimitiveChecker,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Value_CO)
+                    targetFunction: Value_UO)
             },
             {
                 BuiltinFunctionsCore.With,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
-        public static FormulaValue Index_CO(IRContext irContext, FormulaValue[] args)
+        public static FormulaValue Index_UO(IRContext irContext, FormulaValue[] args)
         {
             var arg0 = (UntypedObjectValue)args[0];
             var arg1 = (NumberValue)args[1];
@@ -41,7 +41,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue Value_CO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Value_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
             double number;
@@ -69,7 +69,7 @@ namespace Microsoft.PowerFx.Functions
             return new NumberValue(irContext, number);
         }
 
-        public static FormulaValue Text_CO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Text_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
             string str;
@@ -94,7 +94,7 @@ namespace Microsoft.PowerFx.Functions
             return new StringValue(irContext, str);
         }
 
-        public static FormulaValue Table_CO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Table_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
         {
             var tableType = (TableType)irContext.ResultType;
             var resultType = tableType.ToRecord();

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -45,11 +45,11 @@ namespace Microsoft.PowerFx
         {
             _powerFxConfig = powerFxConfig ?? new PowerFxConfig();
 
-            AddFunction(BuiltinFunctionsCore.Index_CO);
+            AddFunction(BuiltinFunctionsCore.Index_UO);
             AddFunction(BuiltinFunctionsCore.ParseJson);
-            AddFunction(BuiltinFunctionsCore.Table_CO);
-            AddFunction(BuiltinFunctionsCore.Text_CO);
-            AddFunction(BuiltinFunctionsCore.Value_CO);
+            AddFunction(BuiltinFunctionsCore.Table_UO);
+            AddFunction(BuiltinFunctionsCore.Text_UO);
+            AddFunction(BuiltinFunctionsCore.Value_UO);
         }
 
         // Add Builtin functions that aren't yet in the shared library. 


### PR DESCRIPTION
Cleans up the _CO prefix to use _UO instead.