### PR TITLE
Remove runtime type coercions from Value, Text functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -781,7 +781,7 @@ namespace Microsoft.PowerFx.Functions
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
-                    checkRuntimeValues: UntypedObjectPrimitiveChecker,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
                     targetFunction: Text_UO)
             },
@@ -872,7 +872,7 @@ namespace Microsoft.PowerFx.Functions
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
-                    checkRuntimeValues: UntypedObjectPrimitiveChecker,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Value_UO)
             },

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -44,54 +44,32 @@ namespace Microsoft.PowerFx.Functions
         public static FormulaValue Value_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
-            double number;
 
-            if (impl.Type == FormulaType.String)
+            if (impl.Type == FormulaType.Number)
             {
-                if (!double.TryParse(impl.GetString(), out number))
+                var number = impl.GetDouble();
+                if (IsInvalidDouble(number))
                 {
-                    return CommonErrors.InvalidNumberFormatError(irContext);
+                    return CommonErrors.ArgumentOutOfRange(irContext);
                 }
-            }
-            else if (impl.Type == FormulaType.Blank)
-            {
-                return new BlankValue(irContext);
-            }
-            else if (impl.Type == FormulaType.Boolean)
-            {
-                number = impl.GetBoolean() ? 1 : 0;
-            }
-            else
-            {
-                number = impl.GetDouble();
+
+                return new NumberValue(irContext, number);
             }
 
-            return new NumberValue(irContext, number);
+            return CommonErrors.RuntimeTypeMismatch(irContext);
         }
 
         public static FormulaValue Text_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
-            string str;
 
             if (impl.Type == FormulaType.String)
             {
-                str = impl.GetString();
-            }
-            else if (impl.Type == FormulaType.Blank)
-            {
-                str = string.Empty;
-            }
-            else if (impl.Type == FormulaType.Boolean)
-            {
-                str = PowerFxBooleanToString(impl.GetBoolean());
-            }
-            else
-            {
-                str = impl.GetDouble().ToString();
+                var str = impl.GetString();
+                return new StringValue(irContext, str);
             }
 
-            return new StringValue(irContext, str);
+            return CommonErrors.RuntimeTypeMismatch(irContext);
         }
 
         public static FormulaValue Table_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
@@ -114,27 +92,6 @@ namespace Microsoft.PowerFx.Functions
             }
 
             return new InMemoryTableValue(irContext, resultRows);
-        }
-
-        private static FormulaValue UntypedObjectPrimitiveChecker(IRContext irContext, int index, FormulaValue arg)
-        {
-            if (arg is UntypedObjectValue cov)
-            {
-                if (cov.Impl.Type == FormulaType.Number)
-                {
-                    var number = cov.Impl.GetDouble();
-                    if (IsInvalidDouble(number))
-                    {
-                        return CommonErrors.ArgumentOutOfRange(irContext);
-                    }
-                }
-                else if (cov.Impl.Type is ExternalType)
-                {
-                    return CommonErrors.RuntimeTypeMismatch(irContext);
-                }
-            }
-
-            return arg;
         }
 
         private static FormulaValue UntypedObjectArrayChecker(IRContext irContext, int index, FormulaValue arg)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -6,13 +6,13 @@
 5
 
 >> Value(ParseJson("true"))
-1
+#Error
 
 >> Value(ParseJson("false"))
-0
+#Error
 
 >> Value(ParseJson("""5"""))
-5
+#Error
 
 >> Value(ParseJson("""a"""))
 #Error
@@ -49,13 +49,13 @@ Blank()
 ""
 
 >> Text(ParseJson("true"))
-"true"
+#Error
 
 >> Text(ParseJson("false"))
-"false"
+#Error
 
 >> Text(ParseJson("5"))
-"5"
+#Error
 
 >> ParseJson("{""a"": null}").a
 Blank()


### PR DESCRIPTION
This change moves the Value and Text functions for UntypedObject instances towards a "type casting" style and away from parsing. Now the Text_UO and Value_UO functions only allow String and Number types on the UO impl. Tests have been updated to reflect the new RuntimeTypeMismatch errors.