### PR TITLE
[Option Set Cleanup 3/4] Remove more properties from IExternalEntity and IExternalOptionSet

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4212,8 +4212,8 @@ namespace Microsoft.PowerFx.Core.Binding
                 if (!(typeLeft.IsPrimitive && typeRight.IsPrimitive) && !(typeLeft.IsPolymorphic && typeRight.IsPolymorphic) && !(typeLeft.IsControl && typeRight.IsControl)
                     && !(typeLeft.IsPolymorphic && typeRight.IsRecord) && !(typeLeft.IsRecord && typeRight.IsPolymorphic))
                 {
-                    var leftTypeDisambiguation = typeLeft.IsOptionSet && typeLeft.OptionSetInfo != null ? $"({typeLeft.OptionSetInfo.Name})" : string.Empty;
-                    var rightTypeDisambiguation = typeRight.IsOptionSet && typeRight.OptionSetInfo != null ? $"({typeRight.OptionSetInfo.Name})" : string.Empty;
+                    var leftTypeDisambiguation = typeLeft.IsOptionSet && typeLeft.OptionSetInfo != null ? $"({typeLeft.OptionSetInfo.EntityName})" : string.Empty;
+                    var rightTypeDisambiguation = typeRight.IsOptionSet && typeRight.OptionSetInfo != null ? $"({typeRight.OptionSetInfo.EntityName})" : string.Empty;
 
                     _txb.ErrorContainer.EnsureError(
                         DocumentErrorSeverity.Severe,
@@ -4238,8 +4238,8 @@ namespace Microsoft.PowerFx.Core.Binding
                 // Special case for option set values, it should produce an error when the base option sets are different
                 if (typeLeft.Kind == DKind.OptionSetValue && !typeLeft.Accepts(typeRight))
                 {
-                    var leftTypeDisambiguation = typeLeft.IsOptionSet && typeLeft.OptionSetInfo != null ? $"({typeLeft.OptionSetInfo.Name})" : string.Empty;
-                    var rightTypeDisambiguation = typeRight.IsOptionSet && typeRight.OptionSetInfo != null ? $"({typeRight.OptionSetInfo.Name})" : string.Empty;
+                    var leftTypeDisambiguation = typeLeft.IsOptionSet && typeLeft.OptionSetInfo != null ? $"({typeLeft.OptionSetInfo.EntityName})" : string.Empty;
+                    var rightTypeDisambiguation = typeRight.IsOptionSet && typeRight.OptionSetInfo != null ? $"({typeRight.OptionSetInfo.EntityName})" : string.Empty;
 
                     _txb.ErrorContainer.EnsureError(
                         DocumentErrorSeverity.Severe,

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3011,13 +3011,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 if (lookupInfo.Data is IExternalTabularDataSource || lookupInfo.Kind == BindKind.OptionSet || lookupInfo.Kind == BindKind.View)
                 {
                     _txb.FlagPathAsAsync(node);
-
-                    // If we have a static declaration of an OptionSet (primarily from tests) there is no entity we need to import
-                    // If view no need to verify entity existence
-                    if (lookupInfo.Type.OptionSetInfo == null || lookupInfo.Kind == BindKind.View)
-                    {
-                        return;
-                    }
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2985,15 +2985,6 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                 }
 
-                // Check if we are referencing an errored data source and report the error.
-                IExternalTabularDataSource connectedDataSourceInfo = null;
-                if (lookupInfo.Kind == BindKind.Data &&
-                    (connectedDataSourceInfo = lookupInfo.Data as IExternalTabularDataSource) != null &&
-                    connectedDataSourceInfo.Errors.Any(error => error.Severity >= DocumentErrorSeverity.Severe))
-                {
-                    _txb.ErrorContainer.EnsureError(node, TexlStrings.ErrInvalidDataSource);
-                }
-
                 // Update _usesGlobals, _usesResources, etc.
                 UpdateBindKindUseFlags(lookupInfo.Kind);
 
@@ -3017,7 +3008,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // Any connectedDataSourceInfo or option set or view needs to be accessed asynchronously to allow data to be loaded.
-                if (connectedDataSourceInfo != null || lookupInfo.Kind == BindKind.OptionSet || lookupInfo.Kind == BindKind.View)
+                if (lookupInfo.Data is IExternalTabularDataSource || lookupInfo.Kind == BindKind.OptionSet || lookupInfo.Kind == BindKind.View)
                 {
                     _txb.FlagPathAsAsync(node);
 
@@ -3025,14 +3016,6 @@ namespace Microsoft.PowerFx.Core.Binding
                     // If view no need to verify entity existence
                     if (lookupInfo.Type.OptionSetInfo == null || lookupInfo.Kind == BindKind.View)
                     {
-                        return;
-                    }
-
-                    var relatedEntityName = new DName(lookupInfo.Type.OptionSetInfo.RelatedEntityName);
-                    if (!haveNameResolver || !_nameResolver.LookupGlobalEntity(relatedEntityName, out var entityLookupInfo))
-                    {
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrNeedEntity_EntityName, relatedEntityName);
-                        _txb.SetType(node, DType.Error);
                         return;
                     }
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalEntity.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalEntity.cs
@@ -11,7 +11,5 @@ namespace Microsoft.PowerFx.Core.Entities
     internal interface IExternalEntity
     {
         DName EntityName { get; }
-
-        IEnumerable<IDocumentError> Errors { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalOptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalOptionSet.cs
@@ -5,10 +5,6 @@ namespace Microsoft.PowerFx.Core.Entities
 {
     internal interface IExternalOptionSet<T> : IExternalEntity, IDisplayMapped<int>
     {
-        string Name { get; }
-
         bool IsBooleanValued { get; }
-
-        string RelatedEntityName { get; }
     }
 }


### PR DESCRIPTION
This change is to remove more properties from Entity/OptionSet interfaces, to allow creating clean public OptionSet implementation for Interpreter clients. As part of that,  some fields specific to Dataverse have been pulled off of the general option set definition, and checks for Canvas specific logic have been moved out of binder and into Canvas. 