### PR TITLE
[Option Set Cleanup 4/4] Move IExternalOptionSet to use DisplayNameProvider

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalOptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalOptionSet.cs
@@ -1,10 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Utils;
+
 namespace Microsoft.PowerFx.Core.Entities
 {
-    internal interface IExternalOptionSet<T> : IExternalEntity, IDisplayMapped<int>
+    internal interface IExternalOptionSet : IExternalEntity
     {
+        DisplayNameProvider DisplayNameProvider { get; }
+
+        /// <summary>
+        /// Logical names for the fields in this Option Set.
+        /// </summary>
+        IEnumerable<DName> OptionNames { get; }
+                
         bool IsBooleanValued { get; }
+
+        bool IsConvertingDisplayNameMapping { get; } 
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/DisabledDisplayNameProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/DisabledDisplayNameProvider.cs
@@ -29,5 +29,12 @@ namespace Microsoft.PowerFx.Core
             logicalName = default;
             return false;
         }
+
+        public override bool TryRemapLogicalAndDisplayNames(DName displayName, out DName logicalName, out DName newDisplayName)
+        {
+            logicalName = default;
+            newDisplayName = default;
+            return false;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/DisplayNameProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/DisplayNameProvider.cs
@@ -15,5 +15,14 @@ namespace Microsoft.PowerFx.Core
         public abstract bool TryGetLogicalName(DName displayName, out DName logicalName);
 
         public abstract bool TryGetDisplayName(DName logicalName, out DName displayName);
+
+        /// <summary>
+        /// This function attempts to remap logical and display names given a display name.
+        /// It's used for scenarios where display names are changed under the hood while the expression is in display name format already.
+        /// This is a legacy Canvas app behavior, and should not be supported implemented by non-canvas hosts.
+        /// If this isn't supported by a given display name provider, this should return the same as 
+        /// <see cref="TryGetLogicalName(DName, out DName)"/>, with the newDisplayName output populated by the first arg. 
+        /// </summary>
+        public abstract bool TryRemapLogicalAndDisplayNames(DName displayName, out DName logicalName, out DName newDisplayName);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/SingleSourceDisplayNameProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/SingleSourceDisplayNameProvider.cs
@@ -23,6 +23,28 @@ namespace Microsoft.PowerFx.Core
             _displayToLogical = ImmutableDictionary.Create<DName, DName>();
         }
 
+        public SingleSourceDisplayNameProvider(IEnumerable<KeyValuePair<DName, DName>> logicalToDisplayPairs)
+        {
+            var lToDBuilder = ImmutableDictionary.CreateBuilder<DName, DName>();
+            var dToLBuilder = ImmutableDictionary.CreateBuilder<DName, DName>();
+
+            // Validate input while constructing the dictionaries
+            foreach (var kvp in logicalToDisplayPairs)
+            {
+                if (dToLBuilder.ContainsKey(kvp.Value) || lToDBuilder.ContainsKey(kvp.Value) ||
+                    lToDBuilder.ContainsKey(kvp.Key) || dToLBuilder.ContainsKey(kvp.Key))
+                {
+                    throw new NameCollisionException(kvp.Key);
+                }
+
+                lToDBuilder.Add(kvp.Key, kvp.Value);
+                dToLBuilder.Add(kvp.Value, kvp.Key);
+            }
+
+            _logicalToDisplay = lToDBuilder.ToImmutable();
+            _displayToLogical = dToLBuilder.ToImmutable();
+        }
+
         private SingleSourceDisplayNameProvider(ImmutableDictionary<DName, DName> logicalToDisplay, ImmutableDictionary<DName, DName> displayToLogical)
         {
             _logicalToDisplay = logicalToDisplay;
@@ -52,6 +74,12 @@ namespace Microsoft.PowerFx.Core
         public override bool TryGetDisplayName(DName logicalName, out DName displayName)
         {
             return _logicalToDisplay.TryGetValue(logicalName, out displayName);
+        }
+
+        public override bool TryRemapLogicalAndDisplayNames(DName displayName, out DName logicalName, out DName newDisplayName)
+        {
+            newDisplayName = displayName;
+            return TryGetLogicalName(displayName, out logicalName);
         }
     }
 }


### PR DESCRIPTION
This last refactor eliminates the generic param from IExternalOptionSet, and moves to a common Display Name pattern that will be used going forward for all display name work. 