### PR TITLE
Make FeatureFlags accessible to hosts

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/FeatureFlags.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/FeatureFlags.cs
@@ -1,18 +1,37 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
+
 namespace Microsoft.PowerFx
 {
     /// <summary>
     /// Hosts can enable these flags to try out early features. 
     /// Any flags will eventually default to true and then get removed once the feature is finalized. 
+    /// Removing a flag is a breaking change and requires a semver update. 
+    /// Flags can only be set once. 
     /// </summary>
     public static class FeatureFlags
     {
+        private static bool _stringInterpolation = false;
+
         /// <summary>
         /// Enable String Interpolation feature. 
         /// Added 12/3/2021.
         /// </summary>
-        public static bool StringInterpolation = false;
+        public static bool StringInterpolation
+        {
+            get => _stringInterpolation;
+            set
+            {
+                // Once flipped, can't unflip. 
+                if (!value) 
+                { 
+                    throw new NotSupportedException("Can't change field after it's set");
+                }
+
+                _stringInterpolation = value;
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/FeatureFlags.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/FeatureFlags.cs
@@ -7,7 +7,7 @@ namespace Microsoft.PowerFx
     /// Hosts can enable these flags to try out early features. 
     /// Any flags will eventually default to true and then get removed once the feature is finalized. 
     /// </summary>
-    internal static class FeatureFlags
+    public static class FeatureFlags
     {
         /// <summary>
         /// Enable String Interpolation feature. 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
             var allowed = new HashSet<string>()
             {
+                "Microsoft.PowerFx.FeatureFlags",
                 "Microsoft.PowerFx.Core.Texl.Intellisense.IIntellisenseResult",
                 "Microsoft.PowerFx.Core.Texl.Intellisense.IIntellisenseSuggestion",
                 "Microsoft.PowerFx.Core.Texl.Intellisense.SuggestionIconKind",

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ThreadingTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ThreadingTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "DataTypeInfo.AllowedValuesOnly",
                 "DataTypeInfo._validDataFormatsPerDKind",
 
-                "FeatureFlags.StringInterpolation",
+                "FeatureFlags._stringInterpolation",
                 "EmptyEnumerator`1._instance",
                 "Contracts._assertFailExCtor",
                 "CurrentLocaleInfo.<CurrentLocaleName>k__BackingField",


### PR DESCRIPTION
At present, a host can't modify the feature flags.  They should be able to.  For example, I'd like to be able to `FeatureFlags.StringInterpolation = true;` when instancing a new engine in the ConeoleREPL sample, to test out this feature without needing to build the libraries.