### PR TITLE
Adding string interpolation tests

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -427,3 +427,6 @@ Errors: Error 2-2: Unexpected characters. Characters are used in the formula in 
 >> $""""
 /*SqlRunner*/ Compile Error
 """
+
+>> """"
+"""

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -379,3 +379,51 @@ Errors: Error 2-2: Unexpected characters. Characters are used in the formula in 
 >> $"{{a}}-"
 /*SqlRunner*/ Compile Error
 "{a}-"
+
+>> $"! {With({a:4,b:6},a*b)} !"
+/*SqlRunner*/ Compile Error
+"! 24 !"
+
+>> $"! {With({array:[1,5,9]},Sum(Sequence(CountRows(array)) As Index,Power(Last(FirstN(array,Index.Value)).Value, Index.Value)))} !"
+/*SqlRunner*/ Compile Error
+"! 755 !"
+
+>> $"! {$"{$"{true}"}"} !"
+/*SqlRunner*/ Compile Error
+"! true !"
+
+>> $""
+/*SqlRunner*/ Compile Error
+""
+
+>> $"! !"
+/*SqlRunner*/ Compile Error
+"! !"
+
+>> $"! "" !"
+/*SqlRunner*/ Compile Error
+"! " !"
+
+>> $"! {{1,2}} !"
+/*SqlRunner*/ Compile Error
+#Error
+
+>> $"! {[1,2]} !"
+/*SqlRunner*/ Compile Error
+#Error
+
+> $"! {Table({a:1})} !"
+/*SqlRunner*/ Compile Error
+#Error
+
+>> $"! {{a:1,b:2}} !"
+/*SqlRunner*/ Compile Error
+#Error
+
+>> $"! {Date(1980,1,1)} !"
+/*SqlRunner*/ Compile Error
+"! 1/1/1980 12:00:00 AM !"
+
+>> $""""
+/*SqlRunner*/ Compile Error
+"""


### PR DESCRIPTION
The last five tests currently do not pass with various failures.  The first three should not work but do, the date example returns "! shortdate !" instead of the date as a string, and the last one produces a compile time error.