### PR TITLE
Updating tests for Last/First of empty table

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
@@ -63,3 +63,9 @@ Blank()
 
 >> First(First(Table({a:{aa:11,ab:12,ad:Table({aaa:1},{aaa:2})},b:1},{a:{ac:23,ad:Table({bbb:1},{bbb:2})},b:2})).a.ad).aaa
 1
+
+>> First(Filter([1,2,3],Value=4)).Value
+Blank()
+
+>> FirstN(Filter([1,2,3],Value=4),2)
+[]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
@@ -48,3 +48,9 @@ Blank()
 
 >> LastN(Table({Value:1,Zulu:1}, {Value:2,Zulu:2}, {Value:3,Zulu:3}), 2)
 [{Value:2,Zulu:2},{Value:3,Zulu:3}]
+
+>> Last(Filter([1,2,3],Value=4)).Value
+Blank()
+
+>> LastN(Filter([1,2,3],Value=4),2)
+[]


### PR DESCRIPTION
Last/First are returning an error for the empty table returned by Filter.  This should be a blank record, consistent with Canvas.