### PR TITLE
Update First/Last functions to return blank on empty tables

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
@@ -15,12 +15,12 @@ namespace Microsoft.PowerFx.Functions
     {
         public static FormulaValue First(IRContext irContext, TableValue[] args)
         {
-            return args[0].Rows.First().ToFormulaValue();
+            return args[0].Rows.FirstOrDefault()?.ToFormulaValue() ?? new BlankValue(irContext);
         }
 
         public static FormulaValue Last(IRContext irContext, TableValue[] args)
         {
-            return args[0].Rows.Last().ToFormulaValue();
+            return args[0].Rows.LastOrDefault()?.ToFormulaValue() ?? new BlankValue(irContext);
         }
 
         public static FormulaValue FirstN(IRContext irContext, FormulaValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
@@ -63,3 +63,9 @@ Blank()
 
 >> First(First(Table({a:{aa:11,ab:12,ad:Table({aaa:1},{aaa:2})},b:1},{a:{ac:23,ad:Table({bbb:1},{bbb:2})},b:2})).a.ad).aaa
 1
+
+>> First(Filter([1,2,3],Value=4)).Value
+Blank()
+
+>> FirstN(Filter([1,2,3],Value=4),2)
+[]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
@@ -48,3 +48,9 @@ Blank()
 
 >> LastN(Table({Value:1,Zulu:1}, {Value:2,Zulu:2}, {Value:3,Zulu:3}), 2)
 [{Value:2,Zulu:2},{Value:3,Zulu:3}]
+
+>> Last(Filter([1,2,3],Value=4)).Value
+Blank()
+
+>> LastN(Filter([1,2,3],Value=4),2)
+[]


### PR DESCRIPTION
Last/First are returning an error for the empty table returned by Filter. This should be a blank record, consistent with Canvas.