### PR TITLE
Implement Option Set Support in the interpreter

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
@@ -11,7 +11,6 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
 
         // Coercion operations
         BooleanToNumber,
-        StringOptionSetToNumber,
         BooleanOptionSetToNumber,
         DateToNumber,
         TimeToNumber,

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -39,6 +39,9 @@ namespace Microsoft.PowerFx.Core.Public.Types
         public static FormulaType UntypedObject { get; } = new UntypedObjectType();
 
         public static FormulaType Hyperlink { get; } = new HyperlinkType();
+        
+        // This is a dummy option set value, don't use this type for valid option sets.  
+        internal static FormulaType OptionSetValue { get; } = new OptionSetValueType();
 
         // chained by derived type 
         internal FormulaType(DType type)
@@ -67,8 +70,9 @@ namespace Microsoft.PowerFx.Core.Public.Types
                 case DKind.DateTime: return DateTime;
                 case DKind.DateTimeNoTimeZone: return DateTimeNoTimeZone;
 
-                case DKind.OptionSetValue:
-                    return new OptionSetValueType(type.OptionSetInfo);
+                case DKind.OptionSetValue:                    
+                    var isBoolean = type.OptionSetInfo?.IsBooleanValued;
+                    return isBoolean.HasValue && isBoolean.Value ? Boolean : OptionSetValue;
 
                 // This isn't quite right, but once we're in the IR, an option set acts more like a record with optionsetvalue fields. 
                 case DKind.OptionSet:

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -40,7 +40,10 @@ namespace Microsoft.PowerFx.Core.Public.Types
 
         public static FormulaType Hyperlink { get; } = new HyperlinkType();
         
-        // This is a dummy option set value, don't use this type for valid option sets.  
+        /// <summary>
+        /// Internal use only to represent an arbitrary (un-backed) option set value.
+        /// Should be removed if possible.
+        /// </summary>
         internal static FormulaType OptionSetValue { get; } = new OptionSetValueType();
 
         // chained by derived type 
@@ -70,7 +73,7 @@ namespace Microsoft.PowerFx.Core.Public.Types
                 case DKind.DateTime: return DateTime;
                 case DKind.DateTimeNoTimeZone: return DateTimeNoTimeZone;
 
-                case DKind.OptionSetValue:                    
+                case DKind.OptionSetValue:
                     var isBoolean = type.OptionSetInfo?.IsBooleanValued;
                     return isBoolean.HasValue && isBoolean.Value ? Boolean : OptionSetValue;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -36,8 +36,6 @@ namespace Microsoft.PowerFx.Core.Public.Types
 
         public static FormulaType DateTimeNoTimeZone { get; } = new DateTimeNoTimeZoneType();
 
-        public static FormulaType OptionSetValue { get; } = new OptionSetValueType();
-
         public static FormulaType UntypedObject { get; } = new UntypedObjectType();
 
         public static FormulaType Hyperlink { get; } = new HyperlinkType();
@@ -70,8 +68,7 @@ namespace Microsoft.PowerFx.Core.Public.Types
                 case DKind.DateTimeNoTimeZone: return DateTimeNoTimeZone;
 
                 case DKind.OptionSetValue:
-                    var isBoolean = type.OptionSetInfo?.IsBooleanValued;
-                    return isBoolean.HasValue && isBoolean.Value ? Boolean : OptionSetValue;
+                    return new OptionSetValueType(type.OptionSetInfo);
 
                 // This isn't quite right, but once we're in the IR, an option set acts more like a record with optionsetvalue fields. 
                 case DKind.OptionSet:

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerFx.Core.Public.Types
     public class OptionSetValueType : FormulaType
     {
         internal OptionSetValueType(IExternalOptionSet optionSet)
-            : base(DType.CreateOptionSetValue(optionSet))
+            : base(DType.CreateOptionSetValueType(optionSet))
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -13,6 +13,12 @@ namespace Microsoft.PowerFx.Core.Public.Types
         {
         }
 
+        // Constructor for dummy option set values, don't use for valid option sets
+        internal OptionSetValueType()
+            : base(new DType(DKind.OptionSetValue))
+        {
+        }
+
         public override void Visit(ITypeVistor vistor)
         {
             vistor.Visit(this);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Types;
 
 namespace Microsoft.PowerFx.Core.Public.Types
 {
     public class OptionSetValueType : FormulaType
     {
-        internal OptionSetValueType()
-            : base(new DType(DKind.OptionSetValue))
+        internal OptionSetValueType(IExternalOptionSet optionSet)
+            : base(DType.CreateOptionSetType(optionSet))
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerFx.Core.Public.Types
     public class OptionSetValueType : FormulaType
     {
         internal OptionSetValueType(IExternalOptionSet optionSet)
-            : base(DType.CreateOptionSetType(optionSet))
+            : base(DType.CreateOptionSetValue(optionSet))
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -13,7 +13,10 @@ namespace Microsoft.PowerFx.Core.Public.Types
         {
         }
 
-        // Constructor for dummy option set values, don't use for valid option sets
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionSetValueType"/> class.
+        /// Internal use only. Used by legacy clients to represent an un-backed option set, and should be removed.
+        /// </summary>
         internal OptionSetValueType()
             : base(new DType(DKind.OptionSetValue))
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/IValueVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/IValueVisitor.cs
@@ -26,5 +26,7 @@ namespace Microsoft.PowerFx.Core.Public.Values
         void Visit(DateTimeValue value);
 
         void Visit(UntypedObjectValue value);
+
+        void Visit(OptionSetValue value);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerFx.Core.Public.Values
         /// <summary>
         /// Logical name for this option set value.
         /// </summary>
-        public string Option;
+        public readonly string Option;
 
         internal OptionSetValue(string option, IRContext irContext)
             : base(irContext)

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.PowerFx.Core.IR;
+
+namespace Microsoft.PowerFx.Core.Public.Values
+{
+    [DebuggerDisplay("OptionSetValue ({Option})")]
+    public class OptionSetValue : FormulaValue
+    {
+        /// <summary>
+        /// Logical name for this option set value.
+        /// </summary>
+        public string Option;
+
+        internal OptionSetValue(string option, IRContext irContext)
+            : base(irContext)
+        {
+            Option = option;
+        }
+
+        public override object ToObject()
+        {
+            return Option;
+        }
+
+        public override string ToString()
+        {
+            return $"OptionSetValue ({Option})";
+        }
+
+        public override void Visit(IValueVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -844,7 +844,7 @@ namespace Microsoft.PowerFx.Core.Types
             return new DType(DKind.Record, TypeTree.Create(minTypeTree));
         }
 
-        public static DType CreateOptionSetValue(IExternalOptionSet info)
+        public static DType CreateOptionSetValueType(IExternalOptionSet info)
         {
             return new DType(DKind.OptionSetValue, info);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
@@ -36,6 +36,9 @@ namespace Microsoft.PowerFx.Core.Utils
                             tokens[item.Name] = TokenResultType.HostSymbol;
                             break;
                         case BindKind.PowerFxResolvedObject:
+                            tokens[item.Name] = TokenResultType.HostSymbol;
+                            break;
+                        case BindKind.LambdaField:
                             tokens[item.Name] = TokenResultType.Variable;
                             break;
                         default:

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
@@ -33,8 +33,6 @@ namespace Microsoft.PowerFx.Core.Utils
                     switch (item.Kind)
                     {
                         case BindKind.Control:
-                            tokens[item.Name] = TokenResultType.HostSymbol;
-                            break;
                         case BindKind.OptionSet:
                         case BindKind.PowerFxResolvedObject:
                             tokens[item.Name] = TokenResultType.HostSymbol;

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
@@ -35,6 +35,7 @@ namespace Microsoft.PowerFx.Core.Utils
                         case BindKind.Control:
                             tokens[item.Name] = TokenResultType.HostSymbol;
                             break;
+                        case BindKind.OptionSet:
                         case BindKind.PowerFxResolvedObject:
                             tokens[item.Name] = TokenResultType.HostSymbol;
                             break;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx
 
             _displayNameProvider = new SingleSourceDisplayNameProvider(Options);
             FormulaType = new OptionSetValueType(this);
-            _type = FormulaType._type;
+            _type = DType.CreateOptionSetType(this);
         }
         
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
@@ -10,7 +10,9 @@ using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.App.Controls;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public.Types;
+using Microsoft.PowerFx.Core.Public.Values;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.UtilityDataStructures;
 using Microsoft.PowerFx.Core.Utils;
@@ -53,6 +55,16 @@ namespace Microsoft.PowerFx
         /// Use in record/table contexts to define the type of fields using this option set.
         /// </summary>
         public FormulaType FormulaType { get; }
+
+        public OptionSetValue GetValue(DName fieldName)
+        {
+            if (!Options.ContainsKey(fieldName)) 
+            {
+                throw new InvalidOperationException($"{fieldName.Value} is not a member of option set {EntityName.Value}");
+            }
+
+            return new OptionSetValue(fieldName, IRContext.NotInSource(FormulaType));
+        }
 
         IEnumerable<DName> IExternalOptionSet.OptionNames => Options.Keys;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
@@ -10,6 +10,7 @@ using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.App.Controls;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Public.Types;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.UtilityDataStructures;
 using Microsoft.PowerFx.Core.Utils;
@@ -32,7 +33,8 @@ namespace Microsoft.PowerFx
             Options = ImmutableDictionary.CreateRange(options.Select(kvp => new KeyValuePair<DName, DName>(new DName(kvp.Key), new DName(kvp.Value))));
 
             _displayNameProvider = new SingleSourceDisplayNameProvider(Options);
-            _type = DType.CreateOptionSetType(this);
+            FormulaType = new OptionSetValueType(this);
+            _type = FormulaType._type;
         }
         
         /// <summary>
@@ -45,6 +47,12 @@ namespace Microsoft.PowerFx
         /// Key is logical/invariant name, value is display name.
         /// </summary>
         public ImmutableDictionary<DName, DName> Options { get; }
+
+        /// <summary>
+        /// Formula Type corresponding to this option set.
+        /// Use in record/table contexts to define the type of fields using this option set.
+        /// </summary>
+        public FormulaType FormulaType { get; }
 
         IEnumerable<DName> IExternalOptionSet.OptionNames => Options.Keys;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
@@ -56,14 +56,16 @@ namespace Microsoft.PowerFx
         /// </summary>
         public FormulaType FormulaType { get; }
 
-        public OptionSetValue GetValue(DName fieldName)
+        public bool TryGetValue(DName fieldName, out OptionSetValue optionSetValue)
         {
             if (!Options.ContainsKey(fieldName)) 
             {
-                throw new InvalidOperationException($"{fieldName.Value} is not a member of option set {EntityName.Value}");
+                optionSetValue = null;
+                return false;
             }
 
-            return new OptionSetValue(fieldName, IRContext.NotInSource(FormulaType));
+            optionSetValue = new OptionSetValue(fieldName, IRContext.NotInSource(FormulaType));
+            return true;
         }
 
         IEnumerable<DName> IExternalOptionSet.OptionNames => Options.Keys;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -184,10 +184,12 @@ namespace Microsoft.PowerFx
                 case BinaryOpKind.EqMedia:
                 case BinaryOpKind.EqBlob:
                 case BinaryOpKind.EqGuid:
+                case BinaryOpKind.EqOptionSetValue:
                     return OperatorBinaryEq(this, context, node.IRContext, args);
 
                 case BinaryOpKind.NeqNumbers:
                 case BinaryOpKind.NeqText:
+                case BinaryOpKind.NeqOptionSetValue:
                     return OperatorBinaryNeq(this, context, node.IRContext, args);
 
                 case BinaryOpKind.GtNumbers:
@@ -419,26 +421,13 @@ namespace Microsoft.PowerFx
 
         public override FormulaValue Visit(ResolvedObjectNode node, SymbolContext context)
         {
-            if (node.Value is RecalcEngineResolver.ParameterData data)
+            return node.Value switch
             {
-                var paramName = data.ParameterName;
-
-                var value = context.Globals.GetField(node.IRContext, paramName);
-                return value;
-            }
-
-            if (node.Value is RecalcFormulaInfo fi)
-            {
-                var value = fi._value;
-                return value;
-            }
-
-            return new ErrorValue(node.IRContext, new ExpressionError()
-            {
-                Message = $"Unrecognized symbol {node?.Value?.GetType()?.Name}".Trim(),
-                Span = node.IRContext.SourceContext,
-                Kind = ErrorKind.Validation
-            });
+                RecalcEngineResolver.ParameterData data => ResolvedObjectHelpers.ParameterData(data, context, node.IRContext),
+                RecalcFormulaInfo fi => ResolvedObjectHelpers.RecalcFormulaInfo(fi),
+                OptionSet optionSet => ResolvedObjectHelpers.OptionSet(optionSet, node.IRContext),
+                _ => ResolvedObjectHelpers.ResolvedObjectError(node),
+            };
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -423,7 +423,6 @@ namespace Microsoft.PowerFx
         {
             return node.Value switch
             {
-                RecalcEngineResolver.ParameterData data => ResolvedObjectHelpers.ParameterData(data, context, node.IRContext),
                 RecalcFormulaInfo fi => ResolvedObjectHelpers.RecalcFormulaInfo(fi),
                 OptionSet optionSet => ResolvedObjectHelpers.OptionSet(optionSet, node.IRContext),
                 _ => ResolvedObjectHelpers.ResolvedObjectError(node),

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -404,6 +404,8 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue OptionSetValueToString(IRContext irContext, OptionSetValue[] args)
         {
+            // The type checker and IR have already validated that this is a valid OptionSet and that it contains a member matching this Option.
+            // These are just defensive error checks, and should be unreachable.
             var os = args[0].Type?._type?.OptionSetInfo;
             if (os is not OptionSet optionSet) 
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -228,6 +228,16 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: TimeParse)
+            },
+            {
+                UnaryOpKind.OptionSetToText,                
+                StandardErrorHandling<OptionSetValue>(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<OptionSetValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: OptionSetValueToString)
             }
         };
         #endregion
@@ -390,6 +400,24 @@ namespace Microsoft.PowerFx.Functions
             var t = args[0].Value;
             var date = _epoch.Add(t);
             return new DateTimeValue(irContext, date);
+        }
+
+        public static FormulaValue OptionSetValueToString(IRContext irContext, OptionSetValue[] args)
+        {
+            var os = args[0].Type?._type?.OptionSetInfo;
+            if (os is not OptionSet optionSet) 
+            {
+                return CommonErrors.UnreachableCodeError(irContext);
+            }
+
+            var option = args[0].Option;
+
+            if (!optionSet.Options.TryGetValue(new DName(option), out var displayName))
+            { 
+                return CommonErrors.UnreachableCodeError(irContext);
+            }
+
+            return new StringValue(irContext, displayName);
         }
         #endregion
     }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Linq;
+using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.IR.Nodes;
+using Microsoft.PowerFx.Core.Public;
+using Microsoft.PowerFx.Core.Public.Types;
+using Microsoft.PowerFx.Core.Public.Values;
+using Microsoft.PowerFx.Core.Types;
+
+namespace Microsoft.PowerFx.Functions
+{
+    // Core operations for turning ResolvedObjects into PowerFx values
+    internal static class ResolvedObjectHelpers
+    {
+        public static FormulaValue ParameterData(RecalcEngineResolver.ParameterData data, SymbolContext context, IRContext irContext)
+        {
+            var paramName = data.ParameterName;
+            var value = context.Globals.GetField(irContext, paramName);
+            return value;
+        }
+
+        public static FormulaValue RecalcFormulaInfo(RecalcFormulaInfo fi)
+        {
+            return fi._value;
+        }
+
+        public static FormulaValue OptionSet(OptionSet optionSet, IRContext irContext)
+        {
+            var recordValue = FormulaValue.RecordFromFields(
+                optionSet.Options
+                    .Select(option => new NamedValue(
+                        option.Key, 
+                        new OptionSetValue(option.Key, IRContext.NotInSource(optionSet.FormulaType)))));
+            return recordValue;
+        }
+
+        public static FormulaValue ResolvedObjectError(ResolvedObjectNode node)
+        {
+            return new ErrorValue(node.IRContext, new ExpressionError()
+            {
+                Message = $"Unrecognized symbol {node?.Value?.GetType()?.Name}".Trim(),
+                Span = node.IRContext.SourceContext,
+                Kind = ErrorKind.Validation
+            });
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
@@ -21,12 +22,18 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue OptionSet(OptionSet optionSet, IRContext irContext)
         {
-            var recordValue = FormulaValue.RecordFromFields(
-                optionSet.Options
-                    .Select(option => new NamedValue(
-                        option.Key, 
-                        optionSet.GetValue(option.Key))));
-            return recordValue;
+            var options = new List<NamedValue>();
+            foreach (var option in optionSet.Options)
+            {
+                if (!optionSet.TryGetValue(option.Key, out var osValue))
+                {
+                    return CommonErrors.UnreachableCodeError(irContext); 
+                }
+
+                options.Add(new NamedValue(option.Key, osValue));
+            }
+
+            return FormulaValue.RecordFromFields(options);
         }
 
         public static FormulaValue ResolvedObjectError(ResolvedObjectNode node)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -27,12 +27,16 @@ namespace Microsoft.PowerFx.Functions
             {
                 if (!optionSet.TryGetValue(option.Key, out var osValue))
                 {
+                    // This is iterating the Options in the option set
+                    // so we already know TryGetValue will succeed, making this unreachable.
                     return CommonErrors.UnreachableCodeError(irContext); 
                 }
 
                 options.Add(new NamedValue(option.Key, osValue));
             }
 
+            // When evaluating an option set ResolvedObjectNode, we convert the options into a record
+            // This allows the use of the FieldAccess operator to get specific option values.
             return FormulaValue.RecordFromFields(options);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -14,13 +14,6 @@ namespace Microsoft.PowerFx.Functions
     // Core operations for turning ResolvedObjects into PowerFx values
     internal static class ResolvedObjectHelpers
     {
-        public static FormulaValue ParameterData(RecalcEngineResolver.ParameterData data, SymbolContext context, IRContext irContext)
-        {
-            var paramName = data.ParameterName;
-            var value = context.Globals.GetField(irContext, paramName);
-            return value;
-        }
-
         public static FormulaValue RecalcFormulaInfo(RecalcFormulaInfo fi)
         {
             return fi._value;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerFx.Functions
                 optionSet.Options
                     .Select(option => new NamedValue(
                         option.Key, 
-                        new OptionSetValue(option.Key, IRContext.NotInSource(optionSet.FormulaType)))));
+                        optionSet.GetValue(option.Key))));
             return recordValue;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.PowerFx.Core.IR.Nodes;
+using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Public.Values;
 
@@ -11,18 +12,20 @@ namespace Microsoft.PowerFx
     internal class ParsedExpression : IExpression
     {
         internal IntermediateNode _irnode;
+        private readonly ScopeSymbol _topScopeSymbol;
         private readonly CultureInfo _cultureInfo;
 
-        internal ParsedExpression(IntermediateNode irnode, CultureInfo cultureInfo = null)
+        internal ParsedExpression(IntermediateNode irnode, ScopeSymbol topScope, CultureInfo cultureInfo = null)
         {
             _irnode = irnode;
+            _topScopeSymbol = topScope;
             _cultureInfo = cultureInfo ?? CultureInfo.CurrentCulture;
         }
 
         public FormulaValue Eval(RecordValue parameters)
         {
             var ev2 = new EvalVisitor(_cultureInfo);
-            var newValue = _irnode.Accept(ev2, SymbolContext.New().WithGlobals(parameters));
+            var newValue = _irnode.Accept(ev2, SymbolContext.NewTopScope(_topScopeSymbol, parameters));
 
             return newValue;
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -151,16 +151,11 @@ namespace Microsoft.PowerFx
 
             var resolver = new RecalcEngineResolver(this, _powerFxConfig, (RecordType)parameterType);
 
-            // $$$ - intellisense only works with ruleScope.
-            // So if running for intellisense, pass the parameters in ruleScope. 
-            // But if running for eval, let the resolver handle the parameters. 
-            // Resolver is only invoked if not in RuleScope. 
-
             var binding = TexlBinding.Run(
                 new Glue2DocumentBinderGlue(),
                 formula.ParseTree,
                 resolver,
-                ruleScope: intellisense ? parameterType._type : null,
+                ruleScope: parameterType._type,
                 useThisRecordForRuleScope: false);
 
             var errors = formula.HasParseErrors ? formula.GetParseErrors() : binding.ErrorContainer.GetErrors();
@@ -187,7 +182,7 @@ namespace Microsoft.PowerFx
                 }
 
                 (var irnode, var ruleScopeSymbol) = IRTranslator.Translate(result._binding);
-                result.Expression = new ParsedExpression(irnode);
+                result.Expression = new ParsedExpression(irnode, ruleScopeSymbol);
             }
 
             return result;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/SymbolContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/SymbolContext.cs
@@ -15,14 +15,11 @@ namespace Microsoft.PowerFx
     // of this class in the bodies of the various .visit methods
     internal sealed class SymbolContext
     {
-        public SymbolContext(RecordValue globals, ScopeSymbol currentScope, Dictionary<int, IScope> scopeValues)
+        public SymbolContext(ScopeSymbol currentScope, Dictionary<int, IScope> scopeValues)
         {
-            Globals = globals;
             CurrentScope = currentScope;
             ScopeValues = scopeValues;
         }
-
-        public RecordValue Globals { get; }
 
         public ScopeSymbol CurrentScope { get; } = null;
 
@@ -30,17 +27,17 @@ namespace Microsoft.PowerFx
 
         public static SymbolContext New()
         {
-            return new SymbolContext(null, null, new Dictionary<int, IScope>());
+            return new SymbolContext(null, new Dictionary<int, IScope>());
         }
 
-        public SymbolContext WithGlobals(RecordValue globals)
+        public static SymbolContext NewTopScope(ScopeSymbol topScope, RecordValue ruleScope)
         {
-            return new SymbolContext(globals, CurrentScope, ScopeValues);
+            return new SymbolContext(topScope, new Dictionary<int, IScope>() { { topScope.Id, new RecordScope(ruleScope) } });
         }
 
         public SymbolContext WithScope(ScopeSymbol currentScope)
         {
-            return new SymbolContext(Globals, currentScope, ScopeValues);
+            return new SymbolContext(currentScope, ScopeValues);
         }
 
         public SymbolContext WithScopeValues(IScope scopeValues)
@@ -49,7 +46,7 @@ namespace Microsoft.PowerFx
             {
                 [CurrentScope.Id] = scopeValues
             };
-            return new SymbolContext(Globals, CurrentScope, newScopeValues);
+            return new SymbolContext(CurrentScope, newScopeValues);
         }
 
         public SymbolContext WithScopeValues(RecordValue scopeValues)

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/FormulaTypeJsonConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/FormulaTypeJsonConverter.cs
@@ -40,7 +40,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                 Date => FormulaType.Date,
                 DateTime => FormulaType.DateTime,
                 DateTimeNoTimeZone => FormulaType.DateTimeNoTimeZone,
-                OptionSetValue => FormulaType.DateTimeNoTimeZone,
                 Record => RecordFromJson(element, options),
                 Table => TableFromJson(element, options),
                 _ => throw new NotImplementedException($"Unknown {nameof(FormulaType)}: {typeValue}")
@@ -60,7 +59,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                 DateType => Date,
                 DateTimeType => DateTime,
                 DateTimeNoTimeZoneType => DateTimeNoTimeZone,
-                OptionSetValueType => DateTimeNoTimeZone,
+                OptionSetValueType => OptionSetValue,
                 TableType => Table,
                 RecordType => Record,
                 _ => throw new NotImplementedException($"Unknown {nameof(FormulaType)}: {value.GetType().Name}")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
@@ -1,4 +1,4 @@
-// SETUP: OptionSetTestSetup
+#SETUP: OptionSetTestSetup
 
 >> OptionSet.Option1 <> OptionSet.Option2
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
@@ -1,0 +1,2 @@
+// SETUP: OptionSetTestSetup
+

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
@@ -3,7 +3,7 @@
 >> OptionSet.Option1 <> OptionSet.Option2
 true
 
->> OptionSet.Option2 == OptionSet.Option2
+>> OptionSet.Option2 = OptionSet.Option2
 true
 
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
@@ -1,2 +1,11 @@
 // SETUP: OptionSetTestSetup
 
+>> OptionSet.Option1 <> OptionSet.Option2
+true
+
+>> OptionSet.Option2 == OptionSet.Option2
+true
+
+
+>> "Coerces to " & OptionSet.Option2
+"Coerces to Option2"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OptionSet.txt
@@ -6,6 +6,17 @@ true
 >> OptionSet.Option2 = OptionSet.Option2
 true
 
-
 >> "Coerces to " & OptionSet.Option2
 "Coerces to Option2"
+
+>> OtherOptionSet.OptionD & "Coerces"
+"OptionDCoerces"
+
+>> If(TopOptionSetField = OptionSet.Option1, "success", "failure")
+"success"
+
+>> Switch(Nested.InnerOtherOptionSet, OtherOptionSet.OptionA, 1, OtherOptionSet.OptionB, 2, OtherOptionSet.OptionC, 3, OtherOptionSet.OptionD, 4)
+4
+
+>> OtherOptionSet.OptionA <> TopOptionSetField
+Errors: Error 23-25: Incompatible types for comparison. These types can't be compared: OptionSetValue(OtherOptionSet), OptionSetValue(OptionSet).

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -14,6 +14,10 @@ namespace Microsoft.PowerFx.Core.Tests
     {
         public abstract Task<FormulaValue> RunAsync(string expr);
 
+
+        // Return false if setup handler isn't defined for this runner
+        public abstract bool TryDoSetup(string setupHandlerName);
+
         // Get the friendly name of the harness. 
         public virtual string GetName()
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -14,9 +14,9 @@ namespace Microsoft.PowerFx.Core.Tests
     {
         public abstract Task<FormulaValue> RunAsync(string expr);
 
-
-        // Return false if setup handler isn't defined for this runner
-        public abstract bool TryDoSetup(string setupHandlerName);
+        // Throws NotSupportedException, with a message containing the string "Setup Handler"
+        // if setup handler isn't defined for this runner
+        public abstract Task<FormulaValue> RunWithSetup(string expr, string setupHandlerName);
 
         // Get the friendly name of the harness. 
         public virtual string GetName()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/ExpressionTestCase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/ExpressionTestCase.cs
@@ -32,6 +32,7 @@ namespace Microsoft.PowerFx.Core.Tests
         // Location from source file. 
         public string SourceFile;
         public int SourceLine;
+        public string SetupHandlerName;
 
         public override string ToString()
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/ExpressionTestCase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/ExpressionTestCase.cs
@@ -65,6 +65,7 @@ namespace Microsoft.PowerFx.Core.Tests
             Input = info.GetValue<string>("input");
             SourceFile = info.GetValue<string>("sourceFile");
             SourceLine = info.GetValue<int>("sourceLine");
+            SetupHandlerName = info.GetValue<string>("setupHandlerName");
         }
 
         public void Serialize(IXunitSerializationInfo info)
@@ -74,6 +75,7 @@ namespace Microsoft.PowerFx.Core.Tests
             info.AddValue("input", Input, typeof(string));
             info.AddValue("sourceFile", SourceFile, typeof(string));
             info.AddValue("sourceLine", SourceLine, typeof(int));
+            info.AddValue("setupHandlerName", SetupHandlerName, typeof(string));
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestCase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestCase.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerFx.Core.Tests
         // Location from source file. 
         public string SourceFile;
         public int SourceLine;
+        public string SetupHandlerName;
 
         public override string ToString()
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
@@ -68,9 +68,9 @@ namespace Microsoft.PowerFx.Core.Tests
 
             // Preprocess file directives
             string fileSetup = null;
-            if (lines[0].StartsWith("// SETUP: "))
+            if (lines[0].StartsWith("#SETUP:"))
             {
-                fileSetup = lines[0].Substring("// SETUP: ".Length).Trim();
+                fileSetup = lines[0].Substring("#SETUP:".Length).Trim();
                 i++;
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
@@ -65,6 +65,15 @@ namespace Microsoft.PowerFx.Core.Tests
             TestCase test = null;
 
             var i = -1;
+
+            // Preprocess file directives
+            string fileSetup = null;
+            if (lines[0].StartsWith("// SETUP: "))
+            {
+                fileSetup = lines[0].Substring("// SETUP: ".Length).Trim();
+                i++;
+            }
+
             while (true)
             {
                 i++;
@@ -86,7 +95,8 @@ namespace Microsoft.PowerFx.Core.Tests
                     {
                         Input = line,
                         SourceLine = i + 1, // 1-based
-                        SourceFile = thisFile
+                        SourceFile = thisFile,
+                        SetupHandlerName = fileSetup
                     };
                     continue;
                 }
@@ -137,6 +147,14 @@ namespace Microsoft.PowerFx.Core.Tests
                     total++;
 
                     var engineName = runner.GetName();
+
+                    if (test.SetupHandlerName != null && !runner.TryDoSetup(test.SetupHandlerName))
+                    {
+
+                        sb.AppendLine($"SKIPPED: {engineName}, {Path.GetFileName(test.SourceFile)}:{test.SourceLine}");
+                        sb.AppendLine($"SKIPPED: {test.Input}, missing handler: {test.SetupHandlerName}");   
+                        continue;
+                    }
 
                     // var runner = kv.Value;
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
@@ -59,9 +59,9 @@ namespace Microsoft.PowerFx.Core.Tests
 
                 var line = lines[i];
 
-                if (line.StartsWith("// SETUP:"))
+                if (line.StartsWith("#SETUP:"))
                 {
-                    fileSetup = line.Substring("// SETUP:".Length).Trim();
+                    fileSetup = line.Substring("#SETUP:".Length).Trim();
                     continue;
                 }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
@@ -48,12 +48,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
             // Preprocess file directives
             string fileSetup = null;
-            if (lines[0].StartsWith("// SETUP: "))
-            {
-                fileSetup = lines[0].Substring("// SETUP: ".Length).Trim();
-                i++;
-            }
-
+            
             while (true)
             {
                 i++;
@@ -63,6 +58,13 @@ namespace Microsoft.PowerFx.Core.Tests
                 }
 
                 var line = lines[i];
+
+                if (line.StartsWith("// SETUP:"))
+                {
+                    fileSetup = line.Substring("// SETUP:".Length).Trim();
+                    continue;
+                }
+
                 if (string.IsNullOrWhiteSpace(line) || line.StartsWith("//"))
                 {
                     continue;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
@@ -45,6 +45,15 @@ namespace Microsoft.PowerFx.Core.Tests
             ExpressionTestCase test = null;
 
             var i = -1;
+
+            // Preprocess file directives
+            string fileSetup = null;
+            if (lines[0].StartsWith("// SETUP: "))
+            {
+                fileSetup = lines[0].Substring("// SETUP: ".Length).Trim();
+                i++;
+            }
+
             while (true)
             {
                 i++;
@@ -66,7 +75,8 @@ namespace Microsoft.PowerFx.Core.Tests
                     {
                         Input = line,
                         SourceLine = i + 1, // 1-based
-                        SourceFile = thisFile
+                        SourceFile = thisFile,
+                        SetupHandlerName = fileSetup
                     };
                     continue;
                 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Public.Values.IValueVisitor",
                 "Microsoft.PowerFx.Core.Public.Values.NamedValue",
                 "Microsoft.PowerFx.Core.Public.Values.NumberValue",
+                "Microsoft.PowerFx.Core.Public.Values.OptionSetValue",
                 "Microsoft.PowerFx.Core.Public.Values.PrimitiveValue`1",
                 "Microsoft.PowerFx.Core.Public.Values.RecordValue",
                 "Microsoft.PowerFx.Core.Public.Values.StringValue",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -31,7 +31,22 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var exceptionThrown = false;
             try
             {
-                result = _runner.RunAsync(testCase.Input).Result;
+                if (testCase.SetupHandlerName != null)
+                {
+                    try
+                    {
+                        result = _runner.RunWithSetup(testCase.Input, testCase.SetupHandlerName).Result;
+                    }
+                    catch (NotSupportedException ex) when (ex.Message.Contains("Setup Handler"))
+                    {
+                        Skip.If(true, $"Test {testCase.SourceFile}:{testCase.SourceLine} was skipped due to missing setup handler {testCase.SetupHandlerName}");
+                    }
+                }
+                else 
+                {
+                    result = _runner.RunAsync(testCase.Input).Result;
+                }
+
                 actualStr = TestRunner.TestToString(result);
             }
             catch (Exception e)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/GetTokensUtilsTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/GetTokensUtilsTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Utils;
 using Xunit;
@@ -37,6 +39,29 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(TokenResultType.Function, result["Abs"]);
             Assert.Equal(TokenResultType.Function, result["Year"]);
             Assert.Equal(TokenResultType.Function, result["CountRows"]);
+        }
+
+        [Fact]
+        public void GetTokensHostSymbolTest()
+        {
+            var optionSet = new OptionSet("OptionSet", new Dictionary<string, string>() 
+            {
+                    { "option_1", "Option1" },
+                    { "option_2", "Option2" }
+            });
+            var config = new PowerFxConfig(null, null);
+            config.AddOptionSet(optionSet);
+
+            var scope = RecalcEngineScope.FromJson(new RecalcEngine(config), "{\"A\":1,\"B\":[1,2,3]}");
+            var checkResult = scope.Check("If(OptionSet.Option2 = OptionSet.Option1, A, First(B)");
+            
+            var result = GetTokensUtils.GetTokens(checkResult._binding, GetTokensFlags.UsedInExpression);
+            Assert.Equal(5, result.Count);
+            Assert.Equal(TokenResultType.Function, result["If"]);
+            Assert.Equal(TokenResultType.HostSymbol, result["OptionSet"]);
+            Assert.Equal(TokenResultType.Variable, result["A"]);
+            Assert.Equal(TokenResultType.Function, result["First"]);
+            Assert.Equal(TokenResultType.Variable, result["B"]);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -40,10 +40,13 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             config.AddOptionSet(optionSet);
             config.AddOptionSet(otherOptionSet);
 
+            optionSet.TryGetValue(new DName("option_1"), out var o1Val);            
+            otherOptionSet.TryGetValue(new DName("123412983"), out var o2Val);
+
             var parameters = FormulaValue.RecordFromFields(
-                    new NamedValue("TopOptionSetField", optionSet.GetValue(new DName("option_1"))),
+                    new NamedValue("TopOptionSetField", o1Val),
                     new NamedValue("Nested", FormulaValue.RecordFromFields(
-                        new NamedValue("InnerOtherOptionSet", otherOptionSet.GetValue(new DName("123412983")))))); 
+                        new NamedValue("InnerOtherOptionSet", o2Val)))); 
 
             return (new RecalcEngine(config), parameters);
         }


### PR DESCRIPTION
This adds support for Option Set values to the interpreter visitor, as well as adding an interface for defining fields of option set types.
To test this, it also adds the ability to define a test setup handler for .txt files. 