### PR TITLE
Enable StringInterpolation feature flag

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/FeatureFlags.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/FeatureFlags.cs
@@ -13,6 +13,6 @@ namespace Microsoft.PowerFx
         /// Enable String Interpolation feature. 
         /// Added 12/3/2021.
         /// </summary>
-        public static bool StringInterpolation = false;
+        public static bool StringInterpolation = true;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -148,6 +148,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction StartsWith = _library.Append(new StartsWithFunction());
         public static readonly TexlFunction StdevP = _library.Append(new StdevPFunction());
         public static readonly TexlFunction StdevPT = _library.Append(new StdevPTableFunction());
+        public static readonly TexlFunction StringInterpolation = _library.Append(new StringInterpolationFunction());
         public static readonly TexlFunction Substitute = _library.Append(new SubstituteFunction());
         public static readonly TexlFunction SubstituteT = _library.Append(new SubstituteTFunction());
         public static readonly TexlFunction Sum = _library.Append(new SumFunction());
@@ -187,7 +188,6 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Value_UO = new ValueFunction_UO();
         public static readonly TexlFunction Boolean = new BooleanFunction();
         public static readonly TexlFunction Boolean_UO = new BooleanFunction_UO();
-        public static readonly TexlFunction StringInterpolation = new StringInterpolationFunction();
 
         public static readonly TexlFunction IsUTCToday = new IsUTCTodayFunction();
         public static readonly TexlFunction UTCNow = new UTCNowFunction();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense.IntellisenseData
             ReplacementStartIndex = context.CursorPosition;
             MissingTypes = missingTypes;
             BoundTo = string.Empty;
-            CleanupHandlers = new List<ISpecialCaseHandler>();
+            CleanupHandlers = new List<ISpecialCaseHandler>() { new HiddenFunctionsSuggestionHandler() };
         }
 
         internal DType ExpectedType { get; }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/CleanupHandlers/HiddenFunctionsSuggestionHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/CleanupHandlers/HiddenFunctionsSuggestionHandler.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Lexer.Tokens;
+using Microsoft.PowerFx.Core.Utils;
+
+namespace Microsoft.PowerFx.Core.Texl.Intellisense
+{
+    internal sealed class HiddenFunctionsSuggestionHandler : ISpecialCaseHandler
+    {
+        public bool Run(IIntellisenseContext context, IntellisenseData.IntellisenseData intellisenseData, List<IntellisenseSuggestion> suggestions)
+        {
+            IntellisenseSuggestion toRemove = null;
+
+            foreach (var suggestion in suggestions)
+            {
+                if (suggestion.FunctionName == IdentToken.StrInterpIdent)
+                {
+                    toRemove = suggestion;
+                    break;
+                }
+            }
+
+            if (toRemove != null)
+            {
+                suggestions.Remove(toRemove);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -58,7 +58,6 @@ namespace Microsoft.PowerFx
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Value_UO);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Boolean);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Boolean_UO);
-            powerFxConfig.AddFunction(BuiltinFunctionsCore.StringInterpolation);
         }
 
         /// <summary>

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -519,6 +519,9 @@
   <data name="AboutConcatenate_text" xml:space="preserve">
     <value>A text value, to be concatenated with the rest of the arguments.</value>
   </data>
+  <data name="AboutStringInterpolation_text" xml:space="preserve">
+    <value>A text value, to be concatenated with the rest of the arguments.</value>
+  </data>
   <data name="AboutConcatenateT" xml:space="preserve">
     <value>Joins several text values or tables into one column of text values.</value>
     <comment>Description of 'Concatenate' function.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -146,7 +146,6 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("$\"Hello {DisplayMode|} World!\"", "DisplayMode", "DisplayMode.Disabled", "DisplayMode.Edit", "DisplayMode.View")]
         public void TestSuggest(string expression, params string[] expectedSuggestions)
         {
-            FeatureFlags.StringInterpolation = true;
             var actualSuggestions = SuggestStrings(expression, _defaultEnumStore);
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }
@@ -168,7 +167,6 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("Calendar.Months|", "MonthsLong", "MonthsShort")]
         public void TestSuggestEmptyEnumList(string expression, params string[] expectedSuggestions)
         {
-            FeatureFlags.StringInterpolation = true;
             var actualSuggestions = SuggestStrings(expression, _emptyEnumStore);
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -40,7 +40,6 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             public override Task<FormulaValue> RunAsync(string expr)
             {
-                FeatureFlags.StringInterpolation = true;
                 var result = _engine.Eval(expr);
                 return Task.FromResult(result);
             }


### PR DESCRIPTION
Also adds StringInterpolation to the Library, but filters it from Intellisense so it does not appear as a suggestion. There is 1 test:

at|

Which was failing until I added the filter.