### PR TITLE
Enforce that FormulaTypeJsonConverter is one-way

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/AssemblyProperties.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/AssemblyProperties.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#if SIGNASSEMBLY
+[assembly: InternalsVisibleTo("Microsoft.PowerFx.Interpreter.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.PowerFx.Interpreter.Tests")]
+#endif

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/FormulaTypeJsonConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/FormulaTypeJsonConverter.cs
@@ -11,40 +11,25 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 {
     public class FormulaTypeJsonConverter : JsonConverter<FormulaType>
     {
-        private const string TypeProperty = "Type";
-        private const string FieldsProperty = "Fields";
+        internal const string TypeProperty = "Type";
+        internal const string FieldsProperty = "Fields";
 
-        private const string Blank = "Blank";
-        private const string Boolean = "Boolean";
-        private const string Number = "Number";
-        private const string String = "String";
-        private const string Time = "Time";
-        private const string Date = "Date";
-        private const string DateTime = "DateTime";
-        private const string DateTimeNoTimeZone = "DateTimeNoTimezone";
-        private const string OptionSetValue = "OptionSetValue";
-        private const string Record = "Record";
-        private const string Table = "Table";
+        internal const string Blank = "Blank";
+        internal const string Boolean = "Boolean";
+        internal const string Number = "Number";
+        internal const string String = "String";
+        internal const string Time = "Time";
+        internal const string Date = "Date";
+        internal const string DateTime = "DateTime";
+        internal const string DateTimeNoTimeZone = "DateTimeNoTimezone";
+        internal const string OptionSetValue = "OptionSetValue";
+        internal const string Record = "Record";
+        internal const string Table = "Table";
 
         public override FormulaType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var element = JsonDocument.ParseValue(ref reader).RootElement;
-            var typeValue = GetPropertyCasingAware(element, TypeProperty, options).GetString();
-            return typeValue switch
-            {
-                Blank => FormulaType.Blank,
-                Boolean => FormulaType.Boolean,
-                Number => FormulaType.Number,
-                String => FormulaType.String,
-                Time => FormulaType.Time,
-                Date => FormulaType.Date,
-                DateTime => FormulaType.DateTime,
-                DateTimeNoTimeZone => FormulaType.DateTimeNoTimeZone,
-                OptionSetValue => FormulaType.DateTimeNoTimeZone,
-                Record => RecordFromJson(element, options),
-                Table => TableFromJson(element, options),
-                _ => throw new NotImplementedException($"Unknown {nameof(FormulaType)}: {typeValue}")
-            };
+            // This is a one-way serializer, we don't expect to ever read types back from the client
+            throw new NotSupportedException();
         }
 
         public override void Write(Utf8JsonWriter writer, FormulaType value, JsonSerializerOptions options)
@@ -102,72 +87,5 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 
         private void WriteTableContents(Utf8JsonWriter writer, TableType table, JsonSerializerOptions options) =>
             WriteRecordContents(writer, table.ToRecord(), options);
-
-        private static FormulaType FromJson(JsonElement element, JsonSerializerOptions options)
-        {
-            var typeValue = GetPropertyCasingAware(element, TypeProperty, options).GetString();
-            return typeValue switch
-            {
-                Blank => FormulaType.Blank,
-                Boolean => FormulaType.Boolean,
-                Number => FormulaType.Number,
-                String => FormulaType.String,
-                Time => FormulaType.Time,
-                Date => FormulaType.Date,
-                DateTime => FormulaType.DateTime,
-                DateTimeNoTimeZone => FormulaType.DateTimeNoTimeZone,
-                OptionSetValue => FormulaType.DateTimeNoTimeZone,
-                Record => RecordFromJson(element, options),
-                Table => TableFromJson(element, options),
-                _ => throw new NotImplementedException($"Unknown {nameof(FormulaType)}: {typeValue}")
-            };
-        }
-
-        private static RecordType RecordFromJson(JsonElement element, JsonSerializerOptions options)
-        {
-            var record = new RecordType();
-
-            if (!TryGetPropertyCasingAware(element, FieldsProperty, options, out var fields))
-            {
-                return record;
-            }
-
-            foreach (var pair in fields.EnumerateObject())
-            {
-                record = record.Add(pair.Name, FromJson(pair.Value, options));
-            }
-
-            return record;
-        }
-
-        private static TableType TableFromJson(JsonElement element, JsonSerializerOptions options)
-        {
-            return RecordFromJson(element, options).ToTable();
-        }
-
-        private static JsonElement GetPropertyCasingAware(JsonElement element, string property, JsonSerializerOptions options)
-        {
-            if (TryGetPropertyCasingAware(element, property, options, out var value))
-            {
-                return value;
-            }
-
-            throw new KeyNotFoundException($"The given property was not present in the JsonElement");
-        }
-
-        private static bool TryGetPropertyCasingAware(JsonElement element, string property, JsonSerializerOptions options, out JsonElement value)
-        {
-            if (!options.PropertyNameCaseInsensitive)
-            {
-                return element.TryGetProperty(property, out value);
-            }
-
-            if (element.TryGetProperty(JsonNamingPolicy.CamelCase.ConvertName(property), out value))
-            {
-                return true;
-            }
-
-            return element.TryGetProperty(property, out value);
-        }
     }
 }


### PR DESCRIPTION
 We shouldn’t be getting types into powerfx via JSON generally, we have a cleaner C# api for constructing types. This is only used for notifying clients of the types. Move to throwing an exception instead of allowing reads using this serializer. 