### PR TITLE
Remove special case for interpreter formula params 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/GetTokensUtils.cs
@@ -33,9 +33,10 @@ namespace Microsoft.PowerFx.Core.Utils
                     switch (item.Kind)
                     {
                         case BindKind.Control:
+                        case BindKind.PowerFxResolvedObject:
                             tokens[item.Name] = TokenResultType.HostSymbol;
                             break;
-                        case BindKind.PowerFxResolvedObject:
+                        case BindKind.LambdaField:
                             tokens[item.Name] = TokenResultType.Variable;
                             break;
                         default:

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -419,14 +419,6 @@ namespace Microsoft.PowerFx
 
         public override FormulaValue Visit(ResolvedObjectNode node, SymbolContext context)
         {
-            if (node.Value is RecalcEngineResolver.ParameterData data)
-            {
-                var paramName = data.ParameterName;
-
-                var value = context.Globals.GetField(node.IRContext, paramName);
-                return value;
-            }
-
             if (node.Value is RecalcFormulaInfo fi)
             {
                 var value = fi._value;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Microsoft.PowerFx.Core.IR.Nodes;
+using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Public.Values;
 
@@ -11,18 +12,20 @@ namespace Microsoft.PowerFx
     internal class ParsedExpression : IExpression
     {
         internal IntermediateNode _irnode;
-        private readonly CultureInfo _cultureInfo;
+        private readonly CultureInfo _cultureInfo;        
+        private readonly ScopeSymbol _topScopeSymbol;
 
-        internal ParsedExpression(IntermediateNode irnode, CultureInfo cultureInfo = null)
+        internal ParsedExpression(IntermediateNode irnode, ScopeSymbol topScope, CultureInfo cultureInfo = null)
         {
             _irnode = irnode;
+            _topScopeSymbol = topScope;
             _cultureInfo = cultureInfo ?? CultureInfo.CurrentCulture;
         }
 
         public FormulaValue Eval(RecordValue parameters)
         {
             var ev2 = new EvalVisitor(_cultureInfo);
-            var newValue = _irnode.Accept(ev2, SymbolContext.New().WithGlobals(parameters));
+            var newValue = _irnode.Accept(ev2, SymbolContext.NewTopScope(_topScopeSymbol, parameters));
 
             return newValue;
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -149,18 +149,13 @@ namespace Microsoft.PowerFx
             // Ok to continue with binding even if there are parse errors. 
             // We can still use that for intellisense. 
 
-            var resolver = new RecalcEngineResolver(this, _powerFxConfig, (RecordType)parameterType);
-
-            // $$$ - intellisense only works with ruleScope.
-            // So if running for intellisense, pass the parameters in ruleScope. 
-            // But if running for eval, let the resolver handle the parameters. 
-            // Resolver is only invoked if not in RuleScope. 
+            var resolver = new RecalcEngineResolver(this, _powerFxConfig);
 
             var binding = TexlBinding.Run(
                 new Glue2DocumentBinderGlue(),
                 formula.ParseTree,
                 resolver,
-                ruleScope: intellisense ? parameterType._type : null,
+                ruleScope: parameterType._type,
                 useThisRecordForRuleScope: false);
 
             var errors = formula.HasParseErrors ? formula.GetParseErrors() : binding.ErrorContainer.GetErrors();
@@ -187,7 +182,7 @@ namespace Microsoft.PowerFx
                 }
 
                 (var irnode, var ruleScopeSymbol) = IRTranslator.Translate(result._binding);
-                result.Expression = new ParsedExpression(irnode);
+                result.Expression = new ParsedExpression(irnode, ruleScopeSymbol);
             }
 
             return result;
@@ -245,7 +240,7 @@ namespace Microsoft.PowerFx
             var formula = new Formula(expressionText);
             formula.EnsureParsed(TexlParser.Flags.None);
 
-            var resolver = new RecalcEngineResolver(this, _powerFxConfig, parameters);
+            var resolver = new RecalcEngineResolver(this, _powerFxConfig);
             var binding = TexlBinding.Run(
                 new Glue2DocumentBinderGlue(),
                 null,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineResolver.cs
@@ -23,15 +23,12 @@ namespace Microsoft.PowerFx
     {
         private readonly RecalcEngine _parent;
         private readonly PowerFxConfig _powerFxConfig;
-        private readonly RecordType _parameters;
 
         public RecalcEngineResolver(
             RecalcEngine parent,
-            PowerFxConfig powerFxConfig,
-            RecordType parameters)
+            PowerFxConfig powerFxConfig)
             : base(powerFxConfig.EnumStore.EnumSymbols, powerFxConfig.ExtraFunctions.Values.ToArray())
         {
-            _parameters = parameters;
             _parent = parent;
             _powerFxConfig = powerFxConfig;
         }
@@ -40,26 +37,9 @@ namespace Microsoft.PowerFx
         {
             // Kinds of globals:
             // - global formula
-            // - parameters 
             // - environment symbols
 
             var str = name.Value;
-
-            var parameter = _parameters.MaybeGetFieldType(str);
-            if (parameter != null)
-            {
-                var data = new ParameterData { ParameterName = str };
-                var type = parameter._type;
-
-                nameInfo = new NameLookupInfo(
-                    BindKind.PowerFxResolvedObject,
-                    type,
-                    DPath.Root,
-                    0,
-                    data);
-                return true;
-            }
-
             if (_parent.Formulas.TryGetValue(str, out var fi))
             {
                 var data = fi;
@@ -94,11 +74,6 @@ namespace Microsoft.PowerFx
             }
 
             return base.Lookup(name, out nameInfo, preferences);
-        }
-
-        public class ParameterData
-        {
-            public string ParameterName;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/SymbolContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/SymbolContext.cs
@@ -15,14 +15,11 @@ namespace Microsoft.PowerFx
     // of this class in the bodies of the various .visit methods
     internal sealed class SymbolContext
     {
-        public SymbolContext(RecordValue globals, ScopeSymbol currentScope, Dictionary<int, IScope> scopeValues)
+        public SymbolContext(ScopeSymbol currentScope, Dictionary<int, IScope> scopeValues)
         {
-            Globals = globals;
             CurrentScope = currentScope;
             ScopeValues = scopeValues;
         }
-
-        public RecordValue Globals { get; }
 
         public ScopeSymbol CurrentScope { get; } = null;
 
@@ -30,17 +27,17 @@ namespace Microsoft.PowerFx
 
         public static SymbolContext New()
         {
-            return new SymbolContext(null, null, new Dictionary<int, IScope>());
+            return new SymbolContext(null, new Dictionary<int, IScope>());
         }
 
-        public SymbolContext WithGlobals(RecordValue globals)
+        public static SymbolContext NewTopScope(ScopeSymbol topScope, RecordValue ruleScope)
         {
-            return new SymbolContext(globals, CurrentScope, ScopeValues);
+            return new SymbolContext(topScope, new Dictionary<int, IScope>() { { topScope.Id, new RecordScope(ruleScope) } });
         }
 
         public SymbolContext WithScope(ScopeSymbol currentScope)
         {
-            return new SymbolContext(Globals, currentScope, ScopeValues);
+            return new SymbolContext(currentScope, ScopeValues);
         }
 
         public SymbolContext WithScopeValues(IScope scopeValues)
@@ -49,7 +46,7 @@ namespace Microsoft.PowerFx
             {
                 [CurrentScope.Id] = scopeValues
             };
-            return new SymbolContext(Globals, CurrentScope, newScopeValues);
+            return new SymbolContext(CurrentScope, newScopeValues);
         }
 
         public SymbolContext WithScopeValues(RecordValue scopeValues)


### PR DESCRIPTION
We should be treating formula params as the top scope that they are, instead of special casing them through the name resolver. 