### PR TITLE
Update ForAll to return errors if any of the expressions return error

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1213,10 +1213,16 @@ namespace Microsoft.PowerFx.Functions
             var arg0 = (TableValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
 
-            var rows = LazyForAll(runner, symbolContext, arg0.Rows, arg1);
+            var rows = LazyForAll(runner, symbolContext, arg0.Rows, arg1).ToArray();
+
+            var errors = rows.OfType<ErrorValue>();
+            if (errors.Any())
+            {
+                return ErrorValue.Combine(irContext, errors);
+            }
 
             // TODO: verify semantics in the case of heterogeneous record lists
-            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows.ToArray()));
+            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows));
         }
 
         private static IEnumerable<FormulaValue> LazyForAll(

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
@@ -31,13 +31,28 @@ Blank()
 #Error
 
 >> ForAll(Table({Value:1,Zulu:1}, {Value:0,Zulu:0}, {Value:2,Zulu:2}), 1/ThisRecord.Value)
-[1,Microsoft.PowerFx.Core.Public.Values.ErrorValue,0.5]
+#Error
 
 >> First(LastN(ForAll(Table({Value:1,Zulu:1}, {Value:0,Zulu:0}, {Value:2,Zulu:2}), 1/ThisRecord.Value), 2)).Value
 #Error
 
 >> Table({Value:1},First(LastN(ForAll(Table({Value:1,Zulu:1}, {Value:0,Zulu:0}, {Value:2,Zulu:2}), 1/ThisRecord.Value), 2)),{Value:2})
+#Error
+
+>> Table({Value:1},First(LastN(ForAll(Table({Value:1,Zulu:1}, {Value:0,Zulu:0}, {Value:2,Zulu:2}), {Value:1/ThisRecord.Value}), 2)),{Value:2})
 [1,Microsoft.PowerFx.Core.Public.Values.ErrorValue,2]
 
 >> First(First(LastN(ForAll(Table({Value:1}, {Value:0}, {Value:2}), Table({a: 1/ThisRecord.Value})), 2)).Value)
 {a:Microsoft.PowerFx.Core.Public.Values.ErrorValue}
+
+>> Last(FirstN(ForAll(Table({Value:1}, {Value:0}, {Value:2}), {a: 1/ThisRecord.Value}), 2)).a
+#Error
+
+>> Last(FirstN(ForAll(Table({Value:1}, {Value:0}, {Value:2}), {a: 1/ThisRecord.Value}), 1)).a
+1
+
+>> Last(FirstN(ForAll([1,0,2], 1/ThisRecord.Value), 2)).Value
+#Error
+
+>> Last(FirstN(ForAll([1,0,2], 1/ThisRecord.Value), 1)).Value
+#Error


### PR DESCRIPTION
An expression such as `ForAll(<table>, <expression>)` should return an error if one of the invocations of the &lt;expression&gt; return an error (instead of adding the error to the resulting table).