### PR TITLE
Set diagnostic severity on language server publish diagnostics notification

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -443,7 +443,8 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                                 Line = endLine
                             }
                         },
-                        Message = item.Message
+                        Message = item.Message,
+                        Severity = DocumentSeverityToDiagnosticSeverityMap(item.Severity)
                     });
                 }
             }


### PR DESCRIPTION
I believe this was omitted by accident. Was causing all diagnostic responses from the language server to have severity 0.