### PR TITLE
Remove non-empty locale assert in StringResources

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -102,7 +102,13 @@ namespace Microsoft.PowerFx.Core.Localization
             if (locale == null)
             {
                 locale = CurrentLocaleInfo.CurrentUILanguageName;
-                Contracts.CheckNonEmpty(locale, "currentLocale");
+
+                // If the locale is not set here, return false immedately and go to the "en-us" fallback
+                if (string.IsNullOrEmpty(locale))
+                {
+                    resourceValue = default;
+                    return false;
+                }
             }
 
             if (!ErrorResources.TryGetValue(locale, out var errorResources))
@@ -126,7 +132,13 @@ namespace Microsoft.PowerFx.Core.Localization
             if (locale == null)
             {
                 locale = CurrentLocaleInfo.CurrentUILanguageName;
-                Contracts.CheckNonEmpty(locale, "currentLocale");
+
+                // If the locale is not set here, return false immedately and go to the "en-us" fallback
+                if (string.IsNullOrEmpty(locale))
+                {
+                    resourceValue = default;
+                    return false;
+                }
             }
 
             if (!Strings.TryGetValue(locale, out var strings))


### PR DESCRIPTION
CurrentLocaleInfo.CurrentUILanguageName is set by the host, and may be null/empty. In those cases, we should fall back to en-US for our string resources. 