### PR TITLE
Remove 2.1 from tests. This isn't supported anymore and tests don't r…

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -71,8 +71,8 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         // DottedNameNodeSuggestionHandler
         [InlineData("{a:{},b:{},c:{}}.|", "a", "b", "c")]
         [InlineData("$\"Hello { First(Table({a:{},b:{},c:{}})).| } World\"", "a", "b", "c")]
-        [InlineData("$\"Hello { First(Table({a:{},b:{},c:{}})).|", "a", "b", "c")]
-        [InlineData("$\"Hello { {a:{},b:{},c:{}}.|", "a", "b", "c")]
+        [InlineData("$\"Hello { First(Table({a:{},b:{},c:{}})).|   \"", "a", "b", "c")]
+        [InlineData("$\"Hello { {a:{},b:{},c:{}}.|  \"", "a", "b", "c")]
         [InlineData("$ |")]
         [InlineData("$\"foo {|")]
         [InlineData("{abc:{},ab:{},a:{}}.|ab", "ab", "a", "abc")]
@@ -151,6 +151,9 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("$\"Hello {DisplayMode|} World!\"", "DisplayMode", "DisplayMode.Disabled", "DisplayMode.Edit", "DisplayMode.View")]
         public void TestSuggest(string expression, params string[] expectedSuggestions)
         {
+            // Note that the expression string needs to have balanced quotes or we hit a bug in NUnit running the tests:
+            //   https://github.com/nunit/nunit3-vs-adapter/issues/691
+
             FeatureFlags.StringInterpolation = true;
             var actualSuggestions = SuggestStrings(expression, _defaultEnumStore);
             Assert.Equal(expectedSuggestions, actualSuggestions);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
@@ -4,9 +4,8 @@
     <IsPackable Condition="'$(InternalBuild)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(InternalBuild)' != 'true'">false</IsPackable>
     <GeneratePackageOnBuild Condition="'$(InternalBuild)' == 'true'">$(GeneratePackages)</GeneratePackageOnBuild>
-    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp21'">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
 
     <Version Condition=" '$(ReleasePackageVersion)' == '' ">$(LocalPackageVersion)</Version>
     <Version Condition=" '$(ReleasePackageVersion)' != '' ">$(ReleasePackageVersion)</Version>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Microsoft.PowerFx.Interpreter.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Microsoft.PowerFx.Interpreter.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp21'">netcoreapp2.1</TargetFramework>
 		<TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
-		<TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 		<Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
…un if it isn't installed.

See  https://dotnet.microsoft.com/en-us/download/dotnet/2.1
Test still run against 3.1.