### PR TITLE
Improve Suggest api performance

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
@@ -435,7 +435,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
 
             return CollectionUtils.EnsureInstanceCreated(ref _enumsUsedPowerApps, () =>
             {
-                var list = ImmutableList.Create<Tuple<DName, DName, DType>>();
+                var list = ImmutableList.CreateBuilder<Tuple<DName, DName, DType>>();
                 foreach (var enumSpec in EnumDict)
                 {
                     Contracts.Assert(DName.IsValidDName(enumSpec.Key));
@@ -452,7 +452,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                     list.Add(new Tuple<DName, DName, DType>(new DName(enumSpec.Item1), new DName(enumSpec.Item2), _enumTypes[enumSpec.Item2]));
                 }
 
-                return list;
+                return list.ToImmutable();
             });
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
@@ -325,14 +325,6 @@ namespace Microsoft.PowerFx.Core.Types.Enums
             }
         }
 
-        private void ResetEnumCaches()
-        {
-            _enumSpec = RegenerateEnumSpec();
-            _enumTypes = RegenerateEnumTypes();
-            _enumSymbols = null;
-            _enumsUsedPowerApps = null;
-        }
-
         internal bool TryGetLocalizedEnumValue(string enumName, string enumValue, out string locValue)
         {
             Contracts.AssertValue(enumName);
@@ -533,6 +525,14 @@ namespace Microsoft.PowerFx.Core.Types.Enums
             }
 
             return list.ToImmutable();
+        }
+
+        private void ResetEnumCaches()
+        {
+            _enumSpec = RegenerateEnumSpec();
+            _enumTypes = RegenerateEnumTypes();
+            _enumSymbols = null;
+            _enumsUsedPowerApps = null;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
@@ -291,6 +291,11 @@ namespace Microsoft.PowerFx.Core.Types.Enums
 #endif
             };
 
+        private ImmutableList<EnumSymbol> _enumSymbols;
+
+        // TODO: unify _enumSymbols with this variable because they are basically the same thing
+        private ImmutableList<Tuple<DName, DName, DType>> _enumsUsedPowerApps;
+
         protected virtual IDictionary<string, string> EnumDict
         {
             get
@@ -305,8 +310,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
             if (!_customEnumDict.ContainsKey(tupleName))
             {
                 _customEnumDict = _customEnumDict.Add(tupleName, tuple);
-                _enumSpec = RegenerateEnumSpec();
-                _enumTypes = RegenerateEnumTypes();
+                ResetEnumCaches();
                 if (locInfo != null)
                 {
                     if (!_customEnumLocDict.ContainsKey(tupleName))
@@ -319,6 +323,14 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                     }
                 }
             }
+        }
+
+        private void ResetEnumCaches()
+        {
+            _enumSpec = RegenerateEnumSpec();
+            _enumTypes = RegenerateEnumTypes();
+            _enumSymbols = null;
+            _enumsUsedPowerApps = null;
         }
 
         internal bool TryGetLocalizedEnumValue(string enumName, string enumValue, out string locValue)
@@ -344,8 +356,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
         {
             _customEnumDict = ImmutableDictionary<string, Tuple<string, string, string>>.Empty;
             _customEnumLocDict = ImmutableDictionary<string, Dictionary<string, string>>.Empty;
-            _enumSpec = RegenerateEnumSpec();
-            _enumTypes = RegenerateEnumTypes();
+            ResetEnumCaches();
         }
 
         /// <summary>
@@ -430,21 +441,27 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                 return RegenerateEnumTypes();
             });
 
-            foreach (var enumSpec in EnumDict)
+            return CollectionUtils.EnsureInstanceCreated(ref _enumsUsedPowerApps, () =>
             {
-                Contracts.Assert(DName.IsValidDName(enumSpec.Key));
+                var list = ImmutableList.Create<Tuple<DName, DName, DType>>();
+                foreach (var enumSpec in EnumDict)
+                {
+                    Contracts.Assert(DName.IsValidDName(enumSpec.Key));
 
-                var name = new DName(enumSpec.Key);
-                yield return new Tuple<DName, DName, DType>(name, name, _enumTypes[enumSpec.Key]);
-            }
+                    var name = new DName(enumSpec.Key);
+                    list.Add(new Tuple<DName, DName, DType>(name, name, _enumTypes[enumSpec.Key]));
+                }
 
-            foreach (var enumSpec in _customEnumDict.Values)
-            {
-                Contracts.Assert(DName.IsValidDName(enumSpec.Item1));
-                Contracts.Assert(DName.IsValidDName(enumSpec.Item2));
+                foreach (var enumSpec in _customEnumDict.Values)
+                {
+                    Contracts.Assert(DName.IsValidDName(enumSpec.Item1));
+                    Contracts.Assert(DName.IsValidDName(enumSpec.Item2));
 
-                yield return new Tuple<DName, DName, DType>(new DName(enumSpec.Item1), new DName(enumSpec.Item2), _enumTypes[enumSpec.Item2]);
-            }
+                    list.Add(new Tuple<DName, DName, DType>(new DName(enumSpec.Item1), new DName(enumSpec.Item2), _enumTypes[enumSpec.Item2]));
+                }
+
+                return list;
+            });
         }
 
         internal bool TryGetEnumSpec(string name, out string dType)
@@ -503,15 +520,19 @@ namespace Microsoft.PowerFx.Core.Types.Enums
             return false;
         }
 
-        internal IEnumerable<EnumSymbol> EnumSymbols
+        internal IEnumerable<EnumSymbol> EnumSymbols =>
+            CollectionUtils.EnsureInstanceCreated(
+                    ref _enumSymbols, () => RegenerateEnumSymbols());
+
+        private ImmutableList<EnumSymbol> RegenerateEnumSymbols()
         {
-            get
+            var list = ImmutableList.CreateBuilder<EnumSymbol>();
+            foreach (var enumValue in Enums())
             {
-                foreach (var enumValue in Enums())
-                {
-                    yield return new EnumSymbol(this, enumValue.Item1, enumValue.Item2, enumValue.Item3);
-                }
+                list.Add(new EnumSymbol(this, enumValue.Item1, enumValue.Item2, enumValue.Item3));
             }
+
+            return list.ToImmutable();
         }
     }
 }


### PR DESCRIPTION
This change caches the enum objects and re-uses them for Suggestion api.

The following test takes 320 seconds in master and only 12s with the proposed change

        [Fact]
        public void TestSuggestdf()
        {
            var eng = new RecalcEngine();
            for (int i = 0; i < 1000; i++)
            {
                eng.Suggest("Abs", null, 3);
            }
        }