### PR TITLE
Add a new function to the binder to access string interpolation nodes

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -1572,6 +1572,11 @@ namespace Microsoft.PowerFx.Core.Binding
             return BinderNodesVisitor.StringLiterals;
         }
 
+        public IEnumerable<StrInterpNode> GetStringInterpolations()
+        {
+            return BinderNodesVisitor.StringInterpolations;
+        }
+
         public IEnumerable<UnaryOpNode> GetUnaryOperators()
         {
             return BinderNodesVisitor.UnaryOperators;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/TokenizerConstants.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/TokenizerConstants.cs
@@ -11,5 +11,9 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense
         public const string NumericLiteral = "NumLit";
         public const string StringLiteral = "StrLit";
         public const string UnaryOp = "UnaryOp";
+        public const string StringInterpolationStart = "StrInterpStart";
+        public const string StringInterpolationEnd = "StrInterpEnd";
+        public const string IslandStart = "IslandStart";
+        public const string IslandEnd = "IslandEnd";
     }
 }


### PR DESCRIPTION
Adding patterns that literals already support, for use in Tokenizer.cs in document server.