### PR TITLE
Add back a customizable EnumStore as a stopgap awaiting refactor

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -40,6 +40,20 @@ namespace Microsoft.PowerFx.Core
             EnumStore = new EnumStore();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerFxConfig"/> class.
+        /// Stopgap constructor until Enum Store is refactored. Do not rely on, this will be removed. 
+        /// </summary>
+        internal PowerFxConfig(CultureInfo cultureInfo = null, EnumStore enumStore = null)
+        {
+            CultureInfo = cultureInfo ?? CultureInfo.CurrentCulture;
+            _isLocked = false;
+            _extraFunctions = new Dictionary<string, TexlFunction>();
+            _environmentSymbols = new Dictionary<DName, IExternalEntity>();
+            
+            EnumStore = enumStore ?? new EnumStore();
+        }
+
         internal void AddEntity(IExternalEntity entity)
         {
             CheckUnlocked();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioMutation.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioMutation.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void MutabilityTest()
         {
-            var config = new PowerFxConfig();
+            var config = new PowerFxConfig(null);
             config.AddFunction(new Assert2Function());
             config.AddFunction(new Set2Function());
             var engine = new RecalcEngine(config);


### PR DESCRIPTION
We intend to refactor the enum store, so that hosts shouldn’t be configuring an enum stores directly, rather, they should be picking which sets of functions they want to use, and we’ll bring in the appropriate enums as well. 

For hosts using enum store currently, this adds back support for customizing it until that work is completed. This constructor should be removed when that is finished. 

