### PR TITLE
Allow CountIf and LookUp to coerce yes/no to Boolean

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -66,7 +66,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Ensure that all the args starting at index 1 are booleans or can be coersed.
             for (var i = 1; i < args.Length; i++)
             {
-                if (!DType.Boolean.Accepts(argTypes[i]) && !argTypes[i].CoercesTo(DType.Boolean))
+                if (CheckType(args[i], argTypes[i], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion) || DType.Boolean.Accepts(argTypes[i]))
+                {
+                    if (matchedWithCoercion)
+                    {
+                        CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], DType.Boolean, allowDupes: true);
+                    }
+                }
+                else
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrBooleanExpected);
                     fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Ensure that all the args starting at index 1 are booleans or can be coersed.
             for (var i = 1; i < args.Length; i++)
             {
-                if (CheckType(args[i], argTypes[i], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion) || DType.Boolean.Accepts(argTypes[i]))
+                if (CheckType(args[i], argTypes[i], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion))
                 {
                     if (matchedWithCoercion)
                     {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Functions.Delegation;
-using Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Syntax.Nodes;
 using Microsoft.PowerFx.Core.Types;
@@ -22,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool RequiresErrorContext => true;
 
-        public override bool SupportsParamCoercion => false;
+        public override bool SupportsParamCoercion => true;
 
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Filter | DelegationCapability.Count;
 
@@ -64,10 +63,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType == DType.Number);
 
-            // Ensure that all the args starting at index 1 are booleans.
+            // Ensure that all the args starting at index 1 are booleans or can be coersed.
             for (var i = 1; i < args.Length; i++)
             {
-                if (!DType.Boolean.Accepts(argTypes[i]))
+                if (!DType.Boolean.Accepts(argTypes[i]) && !argTypes[i].CoercesTo(DType.Boolean))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrBooleanExpected);
                     fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Functions.Delegation;
 using Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata;
@@ -20,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool RequiresErrorContext => true;
 
-        public override bool SupportsParamCoercion => false;
+        public override bool SupportsParamCoercion => true;
 
         public LookUpFunction()
             : base("LookUp", TexlStrings.AboutLookUp, FunctionCategories.Table, DType.Unknown, 0x6, 2, 3, DType.EmptyTable, DType.Boolean)
@@ -46,6 +47,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             // The return type is dictated by the last argument (projection) if one exists. Otherwise it's based on first argument (source).
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];
+
+            // Ensure that the arg at index 1 is boolean or can be coersed.
+            if (!DType.Boolean.Accepts(argTypes[1]) && !argTypes[1].CoercesTo(DType.Boolean))
+            {
+                errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrBooleanExpected);
+                fValid = false;
+            }
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -49,7 +49,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];
 
             // Ensure that the arg at index 1 is boolean or can be coersed.
-            if (!DType.Boolean.Accepts(argTypes[1]) && !argTypes[1].CoercesTo(DType.Boolean))
+            if (CheckType(args[1], argTypes[1], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion) || DType.Boolean.Accepts(argTypes[1]))
+            {
+                if (matchedWithCoercion)
+                {
+                    CollectionUtils.Add(ref nodeToCoercedTypeMap, args[1], DType.Boolean, allowDupes: true);
+                }
+            }
+            else
             {
                 errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrBooleanExpected);
                 fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];
 
             // Ensure that the arg at index 1 is boolean or can be coersed.
-            if (CheckType(args[1], argTypes[1], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion) || DType.Boolean.Accepts(argTypes[1]))
+            if (CheckType(args[1], argTypes[1], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion))
             {
                 if (matchedWithCoercion)
                 {


### PR DESCRIPTION
Filter coerces yes/no columns in Dataverse to Boolean, but CountIf and LookUp do not do the same thing. This PR remedies that.

Test App:
![image](https://user-images.githubusercontent.com/19300908/156281828-255177dc-df60-4500-b089-8e089661db69.png)

Formulas used:
![image](https://user-images.githubusercontent.com/19300908/156282141-fc9dc6d4-cf7e-4680-b33e-f1359a471f46.png)

![image](https://user-images.githubusercontent.com/19300908/156282002-dd88b8a5-b30a-47b1-9f7c-3f8d65b9a2eb.png)

![image](https://user-images.githubusercontent.com/19300908/156282043-e0b05e58-8c6e-48ca-8e43-58e8f5786566.png)

