### PR TITLE
Small refactor to remove two unneded properties on IExternalDocumentProperties

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/IExternalDocumentProperties.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/IExternalDocumentProperties.cs
@@ -8,9 +8,5 @@ namespace Microsoft.PowerFx.Core.App
     internal interface IExternalDocumentProperties
     {
         IExternalEnabledFeatures EnabledFeatures { get; }
-
-        bool SupportsImplicitThisItem { get; }
-
-        Dictionary<string, int> DisallowedFunctions { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2940,7 +2940,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
                 else if (lookupInfo.Kind == BindKind.DeprecatedImplicitThisItem)
                 {
-                    Contracts.Assert(_txb.Document.Properties.SupportsImplicitThisItem);
                     _txb._hasThisItemReference = true;
 
                     // Even though lookupInfo.Type isn't the full data source type, it still is tagged with the full datasource info if this is a thisitem node


### PR DESCRIPTION
Neither of these properties is needed in PowerFx, this cleans them up. 
The SupportsImplicitThisItem was only used by an assert, which is stripped out on all release builds anyway, and is for a scenario that hasn't been supported by canvas for 2 years, and will never be supported by non-canvas powerfx. 