### PR TITLE
Fix while loop bug in the Mid function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -338,6 +338,10 @@ namespace Microsoft.PowerFx.Functions
                     var count = new NumberValue(IRContext.NotInSource(FormulaType.Number), stringValue.Value.Length);
                     res.Add(count);
                 }
+                else
+                {
+                    break;
+                }
             }
 
             return res.ToArray();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -83,10 +83,8 @@ true
 >> Mid("foo", 0)
 #Error
 
-// Fails due to https://github.com/microsoft/Power-Fx/issues/195 
 >> Mid(Text(1/0, "#.000"), 1)
-#skip 
-//#Error
+#Error
 
 >> IsError(Mid("foo", 0))
 true


### PR DESCRIPTION
Other while loops in the C# interpreter converge in all branches (if any). The exception was the Mid function which had a while loop with a missing else branch.