### PR TITLE
Add new method to TexlBinding for generating transient Concatenate

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/Tokens/IdentToken.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/Tokens/IdentToken.cs
@@ -18,6 +18,8 @@ namespace Microsoft.PowerFx.Core.Lexer.Tokens
         private readonly string _value;
         public readonly DName Name;
 
+        public const string StrInterpIdent = "Concatenate";
+
         public IdentToken(string val, Span span)
             : this(val, span, false, false)
         {
@@ -25,7 +27,7 @@ namespace Microsoft.PowerFx.Core.Lexer.Tokens
 
             // String interpolation sometimes creates tokens that do not exist in the source code
             // so we skip validating the span length for the Ident that the parser generates
-            Contracts.Assert(val.Length == span.Lim - span.Min);
+            Contracts.Assert(val.Length == span.Lim - span.Min || val == StrInterpIdent);
             _value = val;
             Name = DName.MakeValid(val, out IsModified);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/ErrorNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/ErrorNode.cs
@@ -24,7 +24,6 @@ namespace Microsoft.PowerFx.Core.Syntax.Nodes
         public ErrorNode(ref int idNext, Token primaryToken, string msg, params object[] args)
             : base(ref idNext, primaryToken, new SourceList(primaryToken))
         {
-            Contracts.AssertValue(args);
             Message = msg;
             Args = args;
         }


### PR DESCRIPTION
This change makes the binder aware of generated call nodes. This will allow querying of call nodes in the future, for example in JsTranslator.