### PR TITLE
Update local package version number

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LocalPackageVersion>0.2.0-local</LocalPackageVersion>
+    <LocalPackageVersion>0.3.0-local</LocalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Update local package version number to a version higher than the public one, so that it can be used with dependencies that require a version higher than one of the public releases.