### PR TITLE
Coercing only OptionSetValues to boolean for CountIf and LookUp

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -64,10 +64,21 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType == DType.Number);
 
-            // Ensure that all the args starting at index 1 are booleans.
+            // Ensure that all the args starting at index 1 are booleans or coerece to boolean if they are OptionSetValues.
             for (var i = 1; i < args.Length; i++)
             {
-                if (!DType.Boolean.Accepts(argTypes[i]))
+                if (argTypes[i] == DType.OptionSetValue && CheckType(args[i], argTypes[i], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion))
+                {
+                    if (matchedWithCoercion)
+                    {
+                        CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], DType.Boolean, allowDupes: true);
+                    }
+                }
+                else if (DType.Boolean.Accepts(argTypes[i]))
+                {
+                    continue;
+                }
+                else
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrBooleanExpected);
                     fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool RequiresErrorContext => true;
 
-        public override bool SupportsParamCoercion => false;
+        public override bool SupportsParamCoercion => true;
 
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Filter | DelegationCapability.Count;
 
@@ -67,18 +67,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Ensure that all the args starting at index 1 are booleans or coerece to boolean if they are OptionSetValues.
             for (var i = 1; i < args.Length; i++)
             {
-                if (argTypes[i] == DType.OptionSetValue && CheckType(args[i], argTypes[i], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion))
+                if (argTypes[i].Kind == DKind.OptionSetValue && argTypes[i].CoercesTo(DType.Boolean))
                 {
-                    if (matchedWithCoercion)
-                    {
-                        CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], DType.Boolean, allowDupes: true);
-                    }
+                    CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], DType.Boolean, allowDupes: true);
                 }
-                else if (DType.Boolean.Accepts(argTypes[i]))
-                {
-                    continue;
-                }
-                else
+                else if (!DType.Boolean.Accepts(argTypes[i]))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrBooleanExpected);
                     fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -24,6 +24,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
+        public override bool HasPreciseErrors => true;
+
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Filter | DelegationCapability.Count;
 
         public CountIfFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -23,6 +23,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
+        public override bool HasPreciseErrors => true;
+
         public LookUpFunction()
             : base("LookUp", TexlStrings.AboutLookUp, FunctionCategories.Table, DType.Unknown, 0x6, 2, 3, DType.EmptyTable, DType.Boolean)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool RequiresErrorContext => true;
 
-        public override bool SupportsParamCoercion => false;
+        public override bool SupportsParamCoercion => true;
 
         public LookUpFunction()
             : base("LookUp", TexlStrings.AboutLookUp, FunctionCategories.Table, DType.Unknown, 0x6, 2, 3, DType.EmptyTable, DType.Boolean)
@@ -49,17 +49,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];
 
             // Ensure that the arg at index 1 is boolean or can coerece to boolean if they are OptionSetValues.
-            if (DType.Boolean.Accepts(argTypes[1]))
+            if (argTypes[1].Kind == DKind.OptionSetValue && argTypes[1].CoercesTo(DType.Boolean))
             {
-            }
-            else if (argTypes[1] == DType.OptionSetValue && CheckType(args[1], argTypes[1], DType.Boolean, DefaultErrorContainer, out var matchedWithCoercion))
-            {
-                if (matchedWithCoercion)
-                {
                     CollectionUtils.Add(ref nodeToCoercedTypeMap, args[1], DType.Boolean, allowDupes: true);
-                }
             }
-            else
+            else if (!DType.Boolean.Accepts(argTypes[1]))
             {
                 errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrBooleanExpected);
                 fValid = false;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountFunctions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountFunctions.txt
@@ -23,7 +23,7 @@ Blank()
 #Error
 
 >> CountIf([1, 2, 3, 4], 123)
-Errors: Error 22-25: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-26: The function 'CountIf' has some invalid arguments.
+Errors: Error 22-25: Expected boolean. We expect a boolean (true/false) at this point in the formula.
 
 >> CountIf([1, 2, 3, 4], "abc")
-Errors: Error 22-27: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-28: The function 'CountIf' has some invalid arguments.
+Errors: Error 22-27: Expected boolean. We expect a boolean (true/false) at this point in the formula.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountFunctions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountFunctions.txt
@@ -23,4 +23,7 @@ Blank()
 #Error
 
 >> CountIf([1, 2, 3, 4], 123)
-Errors: Error 22-25: Invalid argument type (Number). Expecting a Boolean value instead.
+Errors: Error 22-25: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-26: The function 'CountIf' has some invalid arguments.
+
+>> CountIf([1, 2, 3, 4], "abc")
+Errors: Error 22-27: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-28: The function 'CountIf' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
@@ -110,7 +110,7 @@ Blank()
 Errors: Error 7-11: Invalid argument type.
 
 >> LookUp([1, 2, 3], "string")
-Errors: Error 18-26: Invalid argument type (Text). Expecting a Boolean value instead.
+Errors: Error 18-26: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-27: The function 'LookUp' has some invalid arguments.
 
 >> LookUp([1, 2, 3] As X, Value > 2)
 Errors: Error 23-28: Name isn't valid. This identifier isn't recognized.


### PR DESCRIPTION
Re-do of this PR: 
https://github.com/microsoft/Power-Fx/pull/187

But instead only coercing OptionSetValue.