### PR TITLE
Fix error kind matching in test cases

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerFx.Core.Tests
         /// <returns>Result of evaluating Expr.</returns>
         protected abstract Task<FormulaValue> RunAsyncInternal(string expr, string setupHandlerName = null);
 
-        private static readonly Regex RuntimeErrorExpectedResultRegex = new Regex(@"\#error(\(?:Kind=(?<errorKind>[^\)]+)\))?", RegexOptions.IgnoreCase);
+        private static readonly Regex RuntimeErrorExpectedResultRegex = new Regex(@"\#error(?:\(Kind=(?<errorKind>[^\)]+)\))?", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Returns (Pass,Fail,Skip) and a status message.


### PR DESCRIPTION
The matching for the kind property of errors is not working properly; this fixes the regex that is used to validate it (and adds test cases to guard against regressions)