### PR TITLE
Add new error for empty Islands

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -534,6 +534,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrAsTypeAndIsTypeExpectConnectedDataSource = new ErrorResourceKey("ErrAsTypeAndIsTypeExpectConnectedDataSource");
         public static ErrorResourceKey ErrInvalidControlReference = new ErrorResourceKey("ErrInvalidControlReference");
         public static ErrorResourceKey ErrInvalidStringInterpolation = new ErrorResourceKey("ErrInvalidStringInterpolation");
+        public static ErrorResourceKey ErrEmptyIsland = new ErrorResourceKey("ErrEmptyIsland");
 
         public static ErrorResourceKey ErrErrorIrrelevantField = new ErrorResourceKey("ErrErrorIrrelevantField");
         public static ErrorResourceKey ErrAsNotInContext = new ErrorResourceKey("ErrAsNotInContext");

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -872,15 +872,13 @@ namespace Microsoft.PowerFx.Core.Parser
             {
                 if (_curs.TidCur == TokKind.IslandStart)
                 {
-                    if (i != 0)
+                    var islandStart = _curs.TokMove();
+                    sourceList.Add(new TokenSource(islandStart));
+                    sourceList.Add(ParseTrivia());
+
+                    if (_curs.TidCur == TokKind.IslandEnd)
                     {
-                        var islandStart = _curs.TokMove();
-                        sourceList.Add(new TokenSource(islandStart));
-                        sourceList.Add(ParseTrivia());
-                    }
-                    else
-                    {
-                        _curs.TokMove();
+                        arguments.Add(CreateError(_curs.TokCur, TexlStrings.ErrEmptyIsland));
                     }
                 }
                 else if (_curs.TidCur == TokKind.IslandEnd)

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -6355,19 +6355,19 @@
   </data>
   <data name="ErrorResource_ErrInvalidStringInterpolation_ShortMessage" xml:space="preserve">
     <value>Expressions which appear inside an interpolated string must evaluate to a Text value or to a compatible type.</value>
-    <comment>Error message.</comment>
+    <comment>Error message. The term "interpolated string" should be translated using the same terms used in the C# documentation.</comment>
   </data>
   <data name="ErrorResource_ErrInvalidStringInterpolation_HowToFix_1" xml:space="preserve">
     <value>Check the types of the expressions inside the interpolated string.</value>
-    <comment>How to fix message for an error</comment>
+    <comment>How to fix message for an error. The term "interpolated string" should be translated using the same terms used in the C# documentation.</comment>
   </data>
   <data name="ErrorResource_ErrEmptyIsland_ShortMessage" xml:space="preserve">
     <value>Empty expressions cannot appear inside an interpolated string.</value>
-    <comment>Error message.</comment>
+    <comment>Error message. The term "interpolated string" should be translated using the same terms used in the C# documentation.</comment>
   </data>
   <data name="ErrorResource_ErrEmptyIsland_HowToFix_1" xml:space="preserve">
     <value>Check for empty expressions inside the interpolated string.</value>
-    <comment>How to fix message for an error</comment>
+    <comment>How to fix message for an error. The term "interpolated string" should be translated using the same terms used in the C# documentation.</comment>
   </data>
   <data name="ErrorResource_ErrAsNotInContext_ShortMessage" xml:space="preserve">
     <value>As is not permitted in this context</value>

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -6361,6 +6361,14 @@
     <value>Check the types of the expressions inside the interpolated string.</value>
     <comment>How to fix message for an error</comment>
   </data>
+  <data name="ErrorResource_ErrEmptyIsland_ShortMessage" xml:space="preserve">
+    <value>Empty expressions cannot appear inside an interpolated string.</value>
+    <comment>Error message.</comment>
+  </data>
+  <data name="ErrorResource_ErrEmptyIsland_HowToFix_1" xml:space="preserve">
+    <value>Check for empty expressions inside the interpolated string.</value>
+    <comment>How to fix message for an error</comment>
+  </data>
   <data name="ErrorResource_ErrAsNotInContext_ShortMessage" xml:space="preserve">
     <value>As is not permitted in this context</value>
     <comment>{Locked=As} This is an error message that shows up when the As keyword is used but is not valid</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StringInterpolate.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StringInterpolate.txt
@@ -109,4 +109,4 @@ Errors: Error 6-15: Invalid argument type (Record). Expecting a Text value inste
 Errors: Error 9-10: Unexpected characters. Characters are used in the formula in an unexpected way.|Error 10-10: Unexpected characters. Characters are used in the formula in an unexpected way.
 
 >> $"Hello {}"
-"Hello "
+Errors: Error 9-10: Empty expressions cannot appear inside an interpolated string.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StringInterpolate.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StringInterpolate.txt
@@ -21,6 +21,9 @@
 >> $""
 ""
 
+>> $"{}"
+Errors: Error 3-4: Empty expressions cannot appear inside an interpolated string.
+
 >> $"Hello"
 "Hello"
 


### PR DESCRIPTION
Empty islands such as $"{}" are an error in C# and should be an error in PowerFx.
