### PR TITLE
Add support for Concat's third parameter (separator)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -93,13 +93,10 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<FormulaValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactSequenceWithOptionalParameters(
-                        requiredParamRuntimeChecks: new Func<IRContext, int, FormulaValue, FormulaValue>[]
-                        {
-                            ExactValueTypeOrBlank<TableValue>,
-                            ExactValueTypeOrBlank<LambdaFormulaValue>,
-                        },
-                        optionalParamRuntimeChecks: new Func<IRContext, int, FormulaValue, FormulaValue>[] { ExactValueTypeOrBlank<StringValue> }),
+                    checkRuntimeTypes: ExactSequence(
+                        ExactValueTypeOrBlank<TableValue>,
+                        ExactValueTypeOrBlank<LambdaFormulaValue>,
+                        ExactValueTypeOrBlank<StringValue>),
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Concat)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -93,9 +93,13 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<FormulaValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactSequence(
-                        ExactValueTypeOrBlank<TableValue>,
-                        ExactValueTypeOrBlank<LambdaFormulaValue>),
+                    checkRuntimeTypes: ExactSequenceWithOptionalParameters(
+                        requiredParamRuntimeChecks: new Func<IRContext, int, FormulaValue, FormulaValue>[]
+                        {
+                            ExactValueTypeOrBlank<TableValue>,
+                            ExactValueTypeOrBlank<LambdaFormulaValue>,
+                        },
+                        optionalParamRuntimeChecks: new Func<IRContext, int, FormulaValue, FormulaValue>[] { ExactValueTypeOrBlank<StringValue> }),
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Concat)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -28,16 +28,26 @@ namespace Microsoft.PowerFx.Functions
         {// Streaming 
             var arg0 = (TableValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
+            var separator = args.Length > 2 ? ((StringValue)args[2]).Value : string.Empty;
 
             var sb = new StringBuilder();
+            var first = true;
 
             foreach (var row in arg0.Rows)
             {
                 if (row.IsValue)
                 {
+                    if (first)
+                    {
+                        first = false;
+                    }
+                    else
+                    {
+                        sb.Append(separator);
+                    }
+
                     var childContext = symbolContext.WithScopeValues(row.Value);
 
-                    // Filter evals to a boolean 
                     var result = arg1.Eval(runner, childContext);
 
                     var str = (StringValue)result;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -438,19 +438,6 @@ namespace Microsoft.PowerFx.Functions
             };
         }
 
-        private static Func<IRContext, int, FormulaValue, FormulaValue> ExactSequenceWithOptionalParameters(Func<IRContext, int, FormulaValue, FormulaValue>[] requiredParamRuntimeChecks, Func<IRContext, int, FormulaValue, FormulaValue>[] optionalParamRuntimeChecks)
-        {
-            return (irContext, index, arg) =>
-            {
-                if (index < requiredParamRuntimeChecks.Length)
-                {
-                    return requiredParamRuntimeChecks[index](irContext, index, arg);
-                }
-
-                return optionalParamRuntimeChecks[index - requiredParamRuntimeChecks.Length](irContext, index, arg);
-            };
-        }
-
         private static FormulaValue AddColumnsTypeChecker(IRContext irContext, int index, FormulaValue arg)
         {
             if (index == 0)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -438,6 +438,19 @@ namespace Microsoft.PowerFx.Functions
             };
         }
 
+        private static Func<IRContext, int, FormulaValue, FormulaValue> ExactSequenceWithOptionalParameters(Func<IRContext, int, FormulaValue, FormulaValue>[] requiredParamRuntimeChecks, Func<IRContext, int, FormulaValue, FormulaValue>[] optionalParamRuntimeChecks)
+        {
+            return (irContext, index, arg) =>
+            {
+                if (index < requiredParamRuntimeChecks.Length)
+                {
+                    return requiredParamRuntimeChecks[index](irContext, index, arg);
+                }
+
+                return optionalParamRuntimeChecks[index - requiredParamRuntimeChecks.Length](irContext, index, arg);
+            };
+        }
+
         private static FormulaValue AddColumnsTypeChecker(IRContext irContext, int index, FormulaValue arg)
         {
             if (index == 0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
@@ -1,6 +1,9 @@
 ﻿>> Concat(ForAll(["a","b","c"], With({x:Value}, x)), Value)
 "abc"
 
+>> Concat(ForAll(["a","b","c"], With({x:Value}, x)), Value, "-")
+"a-b-c"
+
 // On name collision, closest scope wins. 
 >> Concat(ForAll(["a","b","c"] As x, With({x:"hide"}, x)), Value)
 "hidehidehide"
@@ -12,6 +15,10 @@
 >> Concat(["A", "B", "C"], ThisRecord.Value)
 "ABC"
 
+// Explicit 'ThisRecord', with separator
+>> Concat(["A", "B", "C"], ThisRecord.Value, ", ")
+"A, B, C"
+
 // Using 'As'
 >> Concat(["A", "B", "C"] As X, X.Value)
 "ABC"
@@ -20,13 +27,14 @@
 >> Concat(["A", "B", "C"], Value)
 "ABC"
 
-
 // Good example of nested ForAll
 // https://powerapps.microsoft.com/en-us/blog/formulas-thisrecord-as-and-sequence/
 
 >> Concat(ForAll(["A","B"] As X,Concat(ForAll(["C","D"] As Y,X.Value&Y.Value),Value)),Value)
 "ACADBCBD"
 
+>> Concat(ForAll(["A","B"] As X,Concat(ForAll(["C","D"] As Y, X.Value & Y.Value),Value, "-")),Value, ", ")
+"AC-AD, BC-BD"
 
 // X dst,src = 2,3
 // Y         = 3,3
@@ -67,4 +75,10 @@
 Blank()
 
 >> Concat(ForAll(Sort([60, 61, 0, 63, 64], 1/Value), Char(Value)), Value)
+#Error
+
+>> Concat(Table({a: "one"}, {a: "two"}, {a: "three"}), a, ", ")
+"one, two, three"
+
+>> Concat(Table({a: "one"}, {a: "two"}, {a: "three"}), a, Left(", ", -1))
 #Error

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
@@ -23,6 +23,10 @@
 >> Concat(["A", "B", "C"] As X, X.Value)
 "ABC"
 
+// Using 'As' and separators
+>> Concat(["A", "B", "C"] As X, X.Value, ".")
+"A.B.C"
+
 // Implicit 'ThisRecord'
 >> Concat(["A", "B", "C"], Value)
 "ABC"
@@ -82,3 +86,9 @@ Blank()
 
 >> Concat(Table({a: "one"}, {a: "two"}, {a: "three"}), a, Left(", ", -1))
 #Error
+
+>> With({a:"."}, Concat(Sequence(5, 65), Char(Value), $"-{a}-"))
+"A-.-B-.-C-.-D-.-E"
+
+>> Concat(["one", "two", "three"], Value, Len(Value)) // Separator cannot access record
+Errors: Error 43-48: Name isn't valid. This identifier isn't recognized.


### PR DESCRIPTION
Currently the Concat function declares that it accepts three parameters, but the C# interpreter can only handle two (and will throw an exception if the third one is passed). This adds support for it.