### PR TITLE
Fix RandBetween to be equivalent to Excel

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -414,8 +414,8 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue RandBetween(IRContext irContext, NumberValue[] args)
         {
-            var lower = (int)args[0].Value;
-            var upper = (int)args[1].Value;
+            var lower = args[0].Value;
+            var upper = args[1].Value;
 
             if (lower > upper)
             {
@@ -427,6 +427,9 @@ namespace Microsoft.PowerFx.Functions
                 });
             }
 
+            lower = Math.Ceiling(lower);
+            upper = Math.Floor(upper);
+
             lock (_randomizerLock)
             {
                 if (_random == null)
@@ -434,7 +437,7 @@ namespace Microsoft.PowerFx.Functions
                     _random = new Random();
                 }
 
-                return new NumberValue(irContext, _random.Next(lower, upper));
+                return new NumberValue(irContext, Math.Floor((_random.NextDouble() * (upper - lower + 1)) + lower));
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Rand.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Rand.txt
@@ -6,9 +6,6 @@
 >>IsError(RandBetween(5, 1))
 true
 
->>RandBetween(Blank(),1)
-0
-
 >>IsError(RandBetween(1/0, 1))
 true
 
@@ -16,7 +13,24 @@ true
 true
 
 >>RandBetween(100.5, 100.7)
-100
+101
+
+// First argument should be included
+>> CountIf(Sequence(200), RandBetween(3, 4) = 3) > 0
+true
+
+// Second argument should be included
+>> CountIf(Sequence(200), RandBetween(3, 4) = 4) > 0
+true
+
+>>RandBetween(Blank(),0.5)
+0
+
+>> CountIf(Sequence(200) RandBetween(Blank(), 1) = 0) > 0
+true
+
+>> CountIf(Sequence(200) RandBetween(Blank(), 1) = 1) > 0
+true
 
 >> Sum(Sequence(100), With({RandomNumber: RandBetween(1,20)}, If(RandomNumber >=1 && RandomNumber <= 20, 1, 0)))
 100
@@ -26,3 +40,20 @@ true
 
 >> Sum(Sequence(100), With({RandomNumber: Rand()}, If(RandomNumber > 0 && RandomNumber < 1.0, 1, 0)))
 100
+
+>> Sum(Sequence(100), With({rnd:RandBetween(-20,-10)}, If(rnd >= -20 And rnd <= -10, 1, 0)))
+100
+
+// Result must be larger than first argument
+>> Sum(Sequence(100), RandBetween(4.5, 5.7))
+500
+
+>> Sum(Sequence(100), With({rnd:RandBetween(-4.5,-2.7)}, If(rnd = -4 Or rnd = -3, 1, 0)))
+100
+
+>> RandBetween(4.7, 4.5)
+#Error
+
+// Just like Excel, if there is no integer between the two numbers, take ceiling
+>> Sum(Sequence(100), RandBetween(3.5, 3.7))
+400

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Rand.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Rand.txt
@@ -26,10 +26,10 @@ true
 >>RandBetween(Blank(),0.5)
 0
 
->> CountIf(Sequence(200) RandBetween(Blank(), 1) = 0) > 0
+>> CountIf(Sequence(200), RandBetween(Blank(), 1) = 0) > 0
 true
 
->> CountIf(Sequence(200) RandBetween(Blank(), 1) = 1) > 0
+>> CountIf(Sequence(200), RandBetween(Blank(), 1) = 1) > 0
 true
 
 >> Sum(Sequence(100), With({RandomNumber: RandBetween(1,20)}, If(RandomNumber >=1 && RandomNumber <= 20, 1, 0)))


### PR DESCRIPTION
The function RandBetween takes two parameters, and it should return _an integer_ greater than or equal to the first argument, and smaller than _or equal to_ the second argument (i.e., inclusive). The current implementation was not returning the second argument, nor was it working properly if the first argument was not a whole number. This change brings it to parity with Excel.