### PR TITLE
Remove all arguments from the generated call node

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2112,7 +2112,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
         private CallNode GenerateCallNode(StrInterpNode node)
         {
-            // We generate a transient CallNode to the Concatenate function
+            // We generate a transient CallNode (with no arguments) to the Concatenate function
             var func = BuiltinFunctionsCore.Concatenate;
             var ident = new IdentToken(func.Name, node.Token.Span);
             var id = node.Id;
@@ -2124,7 +2124,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 sourceList: node.SourceList,
                 head: new Identifier(ident),
                 headNode: null,
-                new ListNode(ref listNodeId, tok: node.Token, args: node.CloneChildren(ref minChildId, node.GetCompleteSpan()), delimiters: null, sourceList: node.SourceList),
+                new ListNode(ref listNodeId, tok: node.Token, args: new TexlNode[0], delimiters: null, sourceList: node.SourceList),
                 node.StrInterpEnd);
             _compilerGeneratedCallNodes[node.Id] = callNode;
             SetInfo(callNode, new CallInfo(func, callNode));

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -80,6 +80,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("$\"{ {a:{},b:{},c:{}}}{|}\"")]
         [InlineData("$ |")]
         [InlineData("$\"foo {|")]
+        [InlineData("$\"foo { {a:| } } \"")]
         [InlineData("{abc:{},ab:{},a:{}}.|ab", "ab", "a", "abc")]
         [InlineData("{abc:{},ab:{},a:{}}.ab|", "ab", "abc")]
         [InlineData("{abc:{},ab:{},a:{}}.ab|c", "abc", "ab")]


### PR DESCRIPTION
We are generating a call node in the binder so that it exists in later phases. This call node previously obtained clones of all the children by calling the Clone method. The Clone method was used because the children could not have multiple parents, and using the arguments directly would result 2 parents: the StrInterp node itself and the generated CallNode.

It appears that the Clone method was not intended to be used in this way, and it fails for error inputs.

This change removes the children from the generated CallNode. They were only being used by JsTranslator, and I can modify JsTranslator to get the arguments from the StrInterpNode instead of the CallNode. The CallNode just needs to exist.