### PR TITLE
Expose OptionSet name, and correctly marshal in FormulaType.Build

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -81,7 +81,16 @@ namespace Microsoft.PowerFx.Core.Public.Types
 
                 case DKind.OptionSetValue:
                     var isBoolean = type.OptionSetInfo?.IsBooleanValued;
-                    return isBoolean.HasValue && isBoolean.Value ? Boolean : OptionSetValue;
+                    if (isBoolean.HasValue && isBoolean.Value)
+                    {
+                        return Boolean;
+                    }
+                    else
+                    {
+                        // In all non-test cases, this option set info must be present
+                        // For some existing tests, it isn't available. Once that's resolved, this should be cleaned up
+                        return type.OptionSetInfo != null ? new OptionSetValueType(type.OptionSetInfo) : OptionSetValue;
+                    }
 
                 // This isn't quite right, but once we're in the IR, an option set acts more like a record with optionsetvalue fields. 
                 case DKind.OptionSet:

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -9,7 +9,10 @@ namespace Microsoft.PowerFx.Core.Public.Types
 {
     public class OptionSetValueType : FormulaType
     {
-        internal DName OptionSetName => _type.OptionSetInfo?.EntityName ?? default;
+        /// <summary>
+        /// The name of the source Option Set for this type.
+        /// </summary>
+        public DName OptionSetName => _type.OptionSetInfo?.EntityName ?? default;
 
         internal OptionSetValueType(IExternalOptionSet optionSet)
             : base(DType.CreateOptionSetValueType(optionSet))

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -389,6 +389,26 @@ namespace Microsoft.PowerFx.Tests
             var checkResult = recalcEngine.Check("OptionSet.Option1 <> OptionSet.Option2");
             Assert.True(checkResult.IsSuccess);
         }
+        
+        [Fact]
+        public void OptionSetResultType()
+        {
+            var config = new PowerFxConfig(null);
+
+            var optionSet = new OptionSet("OptionSetName", new Dictionary<string, string>() 
+            {
+                    { "option_1", "Option1" },
+                    { "option_2", "Option2" }
+            });
+            
+            config.AddOptionSet(optionSet);            
+            var recalcEngine = new RecalcEngine(config);
+
+            var checkResult = recalcEngine.Check("OptionSet.Option1");
+            Assert.True(checkResult.IsSuccess);
+            var osvaluetype = Assert.IsType<OptionSetValueType>(checkResult.ReturnType);
+            Assert.Equal("OptionSetName", osvaluetype.OptionSetName);
+        }
 
         #region Test
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -395,7 +395,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var config = new PowerFxConfig(null);
 
-            var optionSet = new OptionSet("OptionSetName", new Dictionary<string, string>() 
+            var optionSet = new OptionSet("FooOs", new Dictionary<string, string>() 
             {
                     { "option_1", "Option1" },
                     { "option_2", "Option2" }
@@ -404,10 +404,10 @@ namespace Microsoft.PowerFx.Tests
             config.AddOptionSet(optionSet);            
             var recalcEngine = new RecalcEngine(config);
 
-            var checkResult = recalcEngine.Check("OptionSet.Option1");
+            var checkResult = recalcEngine.Check("FooOs.Option1");
             Assert.True(checkResult.IsSuccess);
             var osvaluetype = Assert.IsType<OptionSetValueType>(checkResult.ReturnType);
-            Assert.Equal("OptionSetName", osvaluetype.OptionSetName);
+            Assert.Equal("FooOs", osvaluetype.OptionSetName);
         }
 
         #region Test


### PR DESCRIPTION
Fix #226.

When adding proper option set support, FormulaType.Build wasn't updated to ensure that the internal option set type gets properly converted back to the public FormulaType. This also exposes the name of the option set publicly on the OptionSetValueType, for use in hosts. 