### PR TITLE
Rename ParseJson to ParseJSON

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -431,8 +431,8 @@ namespace Microsoft.PowerFx.Core.Localization
         public static StringGetter SequenceArg2 = (b) => StringResources.Get("SequenceArg2", b);
         public static StringGetter SequenceArg3 = (b) => StringResources.Get("SequenceArg3", b);
 
-        public static StringGetter AboutParseJson = (b) => StringResources.Get("AboutParseJson", b);
-        public static StringGetter ParseJsonArg1 = (b) => StringResources.Get("ParseJsonArg1", b);
+        public static StringGetter AboutParseJSON = (b) => StringResources.Get("AboutParseJSON", b);
+        public static StringGetter ParseJSONArg1 = (b) => StringResources.Get("ParseJSONArg1", b);
 
         public static StringGetter AboutIndex = (b) => StringResources.Get("AboutIndex", b);
         public static StringGetter IndexArg1 = (b) => StringResources.Get("IndexArg1", b);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValue.cs
@@ -430,7 +430,7 @@ namespace Microsoft.PowerFx.Core.Public.Values
             return val;
         }
 
-        // More type safe than base class's ParseJson
+        // More type safe than base class's ParseJSON
         // Parse json. 
         // [1,2,3]  is a single column table, actually equivalent to: 
         // [{Value : 1, Value: 2, Value :3 }]

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerFx.Core.Texl
         // NOTE: These functions should not be part of the core library until they are implemented in all runtimes
         public static readonly TexlFunction Index = new IndexFunction();
         public static readonly TexlFunction Index_UO = new IndexFunction_UO();
-        public static readonly TexlFunction ParseJson = new ParseJsonFunction();
+        public static readonly TexlFunction ParseJSON = new ParseJSONFunction();
         public static readonly TexlFunction Table_UO = new TableFunction_UO();
         public static readonly TexlFunction Text_UO = new TextFunction_UO();
         public static readonly TexlFunction Value_UO = new ValueFunction_UO();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
@@ -10,9 +10,9 @@ using Microsoft.PowerFx.Core.Types;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
-    internal sealed class ParseJsonFunction : BuiltinFunction
+    internal sealed class ParseJSONFunction : BuiltinFunction
     {
-        public const string ParseJsonInvariantFunctionName = "ParseJson";
+        public const string ParseJSONInvariantFunctionName = "ParseJSON";
 
         public override bool RequiresErrorContext => true;
 
@@ -22,14 +22,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsHidden => true;
 
-        public ParseJsonFunction()
-            : base(ParseJsonInvariantFunctionName, TexlStrings.AboutParseJson, FunctionCategories.Text, DType.UntypedObject, 0, 1, 1, DType.String)
+        public ParseJSONFunction()
+            : base(ParseJSONInvariantFunctionName, TexlStrings.AboutParseJSON, FunctionCategories.Text, DType.UntypedObject, 0, 1, 1, DType.String)
         {
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
-            yield return new[] { TexlStrings.ParseJsonArg1 };
+            yield return new[] { TexlStrings.ParseJSONArg1 };
         }
     }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -758,14 +758,14 @@ namespace Microsoft.PowerFx.Functions
             },
             { BuiltinFunctionsCore.Or, Or },
             {
-                BuiltinFunctionsCore.ParseJson,
+                BuiltinFunctionsCore.ParseJSON,
                 StandardErrorHandling<StringValue>(
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: ParseJson)
+                    targetFunction: ParseJSON)
             },
             {
                 BuiltinFunctionsCore.Pi,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryJson.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryJson.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue ParseJson(IRContext irContext, StringValue[] args)
+        public static FormulaValue ParseJSON(IRContext irContext, StringValue[] args)
         {
             var json = args[0].Value;
             JsonElement result;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx
         {
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Index);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Index_UO);
-            powerFxConfig.AddFunction(BuiltinFunctionsCore.ParseJson);
+            powerFxConfig.AddFunction(BuiltinFunctionsCore.ParseJSON);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Table_UO);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Text_UO);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Value_UO);

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -2338,15 +2338,15 @@
   <data name="AboutChar_column_of_numbers" xml:space="preserve">
     <value>A column of code numbers from the character set on your platform.</value>
   </data>
-  <data name="AboutParseJson" xml:space="preserve">
+  <data name="AboutParseJSON" xml:space="preserve">
     <value>Converts a JSON string into an object.</value>
-    <comment>Description of 'ParseJson' function.</comment>
+    <comment>Description of 'ParseJSON' function.</comment>
   </data>
-  <data name="ParseJsonArg1" xml:space="preserve">
+  <data name="ParseJSONArg1" xml:space="preserve">
     <value>input</value>
-    <comment>function_parameter - First argument of the ParseJson function - String type.</comment>
+    <comment>function_parameter - First argument of the ParseJSON function - String type.</comment>
   </data>
-  <data name="AboutParseJson_input" xml:space="preserve">
+  <data name="AboutParseJSON_input" xml:space="preserve">
     <value>A JSON string to process.</value>
   </data>
   <data name="AboutIndex" xml:space="preserve">

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -1,115 +1,115 @@
 ﻿// Value tests
->> Value(Index(ParseJson("[5]"), 1))
+>> Value(Index(ParseJSON("[5]"), 1))
 5
 
->> Value(ParseJson("5"))
+>> Value(ParseJSON("5"))
 5
 
->> Value(ParseJson("true"))
+>> Value(ParseJSON("true"))
 #Error
 
->> Value(ParseJson("false"))
+>> Value(ParseJSON("false"))
 #Error
 
->> Value(ParseJson("""5"""))
+>> Value(ParseJSON("""5"""))
 #Error
 
->> Value(ParseJson("""a"""))
+>> Value(ParseJSON("""a"""))
 #Error
 
->> Value(ParseJson("null"))
+>> Value(ParseJSON("null"))
 Blank()
 
->> Value(ParseJson("{""a"": 5}").a)
+>> Value(ParseJSON("{""a"": 5}").a)
 5
 
->> Value(ParseJson("{""a"": 5, ""A"": 10}").a)
+>> Value(ParseJSON("{""a"": 5, ""A"": 10}").a)
 5
 
->> Value(ParseJson("{""a"": 5, ""A"": 10}").A)
+>> Value(ParseJSON("{""a"": 5, ""A"": 10}").A)
 10
 
->> Value(ParseJson("{""a"": 5}").b)
+>> Value(ParseJSON("{""a"": 5}").b)
 Blank()
 
->> Value(ParseJson("""s""").a)
+>> Value(ParseJSON("""s""").a)
 #Error
 
->> Value(ParseJson("This "" Is , "" Invalid ").a)
+>> Value(ParseJSON("This "" Is , "" Invalid ").a)
 #Error
 
 // Text tests
->> Text(Index(ParseJson("[""s""]"), 1))
+>> Text(Index(ParseJSON("[""s""]"), 1))
 "s"
 
->> Text(ParseJson("""s"""))
+>> Text(ParseJSON("""s"""))
 "s"
 
->> Text(ParseJson("null"))
+>> Text(ParseJSON("null"))
 ""
 
->> Text(ParseJson("true"))
+>> Text(ParseJSON("true"))
 #Error
 
->> Text(ParseJson("false"))
+>> Text(ParseJSON("false"))
 #Error
 
->> Text(ParseJson("5"))
+>> Text(ParseJSON("5"))
 #Error
 
->> Boolean(ParseJson("true"))
+>> Boolean(ParseJSON("true"))
 true
 
->> Boolean(ParseJson("false"))
+>> Boolean(ParseJSON("false"))
 false
 
->> ParseJson("{""a"": null}").a
+>> ParseJSON("{""a"": null}").a
 Blank()
 
->> ParseJson("{""a"": null}").a.b
+>> ParseJSON("{""a"": null}").a.b
 Blank()
 
->> ParseJson("null").a
+>> ParseJSON("null").a
 Blank()
 
->> ParseJson("null").a.b
+>> ParseJSON("null").a.b
 Blank()
 
->> ParseJson("{}").a
+>> ParseJSON("{}").a
 Blank()
 
->> ParseJson("{}").a.b
+>> ParseJSON("{}").a.b
 Blank()
 
->> Sum(Table(ParseJson("[1, 2, 3, 4, 5]")), Value(Value))
+>> Sum(Table(ParseJSON("[1, 2, 3, 4, 5]")), Value(Value))
 15
 
->> ParseJson("5") + ParseJson("5")
+>> ParseJSON("5") + ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
->> ParseJson("5") - ParseJson("5")
+>> ParseJSON("5") - ParseJSON("5")
 Errors: Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
->> ParseJson("5") * ParseJson("5")
+>> ParseJSON("5") * ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.
 
->> ParseJson("5") / ParseJson("5")
+>> ParseJSON("5") / ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.
 
->> ParseJson("5") = ParseJson("5")
+>> ParseJSON("5") = ParseJSON("5")
 Errors: Error 15-16: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
 
->> ParseJson("5") > ParseJson("5")
+>> ParseJSON("5") > ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
 
->> ParseJson("5") < ParseJson("5")
+>> ParseJSON("5") < ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
 
->> ParseJson("5") <> ParseJson("5")
+>> ParseJSON("5") <> ParseJSON("5")
 Errors: Error 15-17: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
 
->> ParseJson("5") >= ParseJson("5")
+>> ParseJSON("5") >= ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 18-32: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
 
->> ParseJson("5") <= ParseJson("5")
+>> ParseJSON("5") <= ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 18-32: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.


### PR DESCRIPTION
Rename ParseJson to ParseJSON to be consistent with the existing JSON function.