### PR TITLE
Add GetRequiredEnumNames method to TexlFunction

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -344,6 +344,13 @@ namespace Microsoft.PowerFx.Core.Functions
         // Functions with optional parameters have more than one signature.
         public abstract IEnumerable<TexlStrings.StringGetter[]> GetSignatures();
 
+        // Return all enums that are required by this function.
+        // This can be used to generate a list of enums required for a function library.
+        public virtual IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>();
+        }
+
         // Return all signatures with at most 'arity' parameters.
         public virtual IEnumerable<TexlStrings.StringGetter[]> GetSignatures(int arity)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFade.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFade.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
@@ -28,6 +29,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             // Parameters are a numeric color value, and a fadeDelta (-1 to 1)
             yield return new[] { TexlStrings.ColorFadeArg1, TexlStrings.ColorFadeArg2 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.ColorEnumString };
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -9,6 +9,7 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Syntax.Nodes;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
@@ -32,6 +33,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.ColorFadeTArg1, TexlStrings.ColorFadeTArg2 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.ColorEnumString };
         }
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -11,6 +11,7 @@ using Microsoft.PowerFx.Core.Functions.Delegation;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Syntax.Nodes;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 
 #pragma warning disable SA1402 // File may only contain a single type
@@ -218,6 +219,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.WeekdayArg1 };
             yield return new[] { TexlStrings.WeekdayArg1, TexlStrings.WeekdayArg2 };
         }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.StartOfWeekEnumString };
+        }
     }
 
     // WeekNum(date:d, [startOfWeek:n])
@@ -241,6 +247,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.WeekNumArg1 };
             yield return new[] { TexlStrings.WeekNumArg1, TexlStrings.WeekNumArg2 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.StartOfWeekEnumString };
         }
     }
 
@@ -274,6 +285,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         protected DateTimeGenericFunction(string name, TexlStrings.StringGetter description, DType returnType)
             : base(name, description, FunctionCategories.DateTime, returnType, 0, 1, 2, DType.String, DType.String)
         {
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.DateTimeFormatEnumString };
         }
 
         public override bool HasSuggestionsForParam(int index)
@@ -361,6 +377,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.DateAddArg1, TexlStrings.DateAddArg2, TexlStrings.DateAddArg3 };
         }
 
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.TimeUnitEnumString };
+        }
+
         // This method returns true if there are special suggestions for a particular parameter of the function.
         public override bool HasSuggestionsForParam(int argumentIndex)
         {
@@ -426,6 +447,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.DateAddTArg1, TexlStrings.DateAddTArg2 };
             yield return new[] { TexlStrings.DateAddTArg1, TexlStrings.DateAddTArg2, TexlStrings.DateAddTArg3 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.TimeUnitEnumString };
         }
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
@@ -539,6 +565,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.DateDiffArg1, TexlStrings.DateDiffArg2, TexlStrings.DateDiffArg3 };
         }
 
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.TimeUnitEnumString };
+        }
+
         // This method returns true if there are special suggestions for a particular parameter of the function.
         public override bool HasSuggestionsForParam(int argumentIndex)
         {
@@ -566,6 +597,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.DateDiffTArg1, TexlStrings.DateDiffTArg2 };
             yield return new[] { TexlStrings.DateDiffTArg1, TexlStrings.DateDiffTArg2, TexlStrings.DateDiffTArg3 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.TimeUnitEnumString };
         }
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -9,6 +9,7 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Syntax.Nodes;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
@@ -34,6 +35,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.ErrorArg1 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { EnumConstants.ErrorKindEnumString };
         }
 
         public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
@@ -43,6 +43,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.SortArg1, TexlStrings.SortArg2, TexlStrings.SortArg3 };
         }
 
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { LanguageConstants.SortOrderEnumString };
+        }
+
         public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -48,6 +48,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.SortByColumnsArg1, TexlStrings.SortByColumnsArg2, TexlStrings.SortByColumnsArg3 };
         }
 
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { LanguageConstants.SortOrderEnumString };
+        }
+
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures(int arity)
         {
             if (arity > 3)
@@ -377,6 +382,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.SortByColumnsWithOrderValuesArg1, TexlStrings.SortByColumnsWithOrderValuesArg2, TexlStrings.SortByColumnsWithOrderValuesArg3 };
+        }
+
+        public override IEnumerable<string> GetRequiredEnumNames()
+        {
+            return new List<string>() { LanguageConstants.SortOrderEnumString };
         }
 
         public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)


### PR DESCRIPTION
Part 1 of a series of changes that will allow required enums to be automatically configured for a given function library. This change adds a new method, GetRequiredEnumNames, to the TexlFunction base class. It overrides this method for functions within our library which require enums.