### PR TITLE
Add GUID support to C# Interpreter

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerFx.Core.IR
         DateToText,
         TimeToText,
         DateTimeToText,
+        GuidToText,
 
         NumberToBoolean,
         TextToBoolean,

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
@@ -346,6 +346,10 @@ namespace Microsoft.PowerFx.Core.IR
             {
                 return CoercionKind.ViewToText;
             }
+            else if (DType.Guid.Accepts(fromType))
+            {
+                return CoercionKind.GuidToText;
+            }
             else
             {
                 return CoercionKind.None; // Implicit coercion?

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -691,6 +691,9 @@ namespace Microsoft.PowerFx.Core.IR
                     case CoercionKind.BooleanToText:
                         unaryOpKind = UnaryOpKind.BooleanToText;
                         break;
+                    case CoercionKind.GuidToText:
+                        unaryOpKind = UnaryOpKind.GuidToText;
+                        break;
                     case CoercionKind.OptionSetToText:
                         unaryOpKind = UnaryOpKind.OptionSetToText;
                         break;

--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
         BooleanToText,
         OptionSetToText,
         ViewToText,
+        GuidToText,
 
         NumberToBoolean,
         TextToBoolean,

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -75,6 +75,8 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction First = _library.Append(new FirstLastFunction(isFirst: true));
         public static readonly TexlFunction FirstN = _library.Append(new FirstLastNFunction(isFirst: true));
         public static readonly TexlFunction ForAll = _library.Append(new ForAllFunction());
+        public static readonly TexlFunction GUIDNoArg = _library.Append(new GUIDNoArgFunction());
+        public static readonly TexlFunction GUIDPure = _library.Append(new GUIDPureFunction());
         public static readonly TexlFunction Hour = _library.Append(new HourFunction());
         public static readonly TexlFunction If = _library.Append(new IfFunction());
         public static readonly TexlFunction IfError = _library.Append(new IfErrorFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1881,7 +1881,6 @@ namespace Microsoft.PowerFx.Core.Types
                         type.Kind == DKind.Media ||
                         type.Kind == DKind.Blob ||
                         type.Kind == DKind.Unknown ||
-                        type.Kind == DKind.Guid ||
                         (type.Kind == DKind.Enum && Accepts(type.GetEnumSupertype()));
                     break;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
@@ -59,6 +59,16 @@ namespace Microsoft.PowerFx.Functions
             });
         }
 
+        public static ErrorValue InvalidGuidError(IRContext irContext)
+        {
+            return new ErrorValue(irContext, new ExpressionError()
+            {
+                Message = $"The argument to 'GUID' function is not in a valid GUID format",
+                Span = irContext.SourceContext,
+                Kind = ErrorKind.InvalidArgument
+            });
+        }
+
         public static ErrorValue InvalidBooleanFormatError(IRContext irContext)
         {
             return new ErrorValue(irContext, new ExpressionError()

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -453,6 +453,20 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: ForAll)
             },
             {
+                BuiltinFunctionsCore.GUIDNoArg,
+                (EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] values) => GuidNoArg(irContext)
+            },
+            {
+                BuiltinFunctionsCore.GUIDPure,
+                StandardErrorHandling<StringValue>(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueType<StringValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: GuidPure)
+            },
+            {
                 BuiltinFunctionsCore.IsBlank,
                 StandardErrorHandling<FormulaValue>(
                     expandArguments: NoArgExpansion,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -300,6 +300,23 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
+        public static FormulaValue GuidNoArg(IRContext irContext)
+        {
+            return new GuidValue(irContext, Guid.NewGuid());
+        }
+
+        public static FormulaValue GuidPure(IRContext irContext, StringValue[] args)
+        {
+            var stringInput = args[0];
+
+            if (Guid.TryParse(stringInput.Value, out var guid))
+            {
+                return new GuidValue(irContext, guid);
+            }
+
+            return CommonErrors.InvalidGuidError(irContext);
+        }
+
         public static FormulaValue Lower(IRContext irContext, StringValue[] args)
         {
             return new StringValue(irContext, args[0].Value.ToLower());

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -78,6 +78,16 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: BooleanToNumber)
             },
             {
+                UnaryOpKind.GuidToText,
+                StandardErrorHandling<GuidValue>(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<GuidValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: GuidToText)
+            },
+            {
                 UnaryOpKind.TextToBoolean,
                 StandardErrorHandling<StringValue>(
                     expandArguments: NoArgExpansion,
@@ -279,6 +289,15 @@ namespace Microsoft.PowerFx.Functions
         {
             var b = args[0].Value;
             return new NumberValue(irContext, b ? 1.0 : 0.0);
+        }
+
+        public static StringValue GuidToText(IRContext irContext, GuidValue[] args)
+        {
+            var g = args[0].Value;
+
+            // The "D" format string is 32 digits, separated by hyphens
+            // 00000000 - 0000 - 0000 - 0000 - 000000000000
+            return new StringValue(irContext, g.ToString("D"));
         }
 
         public static BooleanValue TextToBoolean(IRContext irContext, StringValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Guid.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Guid.txt
@@ -1,0 +1,40 @@
+﻿// Guid function 
+// https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/function-guid
+
+// Guid with no args is volatile, so we can't directly test the output
+
+>> IsBlank(GUID())
+false
+
+>> IsError(GUID())
+false
+
+// Multiple invocations are unique
+>> GUID() <> GUID()
+true
+
+// Coercion to string is 32 chars + 4 hyphens
+>> Len(GUID())
+36
+
+>> GUID("c3987aa4-52ff-462f-9a7c-a13c0dedb16d")
+c3987aa4-52ff-462f-9a7c-a13c0dedb16d
+
+>> GUID("8A9E8006-3EDE-4584-863F-4226BAA73D08")
+8a9e8006-3ede-4584-863f-4226baa73d08
+
+>> GUID("0A6D72E27FDE47C5BB9513BDB51BD7C0")
+0a6d72e2-7fde-47c5-bb95-13bdb51bd7c0
+
+>> GUID("0c99c9a834ed4247861dc9680d72dfd9")
+0c99c9a8-34ed-4247-861d-c9680d72dfd9
+
+>> Text(GUID("41aacfaa-8630-4d9b-8cdd-f62ed8ee8581"))
+"41aacfaa-8630-4d9b-8cdd-f62ed8ee8581"
+
+>> GUID("76353e29-1d57-4315-8af1-884ce7e6c75c") = GUID("76353e29-1d57-4315-8af1-884ce7e6c75c")
+true
+
+// Not comparable to string
+>> GUID("76353e29-1d57-4315-8af1-884ce7e6c75c") = "76353e29-1d57-4315-8af1-884ce7e6c75c"
+Errors: Error 45-46: GUID values can only be compared to other GUID values.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
@@ -309,6 +309,10 @@ namespace Microsoft.PowerFx.Core.Tests
                 // $$$ proper escaping?
                 sb.Append('"' + s.Value + '"');
             }
+            else if (result is GuidValue guid)
+            {
+                sb.Append(guid.Value);
+            }
             else if (result is TableValue t)
             {
                 var tableType = (TableType)t.Type;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
@@ -54,6 +54,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="ExpressionTestCases\Guid.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\libraries\Microsoft.PowerFx.Core\Microsoft.PowerFx.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This moves the GUID functions into the C# interpreter, and brings up an recurring. The DType.Accepts() logic is based heavily around JS's ducktyping behavior. We should consider removing much of that, and switching to a model where we always inject coercion between types. This would require improving function signatures and making the function type checking more metadata-driven, since some functions have custom behavior around Coercion logic. 