### PR TITLE
Async support for interpreter.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/IExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/IExpression.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Public.Values;
 
 namespace Microsoft.PowerFx.Core.Public
@@ -11,9 +13,25 @@ namespace Microsoft.PowerFx.Core.Public
     /// <returns></returns>
     public interface IExpression
     {
+        public Task<FormulaValue> EvalAsync(RecordValue parameters, CancellationToken cancel);
+    }
+
+    /// <summary>
+    /// Extensions for <see cref="IExpression"/>.
+    /// </summary>
+    public static class IExpressionExtensions
+    {
         /// <summary>
         /// Evaluate the expression with a given set of record values.
         /// </summary>
-        public FormulaValue Eval(RecordValue parameters);
+        public static FormulaValue Eval(this IExpression expr, RecordValue parameters, CancellationToken cancel)
+        {
+            return expr.EvalAsync(parameters, cancel).Result;
+        }
+
+        public static FormulaValue Eval(this IExpression expr, RecordValue parameters)
+        {
+            return expr.Eval(parameters, CancellationToken.None);
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerFx
             CultureInfo = cultureInfo;
             _cancel = cancel;
         }
-
+                
         // Check this cooperatively - especially in any loop. 
         public void CheckCancel()
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
@@ -15,22 +18,35 @@ using static Microsoft.PowerFx.Functions.Library;
 
 namespace Microsoft.PowerFx
 {
-    internal class EvalVisitor : IRNodeVisitor<FormulaValue, SymbolContext>
+    // This used ValueTask for async, https://devblogs.microsoft.com/dotnet/understanding-the-whys-whats-and-whens-of-valuetask/ 
+    // Perf comparison of Task vs. ValueTask: https://ladeak.wordpress.com/2019/03/09/valuetask-vs-task 
+    // Use Task for public methods, but ValueTask for internal methods that we expect to be mostly sync. 
+    internal class EvalVisitor : IRNodeVisitor<ValueTask<FormulaValue>, SymbolContext>
     {
         public CultureInfo CultureInfo { get; }
 
-        public EvalVisitor(CultureInfo cultureInfo)
+        private readonly CancellationToken _cancel;
+
+        public EvalVisitor(CultureInfo cultureInfo, CancellationToken cancel)
         {
             CultureInfo = cultureInfo;
+            _cancel = cancel;
+        }
+
+        // Check this cooperatively - especially in any loop. 
+        public void CheckCancel()
+        {
+            // Throws OperationCanceledException exception
+            _cancel.ThrowIfCancellationRequested();
         }
 
         // Helper to eval an arg that might be a lambda.
-        internal DValue<T> EvalArg<T>(FormulaValue arg, SymbolContext context, IRContext irContext)
+        internal async ValueTask<DValue<T>> EvalArgAsync<T>(FormulaValue arg, SymbolContext context, IRContext irContext)
             where T : ValidFormulaValue
         {
             if (arg is LambdaFormulaValue lambda)
             {
-                var val = lambda.Eval(this, context);
+                var val = await lambda.EvalAsync(this, context);
                 return val switch
                 {
                     T t => DValue<T>.Of(t),
@@ -49,22 +65,22 @@ namespace Microsoft.PowerFx
             };
         }
 
-        public override FormulaValue Visit(TextLiteralNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(TextLiteralNode node, SymbolContext context)
         {
             return new StringValue(node.IRContext, node.LiteralValue);
         }
 
-        public override FormulaValue Visit(NumberLiteralNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(NumberLiteralNode node, SymbolContext context)
         {
             return new NumberValue(node.IRContext, node.LiteralValue);
         }
 
-        public override FormulaValue Visit(BooleanLiteralNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(BooleanLiteralNode node, SymbolContext context)
         {
             return new BooleanValue(node.IRContext, node.LiteralValue);
         }
 
-        public override FormulaValue Visit(TableNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(TableNode node, SymbolContext context)
         {
             // single-column table.
 
@@ -74,8 +90,10 @@ namespace Microsoft.PowerFx
             var args = new FormulaValue[len];
             for (var i = 0; i < len; i++)
             {
+                CheckCancel();
+
                 var child = node.Values[i];
-                var arg = child.Accept(this, context);
+                var arg = await child.Accept(this, context);
                 args[i] = arg;
             }
 
@@ -85,30 +103,34 @@ namespace Microsoft.PowerFx
             return tableValue;
         }
 
-        public override FormulaValue Visit(RecordNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(RecordNode node, SymbolContext context)
         {
             var fields = new List<NamedValue>();
 
             foreach (var field in node.Fields)
             {
+                CheckCancel();
+
                 var name = field.Key;
                 var value = field.Value;
 
-                var rhsValue = value.Accept(this, context);
+                var rhsValue = await value.Accept(this, context);
                 fields.Add(new NamedValue(name.Value, rhsValue));
             }
 
             return new InMemoryRecordValue(node.IRContext, fields);
         }
 
-        public override FormulaValue Visit(LazyEvalNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(LazyEvalNode node, SymbolContext context)
         {
-            var val = node.Child.Accept(this, context);
+            var val = await node.Child.Accept(this, context);
             return val;
         }
 
-        public override FormulaValue Visit(CallNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(CallNode node, SymbolContext context)
         {
+            CheckCancel();
+
             // Sum(  [1,2,3], Value * Value)
             // return base.PreVisit(node);
 
@@ -120,12 +142,14 @@ namespace Microsoft.PowerFx
 
             for (var i = 0; i < carg; i++)
             {
+                CheckCancel();
+
                 var child = node.Args[i];
                 var isLambda = node.IsLambdaArg(i);
 
                 if (!isLambda)
                 {
-                    args[i] = child.Accept(this, context);
+                    args[i] = await child.Accept(this, context);
                 }
                 else
                 {
@@ -135,7 +159,12 @@ namespace Microsoft.PowerFx
 
             var childContext = context.WithScope(node.Scope);
 
-            if (func is CustomTexlFunction customFunc)
+            if (func is IAsyncTexlFunction asyncFunc)
+            {
+                var result = await asyncFunc.InvokeAsync(args, _cancel);
+                return result;
+            }
+            else if (func is CustomTexlFunction customFunc)
             {
                 var result = customFunc.Invoke(args);
                 return result;
@@ -144,7 +173,7 @@ namespace Microsoft.PowerFx
             {
                 if (FuncsByName.TryGetValue(func, out var ptr))
                 {
-                    var result = ptr(this, childContext, node.IRContext, args);
+                    var result = await ptr(this, childContext, node.IRContext, args);
 
                     Contract.Assert(result.IRContext.ResultType == node.IRContext.ResultType || result is ErrorValue || result.IRContext.ResultType is BlankType);
 
@@ -155,12 +184,16 @@ namespace Microsoft.PowerFx
             }
         }
 
-        public override FormulaValue Visit(BinaryOpNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(BinaryOpNode node, SymbolContext context)
         {
-            var arg1 = node.Left.Accept(this, context);
-            var arg2 = node.Right.Accept(this, context);
+            var arg1 = await node.Left.Accept(this, context);
+            var arg2 = await node.Right.Accept(this, context);
             var args = new FormulaValue[] { arg1, arg2 };
+            return await VisitBinaryOpNode(node, context, args);
+        }
 
+        private ValueTask<FormulaValue> VisitBinaryOpNode(BinaryOpNode node, SymbolContext context, FormulaValue[] args)
+        { 
             switch (node.Op)
             {
                 case BinaryOpKind.AddNumbers:
@@ -257,72 +290,80 @@ namespace Microsoft.PowerFx
                 case BinaryOpKind.GeqTime:
                     return OperatorGeqTime(this, context, node.IRContext, args);
                 case BinaryOpKind.DynamicGetField:
-                    if (arg1 is UntypedObjectValue cov && arg2 is StringValue sv)
-                    {
-                        if (cov.Impl.Type is ExternalType et && et.Kind == ExternalTypeKind.Object)
-                        {
-                            if (cov.Impl.TryGetProperty(sv.Value, out var res))
-                            {
-                                if (res.Type == FormulaType.Blank)
-                                {
-                                    return new BlankValue(node.IRContext);
-                                }
-
-                                return new UntypedObjectValue(node.IRContext, res);
-                            }
-                            else
-                            {
-                                return new BlankValue(node.IRContext);
-                            }
-                        }
-                        else if (cov.Impl.Type == FormulaType.Blank)
-                        {
-                            return new BlankValue(node.IRContext);
-                        }
-                        else
-                        {
-                            return new ErrorValue(node.IRContext, new ExpressionError()
-                            {
-                                Message = "Accessing a field is not valid on this value",
-                                Span = node.IRContext.SourceContext,
-                                Kind = ErrorKind.BadLanguageCode
-                            });
-                        }
-                    }
-                    else if (arg1 is BlankValue)
-                    {
-                        return new BlankValue(node.IRContext);
-                    }
-                    else if (arg1 is ErrorValue)
-                    {
-                        return arg1;
-                    }
-                    else
-                    {
-                        return CommonErrors.UnreachableCodeError(node.IRContext);
-                    }
+                    return OperatorDynamicGetField(node, args);
 
                 default:
-                    return CommonErrors.UnreachableCodeError(node.IRContext);
+                    return new ValueTask<FormulaValue>(CommonErrors.UnreachableCodeError(node.IRContext));
             }
         }
 
-        public override FormulaValue Visit(UnaryOpNode node, SymbolContext context)
+        private static async ValueTask<FormulaValue> OperatorDynamicGetField(BinaryOpNode node, FormulaValue[] args)
         {
-            var arg1 = node.Child.Accept(this, context);
+            var arg1 = args[0];
+            var arg2 = args[1];
+
+            if (arg1 is UntypedObjectValue cov && arg2 is StringValue sv)
+            {
+                if (cov.Impl.Type is ExternalType et && et.Kind == ExternalTypeKind.Object)
+                {
+                    if (cov.Impl.TryGetProperty(sv.Value, out var res))
+                    {
+                        if (res.Type == FormulaType.Blank)
+                        {
+                            return new BlankValue(node.IRContext);
+                        }
+
+                        return new UntypedObjectValue(node.IRContext, res);
+                    }
+                    else
+                    {
+                        return new BlankValue(node.IRContext);
+                    }
+                }
+                else if (cov.Impl.Type == FormulaType.Blank)
+                {
+                    return new BlankValue(node.IRContext);
+                }
+                else
+                {
+                    return new ErrorValue(node.IRContext, new ExpressionError()
+                    {
+                        Message = "Accessing a field is not valid on this value",
+                        Span = node.IRContext.SourceContext,
+                        Kind = ErrorKind.BadLanguageCode
+                    });
+                }
+            }
+            else if (arg1 is BlankValue)
+            {
+                return new BlankValue(node.IRContext);
+            }
+            else if (arg1 is ErrorValue)
+            {
+                return arg1;
+            }
+            else
+            {
+                return CommonErrors.UnreachableCodeError(node.IRContext);
+            }
+        }
+
+        public override async ValueTask<FormulaValue> Visit(UnaryOpNode node, SymbolContext context)
+        {
+            var arg1 = await node.Child.Accept(this, context);
             var args = new FormulaValue[] { arg1 };
 
             if (UnaryOps.TryGetValue(node.Op, out var unaryOp))
             {
-                return unaryOp(this, context, node.IRContext, args);
+                return await unaryOp(this, context, node.IRContext, args);
             }
 
             return CommonErrors.UnreachableCodeError(node.IRContext);
         }
 
-        public override FormulaValue Visit(AggregateCoercionNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(AggregateCoercionNode node, SymbolContext context)
         {
-            var arg1 = node.Child.Accept(this, context);
+            var arg1 = await node.Child.Accept(this, context);
 
             if (node.Op == UnaryOpKind.TableToTable)
             {
@@ -331,16 +372,20 @@ namespace Microsoft.PowerFx
                 var resultRows = new List<DValue<RecordValue>>();
                 foreach (var row in table.Rows)
                 {
+                    CheckCancel();
+
                     if (row.IsValue)
                     {
                         var fields = new List<NamedValue>();
                         var scopeContext = context.WithScope(node.Scope);
                         foreach (var coercion in node.FieldCoercions)
                         {
+                            CheckCancel();
+
                             var record = row.Value;
                             var newScope = scopeContext.WithScopeValues(record);
 
-                            var newValue = coercion.Value.Accept(this, newScope);
+                            var newValue = await coercion.Value.Accept(this, newScope);
                             var name = coercion.Key;
                             fields.Add(new NamedValue(name.Value, newValue));
                         }
@@ -363,7 +408,7 @@ namespace Microsoft.PowerFx
             return CommonErrors.UnreachableCodeError(node.IRContext);
         }
 
-        public override FormulaValue Visit(ScopeAccessNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(ScopeAccessNode node, SymbolContext context)
         {
             if (node.Value is ScopeAccessSymbol s1)
             {
@@ -384,9 +429,9 @@ namespace Microsoft.PowerFx
             return CommonErrors.UnreachableCodeError(node.IRContext);
         }
 
-        public override FormulaValue Visit(RecordFieldAccessNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(RecordFieldAccessNode node, SymbolContext context)
         {
-            var left = node.From.Accept(this, context);
+            var left = await node.From.Accept(this, context);
 
             if (left is BlankValue)
             {
@@ -404,12 +449,12 @@ namespace Microsoft.PowerFx
             return val;
         }
 
-        public override FormulaValue Visit(SingleColumnTableAccessNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(SingleColumnTableAccessNode node, SymbolContext context)
         {
             return CommonErrors.NotYetImplementedError(node.IRContext, "Single column table access");
         }
 
-        public override FormulaValue Visit(ErrorNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(ErrorNode node, SymbolContext context)
         {
             return new ErrorValue(node.IRContext, new ExpressionError()
             {
@@ -419,17 +464,18 @@ namespace Microsoft.PowerFx
             });
         }
 
-        public override FormulaValue Visit(ColorLiteralNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(ColorLiteralNode node, SymbolContext context)
         {
             return CommonErrors.NotYetImplementedError(node.IRContext, "Color literal");
         }
 
-        public override FormulaValue Visit(ChainingNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(ChainingNode node, SymbolContext context)
         {
+            CheckCancel();
             return CommonErrors.NotYetImplementedError(node.IRContext, "Expression chaining");
         }
 
-        public override FormulaValue Visit(ResolvedObjectNode node, SymbolContext context)
+        public override async ValueTask<FormulaValue> Visit(ResolvedObjectNode node, SymbolContext context)
         {
             return node.Value switch
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public;
@@ -17,12 +18,16 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
-        public delegate FormulaValue FunctionPtr(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args);
+        // Sync FunctionPtr - all args are evaluated before invoking this function.  
+        public delegate FormulaValue FunctionPtr(SymbolContext symbolContext, IRContext irContext, FormulaValue[] args);
+
+        // Async - can invoke lambads.
+        public delegate ValueTask<FormulaValue> AsyncFunctionPtr(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args);
 
         public static IEnumerable<TexlFunction> FunctionList => FuncsByName.Keys;
 
         // Some TexlFunctions are overloaded
-        public static IReadOnlyDictionary<TexlFunction, FunctionPtr> FuncsByName { get; } = new Dictionary<TexlFunction, FunctionPtr>
+        public static IReadOnlyDictionary<TexlFunction, AsyncFunctionPtr> FuncsByName { get; } = new Dictionary<TexlFunction, AsyncFunctionPtr>
         {
             {
                 BuiltinFunctionsCore.Abs,
@@ -1160,7 +1165,7 @@ namespace Microsoft.PowerFx.Functions
             });
         }
 
-        public static FormulaValue Table(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Table(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             // Table literal
             var records = Array.ConvertAll(
@@ -1174,12 +1179,13 @@ namespace Microsoft.PowerFx.Functions
             return new InMemoryTableValue(irContext, records);
         }
 
-        public static FormulaValue Blank(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static ValueTask<FormulaValue> Blank(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
-            return new BlankValue(irContext);
+            var result = new BlankValue(irContext);
+            return new ValueTask<FormulaValue>(result);
         }
 
-        public static FormulaValue IsBlank(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static FormulaValue IsBlank(IRContext irContext, FormulaValue[] args)
         {
             // Blank or empty. 
             var arg0 = args[0];
@@ -1201,20 +1207,20 @@ namespace Microsoft.PowerFx.Functions
             return false;
         }
 
-        public static FormulaValue IsNumeric(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static FormulaValue IsNumeric(IRContext irContext, FormulaValue[] args)
         {
             var arg0 = args[0];
             return new BooleanValue(irContext, arg0 is NumberValue);
         }
 
-        public static FormulaValue With(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> With(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var arg0 = (RecordValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
 
             var childContext = symbolContext.WithScopeValues(arg0);
 
-            return arg1.Eval(runner, childContext);
+            return await arg1.EvalAsync(runner, childContext);
         }
 
         // https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/function-if
@@ -1222,11 +1228,13 @@ namespace Microsoft.PowerFx.Functions
         // If(Condition, Then, Else)
         // If(Condition, Then, Condition2, Then2)
         // If(Condition, Then, Condition2, Then2, Default)
-        public static FormulaValue If(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> If(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             for (var i = 0; i < args.Length - 1; i += 2)
             {
-                var res = runner.EvalArg<BooleanValue>(args[i], symbolContext, args[i].IRContext);
+                runner.CheckCancel();
+
+                var res = await runner.EvalArgAsync<BooleanValue>(args[i], symbolContext, args[i].IRContext);
 
                 if (res.IsValue)
                 {
@@ -1235,7 +1243,7 @@ namespace Microsoft.PowerFx.Functions
                     {
                         var trueBranch = args[i + 1];
 
-                        return runner.EvalArg<ValidFormulaValue>(trueBranch, symbolContext, trueBranch.IRContext).ToFormulaValue();
+                        return (await runner.EvalArgAsync<ValidFormulaValue>(trueBranch, symbolContext, trueBranch.IRContext)).ToFormulaValue();
                     }
                 }
 
@@ -1251,7 +1259,7 @@ namespace Microsoft.PowerFx.Functions
                 if (i + 2 == args.Length - 1)
                 {
                     var falseBranch = args[i + 2];
-                    return runner.EvalArg<ValidFormulaValue>(falseBranch, symbolContext, falseBranch.IRContext).ToFormulaValue();
+                    return (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, symbolContext, falseBranch.IRContext)).ToFormulaValue();
                 }
 
                 // Else, if there are more values, this is another conditional.
@@ -1262,11 +1270,13 @@ namespace Microsoft.PowerFx.Functions
             return new BlankValue(irContext);
         }
 
-        public static FormulaValue IfError(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> IfError(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             for (var i = 0; i < args.Length - 1; i += 2)
             {
-                var res = runner.EvalArg<ValidFormulaValue>(args[i], symbolContext, args[i].IRContext);
+                runner.CheckCancel();
+
+                var res = await runner.EvalArgAsync<ValidFormulaValue>(args[i], symbolContext, args[i].IRContext);
 
                 if (res.IsError)
                 {
@@ -1304,7 +1314,7 @@ namespace Microsoft.PowerFx.Functions
                         new InMemoryRecordValue(
                             IRContext.NotInSource(ifErrorScopeParamType),
                             scopeVariables));
-                    return runner.EvalArg<ValidFormulaValue>(errorHandlingBranch, childContext, errorHandlingBranch.IRContext).ToFormulaValue();
+                    return (await runner.EvalArgAsync<ValidFormulaValue>(errorHandlingBranch, childContext, errorHandlingBranch.IRContext)).ToFormulaValue();
                 }
 
                 if (i + 1 == args.Length - 1)
@@ -1315,7 +1325,7 @@ namespace Microsoft.PowerFx.Functions
                 if (i + 2 == args.Length - 1)
                 {
                     var falseBranch = args[i + 2];
-                    return runner.EvalArg<ValidFormulaValue>(falseBranch, symbolContext, falseBranch.IRContext).ToFormulaValue();
+                    return (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, symbolContext, falseBranch.IRContext)).ToFormulaValue();
                 }
             }
 
@@ -1324,7 +1334,7 @@ namespace Microsoft.PowerFx.Functions
 
         // Error({Kind:<error kind>,Message:<error message>})
         // Error(Table({Kind:<error kind 1>,Message:<error message 1>}, {Kind:<error kind 2>,Message:<error message 2>}))
-        public static FormulaValue Error(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static FormulaValue Error(IRContext irContext, FormulaValue[] args)
         {
             var result = new ErrorValue(irContext);
 
@@ -1367,7 +1377,7 @@ namespace Microsoft.PowerFx.Functions
         // Switch(Formula, Match1, Result1, Match2,Result2)
         // Switch(Formula, Match1, Result1, DefaultResult)
         // Switch(Formula, Match1, Result1)
-        public static FormulaValue Switch(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Switch(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var test = args[0];
 
@@ -1381,7 +1391,7 @@ namespace Microsoft.PowerFx.Functions
             for (var i = 1; i < args.Length - 1; i += 2)
             {
                 var match = (LambdaFormulaValue)args[i];
-                var matchValue = match.Eval(runner, symbolContext);
+                var matchValue = await match.EvalAsync(runner, symbolContext);
 
                 if (matchValue is ErrorValue mve)
                 {
@@ -1395,7 +1405,7 @@ namespace Microsoft.PowerFx.Functions
                 if (equal)
                 {
                     var lambda = (LambdaFormulaValue)args[i + 1];
-                    var result = lambda.Eval(runner, symbolContext);
+                    var result = await lambda.EvalAsync(runner, symbolContext);
                     if (errors.Count != 0)
                     {
                         return ErrorValue.Combine(irContext, errors);
@@ -1413,7 +1423,7 @@ namespace Microsoft.PowerFx.Functions
             if ((args.Length - 4) % 2 == 0)
             {
                 var lambda = (LambdaFormulaValue)args[args.Length - 1];
-                var result = lambda.Eval(runner, symbolContext);
+                var result = await lambda.EvalAsync(runner, symbolContext);
                 if (errors.Count != 0)
                 {
                     return ErrorValue.Combine(irContext, errors);
@@ -1436,18 +1446,20 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // ForAll([1,2,3,4,5], Value * Value)
-        public static FormulaValue ForAll(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> ForAll(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {// Streaming 
             var arg0 = (TableValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
 
-            var rows = LazyForAll(runner, symbolContext, arg0.Rows, arg1);
+            var rowsAsync = LazyForAll(runner, symbolContext, arg0.Rows, arg1);
 
             // TODO: verify semantics in the case of heterogeneous record lists
-            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows.ToArray()));
+            var rows = await Task.WhenAll(rowsAsync);
+
+            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows));
         }
 
-        private static IEnumerable<FormulaValue> LazyForAll(
+        private static IEnumerable<Task<FormulaValue>> LazyForAll(
             EvalVisitor runner,
             SymbolContext context,
             IEnumerable<DValue<RecordValue>> sources,
@@ -1466,19 +1478,19 @@ namespace Microsoft.PowerFx.Functions
                 }
 
                 // Filter evals to a boolean 
-                var result = filter.Eval(runner, childContext);
+                var result = filter.EvalAsync(runner, childContext).AsTask();
 
                 yield return result;
             }
         }
 
-        public static FormulaValue IsError(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> IsError(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var result = args[0] is ErrorValue;
             return new BooleanValue(irContext, result);
         }
 
-        public static FormulaValue IsBlankOrError(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> IsBlankOrError(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             if (IsBlank(args[0]) || args[0] is ErrorValue)
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public.Values;
 
@@ -10,7 +11,7 @@ namespace Microsoft.PowerFx.Functions
 {
     internal partial class Library
     {
-        public static FormulaValue Today(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Today(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             // $$$ timezone?
             var date = DateTime.Today;
@@ -354,12 +355,12 @@ namespace Microsoft.PowerFx.Functions
             return new TimeValue(irContext, result);
         }
 
-        private static FormulaValue Now(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        private static async ValueTask<FormulaValue> Now(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             return new DateTimeValue(irContext, DateTime.Now);
         }
 
-        public static FormulaValue DateParse(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
+        private static async ValueTask<FormulaValue> DateParse(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
         {
             var str = args[0].Value;
             if (DateTime.TryParse(str, runner.CultureInfo, DateTimeStyles.None, out var result))
@@ -372,7 +373,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue DateTimeParse(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
+        public static async ValueTask<FormulaValue> DateTimeParse(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
         {
             var str = args[0].Value;
             if (DateTime.TryParse(str, runner.CultureInfo, DateTimeStyles.None, out var result))
@@ -385,7 +386,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue TimeParse(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
+        public static async ValueTask<FormulaValue> TimeParse(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
         {
             var str = args[0].Value;
             if (TimeSpan.TryParse(str, runner.CultureInfo, out var result))

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryLogical.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryLogical.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public.Values;
 
@@ -14,11 +15,11 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Lazy evaluation 
-        public static FormulaValue And(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> And(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             foreach (var arg in args)
             {
-                var res = runner.EvalArg<BooleanValue>(arg, symbolContext, arg.IRContext);
+                var res = await runner.EvalArgAsync<BooleanValue>(arg, symbolContext, arg.IRContext);
 
                 if (res.IsValue)
                 {
@@ -38,11 +39,13 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Lazy evaluation 
-        public static FormulaValue Or(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Or(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             foreach (var arg in args)
             {
-                var res = runner.EvalArg<BooleanValue>(arg, symbolContext, arg.IRContext);
+                runner.CheckCancel();
+
+                var res = await runner.EvalArgAsync<BooleanValue>(arg, symbolContext, arg.IRContext);
 
                 if (res.IsValue)
                 {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Public.Types;
@@ -151,7 +152,7 @@ namespace Microsoft.PowerFx.Functions
                 if (row.IsValue)
                 {
                     var childContext = context.WithScopeValues(row.Value);
-                    var value = arg1.Eval(runner, childContext);
+                    var value = arg1.EvalAsync(runner, childContext).Result;
 
                     if (value is NumberValue number)
                     {
@@ -186,7 +187,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Sum([1,2,3], Value * Value)     
-        public static FormulaValue SumTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> SumTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             return RunAggregator(new SumAgg(), runner, symbolContext, irContext, args);
         }
@@ -198,7 +199,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Max([1,2,3], Value * Value)     
-        public static FormulaValue MaxTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> MaxTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             return RunAggregator(new MaxAgg(), runner, symbolContext, irContext, args);
         }
@@ -210,7 +211,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Min([1,2,3], Value * Value)     
-        public static FormulaValue MinTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> MinTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             return RunAggregator(new MinAgg(), runner, symbolContext, irContext, args);
         }
@@ -223,7 +224,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Average([1,2,3], Value * Value)     
-        public static FormulaValue AverageTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> AverageTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var arg0 = (TableValue)args[0];
 
@@ -424,7 +425,7 @@ namespace Microsoft.PowerFx.Functions
             return FiniteChecker(irContext, 1, result);
         }
 
-        private static FormulaValue Rand(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        private static async ValueTask<FormulaValue> Rand(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             lock (_randomizerLock)
             {
@@ -466,7 +467,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        private static FormulaValue Pi(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        private static async ValueTask<FormulaValue> Pi(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             return new NumberValue(irContext, Math.PI);
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryOperators.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryOperators.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerFx.Functions
     internal static partial class Library
     {
         #region Operator Standard Error Handling Wrappers
-        public static readonly FunctionPtr OperatorBinaryAdd = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryAdd = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -20,7 +20,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericAdd);
 
-        public static readonly FunctionPtr OperatorBinaryMul = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryMul = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -28,7 +28,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericMul);
 
-        public static readonly FunctionPtr OperatorBinaryDiv = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryDiv = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -36,7 +36,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericDiv);
 
-        public static readonly FunctionPtr OperatorBinaryGt = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryGt = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericGt);
 
-        public static readonly FunctionPtr OperatorBinaryGeq = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryGeq = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericGeq);
 
-        public static readonly FunctionPtr OperatorBinaryLt = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryLt = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -60,7 +60,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericLt);
 
-        public static readonly FunctionPtr OperatorBinaryLeq = StandardErrorHandling<NumberValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryLeq = StandardErrorHandling<NumberValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWithZero,
             checkRuntimeTypes: ExactValueType<NumberValue>,
@@ -68,7 +68,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NumericLeq);
 
-        public static readonly FunctionPtr OperatorBinaryEq = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryEq = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: DeferRuntimeTypeChecking,
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: AreEqual);
 
-        public static readonly FunctionPtr OperatorBinaryNeq = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorBinaryNeq = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: DeferRuntimeTypeChecking,
@@ -84,7 +84,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: NotEqual);
 
-        public static readonly FunctionPtr OperatorTextIn = StandardErrorHandling(
+        public static readonly AsyncFunctionPtr OperatorTextIn = StandardErrorHandling(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: DeferRuntimeTypeChecking,
@@ -92,7 +92,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: StringInOperator(false));
 
-        public static readonly FunctionPtr OperatorTextInExact = StandardErrorHandling(
+        public static readonly AsyncFunctionPtr OperatorTextInExact = StandardErrorHandling(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: DeferRuntimeTypeChecking,
@@ -100,7 +100,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: StringInOperator(true));
 
-        public static readonly FunctionPtr OperatorScalarTableIn = StandardErrorHandling(
+        public static readonly AsyncFunctionPtr OperatorScalarTableIn = StandardErrorHandling(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: DeferRuntimeTypeChecking,
@@ -108,7 +108,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: InScalarTableOperator(false));
 
-        public static readonly FunctionPtr OperatorScalarTableInExact = StandardErrorHandling(
+        public static readonly AsyncFunctionPtr OperatorScalarTableInExact = StandardErrorHandling(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: DeferRuntimeTypeChecking,
@@ -116,7 +116,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: InScalarTableOperator(true));
 
-        public static readonly FunctionPtr OperatorAddDateAndTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorAddDateAndTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: ExactSequence(
@@ -126,7 +126,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: AddDateAndTime);
 
-        public static readonly FunctionPtr OperatorAddDateAndDay = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorAddDateAndDay = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: ExactSequence(
@@ -136,7 +136,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: AddDateAndDay);
 
-        public static readonly FunctionPtr OperatorAddDateTimeAndDay = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorAddDateTimeAndDay = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: ExactSequence(
@@ -146,7 +146,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: AddDateTimeAndDay);
 
-        public static readonly FunctionPtr OperatorDateDifference = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorDateDifference = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: ExactSequence(
@@ -156,7 +156,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: DateDifference);
 
-        public static readonly FunctionPtr OperatorTimeDifference = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorTimeDifference = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: DoNotReplaceBlank,
             checkRuntimeTypes: ExactSequence(
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: TimeDifference);
 
-        public static readonly FunctionPtr OperatorLtDateTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorLtDateTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateTimeValue(IRContext.NotInSource(FormulaType.DateTime), _epoch),
@@ -178,7 +178,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: LtDateTime);
 
-        public static readonly FunctionPtr OperatorLeqDateTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorLeqDateTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateTimeValue(IRContext.NotInSource(FormulaType.DateTime), _epoch),
@@ -190,7 +190,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: LeqDateTime);
 
-        public static readonly FunctionPtr OperatorGtDateTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorGtDateTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateTimeValue(IRContext.NotInSource(FormulaType.DateTime), _epoch),
@@ -202,7 +202,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: GtDateTime);
 
-        public static readonly FunctionPtr OperatorGeqDateTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorGeqDateTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateTimeValue(IRContext.NotInSource(FormulaType.DateTime), _epoch),
@@ -214,7 +214,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: GeqDateTime);
 
-        public static readonly FunctionPtr OperatorLtDate = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorLtDate = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateValue(IRContext.NotInSource(FormulaType.Date), _epoch),
@@ -226,7 +226,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: LtDate);
 
-        public static readonly FunctionPtr OperatorLeqDate = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorLeqDate = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateValue(IRContext.NotInSource(FormulaType.Date), _epoch),
@@ -238,7 +238,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: LeqDate);
 
-        public static readonly FunctionPtr OperatorGtDate = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorGtDate = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateValue(IRContext.NotInSource(FormulaType.Date), _epoch),
@@ -250,7 +250,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: GtDate);
 
-        public static readonly FunctionPtr OperatorGeqDate = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorGeqDate = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new DateValue(IRContext.NotInSource(FormulaType.Date), _epoch),
@@ -262,7 +262,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: GeqDate);
 
-        public static readonly FunctionPtr OperatorLtTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorLtTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new TimeValue(IRContext.NotInSource(FormulaType.Time), TimeSpan.Zero),
@@ -274,7 +274,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: LtTime);
 
-        public static readonly FunctionPtr OperatorLeqTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorLeqTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new TimeValue(IRContext.NotInSource(FormulaType.Time), TimeSpan.Zero),
@@ -286,7 +286,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: LeqTime);
 
-        public static readonly FunctionPtr OperatorGtTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorGtTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new TimeValue(IRContext.NotInSource(FormulaType.Time), TimeSpan.Zero),
@@ -298,7 +298,7 @@ namespace Microsoft.PowerFx.Functions
             returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
             targetFunction: GtTime);
 
-        public static readonly FunctionPtr OperatorGeqTime = StandardErrorHandling<FormulaValue>(
+        public static readonly AsyncFunctionPtr OperatorGeqTime = StandardErrorHandling<FormulaValue>(
             expandArguments: NoArgExpansion,
             replaceBlankValues: ReplaceBlankWith(
                 new TimeValue(IRContext.NotInSource(FormulaType.Time), TimeSpan.Zero),

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Public.Types;
@@ -13,7 +14,7 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
-        public static FormulaValue LookUp(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> LookUp(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             // Streaming 
             var arg0 = (TableValue)args[0];
@@ -31,7 +32,7 @@ namespace Microsoft.PowerFx.Functions
                 else
                 {
                     var childContext = symbolContext.WithScopeValues(row.Value);
-                    var value = arg2.Eval(runner, childContext);
+                    var value = await arg2.EvalAsync(runner, childContext);
 
                     if (value is NumberValue number)
                     {
@@ -80,7 +81,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Create new table
-        public static FormulaValue AddColumns(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> AddColumns(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var sourceArg = (TableValue)args[0];
 
@@ -106,7 +107,7 @@ namespace Microsoft.PowerFx.Functions
 
                     foreach (var column in newColumns)
                     {
-                        var value = column.Lambda.Eval(runner, childContext);
+                        var value = column.Lambda.EvalAsync(runner, childContext).Result;
                         fields.Add(new NamedValue(column.Name, value));
                     }
 
@@ -129,7 +130,7 @@ namespace Microsoft.PowerFx.Functions
             return new NumberValue(irContext, count);
         }
 
-        public static FormulaValue CountIf(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> CountIf(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             // Streaming 
             var sources = (TableValue)args[0];
@@ -144,7 +145,7 @@ namespace Microsoft.PowerFx.Functions
                 if (row.IsValue)
                 {
                     var childContext = symbolContext.WithScopeValues(row.Value);
-                    var result = filter.Eval(runner, childContext);
+                    var result = await filter.EvalAsync(runner, childContext);
 
                     if (result is ErrorValue error)
                     {
@@ -175,7 +176,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Filter ([1,2,3,4,5], Value > 5)
-        public static FormulaValue FilterTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> FilterTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             // Streaming 
             var arg0 = (TableValue)args[0];
@@ -205,7 +206,7 @@ namespace Microsoft.PowerFx.Functions
             return arg0.Index(rowIndex).ToFormulaValue();
         }
 
-        public static FormulaValue SortTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> SortTable(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var arg0 = (TableValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
@@ -216,7 +217,7 @@ namespace Microsoft.PowerFx.Functions
                 if (row.IsValue)
                 {
                     var childContext = symbolContext.WithScopeValues(row.Value);
-                    return new KeyValuePair<DValue<RecordValue>, FormulaValue>(row, arg1.Eval(runner, childContext));
+                    return new KeyValuePair<DValue<RecordValue>, FormulaValue>(row, arg1.EvalAsync(runner, childContext).Result);
                 }
 
                 return new KeyValuePair<DValue<RecordValue>, FormulaValue>(row, row.ToFormulaValue());
@@ -301,7 +302,7 @@ namespace Microsoft.PowerFx.Functions
                     var childContext = context.WithScopeValues(row.Value);
 
                     // Filter evals to a boolean 
-                    var result = filter.Eval(runner, childContext);
+                    var result = filter.EvalAsync(runner, childContext).Result;
                     var include = false;
                     if (result is BooleanValue booleanValue)
                     {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public.Types;
@@ -24,7 +25,7 @@ namespace Microsoft.PowerFx.Functions
             return new StringValue(irContext, str);
         }
 
-        public static FormulaValue Concat(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Concat(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {// Streaming 
             var arg0 = (TableValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
@@ -48,7 +49,7 @@ namespace Microsoft.PowerFx.Functions
 
                     var childContext = symbolContext.WithScopeValues(row.Value);
 
-                    var result = arg1.Eval(runner, childContext);
+                    var result = await arg1.EvalAsync(runner, childContext);
 
                     var str = (StringValue)result;
                     sb.Append(str.Value);
@@ -74,7 +75,7 @@ namespace Microsoft.PowerFx.Functions
 
         // https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/function-value
         // Convert string to number
-        public static FormulaValue Value(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Value(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var arg0 = args[0];
 
@@ -136,7 +137,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // Convert string to boolean
-        public static FormulaValue Boolean(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
+        public static FormulaValue Boolean(IRContext irContext, StringValue[] args)
         {
             var arg0 = args[0];
 
@@ -155,7 +156,7 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/function-text
-        public static FormulaValue Text(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Text(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             // only DateValue and DateTimeValue are supported for now with custom format strings.
             if (args.Length > 1 && args[0] is StringValue)
@@ -260,13 +261,15 @@ namespace Microsoft.PowerFx.Functions
 
         // https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/function-isblank-isempty
         // Take first non-blank value.
-        public static FormulaValue Coalesce(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Coalesce(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             var errors = new List<ErrorValue>();
 
             foreach (var arg in args)
             {
-                var res = runner.EvalArg<ValidFormulaValue>(arg, symbolContext, arg.IRContext);
+                runner.CheckCancel();
+
+                var res = await runner.EvalArgAsync<ValidFormulaValue>(arg, symbolContext, arg.IRContext);
 
                 if (res.IsValue)
                 {
@@ -414,7 +417,7 @@ namespace Microsoft.PowerFx.Functions
             return new StringValue(irContext, result);
         }
 
-        public static FormulaValue Split(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, StringValue[] args)
+        public static FormulaValue Split(IRContext irContext, StringValue[] args)
         {
             var text = args[0].Value;
             var separator = args[1].Value;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.Public.Values;
@@ -15,7 +16,7 @@ namespace Microsoft.PowerFx.Functions
         private static readonly DateTime _epoch = new DateTime(1899, 12, 30, 0, 0, 0, 0);
 
         #region Standard Error Handling Wrappers for Unary Operators
-        public static IReadOnlyDictionary<UnaryOpKind, FunctionPtr> UnaryOps { get; } = new Dictionary<UnaryOpKind, FunctionPtr>()
+        public static IReadOnlyDictionary<UnaryOpKind, AsyncFunctionPtr> UnaryOps { get; } = new Dictionary<UnaryOpKind, AsyncFunctionPtr>()
         {
             {
                 UnaryOpKind.Negate,
@@ -253,7 +254,7 @@ namespace Microsoft.PowerFx.Functions
             return new NumberValue(irContext, result);
         }
 
-        public static FormulaValue NumberToText(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, NumberValue[] args)
+        public static ValueTask<FormulaValue> NumberToText(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, NumberValue[] args)
         {
             return Text(runner, symbolContext, irContext, args);
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue Value_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Value_UO(IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
 
@@ -61,7 +61,7 @@ namespace Microsoft.PowerFx.Functions
             return CommonErrors.RuntimeTypeMismatch(irContext);
         }
 
-        public static FormulaValue Text_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Text_UO(IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
 
@@ -74,7 +74,7 @@ namespace Microsoft.PowerFx.Functions
             return CommonErrors.RuntimeTypeMismatch(irContext);
         }
 
-        public static FormulaValue Table_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Table_UO(IRContext irContext, UntypedObjectValue[] args)
         {
             var tableType = (TableType)irContext.ResultType;
             var resultType = tableType.ToRecord();
@@ -114,7 +114,7 @@ namespace Microsoft.PowerFx.Functions
             return arg;
         }
 
-        public static FormulaValue Boolean_UO(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Boolean_UO(IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Public;
@@ -41,16 +42,16 @@ namespace Microsoft.PowerFx.Functions
         /// <param name="returnBehavior">A flag that can be used to activate pre-defined early return behavior, such as returning Blank() if any argument is Blank().</param>
         /// <param name="targetFunction">The implementation of the builtin function.</param>
         /// <returns></returns>
-        private static FunctionPtr StandardErrorHandling<T>(
+        private static AsyncFunctionPtr StandardErrorHandling<T>(
                 Func<IRContext, IEnumerable<FormulaValue>, IEnumerable<FormulaValue>> expandArguments,
                 Func<IRContext, int, FormulaValue> replaceBlankValues,
                 Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeTypes,
                 Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeValues,
                 ReturnBehavior returnBehavior,
-                Func<EvalVisitor, SymbolContext, IRContext, T[], FormulaValue> targetFunction)
+                Func<EvalVisitor, SymbolContext, IRContext, T[], ValueTask<FormulaValue>> targetFunction)
             where T : FormulaValue
         {
-            return (runner, symbolContext, irContext, args) =>
+            return async (runner, symbolContext, irContext, args) =>
             {
                 var argumentsExpanded = expandArguments(irContext, args);
 
@@ -113,14 +114,14 @@ namespace Microsoft.PowerFx.Functions
                         break;
                 }
 
-                return targetFunction(runner, symbolContext, irContext, runtimeValuesChecked.Select(arg => arg as T).ToArray());
+                return await targetFunction(runner, symbolContext, irContext, runtimeValuesChecked.Select(arg => arg as T).ToArray());
             };
         }
 
         // A wrapper that allows standard error handling to apply to
         // functions which accept the simpler parameter list of
         // an array of arguments, ignoring context, runner etc.
-        private static FunctionPtr StandardErrorHandling<T>(
+        private static AsyncFunctionPtr StandardErrorHandling<T>(
             Func<IRContext, IEnumerable<FormulaValue>, IEnumerable<FormulaValue>> expandArguments,
             Func<IRContext, int, FormulaValue> replaceBlankValues,
             Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeTypes,
@@ -130,13 +131,14 @@ namespace Microsoft.PowerFx.Functions
             where T : FormulaValue
         {
             return StandardErrorHandling<T>(expandArguments, replaceBlankValues, checkRuntimeTypes, checkRuntimeValues, returnBehavior, (runner, symbolContext, irContext, args) =>
-            {
-                return targetFunction(irContext, args);
+            {                
+                var result = targetFunction(irContext, args);
+                return new ValueTask<FormulaValue>(result);
             });
         }
 
         #region Single Column Table Functions
-        public static Func<EvalVisitor, SymbolContext, IRContext, TableValue[], FormulaValue> StandardSingleColumnTable<T>(Func<EvalVisitor, SymbolContext, IRContext, T[], FormulaValue> targetFunction) 
+        public static Func<EvalVisitor, SymbolContext, IRContext, TableValue[], ValueTask<FormulaValue>> StandardSingleColumnTable<T>(Func<EvalVisitor, SymbolContext, IRContext, T[], FormulaValue> targetFunction) 
             where T : FormulaValue
         {
             return (runner, symbolContext, irContext, args) =>
@@ -173,11 +175,12 @@ namespace Microsoft.PowerFx.Functions
                     }
                 }
 
-                return new InMemoryTableValue(irContext, resultRows);
+                var result = new InMemoryTableValue(irContext, resultRows);
+                return new ValueTask<FormulaValue>(result);
             };
         }
 
-        public static Func<EvalVisitor, SymbolContext, IRContext, TableValue[], FormulaValue> StandardSingleColumnTable<T>(Func<IRContext, T[], FormulaValue> targetFunction)
+        public static Func<EvalVisitor, SymbolContext, IRContext, TableValue[], ValueTask<FormulaValue>> StandardSingleColumnTable<T>(Func<IRContext, T[], FormulaValue> targetFunction)
             where T : FormulaValue
         {
             return StandardSingleColumnTable<T>((runner, symbolContext, irContext, args) => targetFunction(irContext, args));
@@ -273,11 +276,11 @@ namespace Microsoft.PowerFx.Functions
          * F([a, b], [c, d]) => [F'([a, c]), F'([b, d])]
          * As a concrete example, Concatenate(["a", "b"], ["1", "2"]) => ["a1", "b2"]
         */
-        public static Func<EvalVisitor, SymbolContext, IRContext, FormulaValue[], FormulaValue> MultiSingleColumnTable(
-            FunctionPtr targetFunction, 
+        public static Func<EvalVisitor, SymbolContext, IRContext, FormulaValue[], ValueTask<FormulaValue>> MultiSingleColumnTable(
+            AsyncFunctionPtr targetFunction, 
             bool transposeEmptyTable)
         {
-            return (runner, symbolContext, irContext, args) =>
+            return async (runner, symbolContext, irContext, args) =>
             {
                 var resultRows = new List<DValue<RecordValue>>();
 
@@ -310,7 +313,7 @@ namespace Microsoft.PowerFx.Functions
 
                     var targetArgs = list.Select((dv, i) => dv.IsValue ? dv.Value.GetField(names[i]) : dv.ToFormulaValue()).ToArray();
 
-                    var namedValue = new NamedValue(BuiltinFunction.OneColumnTableResultNameStr, targetFunction(runner, symbolContext, IRContext.NotInSource(itemType), targetArgs));
+                    var namedValue = new NamedValue(BuiltinFunction.OneColumnTableResultNameStr, await targetFunction(runner, symbolContext, IRContext.NotInSource(itemType), targetArgs));
                     var record = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedValue });
                     resultRows.Add(DValue<RecordValue>.Of(record));
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Microsoft.PowerFx.Interpreter.csproj
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Microsoft.PowerFx.Interpreter.csproj
@@ -20,6 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 		<PackageReference Include="System.Text.Json" Version="5.0.2" />
 		<PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
 		<PackageReference Include="System.Memory" Version="4.5.4" />

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license.
 
 using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Public;
@@ -22,12 +24,13 @@ namespace Microsoft.PowerFx
             _cultureInfo = cultureInfo ?? CultureInfo.CurrentCulture;
         }
 
-        public FormulaValue Eval(RecordValue parameters)
+        public Task<FormulaValue> EvalAsync(RecordValue parameters, CancellationToken cancel)
         {
-            var ev2 = new EvalVisitor(_cultureInfo);
+            var ev2 = new EvalVisitor(_cultureInfo, cancel);            
+
             var newValue = _irnode.Accept(ev2, SymbolContext.NewTopScope(_topScopeSymbol, parameters));
 
-            return newValue;
+            return newValue.AsTask();
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Entities;
@@ -196,6 +198,11 @@ namespace Microsoft.PowerFx
         /// <returns>The formula's result.</returns>
         public FormulaValue Eval(string expressionText, RecordValue parameters = null)
         {
+            return EvalAsync(expressionText, CancellationToken.None, parameters).Result;          
+        }
+
+        public async Task<FormulaValue> EvalAsync(string expressionText, CancellationToken cancel, RecordValue parameters = null)
+        {
             if (parameters == null)
             {
                 parameters = RecordValue.Empty();
@@ -204,7 +211,7 @@ namespace Microsoft.PowerFx
             var check = Check(expressionText, parameters.IRContext.ResultType);
             check.ThrowOnErrors();
 
-            var newValue = check.Expression.Eval(parameters);
+            var newValue = await check.Expression.EvalAsync(parameters, cancel);
             return newValue;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineWorker.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineWorker.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
@@ -69,9 +70,9 @@ namespace Microsoft.PowerFx
                 (var irnode, var ruleScopeSymbol) = IRTranslator.Translate(binding);
 
                 var scope = this;
-                var v = new EvalVisitor(_cultureInfo);
+                var v = new EvalVisitor(_cultureInfo, CancellationToken.None);
 
-                var newValue = irnode.Accept(v, SymbolContext.New());
+                var newValue = irnode.Accept(v, SymbolContext.New()).Result;
 
                 var equal = fi._value != null && // null on initial run. 
                     RuntimeHelpers.AreEqual(newValue, fi._value);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Public.Types;
@@ -152,5 +154,11 @@ namespace Microsoft.PowerFx
 
             return (FormulaValue)result;
         }
+    }
+
+    // A function capable of async invokes. 
+    internal interface IAsyncTexlFunction
+    {
+        Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancel);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Utility.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Utility.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerFx
+{
+    internal static class Utility
+    {
+        // Could also get this from System.Linq.Async nuget. 
+        // https://stackoverflow.com/questions/59380470/convert-iasyncenumerable-to-list
+        public static async Task<List<T>> ToListAsync<T>(
+            this IAsyncEnumerable<T> items,
+            CancellationToken cancellationToken = default)
+        {
+            var results = new List<T>();
+            await foreach (var item in items.WithCancellation(cancellationToken)
+                                            .ConfigureAwait(false))
+            {
+                results.Add(item);
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Values/LambdaFormulaValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Values/LambdaFormulaValue.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.Public.Values;
@@ -22,9 +23,10 @@ namespace Microsoft.PowerFx
             _tree = node;
         }
 
-        public FormulaValue Eval(EvalVisitor runner, SymbolContext context)
+        public async ValueTask<FormulaValue> EvalAsync(EvalVisitor runner, SymbolContext context)
         {
-            var result = _tree.Accept(runner, context);
+            runner.CheckCancel();
+            var result = await _tree.Accept(runner, context);
             return result;
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Public.ExpressionError",
                 "Microsoft.PowerFx.Core.Public.FormulaWithParameters",
                 "Microsoft.PowerFx.Core.Public.IExpression",
+                "Microsoft.PowerFx.Core.Public.IExpressionExtensions",
                 "Microsoft.PowerFx.Core.Public.IPowerFxEngine",
                 "Microsoft.PowerFx.Core.Public.IPowerFxScope",
                 "Microsoft.PowerFx.Core.Public.IPowerFxScopeDisplayName",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -24,9 +24,9 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Converters = { new FormulaTypeJsonConverter() }
         };
 
-        protected static List<string> _sendToClientData;
-        protected static TestPowerFxScopeFactory _scopeFactory;
-        protected static TestLanguageServer _testServer;
+        protected List<string> _sendToClientData;
+        protected TestPowerFxScopeFactory _scopeFactory;
+        protected TestLanguageServer _testServer;
 
         public LanguageServerTests()
         {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(12.0, result.ToObject());
         }
 
-        // Helper for creating a function that waits, and then returns 2x the resu;t
+        // Helper for creating a function that waits, and then returns 2x the result
         private class WaitHelper
         {
             private readonly TaskCompletionSource<FormulaValue> _waiter = new TaskCompletionSource<FormulaValue>();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Core;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Public;
+using Microsoft.PowerFx.Core.Public.Types;
+using Microsoft.PowerFx.Core.Public.Values;
+using Microsoft.PowerFx.Core.Texl;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Xunit;
+using Xunit.Sdk;
+using static Microsoft.PowerFx.Core.Localization.TexlStrings;
+
+namespace Microsoft.PowerFx.Tests
+{
+    // Test async eval features. 
+    public class RecalcEngineAsyncTests
+    {
+        // Trivial async function that runs synchronously. 
+        private static async Task<FormulaValue> Worker(FormulaValue[] args, CancellationToken cancel)
+        {
+            var n = (NumberValue)args[0];
+
+            var result = FormulaValue.New(n.Value * 2);
+            return result;
+        }
+
+        // Call a single async function 
+        [Fact]
+        public async Task SimpleAsync()
+        {
+            var func = new CustomAsyncTexlFunction("CustomAsync", DType.Number, DType.Number)
+            {
+                _impl = Worker
+            };
+
+            var config = new PowerFxConfig(null);
+            config.AddFunction(func);
+
+            var engine = new RecalcEngine(config);
+
+            // Can be invoked. 
+            var cts = new CancellationTokenSource();
+
+            var result = await engine.EvalAsync("CustomAsync(3)", cts.Token);
+            Assert.Equal(6.0, result.ToObject());
+        }
+
+        // Call an expression with multiple asyncs. 
+        [Fact]
+        public async Task MultipleAsync()
+        {
+            var func = new CustomAsyncTexlFunction("CustomAsync", DType.Number, DType.Number)
+            {
+                _impl = Worker
+            };
+
+            var config = new PowerFxConfig(null);
+            config.AddFunction(func);
+
+            var engine = new RecalcEngine(config);
+
+            // Can be invoked. 
+            var cts = new CancellationTokenSource();
+
+            var result = await engine.EvalAsync("If(CustomAsync(3)=6, CustomAsync(1)+CustomAsync(5), 99)", cts.Token);
+            Assert.Equal(12.0, result.ToObject());
+        }
+
+        private class Helper
+        {
+            public TaskCompletionSource<FormulaValue> _waiter = new TaskCompletionSource<FormulaValue>();
+
+            public async Task<FormulaValue> Worker2(FormulaValue[] args, CancellationToken cancel)
+            {
+                await Task.Yield();
+                var result = await _waiter.Task;
+
+                var n = ((NumberValue)result).Value;
+                var x = FormulaValue.New(n * 2);
+
+                return x;
+            }
+        }
+
+        // Verify a custom function can return a non-completed task. 
+        [Fact]
+        public async Task VerifyFunctionIsAsync()
+        {
+            var helper = new Helper();
+            var func = new CustomAsyncTexlFunction("CustomAsync", DType.Number, DType.Number)
+            {
+                _impl = helper.Worker2
+            };
+
+            var config = new PowerFxConfig(null);
+            config.AddFunction(func);
+
+            var engine = new RecalcEngine(config);
+
+            // Can be invoked. 
+            var cts = new CancellationTokenSource();
+
+            var task = engine.EvalAsync("CustomAsync(3)", cts.Token);
+            await Task.Yield();
+
+            // custom func is blocking on our waiter
+            await Task.Delay(TimeSpan.FromMilliseconds(5)); 
+            Assert.False(task.IsCompleted);
+
+            helper._waiter.SetResult(FormulaValue.New(15));
+
+            var result = await task;
+
+            Assert.Equal(30.0, result.ToObject());
+        }
+        
+        private static async Task<FormulaValue> WorkerWaitForCancel(FormulaValue[] args, CancellationToken cancel)
+        {
+            // Block forever until cancellation. 
+            await Task.Delay(-1, cancel); // throws TaskCanceledException
+
+            throw new InvalidOperationException($"Shouldn't get here");
+        }
+
+        // Verify cancellation 
+        [Fact]
+        public async Task Cancel()
+        {
+            var func = new CustomAsyncTexlFunction("CustomAsync", DType.Number, DType.Number)
+            {
+                _impl = WorkerWaitForCancel
+            };
+
+            var config = new PowerFxConfig(null);
+            config.AddFunction(func);
+
+            var engine = new RecalcEngine(config);
+
+            // Can be invoked. 
+            var cts = new CancellationTokenSource();
+
+            var task = engine.EvalAsync("CustomAsync(3)", cts.Token);
+            await Task.Yield();
+
+            // custom func is blocking on our waiter
+            await Task.Delay(TimeSpan.FromMilliseconds(5));
+            Assert.False(task.IsCompleted);
+
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => { await task; });
+        }
+
+        // Verify cancellation 
+        [Fact]
+        public async Task InfiniteLoop()
+        {
+            // Create an expression that will take hang (take very long)
+            var n = 10 * 1000;
+            var expr = $"ForAll(Sequence({n}), ForAll(Sequence({n}), ForAll(Sequence({n}), 5)))";
+
+            var engine = new RecalcEngine();
+
+            // Can be invoked. 
+            var cts = new CancellationTokenSource();
+
+            cts.CancelAfter(5);
+
+            // Eval may never return.             
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await engine.EvalAsync(expr, cts.Token);
+            });
+        }
+
+        // Helper for making async functions. 
+        internal class CustomAsyncTexlFunction : TexlFunction, IAsyncTexlFunction
+        {
+            public Func<FormulaValue[], CancellationToken, Task<FormulaValue>> _impl;
+
+            public override bool SupportsParamCoercion => true;
+
+            public CustomAsyncTexlFunction(string name, FormulaType returnType, params FormulaType[] paramTypes)
+                : this(name, returnType._type, Array.ConvertAll(paramTypes, x => x._type))
+            {
+            }
+
+            public CustomAsyncTexlFunction(string name, DType returnType, params DType[] paramTypes)
+                : base(DPath.Root, name, name, SG("Custom func " + name), FunctionCategories.MathAndStat, returnType, 0, paramTypes.Length, paramTypes.Length, paramTypes)
+            {
+            }
+
+            public override bool IsSelfContained => true;
+
+            public static StringGetter SG(string text)
+            {
+                return (string locale) => text;
+            }
+
+            public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+            {
+                yield return new[] { SG("Arg 1") };
+            }
+
+            public virtual Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancel)
+            {
+                return _impl(args, cancel);
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Public;


### PR DESCRIPTION
Add EvalAsync() to Interpreter and plumb async through EvalVisitor and functions.
Add tests demonstrating true async. 

Still a few .Results to chase down. 

