### PR TITLE
Fix inline table+record bug

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -82,11 +82,8 @@ namespace Microsoft.PowerFx
 
         public override async ValueTask<FormulaValue> Visit(TableNode node, SymbolContext context)
         {
-            // single-column table.
-
             var len = node.Values.Count;
 
-            // Were pushed left-to-right
             var args = new FormulaValue[len];
             for (var i = 0; i < len; i++)
             {
@@ -97,8 +94,8 @@ namespace Microsoft.PowerFx
                 args[i] = arg;
             }
 
-            // Children are on the stack.
-            var tableValue = new InMemoryTableValue(node.IRContext, StandardTableNodeRecords(node.IRContext, args));
+            // This is always a single column table
+            var tableValue = new InMemoryTableValue(node.IRContext, StandardTableNodeRecords(node.IRContext, args, forceSingleColumn: true));
 
             return tableValue;
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1138,23 +1138,23 @@ namespace Microsoft.PowerFx.Functions
             }
         };
 
-        public static IEnumerable<DValue<RecordValue>> StandardTableNodeRecords(IRContext irContext, FormulaValue[] args)
+        public static IEnumerable<DValue<RecordValue>> StandardTableNodeRecords(IRContext irContext, FormulaValue[] args, bool forceSingleColumn)
         {
-            return StandardTableNodeRecordsCore(irContext, args);
+            return StandardTableNodeRecordsCore(irContext, args, forceSingleColumn);
         }
 
-        public static IEnumerable<DValue<RecordValue>> StandardSingleColumnTableFromValues(IRContext irContext, FormulaValue[] args, string columnName)
+        public static IEnumerable<DValue<RecordValue>> StandardSingleColumnTableFromValues(IRContext irContext, FormulaValue[] args, bool forceSingleColumn, string columnName)
         {
-            return StandardTableNodeRecordsCore(irContext, args, columnName);
+            return StandardTableNodeRecordsCore(irContext, args, forceSingleColumn, columnName);
         }
 
-        private static IEnumerable<DValue<RecordValue>> StandardTableNodeRecordsCore(IRContext irContext, FormulaValue[] args, string columnName = BuiltinFunction.ColumnName_ValueStr)
+        private static IEnumerable<DValue<RecordValue>> StandardTableNodeRecordsCore(IRContext irContext, FormulaValue[] args, bool forceSingleColumn, string columnName = BuiltinFunction.ColumnName_ValueStr)
         {
             var tableType = (TableType)irContext.ResultType;
             var recordType = tableType.ToRecord();
             return args.Select(arg =>
             {
-                if (arg is RecordValue record)
+                if (!forceSingleColumn && arg is RecordValue record)
                 {
                     return DValue<RecordValue>.Of(record);
                 }
@@ -1456,7 +1456,7 @@ namespace Microsoft.PowerFx.Functions
             // TODO: verify semantics in the case of heterogeneous record lists
             var rows = await Task.WhenAll(rowsAsync);
 
-            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows));
+            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows, forceSingleColumn: false));
         }
 
         private static IEnumerable<Task<FormulaValue>> LazyForAll(

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -254,7 +254,7 @@ namespace Microsoft.PowerFx.Functions
 
             var rows = LazySequence(records, start, step).Select(n => new NumberValue(IRContext.NotInSource(FormulaType.Number), n));
 
-            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows.ToArray()));
+            return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows.ToArray(), forceSingleColumn: true));
         }
 
         private static IEnumerable<double> LazySequence(double records, double start, double step)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -427,7 +427,7 @@ namespace Microsoft.PowerFx.Functions
             var substrings = string.IsNullOrEmpty(separator) ? text.Select(c => new string(c, 1)) : text.Split(new string[] { separator }, StringSplitOptions.None);
             var rows = substrings.Select(s => new StringValue(IRContext.NotInSource(FormulaType.String), s));
 
-            return new InMemoryTableValue(irContext, StandardSingleColumnTableFromValues(irContext, rows.ToArray(), BuiltinFunction.OneColumnTableResultName));
+            return new InMemoryTableValue(irContext, StandardSingleColumnTableFromValues(irContext, rows.ToArray(), forceSingleColumn: true, columnName: BuiltinFunction.OneColumnTableResultName));
         }
 
         private static FormulaValue Substitute(IRContext irContext, FormulaValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Index.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Index.txt
@@ -40,6 +40,9 @@ Blank()
 >> Index(LastN([1, 2, 3, 4, 5], 3), 1)
 {Value:3}
 
+>> Index([ {a:10, b: "asdf"}, {a: 20, b: "second"}, {a:30, b: "third"}], 1.1).Value.b
+"asdf"
+
 >> Index(Error({Kind: 11}), 1)
 #Error(Kind=Validation)
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Record.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Record.txt
@@ -14,3 +14,9 @@ false
 // valid value in a record In records 
 >> IsBlank({ x : Blank(), y : 2}.x)
 true
+
+>> First([{a: 1}]).Value.a
+1
+
+>> First([{a: 1, b:"abc"}]).Value.b
+"abc"


### PR DESCRIPTION
The [] syntax always creates a single column table, even if it contains records. Adds capability to force single column tables to the helper functions, and adds test coverage for this use. 