### PR TITLE
DateTime function definition / implementation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -188,6 +188,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Year = _library.Append(new YearFunction());
 
         // NOTE: These functions should not be part of the core library until they are implemented in all runtimes
+        public static readonly TexlFunction DateTime = new DateTimeFunction();
         public static readonly TexlFunction Index_UO = new IndexFunction_UO();
         public static readonly TexlFunction ParseJSON = new ParseJSONFunction();
         public static readonly TexlFunction Table_UO = new TableFunction_UO();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -95,6 +95,30 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 
+    // DateTime(year, month, day, hour, minute, second[, millisecond])
+    // Equivalent DAX/Excel function: Time
+    internal sealed class DateTimeFunction : BuiltinFunction
+    {
+        public override bool RequiresErrorContext => true;
+
+        public override bool IsSelfContained => true;
+
+        public override bool HasPreciseErrors => true;
+
+        public override bool SupportsParamCoercion => true;
+
+        public DateTimeFunction()
+            : base("DateTime", TexlStrings.AboutTime, FunctionCategories.DateTime, DType.DateTime, 0, 6, 7, DType.Number, DType.Number, DType.Number, DType.Number, DType.Number, DType.Number, DType.Number)
+        {
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.DateArg1, TexlStrings.DateArg2, TexlStrings.DateArg3, TexlStrings.TimeArg1, TexlStrings.TimeArg2, TexlStrings.TimeArg3 };
+            yield return new[] { TexlStrings.DateArg1, TexlStrings.DateArg2, TexlStrings.DateArg3, TexlStrings.TimeArg1, TexlStrings.TimeArg2, TexlStrings.TimeArg3, TexlStrings.TimeArg4 };
+        }
+    }
+
     // Year()
     // Equivalent DAX/Excel function: Year
     internal sealed class YearFunction : ExtractDateTimeFunctionBase

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -96,7 +96,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     }
 
     // DateTime(year, month, day, hour, minute, second[, millisecond])
-    // Equivalent DAX/Excel function: Time
     internal sealed class DateTimeFunction : BuiltinFunction
     {
         public override bool RequiresErrorContext => true;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -293,6 +293,16 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: DateDiff)
             },
             {
+                BuiltinFunctionsCore.DateTime,
+                StandardErrorHandling<NumberValue>(
+                    expandArguments: InsertDefaultValues(outputArgsCount: 7, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: FiniteChecker,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: DateTimeFunction)
+            },
+            {
                 BuiltinFunctionsCore.DateValue,
                 StandardErrorHandling<StringValue>(
                     expandArguments: NoArgExpansion,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -329,6 +329,11 @@ namespace Microsoft.PowerFx.Functions
             var month = (int)args[1].Value;
             var day = (int)args[2].Value;
 
+            return DateImpl(irContext, year, month, day);
+        }
+
+        private static FormulaValue DateImpl(IRContext irContext, int year, int month, int day)
+        {
             // The final date is built up this way to allow for inputs which overflow,
             // such as: Date(2000, 25, 69) -> 3/10/2002
             var result = new DateTime(year, 1, 1)
@@ -345,6 +350,11 @@ namespace Microsoft.PowerFx.Functions
             var second = (int)args[2].Value;
             var millisecond = (int)args[3].Value;
 
+            return TimeImpl(irContext, hour, minute, second, millisecond);
+        }
+
+        private static FormulaValue TimeImpl(IRContext irContext, int hour, int minute, int second, int millisecond)
+        {
             // The final time is built up this way to allow for inputs which overflow,
             // such as: Time(10, 70, 360) -> 11:16 AM
             var result = new TimeSpan(hour, 0, 0)
@@ -357,8 +367,16 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue DateTimeFunction(IRContext irContext, NumberValue[] args)
         {
-            var date = Date(IRContext.NotInSource(Core.Public.Types.FormulaType.Date), new NumberValue[] { args[0], args[1], args[2] });
-            var time = Time(IRContext.NotInSource(Core.Public.Types.FormulaType.Time), new NumberValue[] { args[3], args[4], args[5], args[6] });
+            var year = (int)args[0].Value;
+            var month = (int)args[1].Value;
+            var day = (int)args[2].Value;
+            var date = DateImpl(IRContext.NotInSource(Core.Public.Types.FormulaType.Date), year, month, day);
+
+            var hour = (int)args[3].Value;
+            var minute = (int)args[4].Value;
+            var second = (int)args[5].Value;
+            var millisecond = (int)args[6].Value;
+            var time = TimeImpl(IRContext.NotInSource(Core.Public.Types.FormulaType.Time), hour, minute, second, millisecond);
 
             var result = AddDateAndTime(irContext, new[] { date, time });
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -355,6 +355,16 @@ namespace Microsoft.PowerFx.Functions
             return new TimeValue(irContext, result);
         }
 
+        public static FormulaValue DateTimeFunction(IRContext irContext, NumberValue[] args)
+        {
+            var date = Date(IRContext.NotInSource(Core.Public.Types.FormulaType.Date), new NumberValue[] { args[0], args[1], args[2] });
+            var time = Time(IRContext.NotInSource(Core.Public.Types.FormulaType.Time), new NumberValue[] { args[3], args[4], args[5], args[6] });
+
+            var result = AddDateAndTime(irContext, new[] { date, time });
+
+            return result;
+        }
+
         private static async ValueTask<FormulaValue> Now(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)
         {
             return new DateTimeValue(irContext, DateTime.Now);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -53,6 +53,7 @@ namespace Microsoft.PowerFx
         // Add Builtin functions that aren't yet in the shared library. 
         private void AddInterpreterFunctions(PowerFxConfig powerFxConfig)
         {
+            powerFxConfig.AddFunction(BuiltinFunctionsCore.DateTime);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Index_UO);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.ParseJSON);
             powerFxConfig.AddFunction(BuiltinFunctionsCore.Table_UO);

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -1923,7 +1923,7 @@
     <value>The millisecond component.</value>
   </data>
   <data name="AboutDateTime" xml:space="preserve">
-    <value>Creates a new date/time value, given its components.</value>
+    <value>Creates a value that represents an instant in time, expressed as a date and time of the day.</value>
     <comment>Description of 'DateTime' function.</comment>
   </data>
   <data name="AboutYear" xml:space="preserve">

--- a/src/strings/en-US/PowerFxResources.resw
+++ b/src/strings/en-US/PowerFxResources.resw
@@ -1922,8 +1922,12 @@
   <data name="AboutTime_millisecond" xml:space="preserve">
     <value>The millisecond component.</value>
   </data>
+  <data name="AboutDateTime" xml:space="preserve">
+    <value>Creates a new date/time value, given its components.</value>
+    <comment>Description of 'DateTime' function.</comment>
+  </data>
   <data name="AboutYear" xml:space="preserve">
-    <value>Year returns the year of a given date, a number greater than 1900.</value>
+    <value>Year returns the year of a given date.</value>
     <comment>Description of 'Year' function.</comment>
   </data>
   <data name="YearArg1" xml:space="preserve">

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
@@ -87,6 +87,10 @@ DateTime(2020,3,3,12,34,0,0)
 >> DateTime(2020, 3, 3, 12, 34, 56, Blank())
 DateTime(2020,3,3,12,34,56,0)
 
+// Strings can be coerced to numbers (Value), booleans can be coerced to numbers (true = 1, false = 0)
+>> DateTime("2022", true, 3, 12, Blank(), false)
+DateTime(2022,1,3,12,0,0,0)
+
 // Errors are returned
 >> DateTime(2020, Sqrt(-1), 23, 1, 2, 3)
 #Error(Kind=Numeric)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
@@ -1,0 +1,64 @@
+>> (Date(2011, 2, 3) + Time(1, 2, 3)) = DateTime(2011, 2, 3, 1, 2, 3)
+true
+
+>> DateTime(2011, 2, 3, 1, 2, 3)
+DateTime(2011,2,3,1,2,3,0)
+
+>> DateTime(2011, 2, 3, 1, 2, 3, 4)
+DateTime(2011,2,3,1,2,3,4)
+
+// Month overflow
+>> DateTime(2021, 13, 14, 0, 0, 0)
+DateTime(2022,1,14,0,0,0,0)
+
+// Month underflow
+>> DateTime(2021, 0, 15, 0, 0, 0)
+DateTime(2020,12,15,0,0,0,0)
+
+// Day overflow
+>> DateTime(2022,2,29,12,34,56,789)
+DateTime(2022,3,1,12,34,56,789)
+
+// Day underflow
+>> DateTime(2020,3,0,1,2,3,4)
+DateTime(2020,2,29,1,2,3,4)
+
+// Hour overflow
+>> DateTime(1987, 12, 16, 24, 0, 0)
+DateTime(1987,12,17,0,0,0,0)
+
+// Hour underflow
+>> DateTime(1988, 1, 2, -1, 0, 0)
+DateTime(1988,1,1,23,0,0,0)
+
+// Minute overflow
+>> DateTime(2000, 3, 6, 12, 185, 0)
+DateTime(2000,3,6,15,5,0,0)
+
+// Minute underflow
+>> DateTime(2001, 1, 2, 2, -1, 59, 999)
+DateTime(2001,1,2,1,59,59,999)
+
+// Second overflow
+>> DateTime(2022, 3, 26, 0, 0, 4000)
+DateTime(2022,3,26,1,6,40,0)
+
+// Second underflow
+>> DateTime(2022, 3, 26, 0, 0, -1)
+DateTime(2022,3,25,23,59,59,0)
+
+// Millisecond overflow
+>> DateTime(2022, 3, 6, 0, 0, 0, 1000)
+DateTime(2022,3,6,4,0,0,1,0)
+
+// Millisecond underflow
+>> DateTime(2022, 3, 15, 12, 34, 56, -1)
+DateTime(2022,3,15,12,34,55,999)
+
+// Millisecond overflow to year
+>> DateTime(2021, 12, 31, 23, 59, 59, 1001)
+DateTime(2022,1,1,0,0,0,1)
+
+// Second underflow to year
+>> DateTime(2021, 1, 1, 0, 0, -1)
+DateTime(2020,12,31,23,59,59)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
@@ -62,3 +62,31 @@ DateTime(2022,1,1,0,0,0,1)
 // Second underflow to year
 >> DateTime(2021, 1, 1, 0, 0, -1)
 DateTime(2020,12,31,23,59,59,0)
+
+// Blanks are interpreted as zero
+>> DateTime(2020, Blank(), 1, 0, 0, 0)
+DateTime(2019,12,1,0,0,0,0)
+
+// Blanks are interpreted as zero
+>> DateTime(2020, 3, Blank(), 0, 0, 0)
+DateTime(2020,2,29,0,0,0,0)
+
+// Blanks are interpreted as zero
+>> DateTime(2020, 3, 3, Blank(), 12, 34)
+DateTime(2020,3,3,0,12,34,0)
+
+// Blanks are interpreted as zero
+>> DateTime(2020, 3, 3, 12, Blank(), 34)
+DateTime(2020,3,3,12,0,34,0)
+
+// Blanks are interpreted as zero
+>> DateTime(2020, 3, 3, 12, 34, Blank())
+DateTime(2020,3,3,12,34,0,0)
+
+// Blanks are interpreted as zero
+>> DateTime(2020, 3, 3, 12, 34, 56, Blank())
+DateTime(2020,3,3,12,34,56,0)
+
+// Errors are returned
+>> DateTime(2020, Sqrt(-1), 23, 1, 2, 3)
+#Error(Kind=Numeric)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateTime.txt
@@ -49,7 +49,7 @@ DateTime(2022,3,25,23,59,59,0)
 
 // Millisecond overflow
 >> DateTime(2022, 3, 6, 0, 0, 0, 1000)
-DateTime(2022,3,6,4,0,0,1,0)
+DateTime(2022,3,6,0,0,1,0)
 
 // Millisecond underflow
 >> DateTime(2022, 3, 15, 12, 34, 56, -1)
@@ -61,4 +61,4 @@ DateTime(2022,1,1,0,0,0,1)
 
 // Second underflow to year
 >> DateTime(2021, 1, 1, 0, 0, -1)
-DateTime(2020,12,31,23,59,59)
+DateTime(2020,12,31,23,59,59,0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
@@ -387,6 +387,12 @@ namespace Microsoft.PowerFx.Core.Tests
                 var date = d.Value;
                 sb.Append($"Date({date.Year},{date.Month},{date.Day})");
             }
+            else if (result is DateTimeValue dt)
+            {
+                // DateTime(yyyy,MM,dd,HH,mm,ss,fff)
+                var dateTime = dt.Value;
+                sb.Append($"DateTime({dateTime.Year},{dateTime.Month},{dateTime.Day},{dateTime.Hour},{dateTime.Minute},{dateTime.Second},{dateTime.Millisecond})");
+            }
             else if (result is ErrorValue)
             {
                 sb.Append(result);


### PR DESCRIPTION
Currently the only way to create a DateTime object is to add together a date object and a time object. Since all other types have a "constructor function", adding it will make expressions that need to create a DateTime object simpler.