### PR TITLE
Change return value of StrInterp suggestion handler

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/StrInterpSuggestionHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/StrInterpSuggestionHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense
                     }
                 }
 
-                return false;
+                return true;
             }
         }
     }


### PR DESCRIPTION
The StrInterpSuggestionHandler differs from the CallNodeSuggestionHandler in that it returns false instead of true at the end of the TryAddSuggestionsForNodeKind method. This PR fixes this small difference.