### PR TITLE
Change TableNode FindNodeVisitor to use the commas

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/FindNodeVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/FindNodeVisitor.cs
@@ -270,18 +270,18 @@ namespace Microsoft.PowerFx.Core.Syntax.Visitors
             }
 
             // Cursor is between the open and closed bracket.
-            for (var i = 0; i < node.Children.Length; i++)
+            for (var i = 0; i < node.Commas.Length; i++)
             {
                 // Cursor position is inside ith child.
-                if (_cursorPosition <= node.Children[i].Token.Span.Lim)
+                if (_cursorPosition <= node.Commas[i].Span.Lim)
                 {
                     node.Children[i].Accept(this);
                     return false;
                 }
             }
 
-            // If we got here the cursor is not within the brackets. return tableNode.
-            _result = node;
+            // If we got here the cursor should be in the last child.
+            node.Children[node.Children.Length - 1].Accept(this);
             return false;
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StringInterpolate.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StringInterpolate.txt
@@ -113,3 +113,12 @@ Errors: Error 9-10: Unexpected characters. Characters are used in the formula in
 
 >> $"Hello {}"
 Errors: Error 9-10: Empty expressions cannot appear inside an interpolated string.
+
+>> $"! { {a:1,b:2}.a } !"
+"! 1 !"
+
+>> $"! {First([{a:1,b:2}.a]).Value} !"
+"! 1 !"
+
+>> First([$"{ {a:1,b:2,c:3}.a }"]).Value
+"1"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -66,6 +66,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("$\"Hello { First(Table({a:{},b:{},c:{}})).| } World\"", "a", "b", "c")]
         [InlineData("$\"Hello { First(Table({a:{},b:{},c:{}})).|   \"", "a", "b", "c")]
         [InlineData("$\"Hello { {a:{},b:{},c:{}}.|  \"", "a", "b", "c")]
+        [InlineData("First([$\"{ {a:1,b:2,c:3}.|", "a", "b", "c")]
         [InlineData("$\"Hello {\"|")]
         [InlineData("$\"Hello {}\"|")]
         [InlineData("$\"Hello {|}\"")]


### PR DESCRIPTION
Change TableNode FindNodeVisitor to use the commas instead of the children. The previous implementation should have never worked.