### PR TITLE
Move IExternalViewInfo to DisplayNameProvider pattern

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalViewInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalViewInfo.cs
@@ -2,13 +2,24 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Entities
 {
-    internal interface IExternalViewInfo : IDisplayMapped<Guid>
+    internal interface IExternalViewInfo : IExternalEntity
     {
+        DisplayNameProvider DisplayNameProvider { get; }
+
+        /// <summary>
+        /// Logical names for the members in this View.
+        /// </summary>
+        IEnumerable<DName> ViewNames { get; }
+
         string Name { get; }
 
         string RelatedEntityName { get; }
+
+        bool IsConvertingDisplayNameMapping { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -430,6 +430,7 @@ namespace Microsoft.PowerFx.Core.Types
             OptionSetInfo = null;
             ViewInfo = info;
             NamedValueKind = null;
+            DisplayNameProvider = info.DisplayNameProvider;
             AssertValid();
         }
 
@@ -451,6 +452,7 @@ namespace Microsoft.PowerFx.Core.Types
             OptionSetInfo = null;
             ViewInfo = info;
             NamedValueKind = null;
+            DisplayNameProvider = info.DisplayNameProvider;
             AssertValid();
         }
 
@@ -820,10 +822,10 @@ namespace Microsoft.PowerFx.Core.Types
 
             var typedNames = new List<TypedName>();
 
-            foreach (var kvp in info.DisplayNameMapping)
+            foreach (var name in info.ViewNames)
             {
                 var type = new DType(DKind.ViewValue, info);
-                typedNames.Add(new TypedName(type, new DName(kvp.Key.ToString())));
+                typedNames.Add(new TypedName(type, name));
             }
 
             return new DType(DKind.View, TypeTree.Create(typedNames.Select(TypedNameToKVP)), info);
@@ -2357,18 +2359,6 @@ namespace Microsoft.PowerFx.Core.Types
 
         internal static bool TryGetDisplayNameForColumn(DType type, string logicalName, out string displayName)
         {
-            // If the type is an view, the view info has the mapping
-            if (type != null && type.IsView && type.ViewInfo != null)
-            {
-                if (System.Guid.TryParse(logicalName, out var value) && type.ViewInfo.DisplayNameMapping.TryGetFromFirst(value, out displayName))
-                {
-                    return true;
-                }
-
-                displayName = null;
-                return false;
-            }
-
             // If we are accessing an entity, then the entity info contains the mapping
             if (TryGetEntityMetadataForDisplayNames(type, out var entityMetadata))
             {
@@ -2407,19 +2397,6 @@ namespace Microsoft.PowerFx.Core.Types
 
         internal static bool TryGetLogicalNameForColumn(DType type, string displayName, out string logicalName, bool isThisItem = false)
         {
-            // If the type is a view, the view info has the mapping
-            if (type != null && type.IsView && !isThisItem && type.ViewInfo != null)
-            {
-                if (type.ViewInfo.DisplayNameMapping.TryGetFromSecond(displayName, out var value))
-                {
-                    logicalName = value.ToString();
-                    return true;
-                }
-
-                logicalName = null;
-                return false;
-            }
-
             // If we are accessing an entity, then the entity info contains the mapping
             if (TryGetEntityMetadataForDisplayNames(type, out var entityMetadata))
             {
@@ -2481,29 +2458,6 @@ namespace Microsoft.PowerFx.Core.Types
         /// </returns>
         internal static bool TryGetConvertedDisplayNameAndLogicalNameForColumn(DType type, string displayName, out string logicalName, out string newDisplayName)
         {
-            // If the type is a view, the info has the mapping
-            if (type != null && type.IsView && type.ViewInfo != null)
-            {
-                if (type.ViewInfo.IsConvertingDisplayNameMapping &&
-                    type.ViewInfo.PreviousDisplayNameMapping != null &&
-                    type.ViewInfo.PreviousDisplayNameMapping.TryGetFromSecond(displayName, out var value))
-                {
-                    logicalName = value.ToString();
-                    if (type.ViewInfo.DisplayNameMapping.TryGetFromFirst(value, out newDisplayName))
-                    {
-                        return true;
-                    }
-
-                    // Converting and no new mapping exists for this column, so the display name is also the logical name
-                    newDisplayName = logicalName;
-                    return true;
-                }
-
-                logicalName = null;
-                newDisplayName = null;
-                return false;
-            }
-
             // If we are accessing an entity, then the entity info contains the mapping
             if (TryGetEntityMetadataForDisplayNames(type, out var entityMetadata))
             {


### PR DESCRIPTION
DisplayNameProvider is the preferred approach to handling display names. This PR continues the work of several previous ones, moving away from the approach of` IDisplayMapped<T>` for another IExternal type. 