### PR TITLE
Fix null reference exception in EnumStoreBuilder

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStoreBuilder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStoreBuilder.cs
@@ -380,7 +380,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
         {
             Contracts.AssertNonEmpty(name);
 
-            return _enumSpec.TryGetValue(name, out dType);
+            return EnumSpec.TryGetValue(name, out dType);
         }
 
         internal DType GetEnum(string name)


### PR DESCRIPTION
This change reverts an incorrect change to EnumStoreBuilder