### PR TITLE
Remove unused methods and fields from EnumStore/Builder

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Intellisense.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Intellisense.cs
@@ -22,9 +22,9 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense
     internal partial class Intellisense : IIntellisense
     {
         protected readonly IReadOnlyList<ISuggestionHandler> _suggestionHandlers;
-        protected readonly EnumStore _enumStore;
+        protected readonly IEnumStore _enumStore;
 
-        public Intellisense(EnumStore enumStore, IReadOnlyList<ISuggestionHandler> suggestionHandlers)
+        public Intellisense(IEnumStore enumStore, IReadOnlyList<ISuggestionHandler> suggestionHandlers)
         {
             Contracts.AssertValue(suggestionHandlers);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -18,9 +18,9 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense.IntellisenseData
     // The IntellisenseData class contains the pre-parsed data for Intellisense to provide suggestions
     internal class IntellisenseData : IIntellisenseData
     {
-        private readonly EnumStore _enumStore;
+        private readonly IEnumStore _enumStore;
 
-        public IntellisenseData(EnumStore enumStore, IIntellisenseContext context, DType expectedType, TexlBinding binding, TexlFunction curFunc, TexlNode curNode, int argIndex, int argCount, IsValidSuggestion isValidSuggestionFunc, IList<DType> missingTypes, List<CommentToken> comments)
+        public IntellisenseData(IEnumStore enumStore, IIntellisenseContext context, DType expectedType, TexlBinding binding, TexlFunction curFunc, TexlNode curNode, int argIndex, int argCount, IsValidSuggestion isValidSuggestionFunc, IList<DType> missingTypes, List<CommentToken> comments)
         {
             Contracts.AssertValue(context);
             Contracts.AssertValid(expectedType);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense
             new Intellisense.RecordNodeSuggestionHandler(),
         };
 
-        internal static IIntellisense GetIntellisense(EnumStore enumStore)
+        internal static IIntellisense GetIntellisense(IEnumStore enumStore)
         {
             return new Intellisense(enumStore, SuggestionHandlers);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStore.cs
@@ -1,33 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Types.Enums
 {
-    internal sealed class EnumStore
+    internal sealed class EnumStore : IEnumStore
     {
-        internal IEnumerable<EnumSymbol> EnumSymbols { get; }
+        public IEnumerable<EnumSymbol> EnumSymbols { get; }
 
-        private readonly IEnumerable<Tuple<DName, DName, DType>> _enumsWithTypes;
-
-        private EnumStore(IEnumerable<EnumSymbol> enumSymbols, IEnumerable<Tuple<DName, DName, DType>> enumsWithTypes)
+        private EnumStore(IEnumerable<EnumSymbol> enumSymbols)
         {
             EnumSymbols = enumSymbols;
-            _enumsWithTypes = enumsWithTypes;
         }
 
-        internal static EnumStore Build(IEnumerable<EnumSymbol> enumSymbols, IEnumerable<Tuple<DName, DName, DType>> enumsWithTypes)
+        internal static EnumStore Build(IEnumerable<EnumSymbol> enumSymbols)
         {
-            return new EnumStore(enumSymbols, enumsWithTypes);
-        }
-
-        internal IEnumerable<Tuple<DName, DName, DType>> Enums()
-        {
-            return _enumsWithTypes;
+            return new EnumStore(enumSymbols);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/IEnumStore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/IEnumStore.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.PowerFx.Core.Types.Enums
+{
+    internal interface IEnumStore
+    {
+        IEnumerable<EnumSymbol> EnumSymbols { get; }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -508,7 +508,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.True(checkResult.IsSuccess);
             Assert.IsType<StringType>(checkResult.ReturnType);
 
-            var enums = config.EnumStoreBuilder.Build().Enums();
+            var enums = config.EnumStoreBuilder.Build().EnumSymbols;
 
             Assert.True(enums.Count() > 0);
         }


### PR DESCRIPTION
Continuing the story of cleaning up EnumStore, this change introduces the IEnumStore interface and changes Intellisense classes to use the new interface. The old EnumStore will be added to PA Client with a new class named LegacyEnumStore, which will implement IEnumStore. This old code was fragile and cannot be changed.