### PR TITLE
Improve null safety of TryGetValidDataSourceForDelegation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1114,6 +1114,11 @@ namespace Microsoft.PowerFx.Core.Functions
                 return false;
             }
 
+            if (dataSource == null)
+            {
+                return false;
+            }
+
             // Check if DS is server delegatable.
             return dataSource.IsDelegatable &&
                     dataSource.DelegationMetadata.VerifyValue().TableCapabilities.HasCapability(expectedCapability.Capabilities);


### PR DESCRIPTION
We are using out parameters to functions which return a boolean. It is possible that the boolean is true even though the out param is set to null. This may have a root cause elsewhere, however we should still improve the null safety of this code to prevent crashes.