### PR TITLE
Fix ErrorResource locale bug

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -25,8 +25,6 @@ namespace Microsoft.PowerFx.Core.Localization
         // If the dependency on ExternalStringResources is removed, this can be as well
         public static bool ShouldThrowIfMissing { get; set; } = true;
 
-        private const string FallbackLocale = "en-US";
-
         private static readonly ThreadSafeResouceManager _resourceManager = new ThreadSafeResouceManager();
 
         [ThreadSafeProtectedByLockAttribute("_errorResources")]

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -99,7 +99,8 @@ namespace Microsoft.PowerFx.Core.Localization
 
             if (string.IsNullOrEmpty(locale))
             {
-                locale = FallbackLocale;
+                locale = CultureInfo.CurrentUICulture.Name;
+                Contracts.CheckNonEmpty(locale, "currentLocale");
             }
 
             // Error resources are a bit odd and need to be reassembled from separate keys.

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerFx.Core.Localization
             if (string.IsNullOrEmpty(locale))
             {
                 locale = CultureInfo.CurrentUICulture.Name;
-                Contracts.CheckNonEmpty(locale, "currentLocale");
+                Contracts.CheckNonEmpty(locale, "locale");
             }
 
             // Error resources are a bit odd and need to be reassembled from separate keys.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerFx.Tests
         }        
 
         [Fact]
-        public void TestNonEnUSLoads()
+        public void TestErrorResourceImport()
         {
             var error = StringResources.GetErrorResource(TexlStrings.ErrIncompatibleTypesForEquality_Left_Right);
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
@@ -54,6 +54,8 @@ namespace Microsoft.PowerFx.Tests
         public void TestResourceImportUsesCurrentUICulture()
         {
             var initialCulture = CultureInfo.CurrentUICulture;
+            var enUsERContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken);
+            var enUsBasicContent = StringResources.Get("AboutAbs");
 
             var loaded = string.Empty;
             var loadedCount = 0;
@@ -68,11 +70,17 @@ namespace Microsoft.PowerFx.Tests
                 AppDomain.CurrentDomain.AssemblyLoad += ResourceAssemblyLoadHandler;
                 CultureInfo.CurrentUICulture = CultureInfo.CreateSpecificCulture("fr-FR");
 
-                var generalError = StringResources.Get("ErrGeneralError");
+                var frERContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken);
+                var frBasicContent = StringResources.Get("AboutAbs");
                 Assert.Contains("fr-FR", loaded);
 
                 // No other assemblies were loaded
                 Assert.Equal(1, loadedCount);
+
+                // Strings are not the same as enUS
+                // Not validating content directly, since it might change
+                Assert.NotEqual(enUsBasicContent, frBasicContent);
+                Assert.NotEqual(enUsERContent.GetSingleValue(ErrorResource.ShortMessageTag), frERContent.GetSingleValue(ErrorResource.ShortMessageTag));
             }
             finally
             {


### PR DESCRIPTION
Basic strings looked up using the correct locale, but error resources were using the fallback. This fixes the issue and adds a test to catch that. 