### PR TITLE
Expose ParseResult.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseResult.cs
@@ -2,29 +2,50 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Lexer.Tokens;
+using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Syntax.Nodes;
 using Microsoft.PowerFx.Core.Syntax.SourceInformation;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Parser
 {
-    internal class ParseResult
+    /// <summary>
+    /// Result of parsing an expression. 
+    /// </summary>
+    public class ParseResult : IOperationStatus
     {
-        internal TexlNode Root { get; }
+        /// <summary>
+        /// The top level node. Not null.
+        /// </summary>
+        public TexlNode Root { get; }
 
-        internal List<TexlError> Errors { get; }
+        internal readonly List<TexlError> _errors;
 
+        /// <summary>
+        /// List of errors or warnings. Check <see cref="ExpressionError.IsWarning"/>.
+        /// </summary>
+        public IEnumerable<ExpressionError> Errors => ExpressionError.New(_errors);
+
+        /// <summary>
+        /// True if there were parse errors. 
+        /// </summary>
         internal bool HasError { get; }
 
+        /// <summary>
+        /// True if no errors. 
+        /// </summary>
+        public bool IsSuccess => !HasError;
+        
         internal List<CommentToken> Comments { get; }
 
         internal SourceList Before { get; }
 
         internal SourceList After { get; }
 
-        public ParseResult(TexlNode root, List<TexlError> errors, bool hasError, List<CommentToken> comments, SourceList before, SourceList after)
+        internal ParseResult(TexlNode root, List<TexlError> errors, bool hasError, List<CommentToken> comments, SourceList before, SourceList after)
         {
             Contracts.AssertValue(root);
             Contracts.AssertValue(comments);
@@ -33,7 +54,7 @@ namespace Microsoft.PowerFx.Core.Parser
             Contracts.Assert(errors != null ? hasError : true);
 
             Root = root;
-            Errors = errors;
+            _errors = errors;
             HasError = hasError;
             Comments = comments;
             Before = before;

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Parser;
+
+namespace Microsoft.PowerFx.Core.Public
+{
+    /// <summary>
+    /// Options for parsing an expression.
+    /// </summary>
+    public class ParserOptions
+    {
+        /// <summary>
+        /// If true, allow parsing a chaining operator. This is only used for side-effecting operations.
+        /// </summary>
+        public bool AllowsSideEffects { get; set; }
+                
+        internal ParseResult Parse(string script)
+        {
+            var flags = AllowsSideEffects ? TexlParser.Flags.EnableExpressionChaining : TexlParser.Flags.None;
+            ILanguageSettings loc = null;
+
+            return TexlParser.ParseScript(script, loc, flags);
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Parser;
 using Microsoft.PowerFx.Core.Public.Types;
 using Microsoft.PowerFx.Core.Syntax;
 using Microsoft.PowerFx.Core.Utils;
@@ -13,9 +14,9 @@ using Microsoft.PowerFx.Core.Utils;
 namespace Microsoft.PowerFx.Core.Public
 {
     /// <summary>
-    /// Result of checking an expression. 
+    /// Result of binding an expression. 
     /// </summary>
-    public class CheckResult
+    public class CheckResult : IOperationStatus
     {
         // Null if type can't be determined. 
         public FormulaType ReturnType { get; set; }
@@ -28,32 +29,42 @@ namespace Microsoft.PowerFx.Core.Public
         public HashSet<string> TopLevelIdentifiers { get; set; }
 
         /// <summary>
-        /// List of errors or warnings. Check <see cref="ExpressionError.Severity"/>.
+        /// List of errors or warnings. Check <see cref="ExpressionError.IsWarning"/>.
+        /// Not null, but empty on success.
         /// </summary>
-        public ExpressionError[] Errors { get; set; }
+        public IEnumerable<ExpressionError> Errors => Parse.Errors.Concat(ExpressionError.New(_binding.ErrorContainer.GetErrors()));
 
         /// <summary>
-        /// Parsed expression, or null if IsSuccess is false.
+        /// Parsed expression for evaluation. 
+        /// Null on failure or if there is no evaluation. 
         /// </summary>
         public IExpression Expression { get; set; }
 
         /// <summary>
         /// True if no errors. 
         /// </summary>
-        public bool IsSuccess => Errors == null || !Errors.Any(x => x.Severity > DocumentErrorSeverity.Warning);
+        public bool IsSuccess => !Errors.Any(x => !x.IsWarning);
 
         internal TexlBinding _binding;
 
-        internal Formula _formula;
+        /// <summary>
+        /// Results from parsing. 
+        /// </summary>
+        public ParseResult Parse { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CheckResult"/> class.
+        /// </summary>
         public CheckResult()
         {
         }
 
-        internal CheckResult(IEnumerable<IDocumentError> errors, TexlBinding binding = null)
+        internal CheckResult(ParseResult parse, TexlBinding binding = null)
         {
+            var errors = parse.HasError ? parse._errors : binding.ErrorContainer.GetErrors();
+            Parse = parse;
+
             _binding = binding;
-            SetErrors(errors);
         }
 
         public void ThrowOnErrors()
@@ -66,25 +77,14 @@ namespace Microsoft.PowerFx.Core.Public
         }
 
         internal IReadOnlyDictionary<string, TokenResultType> GetTokens(GetTokensFlags flags) => GetTokensUtils.GetTokens(_binding, flags);
+    }
 
-        internal CheckResult SetErrors(IEnumerable<IDocumentError> errors)
-        {
-            if (errors == null)
-            {
-                Errors = new ExpressionError[0];
-            }
-            else
-            {
-                Errors = errors.Select(x => new ExpressionError
-                {
-                    Message = x.ShortMessage,
-                    Span = x.TextSpan,
-                    Severity = x.Severity,
-                    MessageKey = x.MessageKey
-                }).ToArray();
-            }
+    // Internal interface to ensure that Result objects have a common contract
+    // for error reporting. 
+    internal interface IOperationStatus
+    {
+        public IEnumerable<ExpressionError> Errors { get; }
 
-            return this;
-        }
+        public bool IsSuccess { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -18,21 +18,27 @@ namespace Microsoft.PowerFx.Core.Public
     /// </summary>
     public class CheckResult : IOperationStatus
     {
-        // Null if type can't be determined. 
+        /// <summary> 
+        /// Return type of the expression. Null if type can't be determined. 
+        /// </summary>
         public FormulaType ReturnType { get; set; }
 
         /// <summary>
         /// Names of fields that this formula uses. 
         /// null if unavailable.  
-        /// This is only valid if there are no errors. 
+        /// This is only valid when <see cref="IsSuccess"/> is true.
         /// </summary>
         public HashSet<string> TopLevelIdentifiers { get; set; }
 
         /// <summary>
-        /// List of errors or warnings. Check <see cref="ExpressionError.IsWarning"/>.
+        /// List of errors and warnings. Check <see cref="ExpressionError.IsWarning"/>.
         /// Not null, but empty on success.
         /// </summary>
-        public IEnumerable<ExpressionError> Errors => Parse.Errors.Concat(ExpressionError.New(_binding.ErrorContainer.GetErrors()));
+        public IEnumerable<ExpressionError> Errors => Parse != null ?
+            Parse.Errors.Concat(BindingErrors) :
+            BindingErrors;
+
+        private IEnumerable<ExpressionError> BindingErrors => ExpressionError.New(_binding.ErrorContainer.GetErrors());
 
         /// <summary>
         /// Parsed expression for evaluation. 
@@ -61,9 +67,8 @@ namespace Microsoft.PowerFx.Core.Public
 
         internal CheckResult(ParseResult parse, TexlBinding binding = null)
         {
-            var errors = parse.HasError ? parse._errors : binding.ErrorContainer.GetErrors();
-            Parse = parse;
-
+            Parse = parse ?? throw new ArgumentNullException(nameof(parse));
+           
             _binding = binding;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -101,11 +101,8 @@ namespace Microsoft.PowerFx
         /// <returns></returns>
         public CheckResult Check(ParseResult parse, RecordType parameterType = null)
         {
-            if (parameterType == null)
-            {
-                parameterType = new RecordType();
-            }
-            
+            parameterType ??= new RecordType();
+                        
             // Ok to continue with binding even if there are parse errors. 
             // We can still use that for intellisense. 
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -68,22 +68,44 @@ namespace Microsoft.PowerFx
             => TexlLexer.LocalizedInstance.GetTokens(expressionText);
 
         /// <summary>
-        /// Type check a formula without executing it. 
+        /// Parse the expression without doing any binding.
         /// </summary>
         /// <param name="expressionText"></param>
-        /// <param name="parameterType"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public ParseResult Parse(string expressionText, ParserOptions options = null)
+        {
+            options ??= new ParserOptions();
+
+            var result = options.Parse(expressionText);
+            return result;
+        }
+
+        /// <summary>
+        /// Parse and Bind an expression. 
+        /// </summary>
+        /// <param name="expressionText">the expression in plain text. </param>
+        /// <param name="parameterType">types of additional args to pass.</param>
         /// <returns></returns>
         public CheckResult Check(string expressionText, RecordType parameterType = null)
+        {
+            var parse = Parse(expressionText);
+            return Check(parse, parameterType);
+        }
+
+        /// <summary>
+        /// Type check a formula without executing it. 
+        /// </summary>
+        /// <param name="parse">the parsed expression. Obtain from <see cref="Parse(string)"/>.</param>
+        /// <param name="parameterType">types of additional args to pass.</param>
+        /// <returns></returns>
+        public CheckResult Check(ParseResult parse, RecordType parameterType = null)
         {
             if (parameterType == null)
             {
                 parameterType = new RecordType();
             }
-
-            var formula = new Formula(expressionText);
-
-            formula.EnsureParsed(TexlParser.Flags.None);
-
+            
             // Ok to continue with binding even if there are parse errors. 
             // We can still use that for intellisense. 
 
@@ -91,17 +113,12 @@ namespace Microsoft.PowerFx
 
             var binding = TexlBinding.Run(
                 new Glue2DocumentBinderGlue(),
-                formula.ParseTree,
+                parse.Root,
                 resolver,
                 ruleScope: parameterType._type,
                 useThisRecordForRuleScope: false);
 
-            var errors = formula.HasParseErrors ? formula.GetParseErrors() : binding.ErrorContainer.GetErrors();
-
-            var result = new CheckResult(errors, binding)
-            {
-                _formula = formula,
-            };
+            var result = new CheckResult(parse, binding);
 
             if (result.IsSuccess)
             {
@@ -146,7 +163,8 @@ namespace Microsoft.PowerFx
         {
             var result = Check(expression, parameterType);
             var binding = result._binding;
-            var formula = result._formula;
+            var formula = new Formula(expression, null);
+            formula.ApplyParse(result.Parse);
 
             var context = new IntellisenseContext(expression, cursorPosition);
             var intellisense = CreateIntellisense();

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ExpressionError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ExpressionError.cs
@@ -1,33 +1,79 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Public.Values;
 
 namespace Microsoft.PowerFx.Core.Public
 {
+    /// <summary>
+    /// Error message. This could be a compile time error from parsing or binding, 
+    /// or it could be a runtime error wrapped in a <see cref="ErrorValue"/>.
+    /// </summary>
     public class ExpressionError
     {
+        /// <summary>
+        /// A description of the error message. 
+        /// </summary>
         public string Message { get; set; }
 
+        /// <summary>
+        /// Source location for this error.
+        /// </summary>
         public Span Span { get; set; }
 
+        /// <summary>
+        /// Runtime error code.This may be empty for compile-time errors. 
+        /// </summary>
         public ErrorKind Kind { get; set; }
 
-        public DocumentErrorSeverity Severity { get; set; }
+        public DocumentErrorSeverity Severity { get; set; } = DocumentErrorSeverity.Severe;
 
         public string MessageKey { get; set; }
 
+        /// <summary>
+        /// A warning does not prevent executing the error. See <see cref="Severity"/> for more details.
+        /// </summary>
+        public bool IsWarning => Severity < DocumentErrorSeverity.Severe;
+
         public override string ToString()
         {
+            var prefix = IsWarning ? "Warning" : "Error";
             if (Span != null)
             {
-                return $"Error {Span.Min}-{Span.Lim}: {Message}";
+                return $"{prefix} {Span.Min}-{Span.Lim}: {Message}";
             }
             else
             {
-                return $"Error {Message}";
+                return $"{prefix} {Message}";
             }    
+        }
+
+        // Build the public object from an internal error object. 
+        internal static ExpressionError New(IDocumentError error)
+        {
+            return new ExpressionError
+            {
+                Message = error.ShortMessage,
+                Span = error.TextSpan,
+                Severity = error.Severity,
+                MessageKey = error.MessageKey
+            };
+        }
+
+        internal static IEnumerable<ExpressionError> New(IEnumerable<IDocumentError> errors)
+        {
+            if (errors == null)
+            {
+                return new ExpressionError[0];
+            }
+            else
+            {
+                return errors.Select(x => ExpressionError.New(x)).ToArray();
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/ErrorValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/ErrorValue.cs
@@ -6,6 +6,9 @@ using Microsoft.PowerFx.Core.IR;
 
 namespace Microsoft.PowerFx.Core.Public.Values
 {
+    /// <summary>
+    /// A Runtime error. 
+    /// </summary>
     public class ErrorValue : FormulaValue
     {
         private readonly List<ExpressionError> _errors = new List<ExpressionError>();

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Formula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Formula.cs
@@ -13,9 +13,13 @@ using Conditional = System.Diagnostics.ConditionalAttribute;
 
 namespace Microsoft.PowerFx.Core.Syntax
 {
-    // This encapsulates a Texl formula, its parse tree and any parse errors. Note that
-    // it doesn't include TexlBinding information, since that depends on context, while parsing
-    // does not.
+    /// <summary>
+    /// This encapsulates a Texl formula, its parse tree and any parse errors. Note that
+    /// it doesn't include TexlBinding information, since that depends on context, while parsing
+    /// does not.
+    /// This a <see cref="ParseResult"/> plus the original expression text. 
+    /// This is also used by intellisense. 
+    /// </summary>
     internal sealed class Formula
     {
         public readonly string Script;
@@ -66,15 +70,20 @@ namespace Microsoft.PowerFx.Core.Syntax
             if (ParseTree == null)
             {
                 var result = TexlParser.ParseScript(Script, loc: Loc, flags: flags);
-                ParseTree = result.Root;
-                _errors = result.Errors;
-                Comments = result.Comments;
-                HasParseErrors = result.HasError;
-                Contracts.AssertValue(ParseTree);
-                AssertValid();
+                ApplyParse(result);
             }
 
             return _errors == null;
+        }
+
+        internal void ApplyParse(ParseResult result)
+        {
+            ParseTree = result.Root;
+            _errors = result._errors;
+            Comments = result.Comments;
+            HasParseErrors = result.HasError;
+            Contracts.AssertValue(ParseTree);
+            AssertValid();
         }
 
         public IEnumerable<TexlError> GetParseErrors()

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Web;
 using Microsoft.PowerFx.Core;
@@ -142,7 +143,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             var expression = didOpenParams.TextDocument.Text;
             var result = scope.Check(expression);
 
-            PublishDiagnosticsNotification(documentUri, expression, result.Errors);
+            PublishDiagnosticsNotification(documentUri, expression, result.Errors.ToArray());
 
             PublishTokens(documentUri, result);
 
@@ -173,7 +174,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             var expression = didChangeParams.ContentChanges[0].Text;
             var result = scope.Check(expression);
 
-            PublishDiagnosticsNotification(documentUri, expression, result.Errors);
+            PublishDiagnosticsNotification(documentUri, expression, result.Errors.ToArray());
 
             PublishTokens(documentUri, result);
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -47,9 +47,13 @@ namespace Microsoft.PowerFx.Tests
 
             var r = new RecordType().Add(
                    new NamedFormulaType("x", FormulaType.Number));
-
+                        
             var check = engine.Check(parse, r);
             Assert.True(check.IsSuccess);
+
+            // Can reuse Parse 
+            var check2 = engine.Check(parse, r);
+            Assert.True(check2.IsSuccess);
         }
 
         // Parse and Bind separately. 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using Microsoft.PowerFx.Core;
+using Microsoft.PowerFx.Core.Public;
 using Microsoft.PowerFx.Core.Public.Types;
 using Microsoft.PowerFx.Core.Tests;
 using Xunit;
@@ -28,6 +29,64 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal("x", result.TopLevelIdentifiers.First());
         }
 
+        // Parse and Bind separately. 
+        [Fact]
+        public void CheckParseSuccess()
+        {
+            var config = new PowerFxConfig();
+            var engine = new Engine(config);
+            var parse = engine.Parse("3*x");
+
+            Assert.False(parse.HasError);
+            Assert.Empty(parse.Errors);
+
+            Assert.NotNull(parse.Root);
+
+            var str = parse.Root.ToString();
+            Assert.Equal("3 * x", str);
+
+            var r = new RecordType().Add(
+                   new NamedFormulaType("x", FormulaType.Number));
+
+            var check = engine.Check(parse, r);
+            Assert.True(check.IsSuccess);
+        }
+
+        // Parse and Bind separately. 
+        [Fact]
+        public void CheckChainingParseSuccess()
+        {
+            var opts = new ParserOptions
+            {  
+                AllowsSideEffects = true
+            };
+
+            var config = new PowerFxConfig();
+            var engine = new Engine(config);
+            var parse = engine.Parse("a;b;c", opts);
+
+            Assert.False(parse.HasError);
+            Assert.Empty(parse.Errors);
+
+            Assert.NotNull(parse.Root);
+
+            var str = parse.Root.ToString();
+            Assert.Equal("a ; b ; c", str);
+        }
+
+        [Fact]
+        public void CheckParseOnlyError()
+        {
+            var config = new PowerFxConfig();
+            var engine = new Engine(config);
+            var result = engine.Parse("3*1+");
+
+            Assert.True(result.HasError);
+            Assert.Single(result.Errors);
+                        
+            AssertContainsError(result, "Error 4-4: Expected an operand");
+        }
+
         [Fact]
         public void CheckParseError()
         {
@@ -36,8 +95,8 @@ namespace Microsoft.PowerFx.Tests
             var result = engine.Check("3*1+");
 
             Assert.False(result.IsSuccess);
-            Assert.Single(result.Errors);
-            Assert.StartsWith("Error 4-4: Expected an operand", result.Errors[0].ToString());
+            Assert.True(result.Errors.Count() >= 1);
+            AssertContainsError(result, "Error 4-4: Expected an operand");
         }
 
         [Fact]
@@ -48,8 +107,7 @@ namespace Microsoft.PowerFx.Tests
             var result = engine.Check("3+foo+2"); // foo is undefined
 
             Assert.False(result.IsSuccess);
-            Assert.Single(result.Errors);
-            Assert.StartsWith("Error 2-5: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            AssertContainsError(result, "Error 2-5: Name isn't valid. 'foo' isn't recognized");
         }
 
         [Fact]
@@ -61,7 +119,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 0-8: 'abc' is an unknown or unsupported function.", result.Errors[0].ToString());
+            AssertContainsError(result, "Error 0-8: 'abc' is an unknown or unsupported function.");
         }
 
         [Fact]
@@ -73,7 +131,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 0-12: 'def' is an unknown or unsupported function in namespace 'abc'.", result.Errors[0].ToString());
+            AssertContainsError(result, "Error 0-12: 'def' is an unknown or unsupported function in namespace 'abc'.");
         }
 
         [Fact]
@@ -85,7 +143,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 31-34: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            AssertContainsError(result, "Error 31-34: Name isn't valid. 'foo' isn't recognized");
         }
 
         [Fact]
@@ -96,8 +154,12 @@ namespace Microsoft.PowerFx.Tests
             var result = engine.Check("[1,2,3].foo");
 
             Assert.False(result.IsSuccess);
-            Assert.Single(result.Errors);
-            Assert.StartsWith("Error 7-11: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            AssertContainsError(result, "Error 7-11: Name isn't valid. 'foo' isn't recognized");
+        }
+
+        private void AssertContainsError(IOperationStatus result, string errorMessage)
+        {
+            Assert.Contains(result.Errors, x => x.ToString().StartsWith(errorMessage));
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionErrorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionErrorTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Lexer;
+using Microsoft.PowerFx.Core.Lexer.Tokens;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Public;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    public class ExpressionErrorTests
+    {
+        [Fact]
+        public void TestError()
+        {
+            var error = new ExpressionError()
+            {
+                Message = "ouch",
+                Span = new Span(2, 5)
+            };
+
+            // Verify defaults for non-nullable objects
+            Assert.False(error.IsWarning);
+            Assert.Equal(ErrorKind.None, error.Kind);
+
+            Assert.Equal("Error 2-5: ouch", error.ToString());
+        }
+
+        [Fact]
+        public void TestWarning()
+        {
+            var error = new ExpressionError()
+            {
+                Message = "ouch",
+                Span = new Span(2, 5),
+                Severity = DocumentErrorSeverity.Warning
+            };
+
+            // Verify defaults for non-nullable objects
+            Assert.True(error.IsWarning);
+            Assert.Equal(ErrorKind.None, error.Kind);
+
+            Assert.Equal("Warning 2-5: ouch", error.ToString());
+        }
+
+        [Fact]
+        public void Empty()
+        {            
+            // We don't want null IEnumerables. 
+            // Null gets normalized to empty.
+            var internalErrors = (IEnumerable<IDocumentError>)null;
+            var errors = ExpressionError.New(internalErrors);
+
+            Assert.Empty(errors);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Tests
         {
             if (!result.IsSuccess)
             {
-                Errors = result.Errors;
+                Errors = result.Errors.ToArray();
             }
         }
 
@@ -64,7 +64,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 {
                     new ExpressionError
                     {
-                         Message = message
+                         Message = message,
+                         Severity = Core.Errors.DocumentErrorSeverity.Severe
                     }
                 }
             };

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -529,7 +529,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var node = result.Root;
 
             Assert.NotNull(node);
-            Assert.Null(result.Errors);
+            Assert.Empty(result.Errors);
         }
 
         [Theory]
@@ -563,7 +563,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var node = result.Root;
 
             Assert.NotNull(node);
-            Assert.Null(result.Errors);
+            Assert.Empty(result.Errors);
             Assert.True(node is DottedNameNode);
 
             var dotted = node as DottedNameNode;
@@ -718,10 +718,10 @@ namespace Microsoft.PowerFx.Core.Tests
             var result = TexlParser.ParseScript(script);
             Assert.NotNull(result.Root);
             Assert.True(result.HasError);
-            Assert.True(result.Errors.Count >= count);
+            Assert.True(result._errors.Count >= count);
 
             //Assert.IsTrue(result.Errors.All(err => err.ErrorKind == DocumentErrorKind.AXL && err.TextSpan != null));
-            Assert.True(errorMessage == null || result.Errors.Any(err => err.ShortMessage == errorMessage));
+            Assert.True(errorMessage == null || result._errors.Any(err => err.ShortMessage == errorMessage));
         }
 
         internal void TestFormulasParseRoundtrip(string script)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -33,6 +33,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Texl.Intellisense.SignatureHelp.SignatureInformation",
                 "Microsoft.PowerFx.Core.BuiltinFormulaTypeConversions",
                 "Microsoft.PowerFx.Core.PowerFxConfig",
+                "Microsoft.PowerFx.Core.Parser.ParseResult",
+                "Microsoft.PowerFx.Core.Public.ParserOptions",
                 "Microsoft.PowerFx.Core.Public.CheckResult",
                 "Microsoft.PowerFx.Core.Public.ErrorKind",
                 "Microsoft.PowerFx.Core.Public.ExpressionError",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -321,8 +321,7 @@ namespace Microsoft.PowerFx.Tests
             var result = engine.Check("3*1+");
 
             Assert.False(result.IsSuccess);
-            Assert.Single(result.Errors);
-            Assert.StartsWith("Error 4-4: Expected an operand", result.Errors[0].ToString());
+            Assert.StartsWith("Error 4-4: Expected an operand", result.Errors.First().ToString());
         }
 
         [Fact]
@@ -333,7 +332,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 2-5: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            Assert.StartsWith("Error 2-5: Name isn't valid. 'foo' isn't recognized", result.Errors.First().ToString());
         }
 
         [Fact]
@@ -344,7 +343,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 31-34: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            Assert.StartsWith("Error 31-34: Name isn't valid. 'foo' isn't recognized", result.Errors.First().ToString());
         }
 
         [Fact]
@@ -355,7 +354,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 7-11: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            Assert.StartsWith("Error 7-11: Name isn't valid. 'foo' isn't recognized", result.Errors.First().ToString());
         }
 
         [Fact]
@@ -366,7 +365,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.False(result.IsSuccess);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 2-8: Name isn't valid. 'Value' isn't recognized", result.Errors[0].ToString());
+            Assert.StartsWith("Error 2-8: Name isn't valid. 'Value' isn't recognized", result.Errors.First().ToString());
         }
 
         [Fact]
@@ -419,7 +418,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.False(result.IsSuccess);
             Assert.Null(result.Expression);
             Assert.Single(result.Errors);
-            Assert.StartsWith("Error 2-5: Name isn't valid. 'foo' isn't recognized", result.Errors[0].ToString());
+            Assert.StartsWith("Error 2-5: Name isn't valid. 'foo' isn't recognized", result.Errors.First().ToString());
         }
 
         [Fact]


### PR DESCRIPTION
This was a bit non-trivial because:
1. Use existing ParseResult class rather than create a new one. The existing FormulaClass doesn't have the right surface and is kept internal.  PAClient uses FormulaClass, not ParseResult.
2. Have consistency between CheckResult and ParseResult, particularly around error handling
3. consistent semantics of null vs empty enumerables.
4. Consistent error vs. warning settings - creating a default ErrorObject leaves the severity enum empty which defaults to warnings.
5. Needed to allow ParserOptions.
6. added some xml comments
7. There are multiple error objects. (public vs. internal) and need to expose public ones for ParseResult, but keep internal accessible for unit tests.

Add some tests.