### PR TITLE
Remove two unneeded transport publics

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/DLP/RequiredDataSourcePermissions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/DLP/RequiredDataSourcePermissions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.PowerFx.Core.Functions.DLP
 {
     [Flags]
     [TransportType(TransportKind.Enum)]
-    public enum RequiredDataSourcePermissions
+    internal enum RequiredDataSourcePermissions
     {
         None = 0x0,
         Create = 0x1,

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Publish/Capabilities.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Publish/Capabilities.cs
@@ -8,7 +8,7 @@ namespace Microsoft.PowerFx.Core.Functions.Publish
 {
     [TransportType(TransportKind.Enum)]
     [Flags]
-    public enum Capabilities : uint
+    internal enum Capabilities : uint
     {
         None = 0x0,
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -87,8 +87,6 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Public.Types.ExternalType",
                 "Microsoft.PowerFx.Core.Localization.ErrorResourceKey",
                 "Microsoft.PowerFx.Core.Localization.Span",
-                "Microsoft.PowerFx.Core.Functions.Publish.Capabilities",
-                "Microsoft.PowerFx.Core.Functions.DLP.RequiredDataSourcePermissions",
                 "Microsoft.PowerFx.Core.Errors.DocumentErrorSeverity",
                 "Microsoft.PowerFx.Core.App.IExternalEnabledFeatures",
                 "Microsoft.PowerFx.Core.App.DefaultEnabledFeatures",


### PR DESCRIPTION
Transport Generation now supports internals, and these shouldn't be on our public surface. 