### PR TITLE
Add PublishToCoveralls.ps1 and coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ For those new to Power-Fx, this video should answer many of your questions:
 
 ## Build Status
 
- | Branch | Description        | Build Status |
- |----|---------------|--------------|
- |Main | 0.2.* Preview Builds |[![Build Status](https://dev.azure.com/FuseLabs/SDK_v4/_apis/build/status/PowerFx/PowerFx-daily?branchName=main)](https://dev.azure.com/FuseLabs/SDK_v4/_build/latest?definitionId=1410&branchName=main)
+ | Branch | Description        | Build Status | Coverage Status |
+ |----|---------------|--------------|--------------|
+ |Main | 0.2.* Preview Builds |[![Build Status](https://dev.azure.com/FuseLabs/SDK_v4/_apis/build/status/PowerFx/PowerFx-daily?branchName=main)](https://dev.azure.com/FuseLabs/SDK_v4/_build/latest?definitionId=1410&branchName=main) |[![Coverage Status](https://coveralls.io/repos/github/microsoft/Power-Fx/badge.svg?branch=bruce/addcoveralls4-26)](https://coveralls.io/github/microsoft/Power-Fx?branch=bruce/addcoveralls4-26)
 
 ## Packages
 

--- a/src/build/PublishToCoveralls.ps1
+++ b/src/build/PublishToCoveralls.ps1
@@ -1,0 +1,70 @@
+#
+# Installs and runs Coveralls.exe to upload coverage files to https://coveralls.io/.
+# Arguments example: -coverallsToken $(Coveralls.Token) -pathToCoverageFiles $(Build.SourcesDirectory)\CodeCoverage
+#
+Param(
+    [string]$coverallsToken = '',  # This arg will display in the Azure pipeline log. To hide it, pass it as environment var CoverallsToken instead.
+    [string]$pathToCoverageFiles,
+    [string]$serviceName = 'Azure DevOps'
+)
+
+Write-Host Install tools
+$basePath = (get-item $pathToCoverageFiles ).parent.FullName
+$coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
+dotnet tool install coveralls.net --version 1.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
+$coverageUploader = ".\tools\csmacnz.Coveralls.exe"
+
+# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
+Import-Module .\archive.psm1
+
+Write-Host "Analyze coverage [$coverageAnalyzer] with args:"
+$coverageFiles = Get-ChildItem -Path "$pathToCoverageFiles" -Include "*.coverage" -Recurse | Select -Exp FullName
+$analyzeArgs = @(
+    "analyze",
+    "/output:""$pathToCoverageFiles\coverage.coveragexml"""
+);
+$analyzeArgs += $coverageFiles
+Foreach ($i in $analyzeArgs) { Write-Host "  $i" }
+."$coverageAnalyzer" @analyzeArgs
+
+# Get $coverallsToken from environment var
+if ($coverallsToken -eq '') {
+    $coverallsToken = $Env:CoverallsToken;
+}
+
+Write-Host "Upload coverage [$coverageUploader] with args"
+if (Test-Path env:System_PullRequest_SourceBranch) {
+    $branchName = $env:System_PullRequest_SourceBranch -replace "refs/heads/", "" 
+}
+$uploadArgs = @(
+    "--dynamiccodecoverage",
+    "-i ""$pathToCoverageFiles\coverage.coveragexml""",
+    "-o ""$pathToCoverageFiles\coverage.json"""
+    "--useRelativePaths",
+    "--basePath ""$basePath""",
+    "--repoToken ""$coverallsToken""",
+    "--jobId ""$env:Build_BuildId""",
+    "--commitId ""$env:Build_SourceVersion""",
+    "--commitAuthor ""$env:Build_RequestedFor""",
+    "--commitEmail ""$env:Build_RequestedForEmail """,
+    "--commitMessage ""$env:Build_SourceVersionMessage""",
+    "--serviceName ""$serviceName"""
+);
+if (Test-Path env:System_PullRequest_SourceBranch) {
+    $uploadArgs += "--commitBranch ""$($env:System_PullRequest_SourceBranch -replace ""refs/heads/"", """")"""
+}
+else {
+    $uploadArgs += "--commitBranch ""$($env:Build_SourceBranch -replace ""refs/heads/"", """")"""
+}
+if (Test-Path env:System_PullRequest_PullRequestNumber) {
+    $uploadArgs += "--pullRequest ""$env:System_PullRequest_PullRequestNumber"""
+}
+Foreach ($i in $uploadArgs) { 
+    if (-not $i.StartsWith("--repoToken")) {
+        Write-Host "  $i";
+    } else {
+        Write-Host "  --repoToken ******";
+    }
+}
+Start-Process $coverageUploader -ArgumentList $uploadArgs -NoNewWindow


### PR DESCRIPTION
This allows the PowerFx-PR pipeline to publish coverage to coveralls.io.
It also sets up a coverage badge in the readme.

(After this PR is merged, a pipeline run, then another PR will finalize the badge.)