### PR TITLE
Allow interpreter to work on any IExternalOptionSet instead of OptionSet

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalOptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalOptionSet.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Public.Values;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Entities
 {
+    /// <summary>
+    /// Describe an option set - maybe implemented by each back end over their existing enum-like symbols. 
+    /// </summary>
     internal interface IExternalOptionSet : IExternalEntity
     {
         DisplayNameProvider DisplayNameProvider { get; }
@@ -18,6 +22,8 @@ namespace Microsoft.PowerFx.Core.Entities
                 
         bool IsBooleanValued { get; }
 
-        bool IsConvertingDisplayNameMapping { get; } 
+        bool IsConvertingDisplayNameMapping { get; }
+
+        bool TryGetValue(DName fieldName, out OptionSetValue optionSetValue);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 
@@ -57,9 +58,47 @@ namespace Microsoft.PowerFx.Core.Public.Types
             _type = type;
         }
 
+        // Entites may be recursive and their Dytype is tagged with additional schema metadata. 
+        // Expand that metadata into a proper Dtype. 
+        private static DType GetExpandedEntityType(DType expandEntityType, string relatedEntityPath)
+        {
+            Contracts.AssertValid(expandEntityType);
+            Contracts.Assert(expandEntityType.HasExpandInfo);
+            Contracts.AssertValue(relatedEntityPath);
+
+            var expandEntityInfo = expandEntityType.ExpandInfo;
+
+            if (expandEntityInfo.ParentDataSource is not IExternalTabularDataSource dsInfo)
+            {
+                return expandEntityType;
+            }
+
+            DType type;
+
+            if (!expandEntityType.TryGetEntityDelegationMetadata(out var metadata))
+            {
+                // We need more metadata to bind this fully
+                return DType.Error;
+            }
+
+            type = expandEntityType.ExpandEntityType(metadata.Schema, metadata.Schema.AssociatedDataSources);
+            Contracts.Assert(type.HasExpandInfo);
+
+            // Update the datasource and relatedEntity path.
+            type.ExpandInfo.UpdateEntityInfo(expandEntityInfo.ParentDataSource, relatedEntityPath);
+
+            return type;
+        }
+
         // Get the correct derived type
         internal static FormulaType Build(DType type)
         {
+            if (type.IsExpandEntity)
+            {
+                var expandedType = GetExpandedEntityType(type, string.Empty);
+                return Build(expandedType);
+            }
+
             switch (type.Kind)
             {
                 case DKind.ObjNull: return Blank;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.Public.Values;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Public.Types
 {
+    /// <summary>
+    /// Power Fx type for an enum-like things such as OptionSets. 
+    /// </summary>
     public class OptionSetValueType : FormulaType
     {
         /// <summary>
@@ -33,7 +40,30 @@ namespace Microsoft.PowerFx.Core.Public.Types
             vistor.Visit(this);
         }
 
-        // $$$ Add this:
-        // public static bool TryGetValue(this OptionSetValueType type, string logicalName, out OptionSetValue osValue)
+        /// <summary>
+        /// List of logical names within this option set. 
+        /// </summary>
+        public IEnumerable<DName> LogicalNames => _type.OptionSetInfo.OptionNames; 
+
+        /// <summary>
+        /// Try to get a value given the logical name. 
+        /// </summary>
+        /// <param name="logicalName"></param>
+        /// <param name="osValue"></param>
+        /// <returns>False if logical name is not in the option set. </returns>
+        public bool TryGetValue(string logicalName, out OptionSetValue osValue)
+        {
+            var info = _type.OptionSetInfo;
+
+            // Verify this value exists in the option set. 
+            if (info.DisplayNameProvider.TryGetDisplayName(new DName(logicalName), out var displayName))
+            {
+                osValue = new OptionSetValue(logicalName, this);
+                return true;
+            }
+
+            osValue = null;
+            return false;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/OptionSetValueType.cs
@@ -32,5 +32,8 @@ namespace Microsoft.PowerFx.Core.Public.Types
         {
             vistor.Visit(this);
         }
+
+        // $$$ Add this:
+        // public static bool TryGetValue(this OptionSetValueType type, string logicalName, out OptionSetValue osValue)
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.Public.Types;
+using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Public.Values
 {
@@ -25,17 +27,44 @@ namespace Microsoft.PowerFx.Core.Public.Values
 
         public override object ToObject()
         {
-            return Option;
+            // $$$ Potential break?
+            return DisplayName;
         }
 
         public override string ToString()
         {
-            return $"OptionSetValue ({Option})";
+            return $"OptionSetValue ({Option}={DisplayName})";
         }
 
         public override void Visit(IValueVisitor visitor)
         {
             visitor.Visit(this);
         }
+
+        // $$$ Add Type property that returns OptionSetValueType
+        // $$$ add ctor that skips IRContext.
+
+        /// <summary>
+        /// Get the display name for this value. If no display name is available, 
+        /// returns the logical name <see cref="Option"/>.
+        /// </summary>
+        public string DisplayName
+        {
+            get
+            {
+                var osvt = (OptionSetValueType)Type;
+                var info = osvt._type.OptionSetInfo;
+
+                var dp = info.DisplayNameProvider;
+
+                var logicalName = Option;
+                if (dp.TryGetDisplayName(new DName(logicalName), out var displayName))
+                {
+                    return displayName.Value;
+                }
+
+                return logicalName;
+            }
+        }        
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/OptionSetValue.cs
@@ -11,23 +11,27 @@ using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Public.Values
 {
-    [DebuggerDisplay("OptionSetValue ({Option})")]
+    /// <summary>
+    /// A value within an option set. 
+    /// </summary>
+    [DebuggerDisplay("{ToString})")]
     public class OptionSetValue : FormulaValue
     {
         /// <summary>
         /// Logical name for this option set value.
         /// </summary>
-        public readonly string Option;
+        public string Option { get; private set; }
 
-        internal OptionSetValue(string option, IRContext irContext)
-            : base(irContext)
+        internal OptionSetValue(string option, OptionSetValueType type)
+            : base(IRContext.NotInSource(type))
         {
             Option = option;
         }
 
+        public new OptionSetValueType Type => (OptionSetValueType)base.Type;
+
         public override object ToObject()
         {
-            // $$$ Potential break?
             return DisplayName;
         }
 
@@ -40,10 +44,7 @@ namespace Microsoft.PowerFx.Core.Public.Values
         {
             visitor.Visit(this);
         }
-
-        // $$$ Add Type property that returns OptionSetValueType
-        // $$$ add ctor that skips IRContext.
-
+                
         /// <summary>
         /// Get the display name for this value. If no display name is available, 
         /// returns the logical name <see cref="Option"/>.
@@ -52,13 +53,12 @@ namespace Microsoft.PowerFx.Core.Public.Values
         {
             get
             {
-                var osvt = (OptionSetValueType)Type;
-                var info = osvt._type.OptionSetInfo;
+                var info = Type._type.OptionSetInfo;
 
-                var dp = info.DisplayNameProvider;
+                var displayNameProvider = info.DisplayNameProvider;
 
                 var logicalName = Option;
-                if (dp.TryGetDisplayName(new DName(logicalName), out var displayName))
+                if (displayNameProvider.TryGetDisplayName(new DName(logicalName), out var displayName))
                 {
                     return displayName.Value;
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerFx
         /// Formula Type corresponding to this option set.
         /// Use in record/table contexts to define the type of fields using this option set.
         /// </summary>
-        public FormulaType FormulaType { get; }
+        public OptionSetValueType FormulaType { get; }
 
         public bool TryGetValue(DName fieldName, out OptionSetValue optionSetValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/OptionSet.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PowerFx
                 return false;
             }
 
-            optionSetValue = new OptionSetValue(fieldName, IRContext.NotInSource(FormulaType));
+            optionSetValue = new OptionSetValue(fieldName, FormulaType);
             return true;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
@@ -492,7 +493,7 @@ namespace Microsoft.PowerFx
             return node.Value switch
             {
                 RecalcFormulaInfo fi => ResolvedObjectHelpers.RecalcFormulaInfo(fi),
-                OptionSet optionSet => ResolvedObjectHelpers.OptionSet(optionSet, node.IRContext),
+                IExternalOptionSet optionSet => ResolvedObjectHelpers.OptionSet(optionSet, node.IRContext),
                 _ => ResolvedObjectHelpers.ResolvedObjectError(node),
             };
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -403,21 +403,8 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue OptionSetValueToString(IRContext irContext, OptionSetValue[] args)
         {
-            // The type checker and IR have already validated that this is a valid OptionSet and that it contains a member matching this Option.
-            // These are just defensive error checks, and should be unreachable.
-            var os = args[0].Type?._type?.OptionSetInfo;
-            if (os is not OptionSet optionSet) 
-            {
-                return CommonErrors.UnreachableCodeError(irContext);
-            }
-
-            var option = args[0].Option;
-
-            if (!optionSet.Options.TryGetValue(new DName(option), out var displayName))
-            { 
-                return CommonErrors.UnreachableCodeError(irContext);
-            }
-
+            var optionSet = args[0];
+            var displayName = optionSet.DisplayName;
             return new StringValue(irContext, displayName);
         }
         #endregion

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.Public;
@@ -20,19 +21,24 @@ namespace Microsoft.PowerFx.Functions
             return fi._value;
         }
 
-        public static FormulaValue OptionSet(OptionSet optionSet, IRContext irContext)
+        // $$$ - this allows behavior we really don't want ... can we block in the IR?
+        // OptionSets can act like Records: 
+        //   TimeUnit.Hours
+        //   If(true, TimeUnit).Hours
+        //   If(true, TextPosition, Align).Left
+        public static FormulaValue OptionSet(IExternalOptionSet optionSet, IRContext irContext)
         {
             var options = new List<NamedValue>();
-            foreach (var option in optionSet.Options)
+            foreach (var optionName in optionSet.OptionNames)
             {
-                if (!optionSet.TryGetValue(option.Key, out var osValue))
+                if (!optionSet.TryGetValue(optionName, out var osValue))
                 {
                     // This is iterating the Options in the option set
                     // so we already know TryGetValue will succeed, making this unreachable.
-                    return CommonErrors.UnreachableCodeError(irContext); 
+                    return CommonErrors.UnreachableCodeError(irContext);
                 }
 
-                options.Add(new NamedValue(option.Key, osValue));
+                options.Add(new NamedValue(optionName, osValue));
             }
 
             // When evaluating an option set ResolvedObjectNode, we convert the options into a record

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -85,6 +85,14 @@ namespace Microsoft.PowerFx
             return new ParsedExpression(irnode, ruleScopeSymbol);
         }
 
+        public static IExpression CreateEvaluator2(CheckResult result)
+        {
+            result.ThrowOnErrors();
+
+            (var irnode, var ruleScopeSymbol) = IRTranslator.Translate(result._binding);
+            return new ParsedExpression(irnode, ruleScopeSymbol);
+        }
+
         // This handles lookups in the global scope. 
         FormulaValue IScope.Resolve(string name)
         {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DisplayNameOptionSetTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DisplayNameOptionSetTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Public.Types;
 using Microsoft.PowerFx.Core.Tests;
@@ -45,6 +46,42 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 var outInvariantExpression = engine.GetInvariantExpression(inputExpression, new RecordType());
                 Assert.Equal(outputExpression, outInvariantExpression);
             }
+        }
+
+        // Verify methods to go between OptionSet/Type/Value
+        [Fact]
+        public void TestHelpers()
+        {
+            var optionSet = new OptionSet("OptionSetName", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
+            {
+                    { "option_1", "DisplayOption1" },
+                    { "option_2", "DisplayOption2" }
+            }));
+            var type = optionSet.FormulaType;
+
+            Assert.Equal("OptionSetName", type.OptionSetName.Value);
+
+            var ok = type.TryGetValue("option_2", out var val2);
+            Assert.True(ok);
+
+            Assert.Equal("option_2", val2.Option);
+            Assert.Equal("DisplayOption2", val2.DisplayName);
+
+            ok = type.TryGetValue("missing", out var valMissing);
+            Assert.False(ok);
+
+            // Can't lookup by display name - avoids ambiguities. 
+            ok = type.TryGetValue(val2.DisplayName, out valMissing);
+            Assert.False(ok);
+
+            // Parent Type matches.
+            var type2 = val2.Type;
+            Assert.True(object.ReferenceEquals(val2.Type, type));
+
+            var names = type.LogicalNames.Select(x => x.Value).OrderBy(x => x).ToArray();
+            Assert.Equal(2, names.Length);
+            Assert.Equal("option_1", names[0]);
+            Assert.Equal("option_2", names[1]);
         }
 
         [Fact]


### PR DESCRIPTION
Allow interpreter to work on any IExternalOptionSet  implementation (not just OptionSet) so that it can execute on optionsets coming from dataverse. 

Also add more helpers on  OptionSetValueType and OptionSetValue (which live in Core) to make them more usable. This lets them work on dataverse option sets too.
