### PR TITLE
Fixup internal intellisense namespaces.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IIntellisenseContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IIntellisenseContext.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AppMagic.Transport;
 
-namespace Microsoft.PowerFx.Intellisense
+namespace Microsoft.PowerFx.Core.Texl.Intellisense
 {
     [TransportType(TransportKind.ByValue)]
     internal interface IIntellisenseContext

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Intellisense.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Intellisense.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Texl.Intellisense;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.PowerFx.Core.Texl.Intellisense;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Intellisense

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Texl.Intellisense;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/CleanupHandlers/ISpecialCaseHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/CleanupHandlers/ISpecialCaseHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Texl.Intellisense;
 
 namespace Microsoft.PowerFx.Intellisense
 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/CleanupHandlers/StringSuggestionHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/CleanupHandlers/StringSuggestionHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Texl.Intellisense;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/TokenTextSpan.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/TokenTextSpan.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.AppMagic.Transport;
 
-namespace Microsoft.PowerFx.Intellisense
+namespace Microsoft.PowerFx.Core.Texl.Intellisense
 {
     [TransportType(TransportKind.ByValue)]
     internal interface ITokenTextSpan

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/TokenType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/TokenType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-namespace Microsoft.PowerFx.Intellisense
+namespace Microsoft.PowerFx.Core.Texl.Intellisense
 {
     // Keep in sync with src/AppMagic/js/AppMagic.WebAuthoring/Constants/Texl.ts
     internal enum TokenType


### PR DESCRIPTION
They're internal classes, and PAClient relies on their specific namespaces because of JS codegen. 

