### PR TITLE
Adding support for MultiSelect optionset with In operator

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2681,7 +2681,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (_txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled && typeLeft.IsTable)
                 {
-                    // Table in table: RHS must be a table with a compatible schema. No coercion is allowed.
+                    // Table in table: RHS must be a single column table with a compatible schema. No coercion is allowed.
                     if (typeRight.IsTable)
                     {
                         var names = typeRight.GetNames(DPath.Root);
@@ -2698,7 +2698,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             return false;
                         }
 
-                        if (typedName.Type.Accepts(typeLeft) || typeLeft.Accepts(typedName.Type))
+                        if (typeLeft.Accepts(typedName.Type))
                         {
                             return true;
                         }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2679,7 +2679,33 @@ namespace Microsoft.PowerFx.Core.Binding
                     return false;
                 }
 
-                // table in anything: not supported
+                if (_txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled && typeLeft.IsTable)
+                {
+                    // Table in table: RHS must be a table with a compatible schema. No coercion is allowed.
+                    if (typeRight.IsTable)
+                    {
+                        var names = typeRight.GetNames(DPath.Root);
+                        if (names.Count() != 1)
+                        {
+                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrInvalidSchemaNeedCol);
+                            return false;
+                        }
+
+                        var typedName = names.Single();
+                        if (!typeLeft.CoercesTo(typedName.Type))
+                        {
+                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
+                            return false;
+                        }
+
+                        if (typedName.Type.Accepts(typeLeft) || typeLeft.Accepts(typedName.Type))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                // Table in scalar or Table in Record or Table in unsupported table: not supported
                 _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrBadType_Type, typeLeft.GetKindString());
                 return false;
             }
@@ -2697,7 +2723,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 return set;
             }
-            
+
             public override void Visit(ErrorNode node)
             {
                 AssertValid();
@@ -2975,10 +3001,10 @@ namespace Microsoft.PowerFx.Core.Binding
                 var fnInfo = FirstNameInfo.Create(node, lookupInfo);
                 var lookupType = lookupInfo.Type;
 
-                if (lookupInfo.DisplayName != default) 
+                if (lookupInfo.DisplayName != default)
                 {
                     if (_txb.UpdateDisplayNames)
-                    {                    
+                    {
                         _txb.NodesToReplace.Add(new KeyValuePair<Token, string>(node.Token, lookupInfo.DisplayName));
                     }
                     else if (lookupInfo.Data is IExternalEntity entity)

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
@@ -162,7 +162,8 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             }
 
             var nodeType = binding.GetType(column);
-            return DType.String.Accepts(nodeType) || nodeType.CoercesTo(DType.String) || (nodeType.IsMultiSelectOptionSet() && nodeType.IsTable);
+            var hasEnhancedDelegation = binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled;
+            return DType.String.Accepts(nodeType) || nodeType.CoercesTo(DType.String) || (hasEnhancedDelegation && nodeType.IsMultiSelectOptionSet() && nodeType.IsTable);
         }
 
         public override bool IsOpSupportedByTable(OperationCapabilityMetadata metadata, TexlNode node, TexlBinding binding)

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             }
 
             var nodeType = binding.GetType(column);
-            return DType.String.Accepts(nodeType) || nodeType.CoercesTo(DType.String);
+            return DType.String.Accepts(nodeType) || nodeType.CoercesTo(DType.String) || (nodeType.IsMultiSelectOptionSet() && nodeType.IsTable);
         }
 
         public override bool IsOpSupportedByTable(OperationCapabilityMetadata metadata, TexlNode node, TexlBinding binding)

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1983,7 +1983,7 @@ namespace Microsoft.PowerFx.Core.Types
                 case DKind.OptionSetValue:
                     accepts = (type.Kind == Kind &&
                                 (OptionSetInfo == null || type.OptionSetInfo == null || type.OptionSetInfo == OptionSetInfo)) ||
-                               type.Kind == DKind.Unknown || (type.IsMultiSelectOptionSet() && (OptionSetInfo != null && type.TypeTree.GetPairs() != null && type.TypeTree.GetPairs().First().Value?.OptionSetInfo == OptionSetInfo));
+                               type.Kind == DKind.Unknown || (type.IsMultiSelectOptionSet() && (OptionSetInfo != null && type.TypeTree.GetPairs().First().Value.OptionSetInfo == OptionSetInfo));
                     break;
                 case DKind.View:
                 case DKind.ViewValue:

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1983,7 +1983,7 @@ namespace Microsoft.PowerFx.Core.Types
                 case DKind.OptionSetValue:
                     accepts = (type.Kind == Kind &&
                                 (OptionSetInfo == null || type.OptionSetInfo == null || type.OptionSetInfo == OptionSetInfo)) ||
-                               type.Kind == DKind.Unknown;
+                               type.Kind == DKind.Unknown || (type.IsMultiSelectOptionSet() && (OptionSetInfo != null && type.TypeTree.GetPairs() != null && type.TypeTree.GetPairs().First().Value?.OptionSetInfo == OptionSetInfo));
                     break;
                 case DKind.View:
                 case DKind.ViewValue:


### PR DESCRIPTION
#### Summary
<!-- What is the problem you're trying to solve? Provide a summary of the issue and proposed changes. -->
MultiSelect Optionsets are currently not supported with the **in** operator, so customers didn't have an easy way to filter records based on the multi-select optionset column, with this change we will now be able to support In operator filtering on these columns in both delegated and non delegated queries.

example: If we need to filter a column - > states visited by a contact (multiselectoptionset) 

The formula would look like this:
**Filter(Contacts,multiselect_state in SelectedStates)**

with this PR we support the both delegated and non delegated scenarios:

1. Delegated query :https://org7c2cf9ed.crm10.dynamics.com/api/data/v9.0/contacts?$filter=Microsoft.Dynamics.CRM.ContainValues(PropertyName=%27cr7fe_multiselect_state%27,PropertyValues=[%27304050000%27])%20and%20Microsoft.Dynamics.CRM.ContainValues(PropertyName=%27cr7fe_multiselect_state%27,PropertyValues=[%27304050001%27])&$select=contactid,cr7fe_multiselect_state,fullname 

2. Non-Delegated: We would locally iterate over all the records and return the records that contain either of the selected optionset values.

#### Validation
<!-- How did you validate the change? How do we make sure the change continues to work as expected (tests/telemetry)? -->
Manual Tests.
TODO: Unit Tests.

#### Risks
<!--- What risks are associated with this change? How can the risk be mitigated? -->
New Feature, the risk is limited and we also have this under our Enhanced Delegation feature flag.


PowerApps Client uptake PR: https://msazure.visualstudio.com/OneAgile/_git/PowerApps-Client/pullrequest/6030875