### PR TITLE
Move Span to the Microsoft.PowerFx.Syntax namespace.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Errors/BaseError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/BaseError.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Text;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Errors
 {

--- a/src/libraries/Microsoft.PowerFx.Core/Errors/IDocumentError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/IDocumentError.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AppMagic.Transport;
 using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Errors
 {

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Core.IR

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Span.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Span.cs
@@ -7,9 +7,9 @@ using System.Linq;
 using System.Text;
 using Microsoft.AppMagic.Transport;
 using Microsoft.PowerFx.Core.Utils;
-using StringBuilderCache = Microsoft.PowerFx.Core.Utils.StringBuilderCache<Microsoft.PowerFx.Core.Localization.Span>;
+using StringBuilderCache = Microsoft.PowerFx.Core.Utils.StringBuilderCache<Microsoft.PowerFx.Syntax.Span>;
 
-namespace Microsoft.PowerFx.Core.Localization
+namespace Microsoft.PowerFx.Syntax
 {
     /// <summary>
     /// Span in the text formula.

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ExpressionError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ExpressionError.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
-using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionErrorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionErrorTests.cs
@@ -1,15 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
-using Microsoft.PowerFx.Core.Localization;
-using Microsoft.PowerFx.Core.Public;
-using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
 using Xunit;
 
 namespace Microsoft.PowerFx.Core.Tests

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Preview.FeatureFlags",
 
                 // Lexer                
+                "Microsoft.PowerFx.Syntax.Span",
                 "Microsoft.PowerFx.Syntax.BinaryOp",
                 "Microsoft.PowerFx.Syntax.TokKind",
                 "Microsoft.PowerFx.Syntax.CommentToken",
@@ -159,8 +160,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Utils.DName",
                 "Microsoft.PowerFx.Core.Utils.DPath",
                 "Microsoft.PowerFx.Core.Utils.ICheckable",
-                "Microsoft.PowerFx.Core.Localization.ErrorResourceKey",
-                "Microsoft.PowerFx.Core.Localization.Span",
+                "Microsoft.PowerFx.Core.Localization.ErrorResourceKey"
             };
 
             var sb = new StringBuilder();
@@ -191,7 +191,7 @@ namespace Microsoft.PowerFx.Core.Tests
         {
             var exceptionList = new HashSet<string>()
             {
-                "Microsoft.PowerFx.Core.Localization.Span"
+                "Microsoft.PowerFx.Syntax.Span"
             };
 
             var asm = typeof(Parser.TexlParser).Assembly;


### PR DESCRIPTION
Move Span from : 
`Microsoft.PowerFx.Core.Localization.Span` to `Microsoft.PowerFx.Syntax.Span`.
This is part of a set of namespace changes. see #361 for details.  
This is part of the public  surface area and many products will depend on it. 


This is primarily provided by Syntax nodes, as well as for error ranges. 
This is a public class.
It also has [TransportAttribute] on it.
