### PR TITLE
Remove RequiresErrorContext from TexlFunction

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -181,9 +181,6 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if this function can return a type with ExpandInfo.
         public virtual bool CanReturnExpandInfo => false;
 
-        // Return true if this function requires error context info.
-        public virtual bool RequiresErrorContext => false;
-
         // Return true if this function requires binding context info.
         public virtual bool RequiresBindingContext => false;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acos.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acos.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Acos(number:n)
     // Equivalent Excel function: acos
     internal sealed class AcosFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AcosFunction()
             : base("Acos", TexlStrings.AboutAcos, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc cosine of each item in the input table.
     internal sealed class AcosTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AcosTableFunction()
             : base("Acos", TexlStrings.AboutAcosT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acot.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Acot.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Acot(number:n)
     // Equivalent Excel function: Acot
     internal sealed class AcotFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AcotFunction()
             : base("Acot", TexlStrings.AboutAcot, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc cotangent of each item in the input table.
     internal sealed class AcotTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AcotTableFunction()
             : base("Acot", TexlStrings.AboutAcotT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AddColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AddColumns.cs
@@ -12,6 +12,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // AddColumns(source:*[...], name:s, valueFunc:func<_>, name:s, valueFunc:func<_>, ...)
@@ -182,3 +185,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
@@ -14,14 +14,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // AsType(record:P, table:*[]): ![]
     internal sealed class AsTypeFunction : BuiltinFunction
     {
         public const string AsTypeInvariantFunctionName = "AsType";
-
-        public override bool RequiresErrorContext => true;
 
         public override bool IsAsync => true;
 
@@ -104,3 +105,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Asin.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Asin.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Asin(number:n)
     // Equivalent Excel function: Asin
     internal sealed class AsinFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AsinFunction()
             : base("Asin", TexlStrings.AboutAsin, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc sine values of each item in the input table.
     internal sealed class AsinTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AsinTableFunction()
             : base("Asin", TexlStrings.AboutAsinT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Atan(number:n)
     // Equivalent Excel function: Atan
     internal sealed class AtanFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AtanFunction()
             : base("Atan", TexlStrings.AboutAtan, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the arc tangent of each item in the input table.
     internal sealed class AtanTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AtanTableFunction()
             : base("Atan", TexlStrings.AboutAtanT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -6,6 +6,9 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Atan2(number:x, number:y)
@@ -13,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class Atan2Function : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool RequiresErrorContext => true;
 
         public Atan2Function()
             : base(
@@ -38,3 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Average.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Average.cs
@@ -5,14 +5,15 @@ using Microsoft.PowerFx.Core.Functions.Delegation;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Average(arg1:n, arg2:n, ..., argN:n)
     // Corresponding Excel function: Average
     internal sealed class AverageFunction : StatisticalFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public AverageFunction()
             : base("Average", TexlStrings.AboutAverage, FunctionCategories.MathAndStat)
         {
@@ -23,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding DAX function: Average
     internal sealed class AverageTableFunction : StatisticalTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Average;
 
         public AverageTableFunction()
@@ -33,3 +32,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Blank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Blank.cs
@@ -6,6 +6,9 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Blank()
@@ -33,3 +36,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -6,6 +6,9 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Boolean(arg:s)
@@ -13,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class BooleanFunction : BuiltinFunction
     {
         public const string BooleanInvariantFunctionName = "Boolean";
-
-        public override bool RequiresErrorContext => true;
 
         public override bool IsSelfContained => true;
 
@@ -34,8 +35,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Boolean(arg:O)
     internal sealed class BooleanFunction_UO : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
@@ -56,3 +55,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Calendar.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Calendar.cs
@@ -7,6 +7,9 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     internal abstract class CalendarFunction : BuiltinFunction
@@ -62,3 +65,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -10,14 +10,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Char(arg:n) : s
     // Corresponding Excel function: Char
     internal sealed class CharFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -36,8 +37,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Char(arg:*[n]) : *[s]
     internal sealed class CharTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -79,3 +78,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Clock.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Clock.cs
@@ -7,6 +7,9 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     internal class ClockFunction : BuiltinFunction
@@ -62,3 +65,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -11,6 +11,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Coalesce(expression:E)
@@ -121,3 +124,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFade.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFade.cs
@@ -7,6 +7,9 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // ColorFade(color:c, fadeDelta:n)
@@ -37,3 +40,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -12,6 +12,9 @@ using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // ColorFade(color:c|*[c], fadeDelta:n|*[n])
@@ -140,3 +143,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorValue.cs
@@ -6,14 +6,15 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // ColorValue(colorstring:s)
     // Returns the color value for the given color string
     internal sealed class ColorValueFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
@@ -29,3 +30,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concat.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concat.cs
@@ -6,6 +6,9 @@ using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Concat(source:*[...], expr, [separator:s])
@@ -30,3 +33,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -10,6 +10,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Concatenate(source1:s, source2:s, ...)
@@ -151,3 +154,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cos.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cos.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Cos(number:n)
     // Equivalent Excel function: Cos
     internal sealed class CosFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public CosFunction()
             : base("Cos", TexlStrings.AboutCos, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the cosine of each item in the input table.
     internal sealed class CosTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public CosTableFunction()
             : base("Cos", TexlStrings.AboutCosT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cot.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Cot.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Cot(number:n)
     // Equivalent Excel function: Cot
     internal sealed class CotFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public CotFunction()
             : base("Cot", TexlStrings.AboutCot, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the cotangent of each item in the input table.
     internal sealed class CotTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public CotTableFunction()
             : base("Cot", TexlStrings.AboutCotT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
@@ -11,6 +11,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Count(source:*)
@@ -64,3 +67,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
@@ -11,6 +11,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // CountA(source:*)
@@ -58,3 +61,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -14,14 +14,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // CountIf(source:*, predicate:b [, predicate:b, ...])
     // Corresponding DAX function: CountAX, CountX
     internal sealed class CountIfFunction : FilterFunctionBase
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool SupportsParamCoercion => true;
 
         public override bool HasPreciseErrors => true;
@@ -137,3 +138,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountRows.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountRows.cs
@@ -12,14 +12,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // CountRows(source:*)
     internal sealed class CountRowsFunction : FunctionWithTableInput
     {
         public const string CountRowsInvariantFunctionName = "CountRows";
-
-        public override bool RequiresErrorContext => true;
 
         public override bool IsSelfContained => true;
 
@@ -110,8 +111,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // CountRows(arg: O)
     internal sealed class CountRowsFunction_UO : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
@@ -132,3 +131,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Date
     internal sealed class DateFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -46,8 +44,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal abstract class ExtractDateTimeFunctionBase : BuiltinFunction
     {
         public override bool HasPreciseErrors => true;
-
-        public override bool RequiresErrorContext => true;
 
         public override bool IsSelfContained => true;
 
@@ -75,8 +71,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Time
     internal sealed class TimeFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -98,8 +92,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateTime(year, month, day, hour, minute, second[, millisecond])
     internal sealed class DateTimeFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -224,8 +216,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Weekday
     internal sealed class WeekdayFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -253,8 +243,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: WeekNum
     internal sealed class WeekNumFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -299,8 +287,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
     internal abstract class DateTimeGenericFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -381,8 +367,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateAdd(timestamp: d, delta: n, [ unit: TimeUnits ]) : d
     internal sealed class DateAddFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -455,8 +439,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateAdd(timestamp:d|*[d], delta:n|*[n], [unit:TimeUnits])
     internal sealed class DateAddTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -569,8 +551,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateDiff(startdate: d, enddate : d, [ unit: TimeUnits ]) : n
     internal sealed class DateDiffFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -605,8 +585,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateDiffT(start:d|*[d], end:d|*[d], [unit:TimeUnits])
     internal sealed class DateDiffTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Degrees.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Degrees.cs
@@ -4,14 +4,15 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Degrees(number:n)
     // Equivalent Excel function: Degrees
     internal sealed class DegreesFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public DegreesFunction()
             : base("Degrees", TexlStrings.AboutDegrees, FunctionCategories.MathAndStat)
         {
@@ -22,11 +23,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the degrees values of each item in the input table.
     internal sealed class DegreesTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public DegreesTableFunction()
             : base("Degrees", TexlStrings.AboutDegreesT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DropColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DropColumns.cs
@@ -10,6 +10,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // DropColumns(source:*[...], name:s, name:s, ...)
@@ -116,3 +119,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/EndsWith.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/EndsWith.cs
@@ -8,6 +8,9 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // EndsWith(text:s, end:s):b
@@ -39,3 +42,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         // Add overload for single-column table as the input for both endsWith and startsWith.
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -12,14 +12,15 @@ using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Error([arg1: any])
     internal sealed class ErrorFunction : BuiltinFunction
     {
         public override bool HasPreciseErrors => true;
-
-        public override bool RequiresErrorContext => true;
 
         public override bool CanSuggestInputColumns => true;
 
@@ -171,3 +172,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Exp.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Exp.cs
@@ -4,6 +4,9 @@
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Exp(number:n)
@@ -11,8 +14,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ExpFunction : MathOneArgFunction
     {
         public override bool HasPreciseErrors => true;
-
-        public override bool RequiresErrorContext => true;
 
         public ExpFunction()
             : base("Exp", TexlStrings.AboutExp, FunctionCategories.MathAndStat)
@@ -26,11 +27,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool HasPreciseErrors => true;
 
-        public override bool RequiresErrorContext => true;
-
         public ExpTableFunction()
             : base("Exp", TexlStrings.AboutExpT, FunctionCategories.Table)
         {
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
@@ -14,14 +14,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Filter(source:*, predicate1:b, [predicate2:b, ...])
     // Corresponding DAX function: Filter
     internal sealed class FilterFunction : FilterFunctionBase
     {
-        public override bool RequiresErrorContext => true;
-
         public FilterFunction()
             : base("Filter", TexlStrings.AboutFilter, FunctionCategories.Table, DType.EmptyTable, -2, 2, int.MaxValue, DType.EmptyTable)
         {
@@ -182,3 +183,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FilterDelegationBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FilterDelegationBase.cs
@@ -10,6 +10,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Abstract base class for all functions "with scope", i.e. that take lambda parameters and participate in filter query server delegation. For example, Filter, LookUp.
@@ -149,3 +152,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
@@ -11,14 +11,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Find(find_text:s, within_text:s, [start_index:n])
     // Equivalent DAX function: Find
     internal sealed class FindFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -38,8 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Find(find_text:s|*[s], within_text:s|*[s], [start_index:n|*[n]])
     internal sealed class FindTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -148,3 +147,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
@@ -12,14 +12,15 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // First(source:*)
     // Last(source:*)
     internal sealed class FirstLastFunction : FunctionWithTableInput
     {
-        public override bool RequiresErrorContext => _isFirst;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
@@ -99,3 +100,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -10,6 +10,9 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // ForAll(source:*, formula)
@@ -18,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SkipScopeForInlineRecords => true;
 
         public override bool IsSelfContained => true;
-
-        public override bool RequiresErrorContext => true;
 
         public override bool SupportsParamCoercion => false;
 
@@ -74,3 +75,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
     }
 }
+
+#pragma warning restore SA1402 // File may only contain a single type
+#pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/GUID.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/GUID.cs
@@ -36,8 +36,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // GUID(GuidString:s)
     internal sealed class GUIDPureFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsStrict => false;
 
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasLambdas => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool RequiresErrorContext => true;
-
         public IndexFunction()
             : base(
                   "Index",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -17,8 +17,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     //  Right(arg:s, count:n)
     internal sealed class LeftRightScalarFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -39,8 +37,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     //  Right(arg:*[_:s], count:n)
     internal sealed class LeftRightTableScalarFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -89,8 +85,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     //  Right(arg:*[_:s], count:*[_:n])
     internal sealed class LeftRightTableTableFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -142,8 +136,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     //  Right(arg:s, count:*[_:n])
     internal sealed class LeftRightScalarTableFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Ln.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Ln.cs
@@ -12,8 +12,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool HasPreciseErrors => true;
 
-        public override bool RequiresErrorContext => true;
-
         public LnFunction()
             : base("Ln", TexlStrings.AboutLn, FunctionCategories.MathAndStat)
         {
@@ -25,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LnTableFunction : MathOneArgTableFunction
     {
         public override bool HasPreciseErrors => true;
-
-        public override bool RequiresErrorContext => true;
 
         public LnTableFunction()
             : base("Ln", TexlStrings.AboutLnT, FunctionCategories.Table)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool RequiresErrorContext => true;
-
         public LogFunction()
             : base("Log", TexlStrings.AboutLog, FunctionCategories.MathAndStat, DType.Number, 0, 1, 2, DType.Number, DType.Number)
         {
@@ -42,8 +40,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;
-
-        public override bool RequiresErrorContext => true;
 
         public LogTFunction()
             : base("Log", TexlStrings.AboutLogT, FunctionCategories.MathAndStat, DType.EmptyTable, 0, 1, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool RequiresErrorContext => true;
-
         public override bool SupportsParamCoercion => true;
 
         internal readonly bool _isAnd;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // LookUp(source:*, predicate, [projectionFunc])
     internal sealed class LookUpFunction : FilterFunctionBase
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool SupportsParamCoercion => true;
 
         public override bool HasPreciseErrors => true;
@@ -53,7 +51,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Ensure that the arg at index 1 is boolean or can coerece to boolean if they are OptionSetValues.
             if (argTypes[1].Kind == DKind.OptionSetValue && argTypes[1].CoercesTo(DType.Boolean))
             {
-                    CollectionUtils.Add(ref nodeToCoercedTypeMap, args[1], DType.Boolean, allowDupes: true);
+                CollectionUtils.Add(ref nodeToCoercedTypeMap, args[1], DType.Boolean, allowDupes: true);
             }
             else if (!DType.Boolean.Accepts(argTypes[1]))
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Mid(source:s, start:n, [count:n])
     internal sealed class MidFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -37,8 +35,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Mid(source:s|*[s], start:n|*[n], [count:n|*[n]])
     internal sealed class MidTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         private readonly DelegationCapability _delegationCapability;
 
-        public override bool RequiresErrorContext => true;
-
         public override DelegationCapability FunctionDelegationCapability => _delegationCapability;
 
         public MinMaxTableFunction(bool isMin)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool RequiresErrorContext => true;
-
         public ModFunction()
             : base("Mod", TexlStrings.AboutMod, FunctionCategories.MathAndStat, DType.Number, 0, 2, 2, DType.Number, DType.Number)
         {
@@ -38,8 +36,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;
-
-        public override bool RequiresErrorContext => true;
 
         public ModTFunction()
             : base("Mod", TexlStrings.AboutModT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool RequiresErrorContext => true;
-
         public PowerFunction()
             : base("Power", TexlStrings.AboutPower, FunctionCategories.MathAndStat, DType.Number, 0, 2, 2, DType.Number, DType.Number)
         {
@@ -39,8 +37,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;
-
-        public override bool RequiresErrorContext => true;
 
         public PowerTFunction()
             : base("Power", TexlStrings.AboutPowerT, FunctionCategories.MathAndStat, DType.EmptyTable, 0, 2, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Radians.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Radians.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Radians
     internal sealed class RadiansFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public RadiansFunction()
             : base("Radians", TexlStrings.AboutRadians, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the radians values of each item in the input table.
     internal sealed class RadiansTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public RadiansTableFunction()
             : base("Radians", TexlStrings.AboutRadiansT, FunctionCategories.Table)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
@@ -17,8 +17,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool RequiresErrorContext => true;
-
         public override bool SupportsParamCoercion => true;
 
         public RandBetweenFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Replace(source:s, start:n, count:n, replacement:s)
     internal sealed class ReplaceFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -36,8 +34,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Replace(source:s|*[s], start:n|*[n], count:n|*[n], replacement:s|*[s])
     internal sealed class ReplaceTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -12,8 +12,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Sequence(records:n, start:n, step:n): *[Value:n]
     internal sealed class SequenceFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sin.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sin.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Sin
     internal sealed class SinFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public SinFunction()
             : base("Sin", TexlStrings.AboutSin, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the sine values of each item in the input table.
     internal sealed class SinTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public SinTableFunction()
             : base("Sin", TexlStrings.AboutSinT, FunctionCategories.Table)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -38,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             SignatureConstraint = new SignatureConstraint(omitStartIndex: 5, repeatSpan: 2, endNonRepeatCount: 0, repeatTopLength: 9);
         }
 
-        public override bool RequiresErrorContext => true;
-
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             // Enumerate just the base overloads (the first 2 possibilities).
@@ -370,8 +368,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             : base("SortByColumns", TexlStrings.AboutSortByColumnsWithOrderValues, FunctionCategories.Table, DType.EmptyTable, 0, 3, 3, DType.EmptyTable, DType.String, DType.EmptyTable)
         {
         }
-
-        public override bool RequiresErrorContext => true;
 
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sqrt.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sqrt.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX function: Sqrt
     internal sealed class SqrtFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public SqrtFunction()
             : base("Sqrt", TexlStrings.AboutSqrt, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the square root values of each item in the input table.
     internal sealed class SqrtTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public SqrtTableFunction()
             : base("Sqrt", TexlStrings.AboutSqrtT, FunctionCategories.Table)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Stdev.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Stdev.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding Excel function: STDEV.P
     internal sealed class StdevPFunction : StatisticalFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public StdevPFunction()
             : base("StdevP", TexlStrings.AboutStdevP, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding DAX function: STDEV.P
     internal sealed class StdevPTableFunction : StatisticalTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public StdevPTableFunction()
             : base("StdevP", TexlStrings.AboutStdevPT, FunctionCategories.Table)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Substitute(source:s, match:s, replacement:s, [instanceCount:n])
     internal sealed class SubstituteFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -37,8 +35,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Substitute(source:s|*[s], match:s|*[s], replacement:s|*[s], [instanceCount:n|*[n]])
     internal sealed class SubstituteTFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sum.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sum.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Sum(arg1:n, arg2:n, ..., argN:n)
     internal sealed class SumFunction : StatisticalFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public SumFunction()
             : base("Sum", TexlStrings.AboutSum, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding DAX functions: Sum, SumX
     internal sealed class SumTableFunction : StatisticalTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Sum;
 
         public SumTableFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -88,8 +88,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
     internal class TableFunction_UO : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Tan.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Tan.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Tan
     internal sealed class TanFunction : MathOneArgFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public TanFunction()
             : base("Tan", TexlStrings.AboutTan, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Table overload that computes the tangent of each item in the input table.
     internal sealed class TanTableFunction : MathOneArgTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public TanTableFunction()
             : base("Tan", TexlStrings.AboutTanT, FunctionCategories.Table)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool SupportsParamCoercion => true;
 
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public TextFunction()
@@ -176,8 +174,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class TextFunction_UO : BuiltinFunction
     {
         public override bool SupportsParamCoercion => false;
-
-        public override bool RequiresErrorContext => true;
 
         public override bool IsSelfContained => true;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/TimezoneOffset.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/TimezoneOffset.cs
@@ -11,8 +11,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // TimeZoneOffset()
     internal sealed class TimeZoneOffsetFunction : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
@@ -14,8 +14,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public const string ParseJSONInvariantFunctionName = "ParseJSON";
 
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
@@ -36,8 +34,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class IndexFunction_UO : BuiltinFunction
     {
         public const string IndexInvariantFunctionName = "Index";
-
-        public override bool RequiresErrorContext => true;
 
         public override bool IsSelfContained => true;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public const string ValueInvariantFunctionName = "Value";
 
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
@@ -86,8 +84,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Value(arg:O)
     internal sealed class ValueFunction_UO : BuiltinFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Variance.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Variance.cs
@@ -10,8 +10,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding Excel function: VARP
     internal sealed class VarPFunction : StatisticalFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public VarPFunction()
             : base("VarP", TexlStrings.AboutVarP, FunctionCategories.MathAndStat)
         {
@@ -22,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding DAX function: VAR.P
     internal sealed class VarPTableFunction : StatisticalTableFunction
     {
-        public override bool RequiresErrorContext => true;
-
         public VarPTableFunction()
             : base("VarP", TexlStrings.AboutVarPT, FunctionCategories.Table)
         {


### PR DESCRIPTION
The RequiresErrorContext property is only applicable to the JS runtime, so it doesn't need to be in the base TexlFunction class.
Also ignored some warnings for function definitions.