### PR TITLE
Set function 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -37,6 +37,10 @@ namespace Microsoft.PowerFx.Core.Localization
         public static StringGetter CountIfArg1 = (b) => StringResources.Get("CountIfArg1", b);
         public static StringGetter CountIfArg2 = (b) => StringResources.Get("CountIfArg2", b);
 
+        public static StringGetter AboutSet = (b) => StringResources.Get("AboutSet", b);
+        public static StringGetter SetArg1 = (b) => StringResources.Get("SetArg1", b);
+        public static StringGetter SetArg2 = (b) => StringResources.Get("SetArg2", b);
+
         public static StringGetter AboutSumT = (b) => StringResources.Get("AboutSumT", b);
         public static StringGetter AboutMaxT = (b) => StringResources.Get("AboutMaxT", b);
         public static StringGetter AboutMinT = (b) => StringResources.Get("AboutMinT", b);
@@ -491,6 +495,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrIncompatibleRecord = new ErrorResourceKey("ErrIncompatibleRecord");
         public static ErrorResourceKey ErrNeedRecord_Func = new ErrorResourceKey("ErrNeedRecord_Func");
         public static ErrorResourceKey ErrNeedEntity_EntityName = new ErrorResourceKey("ErrNeedEntity_EntityName");
+        public static ErrorResourceKey ErrNeedValidVariableName_Arg = new ErrorResourceKey("ErrNeedValidVariableName_Arg");
         public static ErrorResourceKey ErrOperatorExpected = new ErrorResourceKey("ErrOperatorExpected");
         public static ErrorResourceKey ErrNumberExpected = new ErrorResourceKey("ErrNumberExpected");
         public static ErrorResourceKey ErrNumberTooLarge = new ErrorResourceKey("ErrNumberTooLarge");

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -87,7 +87,9 @@ namespace Microsoft.PowerFx
         public CheckResult Check(string expressionText, RecordType parameterType = null, ParserOptions options = null)
         {
             var parse = Parse(expressionText, options);
-            return Check(parse, parameterType);
+
+            var bindingConfig = new BindingConfig(options?.AllowsSideEffects == true);
+            return CheckInternal(parse, parameterType, bindingConfig);
         }
 
         /// <summary>
@@ -97,6 +99,11 @@ namespace Microsoft.PowerFx
         /// <param name="parameterType">types of additional args to pass.</param>
         /// <returns></returns>
         public CheckResult Check(ParseResult parse, RecordType parameterType = null)
+        {
+            return CheckInternal(parse, parameterType, BindingConfig.Default);
+        }
+
+        private CheckResult CheckInternal(ParseResult parse, RecordType parameterType, BindingConfig bindingConfig)
         {
             parameterType ??= new RecordType();
                         
@@ -109,7 +116,7 @@ namespace Microsoft.PowerFx
                 new Glue2DocumentBinderGlue(),
                 parse.Root,
                 resolver,
-                BindingConfig.Default,
+                bindingConfig,
                 ruleScope: parameterType._type,
                 useThisRecordForRuleScope: false);
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Interpreter;
 
 namespace Microsoft.PowerFx
 {
@@ -19,6 +20,15 @@ namespace Microsoft.PowerFx
         public static void AddFunction(this PowerFxConfig powerFxConfig, ReflectionFunction function)
         {
             powerFxConfig.AddFunction(function.GetTexlFunction());
+        }
+
+        /// <summary>
+        /// Enable a Set() function which allows scripts to do <see cref="RecalcEngine.UpdateVariable(string, Types.FormulaValue)"/>.
+        /// </summary>
+        /// <param name="powerFxConfig"></param>
+        public static void EnableSetFunction(this PowerFxConfig powerFxConfig)
+        {
+            powerFxConfig.AddFunction(new RecalcEngineSetFunction());
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -117,8 +117,8 @@ namespace Microsoft.PowerFx
             return val;
         }
 
-        // Handle the Set() function - which is unique because
-        // it has an l-value for the first arg. 
+        // Handle the Set() function -
+        // Set is unique because it has an l-value for the first arg. 
         // Async params can't have out-params. 
         // Return null if not handled. Else non-null if handled.
         private async Task<FormulaValue> TryHandleSet(CallNode node, SymbolContext context)
@@ -134,14 +134,14 @@ namespace Microsoft.PowerFx
 
             var newValue = await arg1.Accept(this, context);
 
-            // ensure this is a firstname node            
+            // Binder has already ensured this is a first name node. 
             if (arg0 is ResolvedObjectNode obj)
             {
-                // $$$ Should we have an interface here instead?
-                // Set(variable, newValue);   
-                if (obj.Value is RecalcFormulaInfo fi)
+                if (obj.Value is ICanSetValue fi)
                 {
-                    fi._value = newValue;
+                    fi.SetValue(newValue);
+
+                    // Set() returns true. 
                     return FormulaValue.New(true);
                 }
             }
@@ -529,7 +529,7 @@ namespace Microsoft.PowerFx
         {
             return node.Value switch
             {
-                RecalcFormulaInfo fi => ResolvedObjectHelpers.RecalcFormulaInfo(fi),
+                ICanGetValue fi => fi.Value,
                 IExternalOptionSet optionSet => ResolvedObjectHelpers.OptionSet(optionSet, node.IRContext),
                 _ => ResolvedObjectHelpers.ResolvedObjectError(node),
             };

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -160,9 +160,6 @@ namespace Microsoft.PowerFx
                 return setResult;
             }            
 
-            // Sum(  [1,2,3], Value * Value)
-            // return base.PreVisit(node);
-
             var func = node.Function;
 
             var carg = node.Args.Count;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ResolvedObjectHelpers.cs
@@ -13,11 +13,6 @@ namespace Microsoft.PowerFx.Functions
     // Core operations for turning ResolvedObjects into PowerFx values
     internal static class ResolvedObjectHelpers
     {
-        public static FormulaValue RecalcFormulaInfo(RecalcFormulaInfo fi)
-        {
-            return fi._value;
-        }
-
         // This allows option sets to be standalone identifiers, like:
         //   Choices(TimeUnit). 
         //

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Types;
+using static Microsoft.PowerFx.Core.Localization.TexlStrings;
+
+namespace Microsoft.PowerFx.Interpreter
+{
+    // Implementation of a Set function which just chains to 
+    // RecalcEngine.UpdateVariable().
+    // Set has no return value. 
+    // Whereas Powerapp's Set() will implicitly define arg0,
+    //  this Set() requires arg0 was already defined and has a type.
+    //
+    // Called as:
+    //   Set(var,newValue)
+    internal class RecalcEngineSetFunction : TexlFunction
+    {
+        // Should set to False, but then we need to be able to bind behavior functions. 
+        //public override bool IsSelfContained => false;
+        public override bool IsSelfContained => true;
+        
+        public override IEnumerable<StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.SetArg1, TexlStrings.SetArg2 };
+        }
+
+        public RecalcEngineSetFunction()
+        : base(
+              DPath.Root,
+              "Set",
+              "Set",
+              TexlStrings.AboutSet,
+              FunctionCategories.Behavior,
+              DType.Boolean,
+              0, // no lambdas
+              2,
+              2)
+        {
+        }
+
+        // 2nd argument should be same type as 1st argument. 
+        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(binding);
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.AssertAllValid(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+            Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
+
+            nodeToCoercedTypeMap = null;
+            returnType = DType.Boolean;
+
+            var arg0 = argTypes[0];
+
+            var firstName = args[0].AsFirstName();
+
+            // Global-scoped variable name should be a firstName.
+            if (firstName == null)
+            {
+                errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrNeedValidVariableName_Arg, Name, args[0]);
+                return false;
+            }
+
+            var arg1 = argTypes[1];
+
+            if (!arg1.Equals(arg0))
+            {
+                errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrBadType);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
@@ -27,10 +27,9 @@ namespace Microsoft.PowerFx.Interpreter
     //   Set(var,newValue)
     internal class RecalcEngineSetFunction : TexlFunction
     {
-        // Should set to False, but then we need to be able to bind behavior functions. 
-        //public override bool IsSelfContained => false;
-        public override bool IsSelfContained => true;
-        
+        // Set() is a behavior function. 
+        public override bool IsSelfContained => false;
+                
         public override IEnumerable<StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.SetArg1, TexlStrings.SetArg2 };

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerFx
         {
             if (Formulas.TryGetValue(name, out var info))
             {
-                return info._value;
+                return info.Value;
             }
 
             // Binder should have caught. 
@@ -120,13 +120,13 @@ namespace Microsoft.PowerFx
                     throw new NotSupportedException($"Can't change '{name}''s type from {fi._type} to {x.Type}.");
                 }
 
-                fi._value = x;
+                fi.Value = x;
 
                 // Be sure to preserve used-by set. 
             }
             else
             {
-                Formulas[name] = new RecalcFormulaInfo { _value = x, _type = x.IRContext.ResultType };
+                Formulas[name] = new RecalcFormulaInfo { Value = x, _type = x.IRContext.ResultType };
             }
 
             // Could trigger recalcs?
@@ -254,7 +254,7 @@ namespace Microsoft.PowerFx
         public FormulaValue GetValue(string name)
         {
             var fi = Formulas[name];
-            return fi._value;
+            return fi.Value;
         }
     } // end class RecalcEngine
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineWorker.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineWorker.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx
             {
                 var info = _parent.Formulas[varName];
 
-                var newValue = info._value;
+                var newValue = info.Value;
                 info._onUpdate?.Invoke(varName, newValue);
             }
         }
@@ -71,18 +71,18 @@ namespace Microsoft.PowerFx
 
                 var newValue = irnode.Accept(v, SymbolContext.New()).Result;
 
-                var equal = fi._value != null && // null on initial run. 
-                    RuntimeHelpers.AreEqual(newValue, fi._value);
+                var equal = fi.Value != null && // null on initial run. 
+                    RuntimeHelpers.AreEqual(newValue, fi.Value);
 
                 if (!equal)
                 {
                     _sendUpdates.Add(name);
                 }
 
-                fi._value = newValue;
+                fi.Value = newValue;
             }
 
-            _calcs[name] = fi._value;
+            _calcs[name] = fi.Value;
         }
 
         // Recalc Name and any downstream formulas that may now be updated.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcFormulaInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcFormulaInfo.cs
@@ -29,13 +29,11 @@ namespace Microsoft.PowerFx
         public TexlBinding _binding;
 
         // Cached value
-        public FormulaValue _value;
-
-        public FormulaValue Value => _value;
+        public FormulaValue Value { get; set; }
 
         void ICanSetValue.SetValue(FormulaValue newValue)
         {
-            _value = newValue;
+            Value = newValue;
         }
     }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcFormulaInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcFormulaInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerFx
 {
     // Information needed for recalc engine
     // Could represent either a fixed variable or a formula. 
-    internal class RecalcFormulaInfo
+    internal class RecalcFormulaInfo : ICanGetValue, ICanSetValue
     {
         // Other variables that this formula depends on. 
         public HashSet<string> _dependsOn;
@@ -30,5 +30,22 @@ namespace Microsoft.PowerFx
 
         // Cached value
         public FormulaValue _value;
+
+        public FormulaValue Value => _value;
+
+        void ICanSetValue.SetValue(FormulaValue newValue)
+        {
+            _value = newValue;
+        }
+    }
+
+    internal interface ICanSetValue
+    {
+        void SetValue(FormulaValue newValue);
+    }
+
+    internal interface ICanGetValue
+    {
+        FormulaValue Value { get; }
     }
 }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -6435,5 +6435,17 @@
   </data>
   <data name="ErrNamedFormula_AlreadyDefined" xml:space="preserve">
     <value>NamedFormula '{0}' already exists.</value>
+  </data>
+  <data name="ErrNeedValidVariableName_Arg" xml:space="preserve">
+    <value>The first argument of '{0}' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type '{1}'</value>
+    <comment>Error Message</comment>
+  </data>
+  <data name="AboutSet" xml:space="preserve">
+    <value>Create and set a global variable.</value>
+    <comment>Description of 'Set' function.</comment>
+  </data>
+  <data name="SetArg2" xml:space="preserve">
+    <value>value</value>
+    <comment>function_parameter - Second argument to the Set function - any Power Apps value.</comment>
   </data>
 </root>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/ParallelAsync.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/ParallelAsync.txt
@@ -8,6 +8,9 @@
 // WaitFor(N) will *fail* if it's started before WaitFor(N-1) completes. 
 // This ensures things that must be serial are indeed serial. 
 
+>> Set(varNumber, WaitFor(0)+1); Set(varNumber, WaitFor(1)*10+varNumber); varNumber
+11
+
 >> Async(0)
 0
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -69,7 +69,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 var waitForHelper = new WaitForFunctionsHelper(verify);
                 config.AddFunction(waitForHelper.GetFunction());
 
+                config.EnableSetFunction();
                 var engine = new RecalcEngine(config);
+                engine.UpdateVariable("varNumber", 9999);
 
                 // Run in special mode that ensures we're not calling .Result
                 var result = await verify.EvalAsync(engine, expr, options);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Types;
+using Xunit;
+
+namespace Microsoft.PowerFx.Interpreter.Tests
+{
+    public class SetFunctionTests : PowerFxTest
+    {
+        [Fact]
+        public void TestSetVar()
+        {
+            var config = new PowerFxConfig();
+            config.EnableSetFunction();
+            var engine = new RecalcEngine(config);
+
+            engine.UpdateVariable("x", FormulaValue.New(12));
+
+            var r1 = engine.Eval("x"); // 12
+            Assert.Equal(12.0, r1.ToObject());
+
+            var r2 = engine.Eval("Set(x, 15)");
+
+            r1 = engine.Eval("x"); // 15
+            Assert.Equal(15.0, r1.ToObject());
+
+            r1 = engine.GetValue("x");
+            Assert.Equal(15.0, r1.ToObject());
+
+            var result = engine.Check("Set(x, true)"); // Fails, type mismatch
+            Assert.False(result.IsSuccess);
+
+            result = engine.Check("Set({y:x}.y, 20)"); // Fails, type mismatch
+            Assert.False(result.IsSuccess);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
@@ -9,6 +9,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class SetFunctionTests : PowerFxTest
     {
+        private readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+
+        // $$$ Trigger a recalc?
         [Fact]
         public void TestSetVar()
         {
@@ -17,22 +20,43 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var engine = new RecalcEngine(config);
 
             engine.UpdateVariable("x", FormulaValue.New(12));
-
-            var r1 = engine.Eval("x"); // 12
+                        
+            var r1 = engine.Eval("x", null, _opts); // 12
             Assert.Equal(12.0, r1.ToObject());
 
-            var r2 = engine.Eval("Set(x, 15)");
+            var r2 = engine.Eval("Set(x, 15)", null, _opts);
 
             r1 = engine.Eval("x"); // 15
             Assert.Equal(15.0, r1.ToObject());
 
             r1 = engine.GetValue("x");
             Assert.Equal(15.0, r1.ToObject());
+        }
 
-            var result = engine.Check("Set(x, true)"); // Fails, type mismatch
+        // Test various failure cases 
+        [Fact]
+        public void TestSetVarFailures()
+        {
+            var config = new PowerFxConfig();
+            config.EnableSetFunction();
+            var engine = new RecalcEngine(config);
+
+            engine.UpdateVariable("x", FormulaValue.New(12));
+
+            // Fails, can't set var that wasn't already declared
+            var result = engine.Check("Set(missing, 12)");
             Assert.False(result.IsSuccess);
 
-            result = engine.Check("Set({y:x}.y, 20)"); // Fails, type mismatch
+            // Fails, behavior function must be in behavior context. 
+            result = engine.Check("Set(x, true)");
+            Assert.False(result.IsSuccess);
+
+            // Fails, type mismatch
+            result = engine.Check("Set(x, true)", null, _opts);
+            Assert.False(result.IsSuccess);
+
+            // Fails, arg0 is not a settable object. 
+            result = engine.Check("Set({y:x}.y, 20)", null, _opts);
             Assert.False(result.IsSuccess);
         }
     }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var engine = new RecalcEngine(config);
 
             engine.UpdateVariable("x", FormulaValue.New(12));
-                        
+
             var r1 = engine.Eval("x", null, _opts); // 12
             Assert.Equal(12.0, r1.ToObject());
 
@@ -57,6 +57,19 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             // Fails, arg0 is not a settable object. 
             result = engine.Check("Set({y:x}.y, 20)", null, _opts);
+            Assert.False(result.IsSuccess);
+        }
+
+        // Set() can only be called if it's enabled.
+        [Fact]
+        public void TestSetVarFailureEnabled()
+        {
+            var config = new PowerFxConfig();
+            var engine = new RecalcEngine(config);
+
+            engine.UpdateVariable("x", FormulaValue.New(12));
+
+            var result = engine.Check("Set(x, 15)", null, _opts);
             Assert.False(result.IsSuccess);
         }
     }


### PR DESCRIPTION
Allow interpreter to add Set() function which just maps to RecalcEngine.UpdateVariable.

- must be explicitly enabled by the host (since many hosts will not want this). 
- only works for firstname nodes.  
- requires that the variable was already declared. 
- type or arg1 must match exactly  to arg0.
