### PR TITLE
Fix nuget package URLs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -62,12 +62,12 @@
 
   <PropertyGroup>
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
-    <PackageProjectUrl>https://github.com/Microsoft/PowerFx-Staging</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/microsoft/PowerFx-Staging/master/icon.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/microsoft/Power-Fx</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/microsoft/Power-Fx/master/icon.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>icon.png</PackageIcon>
-    <RepositoryUrl>https://github.com/Microsoft/PowerFx-Staging</RepositoryUrl>
+    <RepositoryUrl>https://github.com/microsoft/Power-Fx</RepositoryUrl>
     <PackageTags>powerfx</PackageTags>
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
Our URLs on nuget.org point to our now-deleted staging repo from before open sourcing the language. This fixes that. 