### PR TITLE
Only disallow line breaks and tabulation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Utils/CharacterUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/CharacterUtils.cs
@@ -261,6 +261,20 @@ namespace Microsoft.PowerFx.Core.Utils
 
             return false;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsDNameAllowedSpace(char ch)
+        {
+            switch (ch)
+            {
+                case ' ':
+                // Full-Width space used in CJK languages
+                case '\u3000':
+                    return true;
+            }
+
+            return false;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLineTerm(char ch)

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/CharacterUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/CharacterUtils.cs
@@ -231,19 +231,8 @@ namespace Microsoft.PowerFx.Core.Utils
                 return (GetUniCatFlags(ch) & UniCatFlags.SpaceSeparator) != 0;
             }
 
-            switch (ch)
-            {
-                case ' ':
-                // character tabulation
-                case '\u0009':
-                // line tabulation
-                case '\u000B':
-                // form feed
-                case '\u000C':
-                    return true;
-            }
-
-            return false;
+            // Character is regular space or tab
+            return ch == 32 || IsTabulation(ch);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -261,15 +250,16 @@ namespace Microsoft.PowerFx.Core.Utils
 
             return false;
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsDNameAllowedSpace(char ch)
+        public static bool IsTabulation(char ch)
         {
             switch (ch)
             {
-                case ' ':
-                // Full-Width space used in CJK languages
-                case '\u3000':
+                // character tabulation
+                case '\u0009':
+                // line tabulation
+                case '\u000B':
                     return true;
             }
 
@@ -291,6 +281,8 @@ namespace Microsoft.PowerFx.Core.Utils
                 case '\u2028':
                 // Unicode paragraph separator
                 case '\u2029':
+                // form feed
+                case '\u000C':
                     return true;
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/DName.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/DName.cs
@@ -160,26 +160,26 @@ namespace Microsoft.PowerFx.Core.Utils
             }
 
             var fAllSpaces = true;
-            var fHasSpecialWhiteSpaceCharacters = false;
+            var fHasDisallowedWhiteSpaceCharacters = false;
             
             fModified = false;
 
             for (var i = 0; i < strName.Length; i++)
             {
-                var fIsSpace = CharacterUtils.IsDNameAllowedSpace(strName[i]);
-                var fIsWhiteSpace = char.IsWhiteSpace(strName[i]);
-                fAllSpaces = fAllSpaces && fIsWhiteSpace;
-                fHasSpecialWhiteSpaceCharacters |= fIsWhiteSpace && !fIsSpace;
+                var fIsSpace = strName[i] == ChSpace;
+                var fIsDisallowedWhiteSpace = CharacterUtils.IsTabulation(strName[i]) || CharacterUtils.IsLineTerm(strName[i]);
+                fAllSpaces = fAllSpaces && (fIsDisallowedWhiteSpace || fIsSpace);
+                fHasDisallowedWhiteSpaceCharacters |= fIsDisallowedWhiteSpace;
             }
 
-            if (fHasSpecialWhiteSpaceCharacters)
+            if (fHasDisallowedWhiteSpaceCharacters)
             {
                 fModified = true;
                 var builder = new StringBuilder(strName.Length);
 
                 for (var i = 0; i < strName.Length; i++)
                 {
-                    if (char.IsWhiteSpace(strName[i]) && !CharacterUtils.IsDNameAllowedSpace(strName[i]))
+                    if (CharacterUtils.IsTabulation(strName[i]) || CharacterUtils.IsLineTerm(strName[i]))
                     {
                         builder.Append(ChSpace);
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/DName.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/DName.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Core.Utils
 
             for (var i = 0; i < strName.Length; i++)
             {
-                var fIsSpace = strName[i] == ChSpace;
+                var fIsSpace = CharacterUtils.IsDNameAllowedSpace(strName[i]);
                 var fIsWhiteSpace = char.IsWhiteSpace(strName[i]);
                 fAllSpaces = fAllSpaces && fIsWhiteSpace;
                 fHasSpecialWhiteSpaceCharacters |= fIsWhiteSpace && !fIsSpace;
@@ -179,7 +179,7 @@ namespace Microsoft.PowerFx.Core.Utils
 
                 for (var i = 0; i < strName.Length; i++)
                 {
-                    if (char.IsWhiteSpace(strName[i]))
+                    if (char.IsWhiteSpace(strName[i]) && !CharacterUtils.IsDNameAllowedSpace(strName[i]))
                     {
                         builder.Append(ChSpace);
                     }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DNameTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DNameTests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Name\nAbcd", "Name Abcd", true)]
         [InlineData("   ", "_   ", true)]
         [InlineData(" \t ", "_   ", true)]
+        [InlineData("Name\u3000Abcd", "Name\u3000Abcd", false)]
         public void TestMakeValid(string name, string expected, bool expectedModified)
         {
             var result = DName.MakeValid(name, out var modified);


### PR DESCRIPTION
CJK languages use full-width space characters along-side the regular space (half-width in CJK), these should also be allowed in DNames. Switching to disallow line breaks and tabs rather than restrict most whitespace characters