### PR TITLE
Update Boolean and Text functions to have parity with TS

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerFx.Functions
             {
                 Message = "The value could not be interpreted as a Boolean",
                 Span = irContext.SourceContext,
-                Kind = ErrorKind.BadLanguageCode
+                Kind = ErrorKind.InvalidArgument
             });
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Boolean)
+                    targetFunction: TextToBoolean)
             },
             {
                 BuiltinFunctionsCore.Boolean_UO,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
                     targetFunction: Text)
             },
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Text)
             },
             {
@@ -1102,7 +1102,7 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Text_UO)
             },
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -120,16 +120,6 @@ namespace Microsoft.PowerFx.Functions
 
             return CommonErrors.ArgumentOutOfRange(irContext);
         }
-        
-        // Convert string to boolean
-        public static FormulaValue Boolean(IRContext irContext, StringValue[] args)
-        {
-            var arg0 = args[0];
-
-            var val = args[0].Value == "true";
-
-            return new BooleanValue(irContext, val);
-        }
 
         // https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/function-text
         public static FormulaValue Text(EvalVisitor runner, SymbolContext symbolContext, IRContext irContext, FormulaValue[] args)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -126,16 +126,7 @@ namespace Microsoft.PowerFx.Functions
         {
             var arg0 = args[0];
 
-            var str = arg0.Value.Trim().ToLower();
-            if (string.IsNullOrEmpty(str))
-            {
-                return new BlankValue(irContext);
-            }
-
-            if (!bool.TryParse(str, out var val))
-            {
-                return CommonErrors.InvalidBooleanFormatError(irContext);
-            }
+            var val = args[0].Value == "true";
 
             return new BooleanValue(irContext, val);
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -283,7 +283,14 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue TextToBoolean(IRContext irContext, StringValue[] args)
         {
-            var lower = args[0].Value.ToLower();
+            var val = args[0].Value;
+
+            if (string.IsNullOrEmpty(val))
+            {
+                return new BlankValue(irContext);
+            }
+
+            var lower = val.ToLower();
             if (lower == "true")
             {
                 return new BooleanValue(irContext, true);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -281,10 +281,19 @@ namespace Microsoft.PowerFx.Functions
             return new NumberValue(irContext, b ? 1.0 : 0.0);
         }
 
-        public static BooleanValue TextToBoolean(IRContext irContext, StringValue[] args)
+        public static FormulaValue TextToBoolean(IRContext irContext, StringValue[] args)
         {
-            var s = args[0].Value;
-            return new BooleanValue(irContext, s == "true");
+            var lower = args[0].Value.ToLower();
+            if (lower == "true")
+            {
+                return new BooleanValue(irContext, true);
+            }
+            else if (lower == "false")
+            {
+                return new BooleanValue(irContext, false);
+            }
+
+            return CommonErrors.InvalidBooleanFormatError(irContext);
         }
 
         public static FormulaValue DateToNumber(IRContext irContext, FormulaValue[] args)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -290,7 +290,7 @@ namespace Microsoft.PowerFx.Functions
                 return new BlankValue(irContext);
             }
 
-            var lower = val.ToLower();
+            var lower = val.ToLowerInvariant();
             if (lower == "true")
             {
                 return new BooleanValue(irContext, true);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BasicCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BasicCoercion.txt
@@ -35,10 +35,10 @@ true
 
 // can coorce text to bool via logical operators
 >> "true" && "anything"
-#Error
+#Error(Kind=InvalidArgument)
 
 >> "anything" || "true"
-#Error
+#Error(Kind=InvalidArgument)
 
 // blank coorces to false via logical operators
 >> true && !Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BasicCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BasicCoercion.txt
@@ -35,10 +35,10 @@ true
 
 // can coorce text to bool via logical operators
 >> "true" && "anything"
-false
+#Error
 
 >> "anything" || "true"
-true
+#Error
 
 // blank coorces to false via logical operators
 >> true && !Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -5,16 +5,16 @@ true
 false
 
 >> Boolean("x")
-#Error
+false
 
 >> Boolean(" true")
-true
+false
 
 >> Boolean(" false")
 false
 
 >> Boolean("True")
-true
+false
 
 >> Boolean("False")
 false
@@ -22,11 +22,11 @@ false
 >> Boolean(Text(Blank()))
 Blank()
 
->> Boolean(Text(0/1))
+>> Boolean(Text(1/0))
 #Error
 
 >> Boolean("0")
-#Error
+false
 
 >> Boolean(0)
 Errors: Error 0-10: The function 'Boolean' has some invalid arguments.|Error 8-9: Invalid argument type (Number). Expecting a Text value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -29,7 +29,7 @@ false
 Blank()
 
 >> Boolean(Text(1/0))
-#Error
+#Error(Kind=Div0)
 
 >> Boolean("0")
 #Error

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -5,13 +5,13 @@ true
 false
 
 >> Boolean("x")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Boolean(" true")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Boolean(" false")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Boolean("True")
 true
@@ -32,7 +32,7 @@ Blank()
 #Error(Kind=Div0)
 
 >> Boolean("0")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Boolean(0)
 Errors: Error 0-10: The function 'Boolean' has some invalid arguments.|Error 8-9: Invalid argument type (Number). Expecting a Text value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -5,18 +5,24 @@ true
 false
 
 >> Boolean("x")
-false
+#Error
 
 >> Boolean(" true")
-false
+#Error
 
 >> Boolean(" false")
-false
+#Error
 
 >> Boolean("True")
-false
+true
 
 >> Boolean("False")
+false
+
+>> Boolean("TRUE")
+true
+
+>> Boolean("FALSE")
 false
 
 >> Boolean(Text(Blank()))
@@ -26,7 +32,7 @@ Blank()
 #Error
 
 >> Boolean("0")
-false
+#Error
 
 >> Boolean(0)
 Errors: Error 0-10: The function 'Boolean' has some invalid arguments.|Error 8-9: Invalid argument type (Number). Expecting a Text value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -63,6 +63,9 @@ true
 >> Boolean(ParseJSON("false"))
 false
 
+>> Boolean(ParseJSON("null"))
+Blank()
+
 >> ParseJSON("{""a"": null}").a
 Blank()
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -46,7 +46,7 @@ Blank()
 "s"
 
 >> Text(ParseJSON("null"))
-""
+Blank()
 
 >> Text(ParseJSON("true"))
 #Error

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
@@ -5,7 +5,7 @@
 "123.400"
 
 >> Text(Blank(), "#.000")
-Blank()
+""
 
 >> Char(65)
 "A"
@@ -129,10 +129,10 @@ Blank()
 
 //Excel needs two parameters for Text function
 >> Text(Blank())
-Blank()
+""
 
 >> Text(Blank(), Blank())
-Blank()
+""
 
 //Excel needs two parameters for Text function
 >> Text("")
@@ -144,24 +144,24 @@ Blank()
 
 //Excel returns "$"
 >> Text(Blank(), "$ #,###")
-Blank()
+""
 
 >> Text(Blank(), "#,#")
-Blank()
+""
 
 >> Text(Blank(), "#,###")
-Blank()
+""
 
 >> Text(123.4, Blank())
-Blank()
+""
 
 //Excel throws error
 >> Text(DateTimeValue(Blank()), DateTimeFormat.LongDate)
-Blank()
+""
 
 //Excel throws error
 >> Text(DateTimeValue("March 30, 2022 5:30 PM"), Blank())
-Blank()
+""
 
 >> Text(Date(2016,1,31), "pqr")
 "pqr"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
@@ -5,7 +5,7 @@
 "123.400"
 
 >> Text(Blank(), "#.000")
-""
+Blank()
 
 >> Char(65)
 "A"
@@ -111,8 +111,6 @@ Blank()
 >> Text(false)
 "false"
 
-
-
 //Excel needs two parameters for Text function
 >> Text("true")
 "true"
@@ -131,10 +129,10 @@ Blank()
 
 //Excel needs two parameters for Text function
 >> Text(Blank())
-""
+Blank()
 
 >> Text(Blank(), Blank())
-""
+Blank()
 
 //Excel needs two parameters for Text function
 >> Text("")
@@ -146,28 +144,24 @@ Blank()
 
 //Excel returns "$"
 >> Text(Blank(), "$ #,###")
-""
+Blank()
 
 >> Text(Blank(), "#,#")
-""
+Blank()
 
 >> Text(Blank(), "#,###")
-""
+Blank()
 
 >> Text(123.4, Blank())
-""
+Blank()
 
 //Excel throws error
 >> Text(DateTimeValue(Blank()), DateTimeFormat.LongDate)
-""
-
-
+Blank()
 
 //Excel throws error
 >> Text(DateTimeValue("March 30, 2022 5:30 PM"), Blank())
-""
-
-
+Blank()
 
 >> Text(Date(2016,1,31), "pqr")
 "pqr"


### PR DESCRIPTION
Text(Blank()) will now return Blank() instead of ""
Boolean("True") => true, but Boolean(" true") => Error