### PR TITLE
Add option param to Engine.Check overload

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -108,9 +108,7 @@ namespace Microsoft.PowerFx
         public CheckResult Check(string expressionText, RecordType parameterType = null, ParserOptions options = null)
         {
             var parse = Parse(expressionText, options);
-
-            var bindingConfig = new BindingConfig(options?.AllowsSideEffects == true);
-            return CheckInternal(parse, parameterType, bindingConfig);
+            return Check(parse, parameterType, options);
         }
 
         /// <summary>
@@ -118,10 +116,12 @@ namespace Microsoft.PowerFx
         /// </summary>
         /// <param name="parse">the parsed expression. Obtain from <see cref="Parse(string, ParserOptions)"/>.</param>
         /// <param name="parameterType">types of additional args to pass.</param>
+        /// <param name="options">parser options to use.</param>
         /// <returns></returns>
-        public CheckResult Check(ParseResult parse, RecordType parameterType = null)
+        public CheckResult Check(ParseResult parse, RecordType parameterType = null, ParserOptions options = null)
         {
-            return CheckInternal(parse, parameterType, BindingConfig.Default);
+            var bindingConfig = new BindingConfig(options?.AllowsSideEffects == true);
+            return CheckInternal(parse, parameterType, bindingConfig);
         }
 
         private CheckResult CheckInternal(ParseResult parse, RecordType parameterType, BindingConfig bindingConfig)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -208,11 +208,11 @@ namespace Microsoft.PowerFx.Tests
         public void CheckParseResultSideEffects()
         {
             var config = new PowerFxConfig();
-            config.AddFunction(new DummyFunction());
+            config.AddFunction(new BehaviorFunction());
 
             var fncs = config.Functions.Where(fnc => !fnc.IsSelfContained).ToList();
             var engine = new Engine(config);
-            var formula = "Dummy(); Dummy()";
+            var formula = "Behavior(); Behavior()";
             var options = new ParserOptions { AllowsSideEffects = true };
 
             var result1 = engine.Check(formula, options: options);
@@ -223,13 +223,16 @@ namespace Microsoft.PowerFx.Tests
             Assert.True(result2.IsSuccess);
         }
 
-        private class DummyFunction : TexlFunction
+        /// <summary>
+        /// A function with behavior/side-effects used in testing.
+        /// </summary>
+        private class BehaviorFunction : TexlFunction
         {
-            public DummyFunction()
+            public BehaviorFunction()
                 : base(
                       DPath.Root,
-                      "Dummy",
-                      "Dummy",
+                      "Behavior",
+                      "Behavior",
                       TexlStrings.AboutSet, // just to add something
                       FunctionCategories.Behavior,
                       DType.Boolean,

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -210,7 +210,6 @@ namespace Microsoft.PowerFx.Tests
             var config = new PowerFxConfig();
             config.AddFunction(new BehaviorFunction());
 
-            var fncs = config.Functions.Where(fnc => !fnc.IsSelfContained).ToList();
             var engine = new Engine(config);
             var formula = "Behavior(); Behavior()";
             var options = new ParserOptions { AllowsSideEffects = true };

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -219,7 +219,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.True(result1.IsSuccess);
 
             var parseResult2 = engine.Parse(formula, options);
-            var result2 = engine.Check(parseResult2);
+            var result2 = engine.Check(parseResult2, options: options);
             Assert.True(result2.IsSuccess);
         }
 


### PR DESCRIPTION
Engine has two `Check` overloads:
- `Check(string, ...)` and
- `Check(ParseResult, ...)`

The first one takes `ParserOptions` as an argument, while the second does not. This seems intuitive since the second one does not perform any parsing. However, `ParserOptions` have `AllowsSideEffects` property, which is in the first case passed down to the binder, and in the second is not.