### PR TITLE
Port TestAllBuiltinFunctionsHaveParameterDescriptions from PAClient

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Texl
     {
         public static IEnumerable<TexlFunction> BuiltinFunctionsLibrary => _library;
 
-        public static IEnumerable<TexlFunction> AllBuiltinFunctions => _library.Concat(_featureGateFunctions);
+        internal static IEnumerable<TexlFunction> TestOnly_AllBuiltinFunctions => _library.Concat(_featureGateFunctions);
 
         // Functions in this list are shared and may show up in other hosts by default.
         private static readonly List<TexlFunction> _library = new List<TexlFunction>(200);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Texl.Builtins;
 using Microsoft.PowerFx.Core.Utils;
@@ -15,8 +16,11 @@ namespace Microsoft.PowerFx.Core.Texl
     {
         public static IEnumerable<TexlFunction> BuiltinFunctionsLibrary => _library;
 
+        public static IEnumerable<TexlFunction> AllBuiltinFunctions => _library.Concat(_featureGateFunctions);
+
         // Functions in this list are shared and may show up in other hosts by default.
         private static readonly List<TexlFunction> _library = new List<TexlFunction>(200);
+        private static readonly List<TexlFunction> _featureGateFunctions = new List<TexlFunction>();
         
         public static readonly TexlFunction AmPm = _library.Append(new AmPmFunction());
         public static readonly TexlFunction AmPmShort = _library.Append(new AmPmShortFunction());
@@ -188,21 +192,21 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Year = _library.Append(new YearFunction());
 
         // NOTE: These functions should not be part of the core library until they are implemented in all runtimes
-        public static readonly TexlFunction DateTime = new DateTimeFunction();
-        public static readonly TexlFunction Index_UO = new IndexFunction_UO();
-        public static readonly TexlFunction ParseJSON = new ParseJSONFunction();
-        public static readonly TexlFunction Table_UO = new TableFunction_UO();
-        public static readonly TexlFunction Text_UO = new TextFunction_UO();
-        public static readonly TexlFunction Value_UO = new ValueFunction_UO();
-        public static readonly TexlFunction Boolean = new BooleanFunction();
-        public static readonly TexlFunction Boolean_T = new BooleanFunction_T();
-        public static readonly TexlFunction BooleanN = new BooleanNFunction();
-        public static readonly TexlFunction BooleanN_T = new BooleanNFunction_T();
-        public static readonly TexlFunction Boolean_UO = new BooleanFunction_UO();
-        public static readonly TexlFunction CountRows_UO = new CountRowsFunction_UO();
+        public static readonly TexlFunction DateTime = _featureGateFunctions.Append(new DateTimeFunction());
+        public static readonly TexlFunction Index_UO = _featureGateFunctions.Append(new IndexFunction_UO());
+        public static readonly TexlFunction ParseJSON = _featureGateFunctions.Append(new ParseJSONFunction());
+        public static readonly TexlFunction Table_UO = _featureGateFunctions.Append(new TableFunction_UO());
+        public static readonly TexlFunction Text_UO = _featureGateFunctions.Append(new TextFunction_UO());
+        public static readonly TexlFunction Value_UO = _featureGateFunctions.Append(new ValueFunction_UO());
+        public static readonly TexlFunction Boolean = _featureGateFunctions.Append(new BooleanFunction());
+        public static readonly TexlFunction Boolean_T = _featureGateFunctions.Append(new BooleanFunction_T());
+        public static readonly TexlFunction BooleanN = _featureGateFunctions.Append(new BooleanNFunction());
+        public static readonly TexlFunction BooleanN_T = _featureGateFunctions.Append(new BooleanNFunction_T());
+        public static readonly TexlFunction Boolean_UO = _featureGateFunctions.Append(new BooleanFunction_UO());
+        public static readonly TexlFunction CountRows_UO = _featureGateFunctions.Append(new CountRowsFunction_UO());
 
-        public static readonly TexlFunction IsUTCToday = new IsUTCTodayFunction();
-        public static readonly TexlFunction UTCNow = new UTCNowFunction();
-        public static readonly TexlFunction UTCToday = new UTCTodayFunction();
+        public static readonly TexlFunction IsUTCToday = _featureGateFunctions.Append(new IsUTCTodayFunction());
+        public static readonly TexlFunction UTCNow = _featureGateFunctions.Append(new UTCNowFunction());
+        public static readonly TexlFunction UTCToday = _featureGateFunctions.Append(new UTCTodayFunction());
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -72,6 +72,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             return fValid;
         }
+
+        public override bool TryGetParamDescription(string paramName, out string paramDescription)
+        {
+            Contracts.AssertNonEmpty(paramName);
+
+            return StringResources.TryGet("AboutBooleanT_" + paramName, out paramDescription);
+        }
     }
 
     // Boolean(arg:n)
@@ -95,6 +102,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {
             return GetUniqueTexlRuntimeName(suffix: "N");
+        }
+
+        public override bool TryGetParamDescription(string paramName, out string paramDescription)
+        {
+            Contracts.AssertNonEmpty(paramName);
+
+            return StringResources.TryGet("AboutBooleanN_" + paramName, out paramDescription);
         }
     }
 
@@ -134,6 +148,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             returnType = rowType.ToTable();
 
             return fValid;
+        }
+
+        public override bool TryGetParamDescription(string paramName, out string paramDescription)
+        {
+            Contracts.AssertNonEmpty(paramName);
+
+            return StringResources.TryGet("AboutBooleanNT_" + paramName, out paramDescription);
         }
     }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FunctionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestAllBuiltinFunctionsHaveParameterDescriptions()
         {
-            var texlFunctionsLibrary = BuiltinFunctionsCore.AllBuiltinFunctions;
+            var texlFunctionsLibrary = BuiltinFunctionsCore.TestOnly_AllBuiltinFunctions;
             var functions = texlFunctionsLibrary
                 .Where(x => !x.FunctionCategoriesMask.HasFlag(FunctionCategories.REST));
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FunctionTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PowerFx.Core.Public;
+using Microsoft.PowerFx.Core.Texl;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    public class FunctionTests
+    {
+        [Fact]
+        public void TestAllBuiltinFunctionsHaveParameterDescriptions()
+        {
+            var texlFunctionsLibrary = BuiltinFunctionsCore.AllBuiltinFunctions;
+            var functions = texlFunctionsLibrary
+                .Where(x => !x.FunctionCategoriesMask.HasFlag(FunctionCategories.REST));
+
+            foreach (var function in functions)
+            {
+                if (function.MaxArity == 0)
+                {
+                    continue;
+                }
+
+                foreach (var paramName in function.GetParamNames())
+                {
+                    Assert.True(
+                        function.TryGetParamDescription(paramName, out var descr),
+                        "Missing parameter description. Please add the following to Resources.pares: " + "About" + function.LocaleInvariantName + "_" + paramName);
+                }
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ThreadingTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ThreadingTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "DType._kindToSuperkindMapping",
                 "DTypeSpecParser._types",
                 "BuiltinFunctionsCore._library",
+                "BuiltinFunctionsCore._featureGateFunctions",
                 "ArgumentSuggestions._languageCodeSuggestions",
                 "IntellisenseProvider.SuggestionHandlers",
                 "DateAddFunction.SubDayStringList",


### PR DESCRIPTION
This test can fail in PAClient even though the change was in PowerFx and the PowerFx build passed. This change adds this test to PowerFx so that we can catch the failures here, instead of in the PAClient pipeline.