### PR TITLE
Add DateValue_UO and DateTimeValue_UO

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -204,6 +204,8 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction BooleanN_T = _featureGateFunctions.Append(new BooleanNFunction_T());
         public static readonly TexlFunction Boolean_UO = _featureGateFunctions.Append(new BooleanFunction_UO());
         public static readonly TexlFunction CountRows_UO = _featureGateFunctions.Append(new CountRowsFunction_UO());
+        public static readonly TexlFunction DateValue_UO = _featureGateFunctions.Append(new DateValueFunction_UO());
+        public static readonly TexlFunction DateTimeValue_UO = _featureGateFunctions.Append(new DateTimeValueFunction_UO());
 
         public static readonly TexlFunction IsUTCToday = _featureGateFunctions.Append(new IsUTCTodayFunction());
         public static readonly TexlFunction UTCNow = _featureGateFunctions.Append(new UTCNowFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -310,12 +310,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateValue(date_text:s, [languageCode:s]) : D
     internal sealed class DateValueFunction : DateTimeGenericFunction
     {
+        public const string DateValueInvariantFunctionName = "DateValue";
+
         public override bool HasPreciseErrors => true;
 
         public override bool SupportsParamCoercion => true;
 
         public DateValueFunction()
-            : base("DateValue", TexlStrings.AboutDateValue, DType.Date)
+            : base(DateValueInvariantFunctionName, TexlStrings.AboutDateValue, DType.Date)
         {
         }
 
@@ -348,12 +350,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateTimeValue(time_text:s, [languageCode:s]) : d
     internal sealed class DateTimeValueFunction : DateTimeGenericFunction
     {
+        public const string DateTimeValueInvariantFunctionName = "DateTimeValue";
+
         public override bool HasPreciseErrors => true;
 
         public override bool SupportsParamCoercion => true;
 
         public DateTimeValueFunction()
-            : base("DateTimeValue", TexlStrings.AboutDateTimeValue, DType.DateTime)
+            : base(DateTimeValueInvariantFunctionName, TexlStrings.AboutDateTimeValue, DType.DateTime)
         {
         }
 
@@ -681,6 +685,56 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
 
             return fValid;
+        }
+    }
+
+    // DateValue(arg:O) : D
+    internal sealed class DateValueFunction_UO : BuiltinFunction
+    {
+        public override bool HasPreciseErrors => true;
+
+        public override bool SupportsParamCoercion => true;
+
+        public override bool IsSelfContained => true;
+
+        public DateValueFunction_UO()
+            : base(DateValueFunction.DateValueInvariantFunctionName, TexlStrings.AboutDateValue, FunctionCategories.DateTime, DType.Date, 0, 1, 1, DType.UntypedObject)
+        {
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.DateValueArg1 };
+        }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
+    }
+
+    // DateTimeValue(arg:O) : d
+    internal sealed class DateTimeValueFunction_UO : BuiltinFunction
+    {
+        public override bool HasPreciseErrors => true;
+
+        public override bool SupportsParamCoercion => true;
+
+        public override bool IsSelfContained => true;
+
+        public DateTimeValueFunction_UO()
+            : base(DateTimeValueFunction.DateTimeValueInvariantFunctionName, TexlStrings.AboutDateTimeValue, FunctionCategories.DateTime, DType.DateTime, 0, 1, 1, DType.UntypedObject)
+        {
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.DateTimeValueArg1 };
+        }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -371,6 +371,16 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: DateParse)
             },
             {
+                BuiltinFunctionsCore.DateValue_UO,
+                StandardErrorHandling<UntypedObjectValue>(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: DateValue_UO)
+            },
+            {
                 BuiltinFunctionsCore.DateTimeValue,
                 StandardErrorHandling<StringValue>(
                     expandArguments: NoArgExpansion,
@@ -379,6 +389,16 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: DateTimeParse)
+            },
+            {
+                BuiltinFunctionsCore.DateTimeValue_UO,
+                StandardErrorHandling<UntypedObjectValue>(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: DateTimeValue_UO)
             },
             {
                 BuiltinFunctionsCore.Day,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
@@ -132,6 +134,42 @@ namespace Microsoft.PowerFx.Functions
             if (impl.Type is ExternalType externalType && externalType.Kind == ExternalTypeKind.Array)
             {
                 return new NumberValue(irContext, impl.GetArrayLength());
+            }
+
+            return CommonErrors.RuntimeTypeMismatch(irContext);
+        }
+
+        public static FormulaValue DateValue_UO(IRContext irContext, UntypedObjectValue[] args)
+        {
+            var impl = args[0].Impl;
+
+            if (impl.Type == FormulaType.String)
+            {
+                var s = impl.GetString();
+                if (DateTime.TryParseExact(s, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
+                {
+                    return new DateValue(irContext, res.Date);
+                }
+
+                return CommonErrors.InvalidDateTimeError(irContext);
+            }
+
+            return CommonErrors.RuntimeTypeMismatch(irContext);
+        }
+
+        public static FormulaValue DateTimeValue_UO(IRContext irContext, UntypedObjectValue[] args)
+        {
+            var impl = args[0].Impl;
+
+            if (impl.Type == FormulaType.String)
+            {
+                var s = impl.GetString();
+                if (DateTime.TryParseExact(s, "yyyy-MM-dd'T'HH:mm:ss.FFFK", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
+                {
+                    return new DateValue(irContext, res);
+                }
+
+                return CommonErrors.InvalidDateTimeError(irContext);
             }
 
             return CommonErrors.RuntimeTypeMismatch(irContext);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -134,3 +134,20 @@ Errors: Error 0-14: Invalid argument type. Expecting one of the following: Numbe
 >> Value(Index(ParseJSON("{""a"": 5, ""b"": [{""c"": 19 }, {""c"": ""foo"" }] }").b, 1).c)
 19
 
+>> DateDiff(DateValue(ParseJSON("""2011-01-15""")) , DateValue(ParseJSON("""2011-01-30""")))
+15
+
+>> DateValue(ParseJSON("null"))
+Blank()
+
+>> DateValue(ParseJSON("""abcdef"""))
+#Error(Kind=BadLanguageCode)
+
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z""")) , DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
+15
+
+>> DateTimeValue(ParseJSON("null"))
+Blank()
+
+>> DateTimeValue(ParseJSON("""abcdef"""))
+#Error(Kind=BadLanguageCode)


### PR DESCRIPTION
The XR mentions that DateTime and DateTimeValue functions need to support UntypedObjects. DateTime requires the ISO 8601 format as well.