### PR TITLE
Remove max selects limit

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -123,11 +123,6 @@ namespace Microsoft.PowerFx.Core.Binding
         public ErrorContainer ErrorContainer { get; } = new ErrorContainer();
 
         /// <summary>
-        /// The maximum number of selects in a table that will be included in data call.
-        /// </summary>
-        public const int MaxSelectsToInclude = 100;
-
-        /// <summary>
         /// Default name used to access a Lambda scope.
         /// </summary>
         internal DName ThisRecordDefaultName => new DName("ThisRecord");
@@ -909,8 +904,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     {
                         if (expandQueryOptions.Value.ExpandInfo.Identity == expandEntityLogicalName)
                         {
-                            if (!expandQueryOptions.Value.SelectsEqualKeyColumns() &&
-                                expandQueryOptions.Value.Selects.Count() <= MaxSelectsToInclude)
+                            if (!expandQueryOptions.Value.SelectsEqualKeyColumns())
                             {
                                 return expandQueryOptions.Value.Selects;
                             }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/QueryOptions/TabularDataQueryOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/QueryOptions/TabularDataQueryOptions.cs
@@ -108,8 +108,7 @@ namespace Microsoft.PowerFx.Core.Entities.QueryOptions
 
             Contracts.Assert(TabularDataSourceInfo.GetKeyColumns().All(x => _selects.Contains(x)));
 
-            return TabularDataSourceInfo.GetKeyColumns().Count() < _selects.Count
-                 && _selects.Count < TexlBinding.MaxSelectsToInclude;
+            return TabularDataSourceInfo.GetKeyColumns().Count() < _selects.Count;
         }
 
         internal bool ReplaceExpandsWithAnnotation(ExpandQueryOptions expand)


### PR DESCRIPTION
Intention is to have the limit on selects handled on the client rather than the server in case we have a large url generated.
This change would help with an edge case where we don't see lookup fields in player when we have a large number of selects.