### PR TITLE
Fix missing overrides in new UO functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorValue.cs
@@ -46,5 +46,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.ColorValueArg1 };
         }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -730,6 +730,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.TimeValueArg1 };
         }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
     }
 
     // DateTimeValue(arg:O) : d

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/GUID.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/GUID.cs
@@ -66,5 +66,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.GUIDArg };
         }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
     }
 }


### PR DESCRIPTION
Not sure how we missed this. The JS translator was producing the wrong output when tested locally.