### PR TITLE
Define vars PackagesToValidate, ApiContractVersion in Azure

### DIFF
--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -22,14 +22,14 @@ pool:
   - vstest
 
 variables:
-  ApiContractVersion: 0.2.2-preview # The packages version for API validation in the NuGet feed option case.
-  PackagesToValidate: Microsoft.PowerFx.Core,Microsoft.PowerFx.Interpreter,Microsoft.PowerFx.LanguageServerProtocol,Microsoft.PowerFx.Transport.Attributes
   BuildPlatform: 'any cpu'
   BuildSolution: src/Microsoft.PowerFx.sln
   PowerFx_daily_feed_Url: 'https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json'
   skipComponentGovernanceDetection: false
+# ApiContractVersion: define this in Azure. 0.2.2-preview # The packages version for API validation in the NuGet feed option case.
 # BuildConfiguration: define this in Azure
 # DisableApiCompatibityValidation: define this in Azure, settable by user.
+# PackagesToValidate: define this in Azure. Microsoft.PowerFx.Connectors,Microsoft.PowerFx.Core,Microsoft.PowerFx.Interpreter,Microsoft.PowerFx.LanguageServerProtocol,Microsoft.PowerFx.Transport.Attributes
 # PowerFxCoverallsToken: define this in Azure
 
 stages:

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -26,10 +26,10 @@ variables:
   BuildSolution: src/Microsoft.PowerFx.sln
   PowerFx_daily_feed_Url: 'https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json'
   skipComponentGovernanceDetection: false
-# ApiContractVersion: define this in Azure. 0.2.2-preview # The packages version for API validation in the NuGet feed option case.
+# ApiContractVersion: define this in Azure. E.g. 0.2.2-preview # The packages version for API validation in the NuGet feed option case.
 # BuildConfiguration: define this in Azure
 # DisableApiCompatibityValidation: define this in Azure, settable by user.
-# PackagesToValidate: define this in Azure. Microsoft.PowerFx.Connectors,Microsoft.PowerFx.Core,Microsoft.PowerFx.Interpreter,Microsoft.PowerFx.LanguageServerProtocol,Microsoft.PowerFx.Transport.Attributes
+# PackagesToValidate: define this in Azure. E.g. Microsoft.PowerFx.Connectors,Microsoft.PowerFx.Core,Microsoft.PowerFx.Interpreter,Microsoft.PowerFx.LanguageServerProtocol,Microsoft.PowerFx.Transport.Attributes
 # PowerFxCoverallsToken: define this in Azure
 
 stages:


### PR DESCRIPTION
This allows the packages and contract version for API valiadation to be defined in the [Azure DevOps pipeline definition](https://dev.azure.com/FuseLabs/SDK_v4/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=1470&view=Tab_Variables). That way, .yml code revisions are not required to update those values.