### PR TITLE
Add task to delete outdated API compat results

### DIFF
--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -41,7 +41,7 @@ steps:
 
         Write-Host "Deleting comment $COMMENT_ID dated $date";
 
-        $githubPersonalAccessToken = $(GitHubCommentApiKey);
+        $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
 
         $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
         $header = @{authorization = "Basic $token"};

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -34,8 +34,6 @@ steps:
     $compatComments = ($listResult | Where-Object {$_.body -like $stringToMatch});
     $count = $compatComments.count
 
-    Write-Host "Matching comments: $count";
-
     if ($count -gt 0) {
         $oldestCompatComment = $compatComments[0];
         $COMMENT_ID = $oldestCompatComment.id;
@@ -51,8 +49,10 @@ steps:
         $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
 
         Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+    } else {
+        Write-Host "Nothing to delete.";
     }
-  displayName: 'Delete old compat results from GitHub'
+  displayName: 'Delete old compat results'
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -1,5 +1,6 @@
 steps:
 - task: DownloadBuildArtifacts@0
+  condition: false
   displayName: 'Download compat results artifact'
   inputs:
     downloadType: specific
@@ -7,6 +8,7 @@ steps:
     downloadPath: '$(System.ArtifactsDirectory)\ApiCompat'
 
 - task: CopyFiles@2
+  condition: false
   displayName: 'Copy results for publish to Artifacts'
   inputs:
     SourceFolder: '$(System.ArtifactsDirectory)\ApiCompat'
@@ -15,6 +17,7 @@ steps:
     flattenFolders: true
 
 - task: PublishPipelineArtifact@1
+  condition: false
   inputs:
     artifactName: 'ApiCompatibilityResults'
     targetPath: '$(System.ArtifactsDirectory)\ApiCompatibilityResults'
@@ -34,7 +37,7 @@ steps:
     $listResult = Invoke-RestMethod "$listCommentsUri";
     $listResult.count;
 
-    $compatComments = ($listResult | Where-Object {$_.body -like "$stringToMatch" -and $_.user.login -like "$userNameToMatch"});
+    $compatComments = ($listResult | Where-Object {$_.body -like "$stringToMatch" -and $_.user.login -eq "$userNameToMatch"});
     $count = $compatComments.count
     $count;
     
@@ -52,7 +55,7 @@ steps:
 
         $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
 
-        Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+        #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
     } else {
         Write-Host "Nothing to delete.";
     }
@@ -60,6 +63,7 @@ steps:
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
+  condition: false
   displayName: 'Publish compat results to GitHub'
   inputs:
     userToken: '$(GitHubCommentApiKey)'

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -59,7 +59,7 @@ steps:
     } else {
         Write-Host "Nothing to delete.";
     }
-  displayName: 'Delete old compat results'
+  displayName: 'Delete old compat results-'
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -25,13 +25,14 @@ steps:
     $OWNER = 'microsoft';
     $REPO = 'Power-Fx';
     $ISSUE_NUMBER = "$(System.PullRequest.PullRequestNumber)";
-    $stringToMatch = "*Binary Compatibility*";
+    $stringToMatch = "*Binary Compatibility issues*";
+    $userNameToMatch = "BruceHaley";
 
     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
 
     $listResult = Invoke-RestMethod "$listCommentsUri";
 
-    $compatComments = ($listResult | Where-Object {$_.body -like $stringToMatch});
+    $compatComments = ($listResult | Where-Object {$_.body -like $stringToMatch -and $_.user.login -like $userNameToMatch});
     $count = $compatComments.count
 
     if ($count -gt 0) {
@@ -48,7 +49,7 @@ steps:
 
         $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
 
-        Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+        #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
     } else {
         Write-Host "Nothing to delete.";
     }

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -29,12 +29,15 @@ steps:
     $userNameToMatch = "BruceHaley";
 
     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
+    $listCommentsUri;
 
     $listResult = Invoke-RestMethod "$listCommentsUri";
+    $listResult.count;
 
     $compatComments = ($listResult | Where-Object {$_.body -like $stringToMatch -and $_.user.login -like $userNameToMatch});
     $count = $compatComments.count
-
+    $count;
+    
     if ($count -gt 0) {
         $oldestCompatComment = $compatComments[0];
         $COMMENT_ID = $oldestCompatComment.id;
@@ -49,7 +52,7 @@ steps:
 
         $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
 
-        #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+        Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
     } else {
         Write-Host "Nothing to delete.";
     }

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -24,7 +24,7 @@ steps:
 - powershell: |
     $OWNER = 'microsoft';
     $REPO = 'Power-Fx';
-    $ISSUE_NUMBER = $(System.PullRequest.PullRequestNumber);
+    $ISSUE_NUMBER = "$(System.PullRequest.PullRequestNumber)";
     $stringToMatch = "*Binary Compatibility*";
 
     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -59,7 +59,7 @@ steps:
     } else {
         Write-Host "Nothing to delete.";
     }
-  displayName: 'Delete old compat results-'
+  displayName: 'Delete old compat results'
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -50,7 +50,7 @@ steps:
 
             Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
 
-            #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+            Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
             $commentsDeleted++;
             break;
         }

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -1,6 +1,5 @@
 steps:
 - task: DownloadBuildArtifacts@0
-  condition: false
   displayName: 'Download compat results artifact'
   inputs:
     downloadType: specific
@@ -8,7 +7,6 @@ steps:
     downloadPath: '$(System.ArtifactsDirectory)\ApiCompat'
 
 - task: CopyFiles@2
-  condition: false
   displayName: 'Copy results for publish to Artifacts'
   inputs:
     SourceFolder: '$(System.ArtifactsDirectory)\ApiCompat'
@@ -17,7 +15,6 @@ steps:
     flattenFolders: true
 
 - task: PublishPipelineArtifact@1
-  condition: false
   inputs:
     artifactName: 'ApiCompatibilityResults'
     targetPath: '$(System.ArtifactsDirectory)\ApiCompatibilityResults'
@@ -38,11 +35,6 @@ steps:
     Write-Host "Comment Ids:" $listResult.id;
     Write-Host "Users:" $listResult.user.login;
 
-    $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
-
-    $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
-    $header = @{authorization = "Basic $token"};
-    $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
     $commentsDeleted = 0;
 
     for ($i = 0; $i -lt $count; $i++) {
@@ -50,6 +42,12 @@ steps:
             $COMMENT_ID = $listResult[$i].id;
             $date = $listResult[$i].created_at;
             $user = $listResult[$i].user.login;
+
+            $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
+            $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
+            $header = @{authorization = "Basic $token"};
+            $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
+
             Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
 
             #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
@@ -65,14 +63,13 @@ steps:
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
-  condition: false
   displayName: 'Publish compat results to GitHub'
   inputs:
     userToken: '$(GitHubCommentApiKey)'
     bodyFilePath: '$(System.ArtifactsDirectory)\ApiCompat'
     getSubFolders: true
   # Skip forks, as secret tokens are not available to them.
-  # condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - script: |
    cd ..

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -70,7 +70,7 @@ steps:
     bodyFilePath: '$(System.ArtifactsDirectory)\ApiCompat'
     getSubFolders: true
   # Skip forks, as secret tokens are not available to them.
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
+  # condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - script: |
    cd ..

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -32,31 +32,33 @@ steps:
     $userNameToMatch = "BruceHaley";
 
     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
-    $listCommentsUri;
 
     $listResult = Invoke-RestMethod "$listCommentsUri";
-    $listResult.count;
+    $count = $listResult.count;
+    Write-Host "Comment Ids:" $listResult.id;
+    Write-Host "Users:" $listResult.user.login;
 
-    $compatComments = ($listResult | Where-Object {$_.body -like "$stringToMatch" -and $_.user.login -eq "$userNameToMatch"});
-    $count = $compatComments.count
-    $count;
-    
-    if ($count -gt 0) {
-        $oldestCompatComment = $compatComments[0];
-        $COMMENT_ID = $oldestCompatComment.id;
-        $date = $oldestCompatComment.created_at;
+    $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
 
-        Write-Host "Deleting comment $COMMENT_ID dated $date";
+    $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
+    $header = @{authorization = "Basic $token"};
+    $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
+    $commentsDeleted = 0;
 
-        $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
+    for ($i = 0; $i -lt $count; $i++) {
+        if ($listResult[$i].body -like $stringToMatch -and $listResult[$i].user.login -eq $userNameToMatch) {
+            $COMMENT_ID = $listResult[$i].id;
+            $date = $listResult[$i].created_at;
+            $user = $listResult[$i].user.login;
+            Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
 
-        $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
-        $header = @{authorization = "Basic $token"};
+            #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+            $commentsDeleted++;
+            break;
+        }
+    }
 
-        $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
-
-        #Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
-    } else {
+    if ($commentsDeleted -eq 0) {
         Write-Host "Nothing to delete.";
     }
   displayName: 'Delete old compat results'

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -56,7 +56,7 @@ steps:
     } else {
         Write-Host "Nothing to delete.";
     }
-  displayName: 'Delete old compat results' 
+  displayName: 'Delete old compat results'
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -34,7 +34,7 @@ steps:
     $listResult = Invoke-RestMethod "$listCommentsUri";
     $listResult.count;
 
-    $compatComments = ($listResult | Where-Object {$_.body -like $stringToMatch -and $_.user.login -like $userNameToMatch});
+    $compatComments = ($listResult | Where-Object {$_.body -like "$stringToMatch" -and $_.user.login -like "$userNameToMatch"});
     $count = $compatComments.count
     $count;
     
@@ -56,7 +56,7 @@ steps:
     } else {
         Write-Host "Nothing to delete.";
     }
-  displayName: 'Delete old compat results'
+  displayName: 'Delete old compat results' 
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -21,8 +21,42 @@ steps:
   displayName: 'Publish compat results to Artifacts'
   continueOnError: true
 
+- powershell: |
+    $OWNER = 'microsoft';
+    $REPO = 'Power-Fx';
+    $ISSUE_NUMBER = $(System.PullRequest.PullRequestNumber);
+    $stringToMatch = "*Binary Compatibility*";
+
+    $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
+
+    $listResult = Invoke-RestMethod "$listCommentsUri";
+
+    $compatComments = ($listResult | Where-Object {$_.body -like $stringToMatch});
+    $count = $compatComments.count
+
+    Write-Host "Matching comments: $count";
+
+    if ($count -gt 0) {
+        $oldestCompatComment = $compatComments[0];
+        $COMMENT_ID = $oldestCompatComment.id;
+        $date = $oldestCompatComment.created_at;
+
+        Write-Host "Deleting comment $COMMENT_ID dated $date";
+
+        $githubPersonalAccessToken = $(GitHubCommentApiKey);
+
+        $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
+        $header = @{authorization = "Basic $token"};
+
+        $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
+
+        Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+    }
+  displayName: 'Delete old compat results from GitHub'
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
+
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
-  displayName: 'Publish compat results to Github'
+  displayName: 'Publish compat results to GitHub'
   inputs:
     userToken: '$(GitHubCommentApiKey)'
     bodyFilePath: '$(System.ArtifactsDirectory)\ApiCompat'

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -34,7 +34,6 @@ variables:
 
 stages:
 - stage: Build
-  condition: false
   jobs:
   - job: build_and_test
     steps:
@@ -132,14 +131,12 @@ stages:
       condition: succeededOrFailed()
 
 - stage: API_Compatibility_Validation
-  condition: true
-  #dependsOn: Build
-  #condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
+  dependsOn: Build
+  condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:
   - job: generate_multiconfig_var
-    condition: false
     steps:
     - checkout: none
 
@@ -175,9 +172,8 @@ stages:
       displayName: show var MULTICONFIG
 
   - job: check_api_for
-    condition: false
-    # dependsOn: generate_multiconfig_var
-    # condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
+    dependsOn: generate_multiconfig_var
+    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
     timeoutInMinutes: 10
     strategy:
       maxParallel: 10
@@ -198,9 +194,8 @@ stages:
         ContractVersion: "$(contractVersion)"
 
   - job: post_results_to_gitHub
-    condition: true
-    # dependsOn: check_api_for
-    # condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
+    dependsOn: check_api_for
+    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
 
     steps:
     - checkout: none

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -34,6 +34,7 @@ variables:
 
 stages:
 - stage: Build
+  condition: false
   jobs:
   - job: build_and_test
     steps:
@@ -131,12 +132,14 @@ stages:
       condition: succeededOrFailed()
 
 - stage: API_Compatibility_Validation
-  dependsOn: Build
-  condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
+  condition: true
+  #dependsOn: Build
+  #condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:
   - job: generate_multiconfig_var
+    condition: false
     steps:
     - checkout: none
 
@@ -172,8 +175,9 @@ stages:
       displayName: show var MULTICONFIG
 
   - job: check_api_for
-    dependsOn: generate_multiconfig_var
-    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
+    condition: false
+    # dependsOn: generate_multiconfig_var
+    # condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
     timeoutInMinutes: 10
     strategy:
       maxParallel: 10
@@ -194,8 +198,9 @@ stages:
         ContractVersion: "$(contractVersion)"
 
   - job: post_results_to_gitHub
-    dependsOn: check_api_for
-    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
+    condition: true
+    # dependsOn: check_api_for
+    # condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
 
     steps:
     - checkout: none


### PR DESCRIPTION
Add a task to the CI pipeline that deletes outdated API compatibility results from the PR when new results are published. This prevents a PR from accumulating multiple sets of compatibility results.