### PR TITLE
Mark RecordType and TableType empty constructors as obsolete

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerFx.Connectors
                     {
                         // Primitives get marshalled as a SingleColumn table.
                         // Make sure this is consistent with invoker. 
-                        var r2 = new RecordType().Add(TableValue.ValueName, elementType);
+                        var r2 = RecordType.Empty().Add(TableValue.ValueName, elementType);
                         return r2.ToTable();
                     }
                     else
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Connectors
 
                 case "object":
                 case null: // xml
-                    var obj = new RecordType();
+                    var obj = RecordType.Empty();
                     foreach (var kv in schema.Properties)
                     {
                         var propName = kv.Key;

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerFx.Core.IR
                     // Let's add "Value:" here                    
                     children = children.Select(childNode =>
                         new RecordNode(
-                            new IRContext(childNode.IRContext.SourceContext, new RecordType().Add(TableValue.ValueName, childNode.IRContext.ResultType)),
+                            new IRContext(childNode.IRContext.SourceContext, RecordType.Empty().Add(TableValue.ValueName, childNode.IRContext.ResultType)),
                             new Dictionary<DName, IntermediateNode>
                             {
                                 { TableValue.ValueDName, childNode }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerFx
 
         private CheckResult CheckInternal(ParseResult parse, RecordType parameterType, BindingConfig bindingConfig)
         {
-            parameterType ??= new RecordType();
+            parameterType ??= RecordType.Empty();
                         
             // Ok to continue with binding even if there are parse errors. 
             // We can still use that for intellisense. 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/FormulaWithParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/FormulaWithParameters.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx
         public FormulaWithParameters(string expression, RecordType parameterTypes = null)
         {
             _expression = expression;
-            _schema = parameterTypes ?? new RecordType();
+            _schema = parameterTypes ?? RecordType.Empty();
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/RecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/RecordType.cs
@@ -16,6 +16,7 @@ namespace Microsoft.PowerFx.Types
             Contract.Assert(type.IsRecord);
         }
 
+        [Obsolete("Use RecordType.Empty() instead")]
         public RecordType()
             : base(DType.EmptyRecord)
         {
@@ -25,6 +26,8 @@ namespace Microsoft.PowerFx.Types
         {
             vistor.Visit(this);
         }
+
+        public static RecordType Empty() => new RecordType(DType.EmptyRecord);
 
         public RecordType Add(NamedFormulaType field)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/TableType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/TableType.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.PowerFx.Core.Types;
@@ -16,6 +17,7 @@ namespace Microsoft.PowerFx.Types
             Contract.Assert(type.IsTable);
         }
 
+        [Obsolete("UseTableType.Empty() instead")]
         public TableType()
             : base(DType.EmptyTable)
         {
@@ -31,6 +33,8 @@ namespace Microsoft.PowerFx.Types
         {
             vistor.Visit(this);
         }
+
+        public static TableType Empty() => new TableType(DType.EmptyTable);
 
         public TableType Add(NamedFormulaType field)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNewJson.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNewJson.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerFx.Types
             Contract.Assert(element.ValueKind == JsonValueKind.Object);
 
             var fields = new List<NamedValue>();
-            var type = new RecordType();
+            var type = RecordType.Empty();
 
             foreach (var pair in element.EnumerateObject())
             {
@@ -114,7 +114,7 @@ namespace Microsoft.PowerFx.Types
             TableType type;
             if (records.Count == 0)
             {
-                type = new TableType();
+                type = TableType.Empty();
             }
             else
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNewRecord.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNewRecord.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerFx.Types
 
         public static RecordValue NewRecordFromFields(IEnumerable<NamedValue> fields)
         {
-            var type = new RecordType();
+            var type = RecordType.Empty();
             foreach (var field in fields)
             {
                 type = type.Add(new NamedFormulaType(field.Name, field.Value.IRContext.ResultType));

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNewTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNewTable.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerFx.Types
                 throw new InvalidOperationException($"Use NewTable() instead");
             }
 
-            var recordType = new RecordType().Add(TableValue.ValueName, fxType);
+            var recordType = RecordType.Empty().Add(TableValue.ValueName, fxType);
 
             var irContext = IRContext.NotInSource(recordType);
             var recordValues = values.Select(item => new InMemoryRecordValue(

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Types
 
         public static RecordValue Empty()
         {
-            var type = new RecordType();
+            var type = RecordType.Empty();
             return new InMemoryRecordValue(IRContext.NotInSource(type), new Dictionary<string, FormulaValue>());
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -276,7 +276,7 @@ namespace Microsoft.PowerFx.Functions
             else
             {
                 var name = BuiltinFunction.ColumnName_ValueStr;
-                var inputRecordType = new RecordType().Add(name, arg.Type);
+                var inputRecordType = RecordType.Empty().Add(name, arg.Type);
                 var inputRecordNamedValue = new NamedValue(name, arg);
                 var inputRecord = new InMemoryRecordValue(IRContext.NotInSource(inputRecordType), new List<NamedValue>() { inputRecordNamedValue });
                 var inputDValue = DValue<RecordValue>.Of(inputRecord);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/ObjectMarshallerProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/ObjectMarshallerProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerFx
 
             var mapping = new Dictionary<string, Func<object, FormulaValue>>(StringComparer.OrdinalIgnoreCase);
 
-            var fxType = new RecordType();
+            var fxType = RecordType.Empty();
 
             foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TableMarshallerProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TableMarshallerProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx
                 // Single Column table. Wrap in a record. 
                 // This is happens for scalars.
                 // But could also happen for a table of tables. 
-                recordType = new RecordType().Add(TableValue.ValueName, rowMarshaller.Type);
+                recordType = RecordType.Empty().Add(TableValue.ValueName, rowMarshaller.Type);
 
                 rowMarshaller = new SCTMarshaller(recordType, rowMarshaller);
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeMarshallerCacheExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeMarshallerCacheExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx
             {
                 var first = records.FirstOrDefault();
                 var recordType = (first == null) ?
-                    new RecordType() :
+                    RecordType.Empty() :
                     ((RecordType)first.Type);
                 return FormulaValue.NewTable(recordType, records);
             }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/FormulaTypeJsonConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/FormulaTypeJsonConverter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             Contracts.AssertValue(fields);
             Contracts.AssertAllValues(fields);
 
-            var fieldsType = new RecordType();
+            var fieldsType = RecordType.Empty();
             foreach (var field in fields)
             {
                 if (fieldsType.MaybeGetFieldType(field.Key) != null)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PowerFx.Tests
             var engine = new Engine(config);
 
             var expr = "MSNWeather.CurrentWeather(";
-            var result = engine.Suggest(expr, new RecordType(), expr.Length);
+            var result = engine.Suggest(expr, RecordType.Empty(), expr.Length);
 
             var overload = result.FunctionOverloads.Single();
             Assert.Equal(Intellisense.SuggestionKind.Function, overload.Kind);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerFx.Tests
 
             var result = engine.Check(
                 "3*2+x",
-                new RecordType().Add(
+                RecordType.Empty().Add(
                     new NamedFormulaType("x", FormulaType.Number)));
 
             Assert.True(result.IsSuccess);
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Tests
             var str = parse.Root.ToString();
             Assert.Equal("3 * x", str);
 
-            var r = new RecordType().Add(
+            var r = RecordType.Empty().Add(
                    new NamedFormulaType("x", FormulaType.Number));
                         
             var check = engine.Check(parse, r);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameOptionSetTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameOptionSetTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             if (toDisplay)
             {
-                var outDisplayExpression = engine.GetDisplayExpression(inputExpression, new RecordType());
+                var outDisplayExpression = engine.GetDisplayExpression(inputExpression, RecordType.Empty());
                 Assert.Equal(outputExpression, outDisplayExpression);
             }
             else
             {
-                var outInvariantExpression = engine.GetInvariantExpression(inputExpression, new RecordType());
+                var outInvariantExpression = engine.GetInvariantExpression(inputExpression, RecordType.Empty());
                 Assert.Equal(outputExpression, outInvariantExpression);
             }
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void CollisionsThrow()
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number, new DName("DisplayNum")));
 
             Assert.Throws<NameCollisionException>(() => r1.Add(new NamedFormulaType("DisplayNum", FormulaType.Date, "NoCollision")));
@@ -39,7 +39,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void ImmutableDisplayNameProvider()
         {
-            var r1 = new RecordType();
+            var r1 = RecordType.Empty();
 
             var r2 = r1.Add(new NamedFormulaType("Logical", FormulaType.String, "Foo"));
             var r3 = r1.Add(new NamedFormulaType("Logical", FormulaType.String, "Bar"));
@@ -50,10 +50,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void DisableDisplayNames()
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Logical", FormulaType.String, "Foo"));
 
-            var r2 = new RecordType()
+            var r2 = RecordType.Empty()
                 .Add(new NamedFormulaType("Other", FormulaType.String, "Foo"));
 
             Assert.IsType<SingleSourceDisplayNameProvider>(r1._type.DisplayNameProvider);
@@ -76,12 +76,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Sum(NestedDisplay /* The source */ , InnerDisplay /* Sum over the InnerDisplay column */)", "Sum(Nested /* The source */ , Inner /* Sum over the InnerDisplay column */)", false)]
         public void ValidateDisplayNames(string inputExpression, string outputExpression, bool toDisplay)
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number, "DisplayNum"))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean, "DisplayB"))
                 .Add(new NamedFormulaType(
                     "Nested", 
-                    new TableType().Add(new NamedFormulaType("Inner", FormulaType.Number, "InnerDisplay")), 
+                    TableType.Empty().Add(new NamedFormulaType("Inner", FormulaType.Number, "InnerDisplay")), 
                     "NestedDisplay"));
 
             if (toDisplay)
@@ -99,7 +99,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void ConvertToDisplayNamesNoNames()
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean));
 
@@ -111,7 +111,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void ConvertToInvariantNamesNoNames()
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean));
 
@@ -143,18 +143,18 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("With({x: RecordNest, y: RecordNest}, x.SomeString & y.SomeString)", "With({x: RecordNest, y: RecordNest}, x.S2 & y.S2)", "RecordNest.SomeString", "S2")]
         public void RenameParameter(string expressionBase, string expectedExpression, string path, string newName)
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number, "DisplayNum"))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean, "DisplayB"))
                 .Add(new NamedFormulaType(
                         "Nested",
-                        new TableType().Add(new NamedFormulaType("Inner", FormulaType.Number, "InnerDisplay")),
+                        TableType.Empty().Add(new NamedFormulaType("Inner", FormulaType.Number, "InnerDisplay")),
                         "NestedDisplay"))
                 .Add(new NamedFormulaType(
                         "RecordNest",
-                        new RecordType()
+                        RecordType.Empty()
                             .Add(new NamedFormulaType("SomeString", FormulaType.String, "DisplaySomeString"))
-                            .Add(new NamedFormulaType("nest2", new RecordType().Add(new NamedFormulaType("datetest", FormulaType.DateTime, "DisplayDT")), "DisplayReallyNested")),
+                            .Add(new NamedFormulaType("nest2", RecordType.Empty().Add(new NamedFormulaType("datetest", FormulaType.DateTime, "DisplayDT")), "DisplayReallyNested")),
                         "superrecordnest"));
 
             var dpath = DPath.Root;
@@ -171,7 +171,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void ConvertToDisplayNotForced()
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number, "SomeDisplayNum"))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean, "SomeDisplayB"));
 
@@ -218,12 +218,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Sum(NestedDisplay /* The source */ ; InnerDisplay /* Sum over the InnerDisplay column */)", "Sum(Nested /* The source */ , Inner /* Sum over the InnerDisplay column */)", false)]
         public void ValidateExpressionConversionCommaSeparatedLocale(string inputExpression, string outputExpression, bool toDisplay)
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number, "DisplayNum"))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean, "DisplayB"))
                 .Add(new NamedFormulaType(
                     "Nested",
-                    new TableType().Add(new NamedFormulaType("Inner", FormulaType.Number, "InnerDisplay")),
+                    TableType.Empty().Add(new NamedFormulaType("Inner", FormulaType.Number, "InnerDisplay")),
                     "NestedDisplay"));
 
             if (toDisplay)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IRTests/IRTranslatorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IRTests/IRTranslatorTests.cs
@@ -27,10 +27,10 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Sum(numtable, Sum(val,0))", "Sum(val,0)", typeof(NumberType))]
         public void TestLazyEvalNode(string expression, string expectedFragment, Type type)
         {
-            var tableType = new TableType()
+            var tableType = TableType.Empty()
                 .Add(new NamedFormulaType("val", FormulaType.Number));
 
-            var parameterType = new RecordType()
+            var parameterType = RecordType.Empty()
                 .Add(new NamedFormulaType("numtable", tableType));
 
             var engine = new Engine(new PowerFxConfig());

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseOperationsTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseOperationsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var config = new PowerFxConfig();
             var engine = new Engine(config);
 
-            var formulaParams = new RecordType();
+            var formulaParams = RecordType.Empty();
             formulaParams = formulaParams.Add("X", FormulaType.String);
 
             var parseResult = engine.Parse(formula);
@@ -87,10 +87,10 @@ namespace Microsoft.PowerFx.Core.Tests
             var engine = new Engine(config);
 
             var tableType =
-                new TableType().Add(new NamedFormulaType("A", FormulaType.Number))
+                TableType.Empty().Add(new NamedFormulaType("A", FormulaType.Number))
                                .Add(new NamedFormulaType("B", FormulaType.Number));
             var formulaParams =
-                new RecordType().Add("X", FormulaType.Number).Add("Y", FormulaType.Number).Add("Table", tableType);
+                RecordType.Empty().Add("X", FormulaType.Number).Add("Y", FormulaType.Number).Add("Table", tableType);
 
             var parseResult = engine.Parse(formula);
             var args = parseResult.Root.AsCall().Args.ChildNodes;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             else
             {
                 // We leave the context type as an empty record when none is provided
-                contextType = new RecordType();
+                contextType = RecordType.Empty();
             }
 
             return Suggest(expression, config, contextType);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PrimitiveValues.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PrimitiveValues.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var complex = new { x = 15 };
             Assert.Throws<InvalidOperationException>(() => PrimitiveValueConversions.Marshal(complex, complex.GetType()));
 
-            var fxType = new RecordType();
+            var fxType = RecordType.Empty();
             Assert.Throws<InvalidOperationException>(() => PrimitiveValueConversions.Marshal(complex, fxType));
 
             // Verify illegal combinations fail.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TypeTests.cs
@@ -9,13 +9,13 @@ namespace Microsoft.PowerFx.Tests
     public class TypeTests
     {
         [Fact]
-        public void RecordType()
+        public void RecordTypeValidation()
         {
-            var r1 = new RecordType()
+            var r1 = RecordType.Empty()
                 .Add(new NamedFormulaType("Num", FormulaType.Number))
                 .Add(new NamedFormulaType("B", FormulaType.Boolean));
 
-            var r2 = new RecordType()
+            var r2 = RecordType.Empty()
                 .Add(new NamedFormulaType("B", FormulaType.Boolean))
                 .Add(new NamedFormulaType("Num", FormulaType.Number));
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DependencyVisitorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DependencyVisitorTests.cs
@@ -22,10 +22,10 @@ namespace Microsoft.PowerFx.Tests
 
             var engine = new RecalcEngine();
 
-            var accountType = new TableType()
+            var accountType = TableType.Empty()
                 .Add(new NamedFormulaType("Age", FormulaType.Number));
 
-            var type = new RecordType()
+            var type = RecordType.Empty()
                 .Add(new NamedFormulaType("A", FormulaType.Number))
                 .Add(new NamedFormulaType("B", FormulaType.Number))
                 .Add(new NamedFormulaType("Accounts", accountType));

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -53,9 +53,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             config.AddEntity(optionSet);
             config.AddEntity(otherOptionSet);
 
-            var parameterType = new RecordType()
+            var parameterType = RecordType.Empty()
                 .Add(new NamedFormulaType("TopOptionSetField", optionSet.FormulaType))
-                .Add(new NamedFormulaType("Nested", new RecordType()
+                .Add(new NamedFormulaType("Nested", RecordType.Empty()
                     .Add(new NamedFormulaType("InnerOtherOptionSet", otherOptionSet.FormulaType))));
 
             var actualSuggestions = SuggestStrings(expression, config, parameterType);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MarshalTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MarshalTests.cs
@@ -391,7 +391,7 @@ namespace Microsoft.PowerFx.Tests
         // Example of a host-derived object. 
         private class MyRecordValue : RecordValue
         {
-            private static readonly RecordType _type = new RecordType().Add("field1", FormulaType.Number);
+            private static readonly RecordType _type = RecordType.Empty().Add("field1", FormulaType.Number);
 
             // Ctor to let tests override and provide wrong types.
             public MyRecordValue(RecordType type)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PADIntegrationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PADIntegrationTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.PowerFx.Tests
 
             // FormulaType
             // Is this a valid usage of the UnknownType?
-            var fType = new TableType()
+            var fType = TableType.Empty()
                 .Add(new NamedFormulaType("Column1", FormulaType.Unknown))
                 .Add(new NamedFormulaType("Column2", FormulaType.Unknown))
                 .Add(new NamedFormulaType("Column3", FormulaType.Unknown));
 
-            var executionScope = new RecordType()
+            var executionScope = RecordType.Empty()
                 .Add("RobinTable", fType);
 
             var validationResult = engine.Check("Index(RobinTable, 1).Column1", executionScope);
@@ -130,10 +130,10 @@ First(
 
             //FormulaType
             // Is this a valid representation of a List<object> type to a FormulaType?
-            var fType = new TableType()
+            var fType = TableType.Empty()
                 .Add(new NamedFormulaType("Value", FormulaType.Unknown));
 
-            var executionScope = new RecordType()
+            var executionScope = RecordType.Empty()
                 .Add("RobinList", fType);
 
             var validationResult = engine.Check("Index(RobinList, 1).Value", executionScope);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.PowerFx.Tests
             var engine = new RecalcEngine();
             var result = engine.Check(
                 "3*2+x",
-                new RecordType().Add(
+                RecordType.Empty().Add(
                     new NamedFormulaType("x", FormulaType.Number)));
 
             Assert.True(result.IsSuccess);
@@ -315,8 +315,8 @@ namespace Microsoft.PowerFx.Tests
             var config = new PowerFxConfig();
             var engine = new RecalcEngine(config);
 
-            var result = engine.Check("T.Var = 23", new RecordType()
-                .Add(new NamedFormulaType("T", new RecordType().Add(new NamedFormulaType("Var", FormulaType.String)))));
+            var result = engine.Check("T.Var = 23", RecordType.Empty()
+                .Add(new NamedFormulaType("T", RecordType.Empty().Add(new NamedFormulaType("Var", FormulaType.String)))));
 
             Assert.True(result.IsSuccess);
             Assert.Equal(1, result.Errors.Count(x => x.IsWarning));
@@ -407,7 +407,7 @@ namespace Microsoft.PowerFx.Tests
         public void CheckBindErrorWithParseExpression()
         {
             var engine = new RecalcEngine();
-            var result = engine.Check("3+foo+2", new RecordType()); // foo is undefined 
+            var result = engine.Check("3+foo+2", RecordType.Empty()); // foo is undefined 
 
             Assert.False(result.IsSuccess);
             Assert.Null(result.Expression);
@@ -421,7 +421,7 @@ namespace Microsoft.PowerFx.Tests
             var engine = new RecalcEngine();
             var result = engine.Check(
                 "3*2+x",
-                new RecordType().Add(
+                RecordType.Empty().Add(
                     new NamedFormulaType("x", FormulaType.Number)));
 
             // Test that parsing worked
@@ -449,7 +449,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var result = engine.Check(
                "3*2+x",
-               new RecordType().Add(
+               RecordType.Empty().Add(
                    new NamedFormulaType("x", FormulaType.Number)));
 
             Assert.True(result.IsSuccess);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/DataTableMarshallerProvider.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/DataTableMarshallerProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerFx.Tests
 
         public static RecordType ComputeType(DataTable dataTable)
         {
-            var recordType = new RecordType();
+            var recordType = RecordType.Empty();
             foreach (DataColumn column in dataTable.Columns)
             {
                 if (!PrimitiveValueConversions.TryGetFormulaType(column.DataType, out var fxType))

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ObjectListMarshallerProvider.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ObjectListMarshallerProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Tests
 
             public ObjectListMarshaller()
             {
-                _type = new RecordType().Add(TableValue.ValueName, FormulaType.UntypedObject);
+                _type = RecordType.Empty().Add(TableValue.ValueName, FormulaType.UntypedObject);
             }
 
             public FormulaValue Marshal(object value)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioCustomMarshaler.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioCustomMarshaler.cs
@@ -229,11 +229,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 { "bool", true }
             };
 
-            var recordTypeTestObj = new RecordType()
+            var recordTypeTestObj = RecordType.Empty()
                 .Add("Field1", FormulaType.Number)
                 .Add("Field2", FormulaType.Number);
 
-            var recordType = new RecordType()
+            var recordType = RecordType.Empty()
                 .Add("int", FormulaType.Number)
                 .Add("str", FormulaType.String)
                 .Add("test", recordTypeTestObj)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ValueTests.cs
@@ -272,7 +272,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
             TableType type = (TableType)value.Type;
 
-            TableType typeExpected = new TableType()
+            TableType typeExpected = TableType.Empty()
                 .Add(new NamedFormulaType("Value", FormulaType.Number));
             Assert.Equal(typeExpected, type);
 


### PR DESCRIPTION
As part of #471, we're moving away from using the public constructor on Record/Table type. This marks them as obsolete and provides a replacement. 