### PR TITLE
Extend ReflectionFunction to handle SetProperty().

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -147,12 +147,11 @@ namespace Microsoft.PowerFx
                 return null;
             }
 
-            var newValue2 = await arg1.Accept(this, context);
-
-            var argFrom = await r.From.Accept(this, context);
+            var source = await r.From.Accept(this, context);
             var fieldName = r.Field.Value;
+            var newValue = await arg1.Accept(this, context);
 
-            var args = new FormulaValue[] { argFrom, FormulaValue.New(fieldName), newValue2 };
+            var args = new FormulaValue[] { source, FormulaValue.New(fieldName), newValue };
             var result = await setPropFunc.InvokeAsync(args, _cancel);
 
             return result;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -6,10 +6,14 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 using static Microsoft.PowerFx.Core.Localization.TexlStrings;
 
@@ -52,6 +56,77 @@ namespace Microsoft.PowerFx
         }
     }
 
+    // Helper for SetPropertyFunction 
+    // Binds as: 
+    //    SetProperty(control.property:, arg:any)
+    // Invokes as:
+    //    SetProperty(control, "property", arg)
+    internal sealed class CustomSetPropertyFunction : TexlFunction
+    {
+        public override bool IsAsync => true;
+
+        public override bool IsSelfContained => false; // marks as behavior 
+
+        public override bool SupportsParamCoercion => false;
+
+        public Func<FormulaValue[], FormulaValue> _impl;
+
+        public CustomSetPropertyFunction(string name)
+            : base(DPath.Root, name, name, SG(name), FunctionCategories.Behavior, DType.Boolean, 0, 2, 2)
+        {
+        }
+
+        private static StringGetter SG(string text) => CustomTexlFunction.SG(text);
+        
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { SG("Arg 1"), SG("Arg 2") };
+        }
+
+        // 2nd argument should be same type as 1st argument. 
+        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(binding);
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.AssertAllValid(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+            Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
+
+            nodeToCoercedTypeMap = null;
+            returnType = DType.Boolean;
+
+            var arg0 = argTypes[0];
+
+            var dottedName = args[0].AsDottedName();
+
+            // Global-scoped variable name should be a firstName.
+            if (dottedName == null)
+            {
+                errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrNeedValidVariableName_Arg, Name, args[0]);
+                return false;
+            }
+
+            var arg1 = argTypes[1];
+
+            if (!arg0.Accepts(arg1))
+            {
+                errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrBadType);
+                return false;
+            }
+
+            return true;
+        }
+
+        public async Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancellation)
+        {
+            var result = _impl(args);
+            return result;
+        }
+    }
+
     /// <summary>
     /// Base class for importing a C# function into Power Fx. 
     /// Dervied class should follow this convention:
@@ -61,6 +136,10 @@ namespace Microsoft.PowerFx
     public abstract class ReflectionFunction
     {
         private FunctionDescr _info;
+
+        // Using this name opts into special SetProperty binding. 
+        // This also gives us a symbol to track if we remove the special casing. 
+        public const string SetPropertyName = "SetProperty";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReflectionFunction"/> class.
@@ -145,6 +224,16 @@ namespace Microsoft.PowerFx
         internal TexlFunction GetTexlFunction()
         {
             var info = Scan();
+            
+            // Special case SetProperty. Use reference equality to opt into special casing.
+            if (object.ReferenceEquals(info.Name, SetPropertyName))
+            {
+                return new CustomSetPropertyFunction(info.Name)
+                {
+                    _impl = args => Invoke(args)
+                };
+            }
+
             return new CustomTexlFunction(info.Name, info.RetType, info.ParamTypes)
             {
                 _impl = (args) => Invoke(args)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -85,8 +85,6 @@ namespace Microsoft.PowerFx.Tests
             {
             }
 
-            // public Dictionary<string, FormulaValue> _props = new Dictionary<string, FormulaValue>();
-
             // Must have "Execute" method. 
             public static BooleanValue Execute(RecordValue source, StringValue propName, FormulaValue newValue)
             {


### PR DESCRIPTION
Binds as:
   SetProperty(source.Prop, newValue)

But invokes as:
  SetProperty(source, "Prop", newValue)

This is tactical and avoids new public surface, but should be handled by TypeRules.