### PR TITLE
Rouding error fixed (#488)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -690,17 +690,17 @@ namespace Microsoft.PowerFx.Functions
             }
 
             // Dividing by m, since multiplication was introducing floating point error
-            var m = Math.Pow(10d, -dg);
-            var eps = m / 1e12d; // used to manage rounding of 1.4499999999999999999996
+            var m = Math.Pow(10d, dg);
+            var eps = 1 / (m * 1e12d); // used to manage rounding of 1.4499999999999999999996
 
             switch (rt)
             {
                 case RoundType.Default:
-                    return s * Math.Floor((n + (m / 2) + eps) / m) * m;
+                    return s * Math.Floor((n + (1 / (2 * m)) + eps) * m) / m;
                 case RoundType.Down:
-                    return s * Math.Floor(n / m) * m;
+                    return s * Math.Floor(n * m) / m;
                 case RoundType.Up:
-                    return s * Math.Ceiling(n / m) * m;
+                    return s * Math.Ceiling(n * m) / m;
             }
 
             return 0;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -689,17 +689,17 @@ namespace Microsoft.PowerFx.Functions
                 return number;
             }
 
-            var m = Math.Pow(10d, -dg);
-            var eps = m / 1e12d; // used to manage rounding of 1.4499999999999999999996
+            var m = Math.Pow(10d, dg);
+            var eps = 1 / (m * 1e12d); // used to manage rounding of 1.4499999999999999999996
 
             switch (rt)
             {
                 case RoundType.Default:
-                    return s * Math.Floor((n + (m / 2) + eps) / m) * m;
+                    return s * Math.Floor((n + (1 / (2 * m)) + eps) * m) / m;
                 case RoundType.Down:
-                    return s * Math.Floor(n / m) * m;
+                    return s * Math.Floor(n * m) / m;
                 case RoundType.Up:
-                    return s * Math.Ceiling(n / m) * m;
+                    return s * Math.Ceiling(n * m) / m;
             }
 
             return 0;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -689,17 +689,18 @@ namespace Microsoft.PowerFx.Functions
                 return number;
             }
 
-            var m = Math.Pow(10d, dg);
-            var eps = 1 / (m * 1e12d); // used to manage rounding of 1.4499999999999999999996
+            // Dividing by m, since multiplication was introducing floating point error
+            var m = Math.Pow(10d, -dg);
+            var eps = m / 1e12d; // used to manage rounding of 1.4499999999999999999996
 
             switch (rt)
             {
                 case RoundType.Default:
-                    return s * Math.Floor((n + (1 / (2 * m)) + eps) * m) / m;
+                    return s * Math.Floor((n + (m / 2) + eps) / m) * m;
                 case RoundType.Down:
-                    return s * Math.Floor(n * m) / m;
+                    return s * Math.Floor(n / m) * m;
                 case RoundType.Up:
-                    return s * Math.Ceiling(n * m) / m;
+                    return s * Math.Ceiling(n / m) * m;
             }
 
             return 0;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Round.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Round.txt
@@ -105,6 +105,12 @@
 >> Round(1500.34,-3)
 2000
 
+>> Round(12.1,1)
+12.1
+
+>> Round(0.3,1)
+0.3
+
 // Negative Decimal NUMBER parameter
 
 >> Round(-14.123456,0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundDown.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundDown.txt
@@ -103,6 +103,9 @@
 >> RoundDown(1600.34,-3)
 1000
 
+>> RoundDown(0.31,1)
+0.3
+
 // Negative Decimal NUMBER parameter
 
 >> RoundDown(-14.123456,0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundUp.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundUp.txt
@@ -103,6 +103,9 @@
 >> RoundUp(1500.34,-3)
 2000
 
+>> RoundUp(0.3,1)
+0.3
+
 // Negative Decimal NUMBER parameter
 
 >> RoundUp(-14.123456,0)


### PR DESCRIPTION
- Issue was caused by floating point error due to multiplication. 
- Changed multiplication of "m" to division. Also added new test cases!