### PR TITLE
 DateTimeValue error fixed (Issue #493)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Interpreter;
@@ -402,7 +403,7 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        private static bool CultureExists(string name)
+        private static bool TryGetCulture(string name, out CultureInfo value)
         {
             CultureInfo[] availableCultures =
                 CultureInfo.GetCultures(CultureTypes.AllCultures);
@@ -411,10 +412,12 @@ namespace Microsoft.PowerFx.Functions
             {
                 if (string.Equals(culture.Name, name, StringComparison.OrdinalIgnoreCase))
                 {
+                    value = new CultureInfo(name);
                     return true;
                 }
             }
 
+            value = null;
             return false;
         }
 
@@ -422,15 +425,11 @@ namespace Microsoft.PowerFx.Functions
         {
             var str = args[0].Value;
 
-            // argCI will have Cultural info in-case one was passed in argument else it will have the default one.
+            // culture will have Cultural info in-case one was passed in argument else it will have the default one.
             CultureInfo culture = runner.CultureInfo;
             if (args.Length > 1)
             {
-                if (CultureExists(args[1].Value))
-                {
-                    culture = new CultureInfo(args[1].Value);
-                }
-                else
+                if (!TryGetCulture(args[1].Value, out culture))
                 {
                     return CommonErrors.InvalidDateTimeError(irContext);
                 }
@@ -450,15 +449,11 @@ namespace Microsoft.PowerFx.Functions
         {
             var str = args[0].Value;
 
-            // argCI will have Cultural info in-case one was passed in argument else it will have the default one.
-            CultureInfo argCI = runner.CultureInfo;
+            // culture will have Cultural info in-case one was passed in argument else it will have the default one.
+            CultureInfo culture = runner.CultureInfo;
             if (args.Length > 1)
             {
-                if (CultureExists(args[1].Value))
-                {
-                    argCI = new CultureInfo(args[1].Value);
-                }
-                else
+                if (!TryGetCulture(args[1].Value, out culture))
                 {
                     return CommonErrors.InvalidDateTimeError(irContext);
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -406,7 +406,7 @@ namespace Microsoft.PowerFx.Functions
         {
             var str = args[0].Value;
 
-            // argCI will have Culrural info incase one was passed in argument else it will have the default one.
+            // argCI will have Cultural info in-case one was passed in argument else it will have the default one.
             CultureInfo argCI = args.Length > 1 ? new CultureInfo(args[1].Value) : runner.CultureInfo;
 
             if (DateTime.TryParse(str, argCI, DateTimeStyles.None, out var result))

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -405,7 +405,11 @@ namespace Microsoft.PowerFx.Functions
         public static FormulaValue DateTimeParse(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, StringValue[] args)
         {
             var str = args[0].Value;
-            if (DateTime.TryParse(str, runner.CultureInfo, DateTimeStyles.None, out var result))
+
+            // argCI will have Culrural info incase one was passed in argument else it will have the default one.
+            CultureInfo argCI = args.Length > 1 ? new CultureInfo(args[1].Value) : runner.CultureInfo;
+
+            if (DateTime.TryParse(str, argCI, DateTimeStyles.None, out var result))
             {
                 return new DateTimeValue(irContext, result);
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -111,7 +111,21 @@ namespace Microsoft.PowerFx.Functions
                 return new BlankValue(irContext);
             }
 
-            var (val, err) = ConvertToNumber(str, runner.CultureInfo);
+            // Checking if any culture was passed
+            var culture = runner.CultureInfo;
+            if (args.Length > 1)
+            {
+                if (args[1] is StringValue && CultureExists((args[1] as StringValue).Value))
+                {
+                    culture = new CultureInfo((args[1] as StringValue).Value);
+                }
+                else
+                {
+                    return CommonErrors.InvalidDateTimeError(irContext);
+                }
+            }
+
+            var (val, err) = ConvertToNumber(str, culture);
 
             if (err == ConvertionStatus.Ok)
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -111,15 +111,11 @@ namespace Microsoft.PowerFx.Functions
                 return new BlankValue(irContext);
             }
 
-            // Checking if any culture was passed
+            // culture will have Cultural info in-case one was passed in argument else it will have the default one.
             var culture = runner.CultureInfo;
             if (args.Length > 1)
             {
-                if (args[1] is StringValue && CultureExists((args[1] as StringValue).Value))
-                {
-                    culture = new CultureInfo((args[1] as StringValue).Value);
-                }
-                else
+                if (args[1] is StringValue cultureArg && !TryGetCulture(cultureArg.Value, out culture))
                 {
                     return CommonErrors.InvalidDateTimeError(irContext);
                 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
@@ -1,4 +1,4 @@
-
+﻿
 // Use of DateValue, DateTimeValue
 
 >> Text(DateTimeValue("01-01-2001 1:10:20"))
@@ -47,3 +47,18 @@ true
 
 >> Text(DateTimeValue("21-Dec-2016 02:55:00", "EN-US"))
 "12/21/2016 2:55 AM"
+
+>> Text(DateTimeValue("21-Dec-2016 02:55:00", "en-us"))
+"12/21/2016 2:55 AM"
+
+>> Text(DateTimeValue("Thursday 28 July 2022 7:34:03 PM", "EN"))
+"7/28/2022 7:34 PM"
+
+>> Text(DateTimeValue("21.7.2022. 19:34:03", "sr-cyrl-RS"))
+"7/21/2022 7:34 PM"
+
+>> Text(DateTimeValue("2022年07月28日 19:34:03", "ja-JP"))
+"7/28/2022 7:34 PM"
+
+>> Text(DateTimeValue("четвртак 21 јул 2022 19:34:03", "sr-cyrl-RS"))
+"7/21/2022 7:34 PM"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
@@ -62,3 +62,6 @@ true
 
 >> Text(DateTimeValue("четвртак 21 јул 2022 19:34:03", "sr-cyrl-RS"))
 "7/21/2022 7:34 PM"
+
+>> Text(DateTimeValue("четвртак 21 јул 2022 19:34:03", "invalid"))
+#Error(Kind=InvalidArgument)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
@@ -38,3 +38,12 @@ true
 
 >> Second(DateTimeValue("02/14/2001 6:00 AM") - 1.1574e-5)
 59
+
+>> Text(DateTimeValue("jeudi 21 juillet 2022 19:34:03", "fr-FR"))
+"7/21/2022 7:34 PM"
+
+>> Text(DateTimeValue("Thursday 28 July 2022 19:34:03", "EN-US"))
+"7/28/2022 7:34 PM"
+
+>> Text(DateTimeValue("21-Dec-2016 02:55:00", "EN-US"))
+"12/21/2016 2:55 AM"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Value.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Value.txt
@@ -463,6 +463,9 @@ true
 >> Value("1.2e-3")
 0.0012
 
+>> Value("123,456", "es-ES" )
+123.456
+
 // ******** BOOLEAN PARAMETERS ********
 
 >> Value("true")


### PR DESCRIPTION
Existing function was always using System's Culture info, and did not take in account that culture info can be passed in the argument.