### PR TITLE
 prevent support scalar in MultiselectOptionset table

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2640,7 +2640,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
 
                     // scalar in table: RHS must be a one column table. We'll allow coercion.
-                    if (typeRight.IsTable)
+                    if (typeRight.IsTable && !typeRight.IsMultiSelectOptionSet())
                     {
                         var names = typeRight.GetNames(DPath.Root);
                         if (names.Count() != 1)
@@ -2666,8 +2666,8 @@ namespace Microsoft.PowerFx.Core.Binding
                         return true;
                     }
 
-                    // scalar in record: not supported. Flag an error on the RHS.
-                    Contracts.Assert(typeRight.IsRecord);
+                    // scalar in record or multiSelectOptionSet table: not supported. Flag an error on the RHS.
+                    Contracts.Assert(typeRight.IsRecord || typeRight.IsMultiSelectOptionSet());
                     _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
                     return false;
                 }
@@ -2717,13 +2717,13 @@ namespace Microsoft.PowerFx.Core.Binding
                         }
 
                         var typedName = names.Single();
-                        if (!typeLeft.CoercesTo(typedName.Type))
+                        if (!typeRight.CoercesTo(typeLeft))
                         {
                             _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
                             return false;
                         }
 
-                        if (typeLeft.Accepts(typedName.Type))
+                        if (typeRight.Accepts(typeLeft))
                         {
                             return true;
                         }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2717,13 +2717,16 @@ namespace Microsoft.PowerFx.Core.Binding
                         }
 
                         var typedName = names.Single();
+
+                        // Ensure we error when RHS node of table type cannot be coerced to a multiselectOptionset table node.  
                         if (!typeRight.CoercesTo(typeLeft))
                         {
                             _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
                             return false;
                         }
 
-                        if (typeRight.Accepts(typeLeft))
+                        // Check if multiselectoptionset column type accepts RHS node of type table. 
+                        if (typeLeft.Accepts(typedName.Type))
                         {
                             return true;
                         }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -2005,7 +2005,7 @@ namespace Microsoft.PowerFx.Core.Types
                 case DKind.OptionSetValue:
                     accepts = (type.Kind == Kind &&
                                 (OptionSetInfo == null || type.OptionSetInfo == null || type.OptionSetInfo == OptionSetInfo)) ||
-                               type.Kind == DKind.Unknown || (type.IsMultiSelectOptionSet() && (OptionSetInfo != null && type.TypeTree.GetPairs().First().Value.OptionSetInfo == OptionSetInfo));
+                               type.Kind == DKind.Unknown;
                     break;
                 case DKind.View:
                 case DKind.ViewValue:


### PR DESCRIPTION
This change basically restricts a scalar value like optionsetvalue to be used in the IN operator with a MultiselectOptionset Table, this has resulted in issues where formulas in App don't work in edit mode until they are forced to be reevaluated