### PR TITLE
Add a skip API validation for forks

### DIFF
--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -132,11 +132,13 @@ stages:
 
 - stage: API_Compatibility_Validation
   dependsOn: Build
-  condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
+  # Skip API validation against Azure for a fork, as forks do not have access to our private feed.
+  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.feedName }}', 'NuGet')))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:
   - job: generate_multiconfig_var
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     steps:
     - checkout: none
 
@@ -155,6 +157,7 @@ stages:
         tags: |
           Comparing API against v $(GetContract.ContractVersion)
           From ${{ parameters.packageFeed }} feed 
+      continueOnError: true
 
     - powershell: |
         $multiconfig = '{';

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -133,7 +133,7 @@ stages:
 - stage: API_Compatibility_Validation
   dependsOn: Build
   # Skip API validation against Azure for a fork, as forks do not have access to our private feed.
-  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.feedName }}', 'NuGet')))
+  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.packageFeed }}', 'NuGet')))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:


### PR DESCRIPTION
In the [experimental]PowerFx-CI pipeline, API validation against our private Azure feed does not work for a fork because forks do not have OAuth access.

This skips validation for those cases.