### PR TITLE
Remove skip API validation for forks

### DIFF
--- a/src/build/yaml/feed-setup-step.yml
+++ b/src/build/yaml/feed-setup-step.yml
@@ -7,13 +7,13 @@ parameters:
 
 steps:
 - powershell: |
-    if ("$(System.PullRequest.IsFork)" -eq 'True') {
-      $key = "nuget.org";
-      $value = "https://api.nuget.org/v3/index.json";
-      $key2 = "nuget.org2";
-      $value2 = "https://api.nuget.org/v3/index.json";
-      Write-Host 'NuGet feed: System.PullRequest.IsFork = True';
-    } else {
+    # if ("$(System.PullRequest.IsFork)" -eq 'True') {
+    #   $key = "nuget.org";
+    #   $value = "https://api.nuget.org/v3/index.json";
+    #   $key2 = "nuget.org2";
+    #   $value2 = "https://api.nuget.org/v3/index.json";
+    #   Write-Host 'NuGet feed: System.PullRequest.IsFork = True';
+    # } else {
       if ("${{ parameters.feedName }}" -eq 'NuGet') {
         $key = "SDK_Dotnet_V4_org";
         $value = "https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json";
@@ -27,7 +27,7 @@ steps:
         $value2 = "https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json";
         Write-Host 'PowerFx feed';
       }
-    }
+    # }
 
     $file = "$(Build.SourcesDirectory)\nuget.config";
 

--- a/src/build/yaml/feed-setup-step.yml
+++ b/src/build/yaml/feed-setup-step.yml
@@ -1,5 +1,4 @@
 # Create nuget.config for getting packages from PowerFx feed or SDK_Dotnet_V4_org feed or NuGet.org feed.
-# Resolve from nuget.org when PR is from a fork, as forks do not have access to our private feed.
 parameters:
   - name: feedName
     displayName: Azure or NuGet
@@ -7,27 +6,19 @@ parameters:
 
 steps:
 - powershell: |
-    # if ("$(System.PullRequest.IsFork)" -eq 'True') {
-    #   $key = "nuget.org";
-    #   $value = "https://api.nuget.org/v3/index.json";
-    #   $key2 = "nuget.org2";
-    #   $value2 = "https://api.nuget.org/v3/index.json";
-    #   Write-Host 'NuGet feed: System.PullRequest.IsFork = True';
-    # } else {
-      if ("${{ parameters.feedName }}" -eq 'NuGet') {
-        $key = "SDK_Dotnet_V4_org";
-        $value = "https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json";
-        $key2 = "nuget.org";
-        $value2 = "https://api.nuget.org/v3/index.json";
-        Write-Host 'SDK_Dotnet_V4_org feed';
-      } else {
-        $key = "PowerFx";
-        $value = "$(PowerFx_daily_feed_Url)";
-        $key2 = "SDK_Dotnet_V4_org";
-        $value2 = "https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json";
-        Write-Host 'PowerFx feed';
-      }
-    # }
+    if ("${{ parameters.feedName }}" -eq 'NuGet') {
+      $key = "SDK_Dotnet_V4_org";
+      $value = "https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json";
+      $key2 = "nuget.org";
+      $value2 = "https://api.nuget.org/v3/index.json";
+      Write-Host 'SDK_Dotnet_V4_org feed';
+    } else {
+      $key = "PowerFx";
+      $value = "$(PowerFx_daily_feed_Url)";
+      $key2 = "SDK_Dotnet_V4_org";
+      $value2 = "https://pkgs.dev.azure.com/FuseLabs/_packaging/SDK_Dotnet_V4_org/nuget/v3/index.json";
+      Write-Host 'PowerFx feed';
+    }
 
     $file = "$(Build.SourcesDirectory)\nuget.config";
 

--- a/src/build/yaml/get-contract-version-step.yml
+++ b/src/build/yaml/get-contract-version-step.yml
@@ -12,7 +12,7 @@ steps:
     $packageName = ($env:PackagesToValidate.Split(","))[0];
     [string]$contractVersion = "";
 
-    if ("${{ parameters.feedName }}" -eq 'Azure' -and "$(System.PullRequest.IsFork)" -ne 'True') {
+    if ("${{ parameters.feedName }}" -eq 'Azure') { #-and "$(System.PullRequest.IsFork)" -ne 'True') {
 
       Write-Host "Get latest $packageName version number from Azure feed";
 

--- a/src/build/yaml/get-contract-version-step.yml
+++ b/src/build/yaml/get-contract-version-step.yml
@@ -12,7 +12,7 @@ steps:
     $packageName = ($env:PackagesToValidate.Split(","))[0];
     [string]$contractVersion = "";
 
-    if ("${{ parameters.feedName }}" -eq 'Azure') { #-and "$(System.PullRequest.IsFork)" -ne 'True') {
+    if ("${{ parameters.feedName }}" -eq 'Azure') {
 
       Write-Host "Get latest $packageName version number from Azure feed";
 

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -132,7 +132,6 @@ stages:
 
 - stage: API_Compatibility_Validation
   dependsOn: Build
-  # condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.packageFeed }}', 'NuGet')))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -132,13 +132,11 @@ stages:
 
 - stage: API_Compatibility_Validation
   dependsOn: Build
-  # Skip API validation against Azure for a fork, as forks do not have access to our private feed.
-  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.packageFeed }}', 'NuGet')))
+  # condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.packageFeed }}', 'NuGet')))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:
   - job: generate_multiconfig_var
-    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     steps:
     - checkout: none
 
@@ -198,7 +196,7 @@ stages:
 
   - job: post_results_to_gitHub
     dependsOn: check_api_for
-    condition: ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}')
+    condition: and(succeeded(), ne(dependencies.generate_multiconfig_var.outputs['generate_var.MULTICONFIG'], '{}'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
     steps:
     - checkout: none

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -132,11 +132,13 @@ stages:
 
 - stage: API_Compatibility_Validation
   dependsOn: Build
-  condition: and(succeeded(), ne(variables['DisableApiCompatibityValidation'], 'true'))
+  # Skip API validation against Azure for a fork, as forks do not have access to our private feed.
+  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.feedName }}', 'NuGet')))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:
   - job: generate_multiconfig_var
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
     steps:
     - checkout: none
 
@@ -155,6 +157,7 @@ stages:
         tags: |
           Comparing API against v $(GetContract.ContractVersion)
           From ${{ parameters.packageFeed }} feed 
+      continueOnError: true
 
     - powershell: |
         $multiconfig = '{';

--- a/src/build/yaml/powerfx-ci.yml
+++ b/src/build/yaml/powerfx-ci.yml
@@ -133,7 +133,7 @@ stages:
 - stage: API_Compatibility_Validation
   dependsOn: Build
   # Skip API validation against Azure for a fork, as forks do not have access to our private feed.
-  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.feedName }}', 'NuGet')))
+  condition: and(succeeded(), or(ne(variables['System.PullRequest.IsFork'], 'True'), eq('${{ parameters.packageFeed }}', 'NuGet')))
   variables:
     skipComponentGovernanceDetection: true # the task is already injected into the build job, so skip it here.
   jobs:


### PR DESCRIPTION
Allow API validation for forks in the [experimental]PowerFx-CI pipeline: the Azure feed is public, so no secret is used there.

(We still must skip pushing results to the PR for forks. A secret is used there.) 