### PR TITLE
scalar in table optionset

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2649,13 +2649,6 @@ namespace Microsoft.PowerFx.Core.Binding
                             return false;
                         }
 
-                        // restrict scalar in multiselect optionset table. (Not TableA.OptionsetColumn)
-                        if (typeRight.IsMultiSelectOptionSet() && typeLeft.AssociatedDataSources?.Count == 0)
-                        {
-                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrBadType_Type, typeLeft.GetKindString());
-                            return false;
-                        }
-
                         var typedName = names.Single();
                         if (typedName.Type.Accepts(typeLeft) || typeLeft.Accepts(typedName.Type))
                         {
@@ -2674,7 +2667,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
 
                     // scalar in record or multiSelectOptionSet table: not supported. Flag an error on the RHS.
-                    Contracts.Assert(typeRight.IsRecord || typeRight.IsMultiSelectOptionSet());
+                    Contracts.Assert(typeRight.IsRecord);
                     _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
                     return false;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2640,12 +2640,19 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
 
                     // scalar in table: RHS must be a one column table. We'll allow coercion.
-                    if (typeRight.IsTable && !typeRight.IsMultiSelectOptionSet())
+                    if (typeRight.IsTable)
                     {
                         var names = typeRight.GetNames(DPath.Root);
                         if (names.Count() != 1)
                         {
                             _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrInvalidSchemaNeedCol);
+                            return false;
+                        }
+
+                        // restrict scalar in multiselect optionset table. (Not TableA.OptionsetColumn)
+                        if (typeRight.IsMultiSelectOptionSet() && typeLeft.AssociatedDataSources?.Count == 0)
+                        {
+                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrBadType_Type, typeLeft.GetKindString());
                             return false;
                         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
@@ -54,6 +54,14 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return false;
             }
 
+            var leftType = binding.GetType(binaryOpNode.Left);
+            var rightType = binding.GetType(binaryOpNode.Right);
+            if ((leftType.IsMultiSelectOptionSet() && !rightType.IsAggregate) || (rightType.IsMultiSelectOptionSet() && !leftType.IsAggregate))
+            {
+                SuggestDelegationHint(node, binding);
+                return false;
+            }
+
             return base.IsSupportedOpNode(node, metadata, binding);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -299,12 +299,6 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return true;
             }
 
-            if ((leftType.IsMultiSelectOptionSet() && !rightType.IsAggregate) || (rightType.IsMultiSelectOptionSet() && !leftType.IsAggregate))
-            {
-                SuggestDelegationHint(node, binding);
-                return false;
-            }
-
             if (!DoCoercionCheck(binaryOpNode, metadata, binding))
             {
                 SuggestDelegationHint(node, binding);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -299,6 +299,12 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return true;
             }
 
+            if ((leftType.IsMultiSelectOptionSet() && !rightType.IsAggregate) || (rightType.IsMultiSelectOptionSet() && !leftType.IsAggregate))
+            {
+                SuggestDelegationHint(node, binding);
+                return false;
+            }
+
             if (!DoCoercionCheck(binaryOpNode, metadata, binding))
             {
                 SuggestDelegationHint(node, binding);


### PR DESCRIPTION
From the test case, TableA.Optionsetcolumn in multiselectOptionset was supported previously as a delegable call to dataverse resulting in errors, this PR makes it non-delegable.

Ex: Filter(Accounts, optionsetValue in MultiselectTable)  // is now non delegated, instead of being a delegable call.
Filter(Accounts, 'Primary Contact'.optionsetcolumn in MultiselectTable) supported.