### PR TITLE
Power Fx connector improvements

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -16,8 +16,12 @@ namespace Microsoft.PowerFx.Connectors
     // https://docs.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#x-ms-visibility
     public static class OpenApiExtensions
     {
-        public static string GetBasePath(this OpenApiDocument openApiDocument)
-        {            
+        public static string GetBasePath(this OpenApiDocument openApiDocument) => GetUriElement(openApiDocument, (uri) => uri.PathAndQuery);        
+
+        public static string GetAuthority(this OpenApiDocument openApiDocument) => GetUriElement(openApiDocument, (uri) => uri.Authority);        
+
+        private static string GetUriElement(this OpenApiDocument openApiDocument, Func<Uri, string> getElement)
+        {
             if (openApiDocument.Servers == null)
             {
                 return null;
@@ -33,8 +37,7 @@ namespace Microsoft.PowerFx.Connectors
                     // Extract BasePath back out from this. 
                     var fullPath = openApiDocument.Servers[0].Url;
                     var uri = new Uri(fullPath);
-                    var basePath = uri.PathAndQuery;
-                    return basePath;
+                    return getElement(uri);
                 default:
                     throw new NotImplementedException($"Multiple servers not supported");
             }
@@ -46,7 +49,7 @@ namespace Microsoft.PowerFx.Connectors
             {
                 return oas.Value;
             }
-           
+
             return null;
         }
 
@@ -55,7 +58,7 @@ namespace Microsoft.PowerFx.Connectors
         {
             // x-ms-enum-values is: array of { value :string, displayName:string}.
             if (param.Extensions.TryGetValue("x-ms-enum-values", out var value))
-            { 
+            {
                 if (value is OpenApiArray array)
                 {
                     var list = new List<string>(array.Capacity);
@@ -175,7 +178,7 @@ namespace Microsoft.PowerFx.Connectors
                         obj = obj.Add(propName, propType);
                     }
 
-                    return obj;                
+                    return obj;
 
                 default:
 
@@ -193,10 +196,10 @@ namespace Microsoft.PowerFx.Connectors
                 OperationType.Delete => HttpMethod.Delete,
                 OperationType.Options => HttpMethod.Options,
                 OperationType.Head => HttpMethod.Head,
-                OperationType.Trace => HttpMethod.Trace,                
+                OperationType.Trace => HttpMethod.Trace,
                 _ => new HttpMethod(key.ToString())
             };
-        }        
+        }
 
         public static FormulaType GetReturnType(this OpenApiOperation op)
         {
@@ -232,7 +235,7 @@ namespace Microsoft.PowerFx.Connectors
                     }
 
                     var responseType = response.Schema.ToFormulaType();
-                    return responseType;                    
+                    return responseType;
                 }
             }
 
@@ -241,7 +244,7 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         // Keep these constants all lower case
-        public const string ContentType_TextJson = "text/json";        
+        public const string ContentType_TextJson = "text/json";
         public const string ContentType_XWwwFormUrlEncoded = "application/x-www-form-urlencoded";
         public const string ContentType_ApplicationJson = "application/json";
         public const string ContentType_TextPlain = "text/plain";
@@ -250,8 +253,8 @@ namespace Microsoft.PowerFx.Connectors
         {
             ContentType_ApplicationJson,
             ContentType_XWwwFormUrlEncoded,
-            ContentType_TextJson            
-        };        
+            ContentType_TextJson
+        };
 
         /// <summary>
         /// Identifies which ContentType and Schema to use.
@@ -264,7 +267,7 @@ namespace Microsoft.PowerFx.Connectors
             Dictionary<string, OpenApiMediaType> list = new ();
 
             foreach (var ct in _knownContentTypes)
-            {                
+            {
                 if (content.TryGetValue(ct, out var mediaType))
                 {
                     if ((ct == ContentType_ApplicationJson && !mediaType.Schema.Properties.Any()) ||

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerFx.Connectors
 
         private static string GetUriElement(this OpenApiDocument openApiDocument, Func<Uri, string> getElement)
         {
-            if (openApiDocument.Servers == null)
+            if (openApiDocument?.Servers == null)
             {
                 return null;
             }

--- a/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
 
 namespace Microsoft.PowerFx.Connectors
 {
@@ -18,7 +19,7 @@ namespace Microsoft.PowerFx.Connectors
         /// For telemetry - assembly version stamp. 
         /// </summary>
         public static string Version { get; } = typeof(PowerPlatformConnectorClient).Assembly.GetName().Version.ToString();
-        
+
         /// <summary>
         /// Session Id for telemetry.
         /// </summary>
@@ -26,18 +27,23 @@ namespace Microsoft.PowerFx.Connectors
 
         private readonly HttpMessageInvoker _client;
 
-        public string ConnectionId { get; } 
+        public string ConnectionId { get; }
 
         // For example, "firstrelease-001.azure-apim.net" 
-        public string Endpoint { get; }
+        public string Endpoint => BaseAddress.Authority;
 
         /// <summary>
-        /// Callback to get the auth token. 
+        /// Callback to get the auth token.
         /// Invoke as a callback since token may need to be refreshed. 
         /// </summary>
         public Func<string> GetAuthToken { get; }
 
         public string EnvironmentId { get; set; }
+
+        public PowerPlatformConnectorClient(OpenApiDocument swaggerFile, string environmentId, string connectionId, Func<string> getAuthToken, HttpMessageInvoker httpInvoker = null)
+            : this(swaggerFile.GetAuthority() ?? throw new ArgumentException("Swagger document doesn't contain an endpoint"), environmentId, connectionId, getAuthToken, httpInvoker)
+        {
+        }
 
         public PowerPlatformConnectorClient(string endpoint, string environmentId, string connectionId, Func<string> getAuthToken, HttpMessageInvoker httpInvoker = null)
         {
@@ -46,17 +52,29 @@ namespace Microsoft.PowerFx.Connectors
             GetAuthToken = getAuthToken ?? throw new ArgumentNullException(nameof(getAuthToken));
             ConnectionId = connectionId ?? throw new ArgumentNullException(nameof(connectionId));
             EnvironmentId = environmentId ?? throw new ArgumentNullException(nameof(environmentId));
-            Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+
+            // Case insensitive comparison per RFC 9110 [4.2.3 http(s) Normalization and Comparison]
+            if (endpoint.StartsWith($"{Uri.UriSchemeHttp}://", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Cannot accept unsecure endpoint");
+            }
 
             // Must set to allow callers to invoke SendAsync() via other helper methods.
-            BaseAddress = new Uri("https://" + endpoint); // Uri.Parse will validate endpoint syntax. 
+            if (endpoint.StartsWith($"{Uri.UriSchemeHttps}://", StringComparison.OrdinalIgnoreCase))
+            {
+                BaseAddress = new Uri(endpoint);
+            }
+            else
+            {
+                BaseAddress = new Uri("https://" + endpoint); // Uri.Parse will validate endpoint syntax. 
+            }
         }
-                
+
         public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             using HttpRequestMessage req = Transform(request);
 
-            return await _client.SendAsync(req, cancellationToken);            
+            return await _client.SendAsync(req, cancellationToken);
         }
 
         public HttpRequestMessage Transform(HttpRequestMessage request)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/OpenApiExtensionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/OpenApiExtensionTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.PowerFx.Core.Tests;
+using Xunit;
+
+namespace Microsoft.PowerFx.Connectors.Tests
+{
+    public class OpenApiExtensionTests : PowerFxTest
+    {
+        [Theory]
+        [InlineData("https://www.foo.bar", "www.foo.bar", "/")]
+        [InlineData("https://www.FOO.bar", "www.foo.bar", "/")]
+        [InlineData("http://www.foo.bar", "www.foo.bar", "/")]
+        [InlineData("https://www.foo.bar:117", "www.foo.bar:117", "/")]
+        [InlineData("https://www.foo.bar/xyz", "www.foo.bar", "/xyz")]
+        [InlineData("https://www.FOO.BAR:2883/xyz/ABC", "www.foo.bar:2883", "/xyz/ABC")]
+        [InlineData("https://localhost:44/efgh", "localhost:44", "/efgh")]
+        [InlineData(null, null, null)]
+        public void OpenApiExtension_Get(string url, string expectedAuthority, string expectedBasePath)
+        {
+            var doc = new OpenApiDocument();
+
+            if (!string.IsNullOrEmpty(url))
+            {
+                var srv = new OpenApiServer { Url = url };
+                doc.Servers.Add(srv);
+            }
+
+            Assert.Equal(expectedAuthority, doc.GetAuthority());
+            Assert.Equal(expectedBasePath, doc.GetBasePath());
+        }
+
+        [Fact]
+        public void OpenApiExtension_Null()
+        {
+            Assert.Null((null as OpenApiDocument).GetAuthority());
+            Assert.Null((null as OpenApiDocument).GetBasePath());
+        }
+
+        [Fact]
+        public void OpenApiExtension_MultipleServers()
+        {
+            var doc = new OpenApiDocument();
+            var srv1 = new OpenApiServer { Url = "https://server1" };
+            var srv2 = new OpenApiServer { Url = "https://server2" };
+            doc.Servers.Add(srv1);
+            doc.Servers.Add(srv2);
+
+            Assert.Throws<NotImplementedException>(() => doc.GetAuthority());
+            Assert.Throws<NotImplementedException>(() => doc.GetBasePath());
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -86,9 +86,10 @@ namespace Microsoft.PowerFx.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task AzureBlobConnector_UploadFile(bool useSwaggerParameter)
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        public async Task AzureBlobConnector_UploadFile(bool useSwaggerParameter, bool useHttpsPrefix)
         {
             using var testConnector = new LoggingTestServer(@"Swagger\AzureBlobStorage.json");
             var apiDoc = testConnector._apiDocument;
@@ -107,7 +108,8 @@ namespace Microsoft.PowerFx.Tests
                     SessionId = "ccccbff3-9d2c-44b2-bee6-cf24aab10b7e"
                 }
                 : new PowerPlatformConnectorClient(
-                    "firstrelease-001.azure-apim.net",      // endpoint
+                    (useHttpsPrefix ? "https://" : "") + 
+                        "firstrelease-001.azure-apim.net",  // endpoint
                     "839eace6-59ab-4243-97ec-a5b8fcc104e4", // environment
                     "453f61fa88434d42addb987063b1d7d2",     // connectionId
                     () => $"{token}",

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -16,23 +17,36 @@ namespace Microsoft.PowerFx.Tests
     public class PowerPlatformConnectorTests : PowerFxTest
     {
         // Exercise calling the MSNWeather connector against mocked Swagger and Response.json. 
-        [Fact]
-        public async Task MSNWeatherConnector_CurrentWeather()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task MSNWeatherConnector_CurrentWeather(bool useSwaggerParameter)
         {
             using var testConnector = new LoggingTestServer(@"Swagger\MSNWeather.json");
             var apiDoc = testConnector._apiDocument;
             var config = new PowerFxConfig();
 
             using var httpClient = new HttpClient(testConnector);
-            using var client = new PowerPlatformConnectorClient(
-                "firstrelease-001.azure-apim.net", // endpoint
-                "839eace6-59ab-4243-97ec-a5b8fcc104e4", // environment
-                "shared-msnweather-8d08e763-937a-45bf-a2ea-c5ed-ecc70ca4", // connectionId
-                () => "AuthToken1",
-                httpClient)
-            {
-                SessionId = "MySessionId"
-            };
+
+            using var client = useSwaggerParameter ?
+                new PowerPlatformConnectorClient(
+                    apiDoc,                                                     // Swagger file
+                    "839eace6-59ab-4243-97ec-a5b8fcc104e4",                     // environment
+                    "shared-msnweather-8d08e763-937a-45bf-a2ea-c5ed-ecc70ca4",  // connectionId
+                    () => "AuthToken1",
+                    httpClient)
+                {
+                    SessionId = "MySessionId"
+                }
+                : new PowerPlatformConnectorClient(
+                    "firstrelease-001.azure-apim.net",                          // endpoint
+                    "839eace6-59ab-4243-97ec-a5b8fcc104e4",                     // environment
+                    "shared-msnweather-8d08e763-937a-45bf-a2ea-c5ed-ecc70ca4",  // connectionId
+                    () => "AuthToken1",
+                    httpClient)
+                {
+                    SessionId = "MySessionId"
+                };
 
             var funcs = config.AddService("MSNWeather", apiDoc, client);
 
@@ -71,24 +85,36 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Fact]
-        public async Task AzureBlobConnector_UploadFile()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task AzureBlobConnector_UploadFile(bool useSwaggerParameter)
         {
             using var testConnector = new LoggingTestServer(@"Swagger\AzureBlobStorage.json");
-            var apiDoc = testConnector._apiDocument;                       
+            var apiDoc = testConnector._apiDocument;
             var config = new PowerFxConfig();
             var token = @"AuthToken2";
 
             using var httpClient = new HttpClient(testConnector);
-            using var client = new PowerPlatformConnectorClient(
-                "firstrelease-001.azure-apim.net",      // endpoint
-                "839eace6-59ab-4243-97ec-a5b8fcc104e4", // environment
-                "453f61fa88434d42addb987063b1d7d2",     // connectionId
-                () => $"{token}",
-                httpClient)
-            {
-                SessionId = "ccccbff3-9d2c-44b2-bee6-cf24aab10b7e"
-            };
+            using var client = useSwaggerParameter ?
+                new PowerPlatformConnectorClient(
+                    apiDoc,                                 // Swagger file
+                    "839eace6-59ab-4243-97ec-a5b8fcc104e4", // environment
+                    "453f61fa88434d42addb987063b1d7d2",     // connectionId
+                    () => $"{token}",
+                    httpClient)
+                {
+                    SessionId = "ccccbff3-9d2c-44b2-bee6-cf24aab10b7e"
+                }
+                : new PowerPlatformConnectorClient(
+                    "firstrelease-001.azure-apim.net",      // endpoint
+                    "839eace6-59ab-4243-97ec-a5b8fcc104e4", // environment
+                    "453f61fa88434d42addb987063b1d7d2",     // connectionId
+                    () => $"{token}",
+                    httpClient)
+                {
+                    SessionId = "ccccbff3-9d2c-44b2-bee6-cf24aab10b7e"
+                };
 
             var funcs = config.AddService("AzureBlobStorage", apiDoc, client);
 
@@ -97,15 +123,15 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(funcNames, new string[] { "AppendFile", "CopyFile", "CopyFile_Old", "CreateFile", "CreateFile_Old", "DeleteFile", "DeleteFile_Old", "ExtractFolder_Old", "ExtractFolderV2", "GetDataSetsMetadata", "GetFileContent", "GetFileContent_Old", "GetFileContentByPath", "GetFileContentByPath_Old", "GetFileMetadata", "GetFileMetadata_Old", "GetFileMetadataByPath", "GetFileMetadataByPath_Old", "ListAllRootFolders", "ListAllRootFoldersV2", "ListFolder", "ListFolder_Old", "ListFolderV2", "ListRootFolder", "ListRootFolder_Old", "ListRootFolderV2", "TestConnection", "UpdateFile", "UpdateFile_Old" });
 
             // Now execute it...
-            var engine = new RecalcEngine(config);            
+            var engine = new RecalcEngine(config);
             testConnector.SetResponseFromFile(@"Responses\AzureBlobStorage_Response.json");
 
             var result = await engine.EvalAsync(
                 @"AzureBlobStorage.CreateFile(""container"", ""bora1.txt"", ""abc"").Size",
-                CancellationToken.None, 
+                CancellationToken.None,
                 options: new ParserOptions() { AllowsSideEffects = true });
 
-            dynamic res = result.ToObject();                       
+            dynamic res = result.ToObject();
             var size = (double)res;
 
             Assert.Equal(3.0, size);
@@ -116,9 +142,10 @@ namespace Microsoft.PowerFx.Tests
             var actual = testConnector._log.ToString();
 
             var version = PowerPlatformConnectorClient.Version;
+            var host = useSwaggerParameter ? "tip1-shared.azure-apim.net" : "firstrelease-001.azure-apim.net";
             var expected =
-@$"POST https://firstrelease-001.azure-apim.net/invoke
- authority: firstrelease-001.azure-apim.net
+@$"POST https://{host}/invoke
+ authority: {host}
  Authorization: Bearer {token}
  path: /invoke
  scheme: https
@@ -130,7 +157,7 @@ namespace Microsoft.PowerFx.Tests
  [content-header] Content-Type: text/plain; charset=utf-8
  [body] abc
 ";
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -166,6 +193,66 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.Equal("units", p1.Label);
             Assert.Equal("The measurement system used for all the meausre values in the request and response. Valid options are 'Imperial' and 'Metric'.", p1.Documentation);
+        }
+
+        [Fact]
+        public void PowerPlatformConnectorClientCtor()
+        {
+            using var httpClient = new HttpClient();
+
+            var ex = Assert.Throws<ArgumentException>(() => new PowerPlatformConnectorClient(
+                "http://firstrelease-001.azure-apim.net:117",  // endpoint not allowed with http scheme
+                "839eace6-59ab-4243-97ec-a5b8fcc104e4",
+                "453f61fa88434d42addb987063b1d7d2",
+                () => "AuthToken",
+                httpClient));
+
+            Assert.Equal("Cannot accept unsecure endpoint", ex.Message);
+
+            using var ppcl1 = new PowerPlatformConnectorClient(
+                "https://firstrelease-001.azure-apim.net:117", // endpoint is valid with https scheme
+                "839eace6-59ab-4243-97ec-a5b8fcc104e4",
+                "453f61fa88434d42addb987063b1d7d2",
+                () => "AuthToken",
+                httpClient);
+
+            Assert.NotNull(ppcl1);
+            Assert.Equal("firstrelease-001.azure-apim.net:117", ppcl1.Endpoint);
+
+            using var ppcl2 = new PowerPlatformConnectorClient(
+                "firstrelease-001.azure-apim.net:117",         // endpoint is valid with no scheme (https assumed)
+                "839eace6-59ab-4243-97ec-a5b8fcc104e4",
+                "453f61fa88434d42addb987063b1d7d2",
+                () => "AuthToken",
+                httpClient);
+
+            Assert.NotNull(ppcl2);
+            Assert.Equal("firstrelease-001.azure-apim.net:117", ppcl2.Endpoint);
+
+            using var testConnector = new LoggingTestServer(@"Swagger\AzureBlobStorage.json");
+            var apiDoc = testConnector._apiDocument;
+
+            using var ppcl3 = new PowerPlatformConnectorClient(
+                apiDoc,                                        // Swagger file with "host" param
+                "839eace6-59ab-4243-97ec-a5b8fcc104e4",
+                "453f61fa88434d42addb987063b1d7d2",
+                () => "AuthToken",
+                httpClient);
+
+            Assert.NotNull(ppcl3);
+            Assert.Equal("tip1-shared.azure-apim.net", ppcl3.Endpoint);
+
+            using var testConnector2 = new LoggingTestServer(@"Swagger\TestOpenAPI.json");
+            var apiDoc2 = testConnector2._apiDocument;
+
+            var ex2 = Assert.Throws<ArgumentException>(() => new PowerPlatformConnectorClient(
+                apiDoc2,                                        // Swagger file without "host" param
+                "839eace6-59ab-4243-97ec-a5b8fcc104e4",
+                "453f61fa88434d42addb987063b1d7d2",
+                () => "AuthToken",
+                httpClient));
+
+            Assert.Equal("Swagger document doesn't contain an endpoint", ex2.Message);
         }
     }
 }


### PR DESCRIPTION
Connectors: 
- allow use of Swagger document in lieu of endpoint (retrieve it automatically, when available)
- disallow endpoints starting with http://