### PR TITLE
Update DateValue_UO and DateTimeValue_UO to use TS semantics

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -152,12 +152,7 @@ namespace Microsoft.PowerFx.Functions
             {
                 var s = impl.GetString();
 
-                if (!IsValidDateTimeUO(s))
-                {
-                    return CommonErrors.InvalidDateTimeError(irContext);
-                }
-
-                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
+                if (IsValidDateTimeUO(s) && DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
                 {
                     return new DateValue(irContext, res.Date);
                 }
@@ -194,12 +189,7 @@ namespace Microsoft.PowerFx.Functions
             {
                 var s = impl.GetString();
 
-                if (!IsValidDateTimeUO(s))
-                {
-                    return CommonErrors.InvalidDateTimeError(irContext);
-                }
-
-                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
+                if (IsValidDateTimeUO(s) && DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
                 {
                     return new DateTimeValue(irContext, res);
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Types;
@@ -12,6 +13,11 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
+        private static bool IsValidDateTimeUO(string s)
+        {
+            return Regex.IsMatch(s, @"^[0-9]{4,4}(-[0-1][0-9](-[0-3][0-9](T[0-9]{2,2}(:[0-9]{2,2}(:[0-9]{2,2}(\.[0-9]{3,3}Z)?)?)?)?)?)?$");
+        }
+
         public static FormulaValue Index_UO(IRContext irContext, FormulaValue[] args)
         {
             var arg0 = (UntypedObjectValue)args[0];
@@ -145,7 +151,13 @@ namespace Microsoft.PowerFx.Functions
             if (impl.Type == FormulaType.String)
             {
                 var s = impl.GetString();
-                if (DateTime.TryParseExact(s, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
+
+                if (!IsValidDateTimeUO(s))
+                {
+                    return CommonErrors.InvalidDateTimeError(irContext);
+                }
+
+                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
                 {
                     return new DateValue(irContext, res.Date);
                 }
@@ -182,11 +194,12 @@ namespace Microsoft.PowerFx.Functions
             {
                 var s = impl.GetString();
 
-                // Year-month-date, the literal T, Hours-minutes-seconds
-                // F is 10ths of a second if non-zero, K is time zone information
-                var iso8601Format = "yyyy-MM-dd'T'HH:mm:ss.FFFK";
+                if (!IsValidDateTimeUO(s))
+                {
+                    return CommonErrors.InvalidDateTimeError(irContext);
+                }
 
-                if (DateTime.TryParseExact(s, iso8601Format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
+                if (DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime res))
                 {
                     return new DateTimeValue(irContext, res);
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerFx.Functions
     {
         private static bool IsValidDateTimeUO(string s)
         {
-            return Regex.IsMatch(s, @"^[0-9]{4,4}(-[0-1][0-9](-[0-3][0-9](T[0-9]{2,2}(:[0-9]{2,2}(:[0-9]{2,2}(\.[0-9]{3,3}Z)?)?)?)?)?)?$");
+            return Regex.IsMatch(s, @"^[0-9]{4,4}-[0-1][0-9]-[0-3][0-9](T[0-2][0-9]:[0-5][0-9]:[0-5][0-9](\.[0-9]{3,3})?Z?)?$");
         }
 
         public static FormulaValue Index_UO(IRContext irContext, FormulaValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -134,8 +134,8 @@ Errors: Error 0-14: Invalid argument type. Expecting one of the following: Numbe
 >> Value(Index(ParseJSON("{""a"": 5, ""b"": [{""c"": 19 }, {""c"": ""foo"" }] }").b, 1).c)
 19
 
->> Text(DateValue(ParseJSON("""2011-01-30""")), "yyyy-MM-dd")
-"2011-01-30"
+>> DateDiff(DateValue(ParseJSON("""2011-01-15""")), DateValue(ParseJSON("""2011-01-30""")))
+15
 
 >> DateValue(ParseJSON("""2011-1-15"""))
 #Error(Kind=InvalidArgument)
@@ -152,14 +152,14 @@ Blank()
 >> DateValue(ParseJSON("""abcdef"""))
 #Error(Kind=InvalidArgument)
 
->> Text(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000""")), "yyyy-MM-dd HH:mm:ss")
-"2011-01-15 08:00:00"
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
+15
 
->> Text(DateTimeValue(ParseJSON("""2011-01-15T08:00:00""")), "yyyy-MM-dd HH:mm:ss")
-"2011-01-15 08:00:00"
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000""")))
+15
 
->> Text(DateTimeValue(ParseJSON("""2011-01-15""")), "yyyy-MM-dd HH:mm:ss")
-"2011-01-15 00:00:00"
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T00:00:00""")), DateTimeValue(ParseJSON("""2011-01-30""")))
+15
 
 >> DateTimeValue(ParseJSON("""2011-01-15T08:0:00.000Z"""))
 #Error(Kind=InvalidArgument)
@@ -176,17 +176,17 @@ Blank()
 >> DateTimeValue(ParseJSON("""abcdef"""))
 #Error(Kind=InvalidArgument)
 
->> Text(DateValue(ParseJSON("""2022-05-05""")), "yyyy-MM-dd")
-"2022-05-05"
+>> Text(DateTimeValue(ParseJSON("""2022-05-05""")), "yyyy-MM-dd HH:mm:ss")
+"2022-05-05 00:00:00"
 
->> Text(DateValue(ParseJSON("""2011-01-15T08:00:00.000""")), "yyyy-MM-dd")
-"2011-01-15"
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
+15
 
->> Text(DateValue(ParseJSON("""2011-01-15T08:00:00""")), "yyyy-MM-dd")
-"2011-01-15"
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000""")))
+15
 
->> Text(DateValue(ParseJSON("""2011-01-15""")), "yyyy-MM-dd")
-"2011-01-15"
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T00:00:00""")), DateValue(ParseJSON("""2011-01-30""")))
+15
 
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")), "HH:mm:ss")
 "08:03:05"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -134,8 +134,8 @@ Errors: Error 0-14: Invalid argument type. Expecting one of the following: Numbe
 >> Value(Index(ParseJSON("{""a"": 5, ""b"": [{""c"": 19 }, {""c"": ""foo"" }] }").b, 1).c)
 19
 
->> DateDiff(DateValue(ParseJSON("""2011-01-15""")), DateValue(ParseJSON("""2011-01-30""")))
-15
+>> Text(DateValue(ParseJSON("""2011-01-30""")), "yyyy-MM-dd")
+"2011-01-30"
 
 >> DateValue(ParseJSON("""2011-1-15"""))
 #Error(Kind=InvalidArgument)
@@ -152,14 +152,14 @@ Blank()
 >> DateValue(ParseJSON("""abcdef"""))
 #Error(Kind=InvalidArgument)
 
->> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
-15
+>> Text(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000""")), "yyyy-MM-dd HH:mm:ss")
+"2011-01-15 08:00:00"
 
->> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000""")))
-15
+>> Text(DateTimeValue(ParseJSON("""2011-01-15T08:00:00""")), "yyyy-MM-dd HH:mm:ss")
+"2011-01-15 08:00:00"
 
->> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T00:00:00""")), DateTimeValue(ParseJSON("""2011-01-30""")))
-15
+>> Text(DateTimeValue(ParseJSON("""2011-01-15""")), "yyyy-MM-dd HH:mm:ss")
+"2011-01-15 00:00:00"
 
 >> DateTimeValue(ParseJSON("""2011-01-15T08:0:00.000Z"""))
 #Error(Kind=InvalidArgument)
@@ -176,17 +176,17 @@ Blank()
 >> DateTimeValue(ParseJSON("""abcdef"""))
 #Error(Kind=InvalidArgument)
 
->> Text(DateTimeValue(ParseJSON("""2022-05-05""")), "yyyy-MM-dd HH:mm:ss")
-"2022-05-05 00:00:00"
+>> Text(DateValue(ParseJSON("""2022-05-05""")), "yyyy-MM-dd")
+"2022-05-05"
 
->> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
-15
+>> Text(DateValue(ParseJSON("""2011-01-15T08:00:00.000""")), "yyyy-MM-dd")
+"2011-01-15"
 
->> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000""")))
-15
+>> Text(DateValue(ParseJSON("""2011-01-15T08:00:00""")), "yyyy-MM-dd")
+"2011-01-15"
 
->> DateDiff(DateValue(ParseJSON("""2011-01-15T00:00:00""")), DateValue(ParseJSON("""2011-01-30""")))
-15
+>> Text(DateValue(ParseJSON("""2011-01-15""")), "yyyy-MM-dd")
+"2011-01-15"
 
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")), "HH:mm:ss")
 "08:03:05"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -149,6 +149,12 @@ Blank()
 >> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
 15
 
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000""")))
+15
+
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T00:00:00""")), DateTimeValue(ParseJSON("""2011-01-30""")))
+15
+
 >> DateTimeValue(ParseJSON("""2011-01-15T08:0:00.000Z"""))
 #Error(Kind=InvalidArgument)
 
@@ -162,6 +168,12 @@ Blank()
 "5/5/2022 12:00 AM"
 
 >> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
+15
+
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000""")))
+15
+
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T00:00:00""")), DateValue(ParseJSON("""2011-01-30""")))
 15
 
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -164,8 +164,8 @@ Blank()
 >> DateTimeValue(ParseJSON("""abcdef"""))
 #Error(Kind=InvalidArgument)
 
->> Text(DateTimeValue(ParseJSON("""2022-05-05""")))
-"5/5/2022 12:00 AM"
+>> Text(DateTimeValue(ParseJSON("""2022-05-05""")), "yyyy-MM-dd HH:mm:ss")
+"2022-05-05 00:00:00"
 
 >> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
 15
@@ -176,8 +176,8 @@ Blank()
 >> DateDiff(DateValue(ParseJSON("""2011-01-15T00:00:00""")), DateValue(ParseJSON("""2011-01-30""")))
 15
 
->> Text(TimeValue(ParseJSON("""08:03:05.000""")))
-"8:03 AM"
+>> Text(TimeValue(ParseJSON("""08:03:05.000""")), "HH:mm:ss")
+"08:03:05"
 
 >> TimeValue(ParseJSON("""08:93:05.000"""))
 #Error(Kind=InvalidArgument)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -140,6 +140,12 @@ Errors: Error 0-14: Invalid argument type. Expecting one of the following: Numbe
 >> DateValue(ParseJSON("""2011-1-15"""))
 #Error(Kind=InvalidArgument)
 
+>> DateValue(ParseJSON("""2011-01"""))
+#Error(Kind=InvalidArgument)
+
+>> DateValue(ParseJSON("""2011"""))
+#Error(Kind=InvalidArgument)
+
 >> DateValue(ParseJSON("null"))
 Blank()
 
@@ -156,6 +162,12 @@ Blank()
 15
 
 >> DateTimeValue(ParseJSON("""2011-01-15T08:0:00.000Z"""))
+#Error(Kind=InvalidArgument)
+
+>> DateTimeValue(ParseJSON("""2011-01-15T08"""))
+#Error(Kind=InvalidArgument)
+
+>> DateTimeValue(ParseJSON("""2011T08:00:00.000Z"""))
 #Error(Kind=InvalidArgument)
 
 >> DateTimeValue(ParseJSON("null"))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -158,6 +158,9 @@ Blank()
 >> DateTimeValue(ParseJSON("""abcdef"""))
 #Error(Kind=InvalidArgument)
 
+>> Text(DateTimeValue(ParseJSON("""2022-05-05""")))
+"5/5/2022 12:00 AM"
+
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")))
 "8:03 AM"
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -161,6 +161,9 @@ Blank()
 >> Text(DateTimeValue(ParseJSON("""2022-05-05""")))
 "5/5/2022 12:00 AM"
 
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
+15
+
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")))
 "8:03 AM"
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -155,7 +155,10 @@ Blank()
 >> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
 15
 
->> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000""")))
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00Z""")))
+15
+
+>> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000""")), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000""")))
 15
 
 >> DateDiff(DateTimeValue(ParseJSON("""2011-01-15T00:00:00""")), DateTimeValue(ParseJSON("""2011-01-30""")))
@@ -182,10 +185,13 @@ Blank()
 >> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
 15
 
->> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000""")))
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00Z""")), DateValue(ParseJSON("""2011-01-30T08:00:00Z""")))
 15
 
 >> DateDiff(DateValue(ParseJSON("""2011-01-15T00:00:00""")), DateValue(ParseJSON("""2011-01-30""")))
+15
+
+>> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000""")))
 15
 
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")), "HH:mm:ss")


### PR DESCRIPTION
An issue uncovered in the bug bash. DateValue and DateTimeValue both need to work with the output of the other function.