### PR TITLE
SetProperty check failing scenarios for record and table type

### DIFF
--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -43,6 +43,15 @@ namespace Microsoft.PowerFx.Tests
             public double NumProp { get; set; }
 
             public bool BoolProp { get; set; }
+
+            public RecordObj RecordProp { get; set; }
+
+            public RecordObj[] TableProp { get; set; }
+        }
+
+        public class RecordObj
+        {
+            public string Value { get; set; }
         }
 
         private static readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
@@ -71,6 +80,12 @@ namespace Microsoft.PowerFx.Tests
             Assert.False(check.IsSuccess);
 
             check = engine.Check("SetProperty(x.BoolProp, 123)"); // arg mismatch
+            Assert.False(check.IsSuccess);
+
+            check = engine.Check("SetProperty(x.RecordProp, {Value : \"2\"})");  // behavior function in a non behavior property error
+            Assert.False(check.IsSuccess);
+
+            check = engine.Check("SetProperty(x.TableProp, Table({Value:\"1\"},{Value:\"2\"}))"); // behavior function in a non behavior property error
             Assert.False(check.IsSuccess);
 
             check = engine.Check("SetProperty(x.numMissing, 123)", options: _opts); // Binding Fail


### PR DESCRIPTION
Engine check fails on setProperty() when I try to access Comboxbox or Dropdown or Listbox properties. These expect table and record type values.Engine.Check() Fails and throws " **behavior function in a non behavior property error**" .

**Example Engine check() passes**
 `SetProperty(TextInput1.Text, "hi");
 SetProperty(Toggle1.Value, true);` 
**Example Engine check() fails**
`SetProperty(Dropdown1.Selected, {Value:"2"});
SetProperty(ComboBox1.SelectedItems, Table({Value:"1"},{Value:"2"}));          
 SetProperty(ListBox1.SelectedItems, Table({Value:"1"},{Value:"3"}));`

Adding specific testcases where Check() fails.

Would need these Check() to pass