### PR TITLE
Fix PublishToCoveralls.ps1

### DIFF
--- a/src/build/PublishToCoveralls.ps1
+++ b/src/build/PublishToCoveralls.ps1
@@ -14,10 +14,6 @@ $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterpr
 dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
-# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
-#Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
-#Import-Module .\archive.psm1
-
 Write-Host "Analyze coverage [$coverageAnalyzer] with args:"
 $coverageFiles = Get-ChildItem -Path "$pathToCoverageFiles" -Include "*.coverage" -Recurse | Select -Exp FullName
 $analyzeArgs = @(

--- a/src/build/PublishToCoveralls.ps1
+++ b/src/build/PublishToCoveralls.ps1
@@ -15,8 +15,8 @@ dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
 # Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
-Import-Module .\archive.psm1
+#Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
+#Import-Module .\archive.psm1
 
 Write-Host "Analyze coverage [$coverageAnalyzer] with args:"
 $coverageFiles = Get-ChildItem -Path "$pathToCoverageFiles" -Include "*.coverage" -Recurse | Select -Exp FullName

--- a/src/build/PublishToCoveralls.ps1
+++ b/src/build/PublishToCoveralls.ps1
@@ -10,7 +10,12 @@ Param(
 
 Write-Host Install tools
 $basePath = (get-item $pathToCoverageFiles ).parent.FullName
-$coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
+
+$coverageAnalyzer = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
+if (-not (Test-Path $coverageAnalyzer)) {
+  $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
+}
+
 dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 


### PR DESCRIPTION
This fixes PublishToCoveralls.ps1 which was installing a Powershell patch that fixed a path separator bug. 

The patch is no longer available. That broke PublishToCoveralls.ps1, making the "Upload Coverage Files" task fail in the PowerFx-PR pipeline.

Also implement codecoverage.exe access for VS 2022 installations.