### PR TITLE
Fix the Upload coverage files task

### DIFF
--- a/src/build/PublishToCoveralls.ps1
+++ b/src/build/PublishToCoveralls.ps1
@@ -16,7 +16,7 @@ if (-not (Test-Path $coverageAnalyzer)) {
   $coverageAnalyzer = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe"
 }
 
-dotnet tool install coveralls.net --version 3.0.0 --tool-path tools --add-source https://api.nuget.org/v3/index.json
+dotnet tool install coveralls.net --version 4.0.1 --tool-path tools --add-source https://api.nuget.org/v3/index.json
 $coverageUploader = ".\tools\csmacnz.Coveralls.exe"
 
 Write-Host "Analyze coverage [$coverageAnalyzer] with args:"


### PR DESCRIPTION
PowerFx-PR pipeline still fails to upload coverage report to coveralls.io.

The fix: upgrade coveralls.net to 4.0.1 in src/build/PublishToCoveralls.ps1.