### PR TITLE
Remove task 'Delete old compat results' from pipeline

### DIFF
--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -21,6 +21,47 @@ steps:
   displayName: 'Publish compat results to Artifacts'
   continueOnError: true
 
+# - powershell: |
+#     $OWNER = 'microsoft';
+#     $REPO = 'Power-Fx';
+#     $ISSUE_NUMBER = "$(System.PullRequest.PullRequestNumber)";
+#     $stringToMatch = "*Binary Compatibility issues*";
+#     $userNameToMatch = "BruceHaley";
+
+#     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
+
+#     $listResult = Invoke-RestMethod "$listCommentsUri";
+#     $count = $listResult.count;
+#     Write-Host "Comment Ids:" $listResult.id;
+#     Write-Host "Users:" $listResult.user.login;
+
+#     $commentsDeleted = 0;
+
+#     for ($i = 0; $i -lt $count; $i++) {
+#         if ($listResult[$i].body -like $stringToMatch -and $listResult[$i].user.login -eq $userNameToMatch) {
+#             $COMMENT_ID = $listResult[$i].id;
+#             $date = $listResult[$i].created_at;
+#             $user = $listResult[$i].user.login;
+
+#             $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
+#             $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
+#             $header = @{authorization = "Basic $token"};
+#             $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
+
+#             Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
+
+#             Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+#             $commentsDeleted++;
+#             break;
+#         }
+#     }
+
+#     if ($commentsDeleted -eq 0) {
+#         Write-Host "Nothing to delete.";
+#     }
+#   displayName: 'Delete old compat results'
+#   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
+
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
   displayName: 'Publish compat results to GitHub'
   inputs:

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -21,46 +21,46 @@ steps:
   displayName: 'Publish compat results to Artifacts'
   continueOnError: true
 
-- powershell: |
-    $OWNER = 'microsoft';
-    $REPO = 'Power-Fx';
-    $ISSUE_NUMBER = "$(System.PullRequest.PullRequestNumber)";
-    $stringToMatch = "*Binary Compatibility issues*";
-    $userNameToMatch = "BruceHaley";
+# - powershell: |
+#     $OWNER = 'microsoft';
+#     $REPO = 'Power-Fx';
+#     $ISSUE_NUMBER = "$(System.PullRequest.PullRequestNumber)";
+#     $stringToMatch = "*Binary Compatibility issues*";
+#     $userNameToMatch = "BruceHaley";
 
-    $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
+#     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
 
-    $listResult = Invoke-RestMethod "$listCommentsUri";
-    $count = $listResult.count;
-    Write-Host "Comment Ids:" $listResult.id;
-    Write-Host "Users:" $listResult.user.login;
+#     $listResult = Invoke-RestMethod "$listCommentsUri";
+#     $count = $listResult.count;
+#     Write-Host "Comment Ids:" $listResult.id;
+#     Write-Host "Users:" $listResult.user.login;
 
-    $commentsDeleted = 0;
+#     $commentsDeleted = 0;
 
-    for ($i = 0; $i -lt $count; $i++) {
-        if ($listResult[$i].body -like $stringToMatch -and $listResult[$i].user.login -eq $userNameToMatch) {
-            $COMMENT_ID = $listResult[$i].id;
-            $date = $listResult[$i].created_at;
-            $user = $listResult[$i].user.login;
+#     for ($i = 0; $i -lt $count; $i++) {
+#         if ($listResult[$i].body -like $stringToMatch -and $listResult[$i].user.login -eq $userNameToMatch) {
+#             $COMMENT_ID = $listResult[$i].id;
+#             $date = $listResult[$i].created_at;
+#             $user = $listResult[$i].user.login;
 
-            $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
-            $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
-            $header = @{authorization = "Basic $token"};
-            $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
+#             $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
+#             $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
+#             $header = @{authorization = "Basic $token"};
+#             $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
 
-            Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
+#             Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
 
-            Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
-            $commentsDeleted++;
-            break;
-        }
-    }
+#             Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
+#             $commentsDeleted++;
+#             break;
+#         }
+#     }
 
-    if ($commentsDeleted -eq 0) {
-        Write-Host "Nothing to delete.";
-    }
-  displayName: 'Delete old compat results'
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
+#     if ($commentsDeleted -eq 0) {
+#         Write-Host "Nothing to delete.";
+#     }
+#   displayName: 'Delete old compat results'
+#   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
 
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
   displayName: 'Publish compat results to GitHub'

--- a/src/build/yaml/ci-post-to-github-steps.yml
+++ b/src/build/yaml/ci-post-to-github-steps.yml
@@ -21,47 +21,6 @@ steps:
   displayName: 'Publish compat results to Artifacts'
   continueOnError: true
 
-# - powershell: |
-#     $OWNER = 'microsoft';
-#     $REPO = 'Power-Fx';
-#     $ISSUE_NUMBER = "$(System.PullRequest.PullRequestNumber)";
-#     $stringToMatch = "*Binary Compatibility issues*";
-#     $userNameToMatch = "BruceHaley";
-
-#     $listCommentsUri = "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER/comments";
-
-#     $listResult = Invoke-RestMethod "$listCommentsUri";
-#     $count = $listResult.count;
-#     Write-Host "Comment Ids:" $listResult.id;
-#     Write-Host "Users:" $listResult.user.login;
-
-#     $commentsDeleted = 0;
-
-#     for ($i = 0; $i -lt $count; $i++) {
-#         if ($listResult[$i].body -like $stringToMatch -and $listResult[$i].user.login -eq $userNameToMatch) {
-#             $COMMENT_ID = $listResult[$i].id;
-#             $date = $listResult[$i].created_at;
-#             $user = $listResult[$i].user.login;
-
-#             $githubPersonalAccessToken = "$(GitHubCommentApiKey)";
-#             $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$githubPersonalAccessToken"));
-#             $header = @{authorization = "Basic $token"};
-#             $deleteCommentUri = "https://api.github.com/repos/$OWNER/$REPO/issues/comments/$COMMENT_ID";
-
-#             Write-Host "Deleting comment $COMMENT_ID from $user dated $date";
-
-#             Invoke-RestMethod -Method Delete -Uri $deleteCommentUri -Headers $header;
-#             $commentsDeleted++;
-#             break;
-#         }
-#     }
-
-#     if ($commentsDeleted -eq 0) {
-#         Write-Host "Nothing to delete.";
-#     }
-#   displayName: 'Delete old compat results'
-#   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.PullRequest.IsFork'], 'True'))
-
 - task: SOUTHWORKS.github-pr-comment.custom-publish-comment-task.github-pr-comment@0
   displayName: 'Publish compat results to GitHub'
   inputs:


### PR DESCRIPTION
Task 'Publish compat results to GitHub' was recently changed to overwrite its previous publish. That means the second time [experimental]PowerFx-CI runs against a PR, the second published API compatibility comment does not create a duplicate. That makes the workaround, task 'Delete old compat results', redundant.

**The fix:**
Remove redundant task 'Delete old compat results'.