### PR TITLE
Mark Date <-> Time Coercions in binder

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4305,6 +4305,14 @@ namespace Microsoft.PowerFx.Core.Binding
                         _txb.SetCoercedType(left, DType.Number);
                         return;
                     }
+
+                    // Handle Date <=> Time comparison by coercing both to DateTime
+                    if (DType.DateTime.Accepts(typeLeft) && DType.DateTime.Accepts(typeRight))
+                    {
+                        _txb.SetCoercedType(left, DType.DateTime);
+                        _txb.SetCoercedType(right, DType.DateTime);
+                        return;
+                    }
                 }
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
@@ -73,6 +73,9 @@ true
 >> Time( 11, 23, 45 ) > Date( 2019, 5, 16 )
 false
 
+>> Date(1899, 12, 30) < Time(12,0,0)
+true
+
 >> Time(1/0, 2, 3) <= Time(8,1,30)
 #Error
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
@@ -67,6 +67,9 @@ false
 >> Time(1/0, 2, 3) < Time(8,1,30)
 #Error
 
+// Date <-> Time comparison is supported for back compat reasons
+// It's handled by promoting Times to DateTimes on the day of the epoch, and comparing using that.
+
 >> Date( 2019, 5, 16 ) > Time( 11, 23, 45 )
 true
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
@@ -67,6 +67,12 @@ false
 >> Time(1/0, 2, 3) < Time(8,1,30)
 #Error
 
+>> Date( 2019, 5, 16 ) > Time( 11, 23, 45 )
+true
+
+>> Time( 11, 23, 45 ) > Date( 2019, 5, 16 )
+false
+
 >> Time(1/0, 2, 3) <= Time(8,1,30)
 #Error
 


### PR DESCRIPTION
Date/Time implicitly are comparable, however the binder does not mark this as a coercion to DateTime, even though it should. This fixes that, and allows the binary op matrix to correctly generate IR for this. 