### PR TITLE
Fix OperationId name

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiHelperFunctions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiHelperFunctions.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    internal class OpenApiHelperFunctions
+    {
+        private static readonly Regex NotAnXsdNCNameCharRegex = new Regex(@"[^a-zA-Z0-9_-]+", RegexOptions.Compiled);
+        private static readonly Regex XsdNCNameStartCharRegex = new Regex(@"^[a-zA-Z_]", RegexOptions.Compiled);
+
+        internal static string NormalizeOperationId(string operationId)
+        {
+            return MakeValidXsdNCName(Regex.Replace(operationId, @"[^A-Za-z0-9]", string.Empty));
+        }
+        
+        private static string MakeValidXsdNCName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+
+            name = NotAnXsdNCNameCharRegex.Replace(name, EncodeInvalidNCNameChars);
+
+            // Handle the start char to make it is a valid start char.
+            // If the first char is not a valid start char, just prepend a valid char.
+            if (!XsdNCNameStartCharRegex.IsMatch(name))
+            {
+                name = "_" + name;
+            }
+
+            return name;
+        }
+
+        private static string EncodeInvalidNCNameChars(Match match)
+        {
+            var sb = new StringBuilder();
+            
+            // The period char '.' is commonly-used in the swagger. To reduce the size of
+            // the generated WADL, we directly map it to the underscore. For all other invalid chars,
+            // use 2-digit hex ("X2") if char can fit. Otherwise, use 4-digit hex ("X4")
+            foreach (var c in match.Value)
+            {
+                if (c == '.')
+                {
+                    sb.Append("_");
+                }
+                else if (c <= 255)
+                {
+                    sb.Append("_ux" + ((int)c).ToString("X2"));
+                }
+                else
+                {
+                    sb.Append("_Ux" + ((int)c).ToString("X4"));
+                }
+            }
+
+            // End the encoding with an underscore character to make the resulting encoding more 
+            // readable (i.e. "!?.$" -> "_ux21_ux3F__ux24_"
+            if (sb[sb.Length - 1] != '_')
+            {
+                sb.Append("_");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiParser.cs
@@ -9,6 +9,7 @@ using Microsoft.AppMagic.Authoring.Texl.Builtins;
 using Microsoft.OpenApi.Models;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
+using static Microsoft.PowerFx.Connectors.OpenApiHelperFunctions;
 
 namespace Microsoft.PowerFx.Connectors
 {
@@ -51,7 +52,8 @@ namespace Microsoft.PowerFx.Connectors
                         continue;
                     }
 
-                    var operationName = op.OperationId ?? path.Replace("/", string.Empty);
+                    // We need to remove invalid chars to be consistent with Power Apps
+                    var operationName = NormalizeOperationId(op.OperationId) ?? path.Replace("/", string.Empty);
                     var returnType = op.GetReturnType();
                     var opPath = basePath != null ? basePath + path : path;                    
 
@@ -110,7 +112,7 @@ namespace Microsoft.PowerFx.Connectors
 
             return newFunctions;
         }
-
+       
         private static bool IsSafeHttpMethod(HttpMethod httpMethod)
         {
             // HTTP/1.1 spec states that only GET and HEAD requests are 'safe' by default.

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.PowerFx.Tests
 
             // Function we added where specified in MSNWeather.json
             var funcNames = funcs.Select(func => func.Name).OrderBy(x => x).ToArray();
-            Assert.Equal(funcNames, new string[] { "AppendFile", "CopyFile", "CopyFile_Old", "CreateFile", "CreateFile_Old", "DeleteFile", "DeleteFile_Old", "ExtractFolder_Old", "ExtractFolderV2", "GetDataSetsMetadata", "GetFileContent", "GetFileContent_Old", "GetFileContentByPath", "GetFileContentByPath_Old", "GetFileMetadata", "GetFileMetadata_Old", "GetFileMetadataByPath", "GetFileMetadataByPath_Old", "ListAllRootFolders", "ListAllRootFoldersV2", "ListFolder", "ListFolder_Old", "ListFolderV2", "ListRootFolder", "ListRootFolder_Old", "ListRootFolderV2", "TestConnection", "UpdateFile", "UpdateFile_Old" });
+            Assert.Equal(funcNames, new string[] { "AppendFile", "CopyFile", "CopyFileOld", "CreateFile", "CreateFileOld", "DeleteFile", "DeleteFileOld", "ExtractFolderOld", "ExtractFolderV2", "GetDataSetsMetadata", "GetFileContent", "GetFileContentByPath", "GetFileContentByPathOld", "GetFileContentOld", "GetFileMetadata", "GetFileMetadataByPath", "GetFileMetadataByPathOld", "GetFileMetadataOld", "ListAllRootFolders", "ListAllRootFoldersV2", "ListFolder", "ListFolderOld", "ListFolderV2", "ListRootFolder", "ListRootFolderOld", "ListRootFolderV2", "TestConnection", "UpdateFile", "UpdateFileOld" });
 
             // Now execute it...
             var engine = new RecalcEngine(config);
@@ -389,7 +389,7 @@ namespace Microsoft.PowerFx.Tests
             config.AddService("Office365Users", apiDoc, client);           
             var engine = new RecalcEngine(config);            
             testConnector.SetResponseFromFile(@"Responses\Office365_UserProfileV2.json");            
-            var result = await engine.EvalAsync(@"Office365Users.UserProfile_V2(""johndoe@microsoft.com"").mobilePhone", CancellationToken.None);
+            var result = await engine.EvalAsync(@"Office365Users.UserProfileV2(""johndoe@microsoft.com"").mobilePhone", CancellationToken.None);
 
             Assert.IsType<StringValue>(result);
             Assert.Equal("+33 799 999 999", (result as StringValue).Value);
@@ -417,7 +417,7 @@ namespace Microsoft.PowerFx.Tests
             config.AddService("Office365Users", apiDoc, client);
             var engine = new RecalcEngine(config);
             testConnector.SetResponseFromFile(@"Responses\Office365_UserProfileV2.json");
-            var result = await engine.EvalAsync(@"Office365Users.MyProfile_V2().mobilePhone", CancellationToken.None);
+            var result = await engine.EvalAsync(@"Office365Users.MyProfileV2().mobilePhone", CancellationToken.None);
 
             Assert.IsType<StringValue>(result);
             Assert.Equal("+33 799 999 999", (result as StringValue).Value);
@@ -445,7 +445,7 @@ namespace Microsoft.PowerFx.Tests
             config.AddService("Office365Users", apiDoc, client);
             var engine = new RecalcEngine(config);
             testConnector.SetResponseFromFile(@"Responses\Office365_DirectsV2.json");
-            var result = await engine.EvalAsync(@"First(Office365Users.DirectReports_V2(""jmstall@microsoft.com"", {'$top': 4 }).value).city", CancellationToken.None);
+            var result = await engine.EvalAsync(@"First(Office365Users.DirectReportsV2(""jmstall@microsoft.com"", {'$top': 4 }).value).city", CancellationToken.None);
 
             Assert.IsType<StringValue>(result);
             Assert.Equal("Paris", (result as StringValue).Value);


### PR DESCRIPTION
To be consistent with Power Apps, we need to remove unsupported characters like underscore, dashes, ...