### PR TITLE
Use ServiceProvider for Rand() 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
@@ -47,7 +47,6 @@ namespace Microsoft.PowerFx
         }
 
         public T GetService<T>() 
-            where T : class
         {
             return (T)GetService(typeof(T));
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -37,6 +37,16 @@ namespace Microsoft.PowerFx
             _runtimeConfig = runtimeConfig;
         }
 
+        public T GetService<T>()
+        {
+            if (_runtimeConfig != null)
+            {
+                return (T)_runtimeConfig.GetService(typeof(T));
+            }
+
+            return default;
+        }
+
         // Check this cooperatively - especially in any loop. 
         public void CheckCancel()
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -37,15 +38,22 @@ namespace Microsoft.PowerFx
             _runtimeConfig = runtimeConfig;
         }
 
-        public T GetService<T>()
+        /// <summary>
+        /// Get a service from the <see cref="ReadOnlySymbolValues"/>. Returns null if not present.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T GetService<T>() 
         {
             if (_runtimeConfig != null)
             {
-                return (T)_runtimeConfig.GetService(typeof(T));
+                return _runtimeConfig.GetService<T>();
             }
 
             return default;
         }
+
+        public IServiceProvider FunctionServices => _runtimeConfig;
 
         // Check this cooperatively - especially in any loop. 
         public void CheckCancel()

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/IRandomService.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/IRandomService.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerFx.Functions
+{
+    /// <summary>
+    /// Service for any functions needing Random behavior, 
+    /// such as Rand(), RandBetween(), or Shuffle().
+    /// </summary>
+    public interface IRandomService
+    {
+        /// <summary>
+        /// Get the next random number. 
+        /// </summary>
+        /// <returns></returns>
+        double NextDouble();
+    }
+
+    // Default implementation of IRandomService
+    internal class DefaultRandomService : IRandomService
+    {
+        private static readonly object _randomizerLock = new object();
+
+        [ThreadSafeProtectedByLock(nameof(_randomizerLock))]
+        private static readonly Random _random = new Random();
+
+        public virtual double NextDouble()
+        {
+            lock (_randomizerLock)
+            {
+                return _random.NextDouble();
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/IRandomService.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/IRandomService.cs
@@ -11,10 +11,13 @@ namespace Microsoft.PowerFx.Functions
     /// Service for any functions needing Random behavior, 
     /// such as Rand(), RandBetween(), or Shuffle().
     /// </summary>
+    [ThreadSafeImmutable]
     public interface IRandomService
     {
         /// <summary>
-        /// Get the next random number. 
+        /// Returns a random floating-point number that is greater than or equal to 0.0, and less than 1.0.
+        /// Should be from a linear distribution. 
+        /// Expected this call is thread-safe and may be called concurrently from multiple threads.
         /// </summary>
         /// <returns></returns>
         double NextDouble();

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -16,6 +16,13 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
+        // Helper to get a service or fallback to a default if the service is missing.
+        private static T GetService<T>(this IServiceProvider services, T defaultService)
+        {
+            var service = (T)services.GetService(typeof(T));
+            return service ?? defaultService;
+        }
+
         // Sync FunctionPtr - all args are evaluated before invoking this function.  
         public delegate FormulaValue FunctionPtr(SymbolContext symbolContext, IRContext irContext, FormulaValue[] args);
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -934,7 +934,7 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Rand,
-                NoErrorHandling(Rand)
+                Rand
             },
             {
                 BuiltinFunctionsCore.RandBetween,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -15,12 +15,6 @@ namespace Microsoft.PowerFx.Functions
     {
         private static readonly IRandomService _defaultRandService = new DefaultRandomService();
 
-        private static T GetService<T>(this IServiceProvider services, T defaultService)
-        {
-            var service = (T)services.GetService(typeof(T));
-            return service ?? defaultService;
-        }
-
         // Support for aggregators. Helpers to ensure that Scalar and Tabular behave the same.
         private interface IAggregator
         {
@@ -823,7 +817,7 @@ namespace Microsoft.PowerFx.Functions
 
             if (value < 0 || value > 1)
             {
-                // this a bug in the host's IRandomService
+                // This is a bug in the host's IRandomService.
                 throw new InvalidOperationException($"IRandomService ({random.GetType().FullName}) returned an illegal value {value}. Must be between 0 and 1");
             }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
@@ -353,14 +353,14 @@ namespace Microsoft.PowerFx.Functions
             return arg0.Index(rowIndex).ToFormulaValue();
         }
 
-        public static FormulaValue Shuffle(IRContext irContext, FormulaValue[] args)
+        public static FormulaValue Shuffle(IServiceProvider services, IRContext irContext, FormulaValue[] args)
         {
             var table = (TableValue)args[0];
             var records = table.Rows;
 
-            var random = _defaultRandService;
+            var random = services.GetService<IRandomService>(_defaultRandService);
 
-            var shuffledRecords = records.OrderBy(a => random.NextDouble()).ToList();
+            var shuffledRecords = records.OrderBy(a => random.SafeNextDouble()).ToList();
             return new InMemoryTableValue(irContext, shuffledRecords);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
@@ -358,12 +358,9 @@ namespace Microsoft.PowerFx.Functions
             var table = (TableValue)args[0];
             var records = table.Rows;
 
-            lock (_randomizerLock)
-            {
-                _random ??= new Random();
-            }
+            var random = _defaultRandService;
 
-            var shuffledRecords = records.OrderBy(a => _random.Next()).ToList();
+            var shuffledRecords = records.OrderBy(a => random.NextDouble()).ToList();
             return new InMemoryTableValue(irContext, shuffledRecords);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -136,6 +136,25 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // A wrapper that allows standard error handling to apply to
+        // sync functions which accept the simpler parameter list of
+        // an array of arguments, ignoring context, runner etc.
+        private static AsyncFunctionPtr StandardErrorHandling<T>(
+            Func<IRContext, IEnumerable<FormulaValue>, IEnumerable<FormulaValue>> expandArguments,
+            Func<IRContext, int, FormulaValue> replaceBlankValues,
+            Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeTypes,
+            Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeValues,
+            ReturnBehavior returnBehavior,
+            Func<IServiceProvider, IRContext, T[], FormulaValue> targetFunction)
+            where T : FormulaValue
+        {
+            return StandardErrorHandlingAsync<T>(expandArguments, replaceBlankValues, checkRuntimeTypes, checkRuntimeValues, returnBehavior, (runner, context, irContext, args) =>
+            {
+                var result = targetFunction(runner.FunctionServices, irContext, args);
+                return new ValueTask<FormulaValue>(result);
+            });
+        }
+
+        // A wrapper that allows standard error handling to apply to
         // sync functions with the full parameter list
         private static AsyncFunctionPtr StandardErrorHandling<T>(
             Func<IRContext, IEnumerable<FormulaValue>, IEnumerable<FormulaValue>> expandArguments,

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -15,6 +15,7 @@ using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Interpreter;
 using Microsoft.PowerFx.Interpreter.UDF;
 using Microsoft.PowerFx.Types;
@@ -770,6 +771,25 @@ namespace Microsoft.PowerFx.Tests
             var str = "Foo(x: Number): Number => { 1+1; 2+2; };";
             recalcEngine.DefineFunctions(str);
             Assert.Equal(4.0, recalcEngine.Eval("Foo(1)", null, new ParserOptions { AllowsSideEffects = true }).ToObject());
+        }
+
+        [Fact]
+        public void FunctionServices()
+        {
+            var engine = new RecalcEngine();
+            var values = new SymbolValues();
+            values.AddService<IRandomService>(new TestRandService());
+
+            var result = engine.EvalAsync("Rand()", CancellationToken.None, runtimeConfig: values).Result;
+            Assert.Equal(555.0, result.ToObject());
+        }
+
+        private class TestRandService : IRandomService
+        {
+            public double NextDouble()
+            {
+                return 555;
+            }
         }
 
         #region Test


### PR DESCRIPTION
This PR shows how we can use the new Dependency Injection support from #503 to have Rand() use a rand service, rather than just call Random directly. 

See the new unit test. 