### PR TITLE
Add new intellisense test for top-level  display names

### DIFF
--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -87,6 +87,30 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             Assert.Equal(expectedSuggestions, actualSuggestions2);
         }
 
+        // Test with display names. 
+        [Theory]
+        [InlineData("Dis|", "DisplayOpt", "DisplayRowScope")] // Match to row scope       
+        public void TestSuggestOptionSetsDisplayName(string expression, params string[] expectedSuggestions)
+        {
+            var config = PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder(), new TexlFunction[0]);
+
+            var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
+            {
+                    { "option_1", "Option1" },
+                    { "option_2", "Option2" }
+            }));
+                        
+            config.AddEntity(optionSet, new DName("DisplayOpt"));
+
+            var parameterType = RecordType.Empty()
+                .Add(new NamedFormulaType("XXX", optionSet.FormulaType, new DName("DisplayRowScope")));
+
+            var engine = new Engine(config);
+
+            var actualSuggestions = SuggestStrings(expression, engine, parameterType);
+            Assert.Equal(expectedSuggestions, actualSuggestions);     
+        }
+
         [Theory]
         [InlineData("Hou|", "Hour", "TimeUnit.Hours")]
         public void TestSuggestHour(string expression, params string[] expectedSuggestions)


### PR DESCRIPTION
- display name for records in RowScope
- display name for option sets.