### PR TITLE
Do not provide Intellisense error suggestions in string interpolation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx.Intellisense
                 // ThisItemProperties only in the context of thisItem.
                 var curNode = intellisenseData.CurNode;
 
-                if (curNode.Parent.Kind == NodeKind.StrInterp)
+                if (curNode.Parent != null && curNode.Parent.Kind == NodeKind.StrInterp)
                 {
                     return true;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerFx.Intellisense
                 // ThisItemProperties only in the context of thisItem.
                 var curNode = intellisenseData.CurNode;
 
+                // Do not provide error suggestions in string interpolation scenario
                 if (curNode.Parent != null && curNode.Parent.Kind == NodeKind.StrInterp)
                 {
                     return true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
@@ -23,6 +23,11 @@ namespace Microsoft.PowerFx.Intellisense
                 // ThisItemProperties only in the context of thisItem.
                 var curNode = intellisenseData.CurNode;
 
+                if (curNode.Parent.Kind == NodeKind.StrInterp)
+                {
+                    return true;
+                }
+
                 // Three methods that implement custom behavior here, one that adds suggestions before
                 // top level suggestions are added, one after, and one to handle the case where there aren't
                 // any top level suggestions to add.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/ErrorNodeSuggestionHandlerBase.cs
@@ -23,7 +23,8 @@ namespace Microsoft.PowerFx.Intellisense
                 // ThisItemProperties only in the context of thisItem.
                 var curNode = intellisenseData.CurNode;
 
-                // Do not provide error suggestions in string interpolation scenario
+                // If the parent is a StrInterp node and current node is an error node (not an island)
+                // this node will always be a partial string literal and we should not provide suggestions
                 if (curNode.Parent != null && curNode.Parent.Kind == NodeKind.StrInterp)
                 {
                     return true;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -135,6 +135,11 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("| Not false")]
         [InlineData("Not |")]
 
+        // StrInterpSuggestionHandler
+        [InlineData("With( {Apples:3}, $\"We have {appl|", "Apples")]
+        [InlineData("With( {Apples:3}, $\"We have {appl|} apples.", "Apples")]
+        [InlineData("$\"This is a randomly generated number: {rand|", "Rand", "RandBetween")]
+
         // StrNumLitNodeSuggestionHandler
         [InlineData("1 |", "-", "&", "&&", "*", "/", "^", "||", "+", "<", "<=", "<>", "=", ">", ">=", "And", "As", "exactin", "in", "Or")]
         [InlineData("1|0")]
@@ -152,7 +157,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("ForAll([0],`|", "ThisRecord", "Value")]
         [InlineData("ForAll(-],|", "ThisRecord")]
         [InlineData("ForAll()~|")]
-        [InlineData("With( {Apples:3}, $\"We {Apples} apples|")]
+        [InlineData("With( {Apples:3}, $\"We have {Apples} apples|")]
 
         // BlankNodeSuggestionHandler
         [InlineData("|")]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -152,6 +152,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("ForAll([0],`|", "ThisRecord", "Value")]
         [InlineData("ForAll(-],|", "ThisRecord")]
         [InlineData("ForAll()~|")]
+        [InlineData("With( {Apples:3}, $\"We {Apples} apples|")]
 
         // BlankNodeSuggestionHandler
         [InlineData("|")]


### PR DESCRIPTION
If the parent of the current node is a string interpolation node, we won't provide any error suggestions - suggestions should only be provided inside the island.