### PR TITLE
Fixes to integrate into PowerApps

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -55,6 +55,15 @@ namespace Microsoft.PowerFx
         }
 
         /// <summary>
+        /// Information about available functions.
+        /// </summary>
+        [Obsolete("Migrate to SymbolTables")]
+        public IEnumerable<FunctionInfo> FunctionInfos => 
+            new Engine(this).SupportedFunctions.Functions
+            .Concat(SymbolTable.Functions)
+            .Select(f => new FunctionInfo(f));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PowerFxConfig"/> class.
         /// </summary>
         /// <param name="cultureInfo">Culture to use.</param>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/CompatTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/CompatTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Binding.BindInfo;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Intellisense;
+using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Types;
+using Xunit;
+using static Microsoft.PowerFx.Tests.BindingEngineTests;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    // Test obselete functions, but still required for compat 
+#pragma warning disable SA1507 // Code should not contain multiple blank lines in a row
+#pragma warning disable CS0618 // Type or member is obsolete
+    public class CompatTests : PowerFxTest
+    {
+        [Fact]
+        public void ConfigFunctionInfos()
+        {
+            var config = new PowerFxConfig();
+
+            var func = new BehaviorFunction();
+            config.AddFunction(func);
+
+            // Includes default functions 
+            var functions = config.FunctionInfos.ToArray();
+
+            Assert.True(functions.Length > 100);
+            Assert.Contains(functions, x => x.Name == func.Name);
+        }
+
+        // Verify that an engine can override CreateResolver() directly. 
+        // They shouldn't do this - instead use SymbolTables.
+        [Fact]
+        public void OverrideResolver()
+        {
+            var engine = new TestEngine();
+            var result = engine.Check("x"); // defined in TestEngine's custom resolver
+            Assert.True(result.IsSuccess);
+            Assert.Equal(FormulaType.Number, result.ReturnType);
+        }
+
+        private class TestEngine : Engine
+        {
+            public TestEngine() 
+                : base(new PowerFxConfig())
+            {
+            }
+
+            [Obsolete]
+            private protected override INameResolver CreateResolver()
+            {
+                // Use SymbolTable as an easy way to implement INameResolver.
+                var s = new SymbolTable();
+                s.AddConstant("x", FormulaValue.New(3));
+                return s;
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue.txt
@@ -59,6 +59,7 @@ DateTime(2022,7,21,19,34,3,0)
 >> DateTimeValue("2022年07月28日 19:34:03", "ja-JP")
 DateTime(2022,7,28,19,34,3,0)
 
+// This locale isn't supported in PowerApps.  
 >> DateTimeValue("четвртак 21 јул 2022 19:34:03", "sr-cyrl-RS")
 DateTime(2022,7,21,19,34,3,0)
 


### PR DESCRIPTION
Add back some deprecated functionality that Prose depends on. 
Add tests.