### PR TITLE
Add user-visible type name for derived record types

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
@@ -14,6 +14,12 @@ namespace Microsoft.PowerFx.Types
     {
         public virtual IEnumerable<string> FieldNames { get; }
 
+        /// <summary>
+        /// Override to add a more specific user-visible type name when this type shows up
+        /// in error messages, suggestions, etc..
+        /// </summary>
+        public virtual string UserVisibleTypeName => null; 
+
         internal AggregateType(DType type)
             : base(type)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Types/BuiltInLazyTypes/AttachmentType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/BuiltInLazyTypes/AttachmentType.cs
@@ -25,6 +25,8 @@ namespace Microsoft.PowerFx.Core.Types.BuiltInLazyTypes
 
         public override IEnumerable<string> FieldNames => Attachment.GetRootFieldNames().Select(name => name.Value);
 
+        public override string UserVisibleTypeName => "Attachment";
+
         public override bool TryGetFieldType(string name, out FormulaType type)
         {
             if (!Attachment.TryGetType(new DName(name), out var dType))

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -957,6 +957,12 @@ namespace Microsoft.PowerFx.Core.Types
                 return "Control";
             }
 
+            if (IsLazyType)
+            {
+                var typeSuffix = string.IsNullOrEmpty(LazyTypeProvider.UserVisibleTypeName) ? string.Empty : $" ({LazyTypeProvider.UserVisibleTypeName})";
+                return (IsTable ? DKind.Table : DKind.Record) + typeSuffix;
+            }
+
             return Kind.ToString();
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/LazyTypeProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/LazyTypeProvider.cs
@@ -23,6 +23,8 @@ namespace Microsoft.PowerFx.Core.Types
 
         internal IEnumerable<DName> FieldNames => BackingFormulaType.FieldNames.Select(field => new DName(field));
 
+        internal string UserVisibleTypeName => BackingFormulaType.UserVisibleTypeName;
+
         public LazyTypeProvider(AggregateType type)
         {
             // Ensure we aren't trying to wrap a Known type as lazy. This would cause StackOverflows when calling Equals()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/LazyTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/LazyTypeTests.cs
@@ -19,7 +19,9 @@ namespace Microsoft.PowerFx.Core.Tests
             public delegate bool TryGetFieldDelegate(string name, out FormulaType type);
 
             private readonly TryGetFieldDelegate _tryGetField;
-            
+
+            public override string UserVisibleTypeName => "TestType";
+
             internal string Identity;
 
             public override IEnumerable<string> FieldNames { get; }
@@ -106,7 +108,14 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(0, _getter1CalledCount);
             Assert.Equal(0, _getter2CalledCount);
         }
-        
+
+        [Fact]
+        public void KindString()
+        {
+            Assert.Equal("Table (TestType)", _lazyTable1._type.GetKindString());
+            Assert.Equal("Record (TestType)", _lazyRecord1._type.GetKindString());
+        }
+
         [Fact]
         public void AcceptsSimple()
         {


### PR DESCRIPTION
This allows derived record types a bit more control over how they're referred to in Error Messages. 