### PR TITLE
Add nuget.config to pull from Nuget.Org

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,5 +3,5 @@
     <packageSources>
         <clear />
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    </packageSource>
+    </packageSources>
 </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    </packageSource>
+</configuration>


### PR DESCRIPTION
Project was missing a nuget.config, and was using only the local configuration. This removes a point of dependency on local environments. 