### PR TITLE
DType.DropMatching should be non-erroneous to call if the type isn't present

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -2213,7 +2213,7 @@ namespace Microsoft.PowerFx.Core.Types
             type1.AssertValid();
             type2.AssertValid();
 
-            if (type1.IsAggregate && type2.IsAggregate)
+            if (type1.IsAggregate && type2.IsAggregate && !(type1.IsLazyType || type2.IsLazyType))
             {
                 if (type1.Kind != type2.Kind)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1434,10 +1434,8 @@ namespace Microsoft.PowerFx.Core.Types
                 }
             }
 
-            // Set error if no type of given kind was found.
             if (tree == typeOuter.TypeTree)
             {
-                fError = true;
                 return this;
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
@@ -314,6 +314,12 @@ namespace Microsoft.PowerFx.Tests
             fError = false;
             newType = type7.DropAllMatching(ref fError, DPath.Root, type => type.IsAttachment);
             Assert.Equal(TestUtils.DT("*[A:n, B:n, C:s]"), newType);
+            
+            // Safe to call when type isn't present
+            fError = false;
+            newType = type1.DropAllMatching(ref fError, DPath.Root, type => type.IsAttachment);
+            Assert.False(fError);
+            Assert.Equal(TestUtils.DT("*[A:n, B:n, C:s]"), newType);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
@@ -291,10 +291,6 @@ namespace Microsoft.PowerFx.Tests
             Assert.False(fError);
             Assert.Equal(TestUtils.DT("*[C:s]"), newType);
 
-            newType = type1.DropAllOfKind(ref fError, DPath.Root, DKind.Control);
-            Assert.True(fError);
-            Assert.Equal(TestUtils.DT("*[A:n, B:n, C:s]"), newType);
-
             fError = false;
             newType = DType.Number.DropAllOfKind(ref fError, DPath.Root, DKind.Number);
             Assert.True(fError);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/LazyTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/LazyTypeTests.cs
@@ -262,5 +262,14 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.NotEqual(_lazyRecord1, _lazyRecord2.ToTable().ToRecord());
             Assert.NotEqual(_lazyTable2, _lazyTable1.ToRecord().ToTable());
         }
+
+        [Fact]
+        public void Supertype()
+        {
+            Assert.Equal(_lazyRecord1, FormulaType.Build(DType.Supertype(_lazyRecord1._type, _lazyRecord1._type)));
+            Assert.Equal(_lazyTable1, FormulaType.Build(DType.Supertype(_lazyTable1._type, _lazyTable1._type)));
+            Assert.Equal(FormulaType.BindingError, FormulaType.Build(DType.Supertype(_lazyTable1._type, _lazyRecord1._type)));
+            Assert.Equal(FormulaType.BindingError, FormulaType.Build(DType.Supertype(_lazyRecord2._type, _lazyRecord1._type)));
+        }
     }
 }


### PR DESCRIPTION
Found from integrating #520, dropping a type should be allowed even if it's not present (it's just a no-op in that case)