### PR TITLE
Fix StandardSingleColumnTable to work with different input schemas

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -196,6 +196,7 @@ namespace Microsoft.PowerFx.Functions
                 var outputTableType = (TableType)irContext.ResultType;
                 var resultType = outputTableType.ToRecord();
                 var outputColumnNameStr = outputTableType.SingleColumnFieldName;
+                var outputItemType = outputTableType.GetFieldType(outputColumnNameStr);
                 var resultRows = new List<DValue<RecordValue>>();
                 foreach (var row in args[0].Rows)
                 {
@@ -205,7 +206,7 @@ namespace Microsoft.PowerFx.Functions
                         NamedValue namedValue;
                         namedValue = value switch
                         {
-                            T t => new NamedValue(outputColumnNameStr, targetFunction(runner, context, IRContext.NotInSource(inputItemType), new T[] { t })),
+                            T t => new NamedValue(outputColumnNameStr, targetFunction(runner, context, IRContext.NotInSource(outputItemType), new T[] { t })),
                             BlankValue bv => new NamedValue(outputColumnNameStr, bv),
                             ErrorValue ev => new NamedValue(outputColumnNameStr, ev),
                             _ => new NamedValue(outputColumnNameStr, CommonErrors.RuntimeTypeMismatch(IRContext.NotInSource(inputItemType)))

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -189,23 +189,26 @@ namespace Microsoft.PowerFx.Functions
         {
             return (runner, context, irContext, args) =>
             {
-                var tableType = (TableType)irContext.ResultType;
-                var resultType = tableType.ToRecord();
-                var columnNameStr = tableType.SingleColumnFieldName;
-                var itemType = resultType.GetFieldType(columnNameStr);
+                var inputTableType = (TableType)args[0].Type;
+                var inputColumnNameStr = inputTableType.SingleColumnFieldName;
+                var inputItemType = inputTableType.GetFieldType(inputColumnNameStr);
+
+                var outputTableType = (TableType)irContext.ResultType;
+                var resultType = outputTableType.ToRecord();
+                var outputColumnNameStr = outputTableType.SingleColumnFieldName;
                 var resultRows = new List<DValue<RecordValue>>();
                 foreach (var row in args[0].Rows)
                 {
                     if (row.IsValue)
                     {
-                        var value = row.Value.GetField(BuiltinFunction.ColumnName_ValueStr);
+                        var value = row.Value.GetField(inputColumnNameStr);
                         NamedValue namedValue;
                         namedValue = value switch
                         {
-                            T t => new NamedValue(columnNameStr, targetFunction(runner, context, IRContext.NotInSource(itemType), new T[] { t })),
-                            BlankValue bv => new NamedValue(columnNameStr, bv),
-                            ErrorValue ev => new NamedValue(columnNameStr, ev),
-                            _ => new NamedValue(columnNameStr, CommonErrors.RuntimeTypeMismatch(IRContext.NotInSource(itemType)))
+                            T t => new NamedValue(outputColumnNameStr, targetFunction(runner, context, IRContext.NotInSource(inputItemType), new T[] { t })),
+                            BlankValue bv => new NamedValue(outputColumnNameStr, bv),
+                            ErrorValue ev => new NamedValue(outputColumnNameStr, ev),
+                            _ => new NamedValue(outputColumnNameStr, CommonErrors.RuntimeTypeMismatch(IRContext.NotInSource(inputItemType)))
                         };
                         var record = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedValue });
                         resultRows.Add(DValue<RecordValue>.Of(record));

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT.txt
@@ -11,3 +11,5 @@ Errors: Error 0-8: The function 'Sqrt' has some invalid arguments.|Error 5-7: In
 >> Sqrt([Blank(), 1444])
 [Blank(),38]
 
+>> Sqrt(Table({a:0}, {a:1}, {a:4}, {a:9}, {a:16}))
+Table({a:0},{a:1},{a:2},{a:3},{a:4})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT.txt
@@ -13,3 +13,6 @@ Errors: Error 0-8: The function 'Sqrt' has some invalid arguments.|Error 5-7: In
 
 >> Sqrt(Table({a:0}, {a:1}, {a:4}, {a:9}, {a:16}))
 Table({a:0},{a:1},{a:2},{a:3},{a:4})
+
+>> Sqrt(Table({a:1,b:2},{a:4,b:8}))
+Errors: Error 0-32: The function 'Sqrt' has some invalid arguments.|Error 5-31: Invalid schema, expected a one-column table.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT_ConsistentOneColumnTableResult.txt
@@ -11,3 +11,6 @@ Errors: Error 0-8: The function 'Sqrt' has some invalid arguments.|Error 5-7: In
 
 >> Sqrt([Blank(), 1444])
 [Blank(),38]
+
+>> Sqrt(Table({a:0}, {a:1}, {a:4}, {a:9}, {a:16}))
+[0,1,2,3,4]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT_ConsistentOneColumnTableResult.txt
@@ -11,6 +11,3 @@ Errors: Error 0-8: The function 'Sqrt' has some invalid arguments.|Error 5-7: In
 
 >> Sqrt([Blank(), 1444])
 [Blank(),38]
-
->> Sqrt(Table({a:0}, {a:1}, {a:4}, {a:9}, {a:16}))
-[0,1,2,3,4]


### PR DESCRIPTION
Single column table functions should work with any table that has a single column. Currently it is only working for tables where the column is named 'Value'