### PR TITLE
Move Control onto derived RecordType

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         bool IsCommandComponentInstance { get; }
 
-        RecordType GetControlType(bool calculateAugmentedExpandoType, bool isDataLimited);
+        DType GetControlType(bool calculateAugmentedExpandoType, bool isDataLimited);
 
         bool IsDescendentOf(IExternalControl controlInfo);
 

--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Core.App.Controls
 {
@@ -26,7 +27,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         bool IsCommandComponentInstance { get; }
 
-        IExternalControlType GetControlDType(bool calculateAugmentedExpandoType, bool isDataLimited);
+        RecordType GetControlDType(bool calculateAugmentedExpandoType, bool isDataLimited);
 
         bool IsDescendentOf(IExternalControl controlInfo);
 

--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         bool IsCommandComponentInstance { get; }
 
-        RecordType GetControlDType(bool calculateAugmentedExpandoType, bool isDataLimited);
+        RecordType GetControlType(bool calculateAugmentedExpandoType, bool isDataLimited);
 
         bool IsDescendentOf(IExternalControl controlInfo);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3619,7 +3619,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             // If visiting an expando type property of control type variable, we cannot calculate the type here because
                             // The LHS associated ControlInfo is App/Component.
                             // e.g. Set(controlVariable1, DropDown1), Label1.Text = controlVariable1.Selected.Value.
-                            leftType = controlInfo.GetControlType(calculateAugmentedExpandoType: true, isDataLimited: false)._type;
+                            leftType = controlInfo.GetControlType(calculateAugmentedExpandoType: true, isDataLimited: false);
                         }
 
                         if (!leftType.ToRecord().TryGetType(property.InvariantName, out typeRhs))

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2034,8 +2034,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         }
 
                         // Get the RHS property type reported by the scope
-                        var tempRhsType = lambdaParamType.IsControl ? lambdaParamType.ToRecord() : lambdaParamType;
-                        if (!tempRhsType.TryGetType(dotted.Right.Name, out var propertyType))
+                        if (!lambdaParamType.TryGetType(dotted.Right.Name, out var propertyType))
                         {
                             propertyType = DType.Unknown;
                         }
@@ -3460,7 +3459,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 var leftType = _txb.GetType(node.Left);
 
-                if (!leftType.IsControl && !leftType.IsAggregate && !leftType.IsEnum && !leftType.IsOptionSet && !leftType.IsView && !leftType.IsUntypedObject)
+                if (!leftType.IsAggregate && !leftType.IsEnum && !leftType.IsOptionSet && !leftType.IsView && !leftType.IsUntypedObject)
                 {
                     SetDottedNameError(node, TexlStrings.ErrInvalidDot);
                     return;
@@ -3779,7 +3778,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 else
                 {
                     // v[prop:type, ...] . prop --> type
-                    Contracts.Assert(leftType.IsControl || leftType.IsExpandEntity || leftType.IsAttachment);
+                    Contracts.Assert(leftType.IsExpandEntity);
                     _txb.SetType(node, typeRhs);
                 }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3619,7 +3619,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             // If visiting an expando type property of control type variable, we cannot calculate the type here because
                             // The LHS associated ControlInfo is App/Component.
                             // e.g. Set(controlVariable1, DropDown1), Label1.Text = controlVariable1.Selected.Value.
-                            leftType = controlInfo.GetControlDType(calculateAugmentedExpandoType: true, isDataLimited: false)._type;
+                            leftType = controlInfo.GetControlType(calculateAugmentedExpandoType: true, isDataLimited: false)._type;
                         }
 
                         if (!leftType.ToRecord().TryGetType(property.InvariantName, out typeRhs))

--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PowerFx.Syntax
             }
 
             // TASK 97994: Investigate and Implement the functionality if lhs of  'in' operator is a control type.
-            if (type.IsAggregate || type.IsControl)
+            if (type.IsAggregate)
             {
                 return _operatorKeywordsAggregate;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
@@ -20,6 +20,9 @@ namespace Microsoft.PowerFx.Types
         /// </summary>
         public virtual string UserVisibleTypeName => null; 
 
+        // Internal property, allows Canvas to control whether a Union operation is permitted on a derived record type
+        internal virtual bool AllowsUnion => true;
+
         internal AggregateType(DType type)
             : base(type)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return false;
             }
 
-            if (argTypes[0] is IExternalControlType controlType)
+            if (argTypes[0].IsControl && argTypes[0].LazyTypeProvider.BackingFormulaType is IExternalControlType controlType)
             {
                 // A control will never be null. It never worked as intended.
                 // We coerce the control to control.primaryOutProperty.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerFx.Intellisense
                 if ((!suggestionKindIsGlobalOrScope &&
                      s.Kind != SuggestionKind.Global &&
                      s.Kind != SuggestionKind.ScopeVariable) ||
-                    (s.Type == type && !type.IsControl))
+                    s.Type == type)
                 {
                     continue;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerFx.Intellisense
                 if ((!suggestionKindIsGlobalOrScope &&
                      s.Kind != SuggestionKind.Global &&
                      s.Kind != SuggestionKind.ScopeVariable) ||
-                    s.Type == type)
+                    (s.Type == type && !type.IsControl))
                 {
                     continue;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DKind.cs
@@ -55,10 +55,7 @@ namespace Microsoft.PowerFx.Core.Types
         OptionSetValue = 22,
         ViewValue = 23,
         NamedValue = 24,
-        _LimPrimitive = Control,
-
-        // Control type.
-        Control = 25,
+        _LimPrimitive = 25,
 
         // Expand Entity type.
         DataEntity = 26,

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -932,11 +932,6 @@ namespace Microsoft.PowerFx.Core.Types
                 return "Text";
             }
 
-            if (Kind == DKind._LimPrimitive)
-            {
-                return "Control";
-            }
-
             if (IsLazyType)
             {
                 var typeSuffix = string.IsNullOrEmpty(LazyTypeProvider.UserVisibleTypeName) ? string.Empty : $" ({LazyTypeProvider.UserVisibleTypeName})";

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DTypeSpecParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DTypeSpecParser.cs
@@ -39,8 +39,8 @@ namespace Microsoft.PowerFx.Core.Types
                 token = DType.MapKindToStr(DKind.Blob);
             }
 
-            // Note that control types "v" or "E" are parsed to Error, since the type spec language is not a mechanism for serializing/deserializing controls.
-            if (token == DType.MapKindToStr(DKind.Control) || token == DType.MapKindToStr(DKind.DataEntity))
+            // Note that "E" is parsed to Error, since the type spec language is not a mechanism for serializing/deserializing entities.
+            if (token == DType.MapKindToStr(DKind.DataEntity))
             {
                 type = DType.Error;
                 return true;

--- a/src/libraries/Microsoft.PowerFx.Core/Types/LazyTypeProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/LazyTypeProvider.cs
@@ -25,6 +25,8 @@ namespace Microsoft.PowerFx.Core.Types
 
         internal string UserVisibleTypeName => BackingFormulaType.UserVisibleTypeName;
 
+        internal bool AllowsUnion => BackingFormulaType.AllowsUnion;
+
         public LazyTypeProvider(AggregateType type)
         {
             // Ensure we aren't trying to wrap a Known type as lazy. This would cause StackOverflows when calling Equals()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
@@ -2151,9 +2151,9 @@ namespace Microsoft.PowerFx.Tests
             //Attachment
             var type1 = DType.CreateAttachmentType(DType.CreateAttachmentType(DType.CreateTable(new TypedName(DType.String, new DName("DisplayName")))));
             var type2 = DType.CreateAttachmentType(DType.CreateAttachmentType(DType.CreateTable(new TypedName(DType.String, new DName("Name")))));
-            TestUnion(type1, type1, type1.LazyTypeProvider.GetExpandedType(type1.IsTable));
+            TestUnion(type1, type1, type1);
             TestUnion(type1, type2, TestUtils.DT("*[DisplayName:s, Name:s]"));
-            TestUnion(type2, type2, type2.LazyTypeProvider.GetExpandedType(type2.IsTable));
+            TestUnion(type2, type2, type2);
             TestUnion(DType.Unknown, type1, type1.LazyTypeProvider.GetExpandedType(type1.IsTable));
             TestUnion(DType.ObjNull, type1, type1.LazyTypeProvider.GetExpandedType(type1.IsTable));
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
@@ -69,7 +69,6 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(0, new DType(DKind.Hyperlink).MaxDepth);
             Assert.Equal(0, new DType(DKind.Color).MaxDepth);
             Assert.Equal(0, new DType(DKind.Guid).MaxDepth);
-            Assert.Equal(0, new DType(DKind.Control).MaxDepth);
             Assert.Equal(0, new DType(DKind.DataEntity).MaxDepth);
             Assert.Equal(0, new DType(DKind.Polymorphic).MaxDepth);
             Assert.Equal(1, new DType(DKind.Record).MaxDepth);


### PR DESCRIPTION
The DKind.Control is a special case of a record. Now that we support derived record types, we can eliminate this special case and move it to be an impl of RecordType.

This PR picks up the PowerFx side of the changes needed to make that work. 