### PR TITLE
Add implementation for tabular version of Round function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -995,6 +995,24 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Round)
             },
             {
+                BuiltinFunctionsCore.RoundT,
+                StandardErrorHandlingAsync(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: MultiSingleColumnTable(
+                            StandardErrorHandling<NumberValue>(
+                                expandArguments: NoArgExpansion,
+                                replaceBlankValues: ReplaceBlankWithEmptyString,
+                                checkRuntimeTypes: ExactValueType<NumberValue>,
+                                checkRuntimeValues: DeferRuntimeValueChecking,
+                                returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                                targetFunction: Round),
+                            transposeEmptyTable: true))
+            },
+            {
                 BuiltinFunctionsCore.RoundUp,
                 StandardErrorHandling<NumberValue>(
                     expandArguments: NoArgExpansion,

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundTable.txt
@@ -1,0 +1,37 @@
+// Round(Number_or_table, digits_or_table)
+
+// Table and scalar
+
+>> Round([1.2, 3.4, 5.6, 7.8], 0)
+[1,3,6,8]
+
+>> Round([1.23, 4.56, 7.89, 10.12], 1)
+[1.2,4.6,7.9,10.1]
+
+>> Round([-9.8765, -8.7654, -7.6543, -6.5432, -5.4321], 2)
+[-9.88,-8.77,-7.65,-6.54,-5.43]
+
+>> Round(Filter([1,2,3], Value > 10), 0) // Empty table
+[]
+
+// Scalar and table
+>> Round(1234.5678, [-2, 1, 0, 1, 2])
+Table({Result:1200},{Result:1234.6},{Result:1235},{Result:1234.6},{Result:1234.57})
+
+// Table and table
+>> Round([123.456, 345.678], [1, 2])
+[123.5,345.68]
+
+// Blank values
+>> Round( If(1<0,[1]), 1 )
+[]
+
+// Errors
+>> Round( If(1/0<2, [1]), 1 )
+#Error(Kind=Div0)
+
+>> Round( [1.2, 2.3, 3.4], 1/0 )
+#Error(Kind=Div0)
+
+>> Round( [1.23, Sqrt(-1), 7.89], 1)
+[1.2,Microsoft.PowerFx.Types.ErrorValue,7.9]


### PR DESCRIPTION
Missing functionality in the interpreter. This function will be useful for adding tests for tabular versions of other numeric functions.