### PR TITLE
Make CheckType more functional

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2753,7 +2753,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 return res.Success;
             }
 
-            // Performs type checking for the arguments passed to the membership "in"/"exactin" operators.
             private bool CheckInArgTypes(TexlNode left, TexlNode right)
             {
                 var res = CheckInArgTypesCore(

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2520,21 +2520,23 @@ namespace Microsoft.PowerFx.Core.Binding
 
             // Returns whether the node was of the type wanted, and reports appropriate errors.
             // A list of allowed alternate types specifies what other types of values can be coerced to the wanted type.
-            private bool CheckType(TexlNode node, DType nodeType, DType typeWant, params DType[] alternateTypes)
+            internal static BinderCheckTypeResult CheckTypeCore(ErrorContainer errorContainer, TexlNode node, DType nodeType, DType typeWant, params DType[] alternateTypes)
             {
                 Contracts.AssertValue(node);
                 Contracts.Assert(typeWant.IsValid);
                 Contracts.Assert(!typeWant.IsError);
                 Contracts.AssertValue(alternateTypes);
 
+                var coercions = new List<BinderCoercionResult>();
+
                 if (typeWant.Accepts(nodeType))
                 {
                     if (nodeType.RequiresExplicitCast(typeWant))
                     {
-                        _txb.SetCoercedType(node, typeWant);
+                        coercions.Add(new BinderCoercionResult() { Node = node, CoercedType = typeWant });
                     }
 
-                    return true;
+                    return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                 }
 
                 // Normal (non-control) coercion
@@ -2552,8 +2554,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
 
                     // We found an alternate type that is accepted and will be coerced.
-                    _txb.SetCoercedType(node, typeWant);
-                    return true;
+                    coercions.Add(new BinderCoercionResult() { Node = node, CoercedType = typeWant });
+                    return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                 }
 
                 // If the node is a control, we may be able to coerce its primary output property
@@ -2566,36 +2568,36 @@ namespace Microsoft.PowerFx.Core.Binding
                     {
                         // We'll "coerce" the control to the desired type, by pulling from the control's
                         // primary output property. See codegen for details.
-                        _txb.SetCoercedType(node, typeWant);
-                        return true;
+                        coercions.Add(new BinderCoercionResult() { Node = node, CoercedType = typeWant });
+                        return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                     }
                 }
 
                 var messageKey = alternateTypes.Length == 0 ? TexlStrings.ErrBadType_ExpectedType : TexlStrings.ErrBadType_ExpectedTypesCSV;
                 var messageArg = alternateTypes.Length == 0 ? typeWant.GetKindString() : string.Join(", ", new[] { typeWant }.Concat(alternateTypes).Select(t => t.GetKindString()));
 
-                _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, node, messageKey, messageArg);
-                return false;
+                errorContainer.EnsureError(DocumentErrorSeverity.Severe, node, messageKey, messageArg);
+                return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
             }
 
             // Performs type checking for the arguments passed to the membership "in"/"exactin" operators.
-            private bool CheckInArgTypes(TexlNode left, TexlNode right)
+            internal static BinderCheckTypeResult CheckInArgTypesCore(ErrorContainer errorContainer, TexlNode left, TexlNode right, DType typeLeft, DType typeRight, bool isEnhancedDelegationEnabled = false)
             {
                 Contracts.AssertValue(left);
                 Contracts.AssertValue(right);
 
-                var typeLeft = _txb.GetType(left);
+                var coercions = new List<BinderCoercionResult>();
+
                 if (!typeLeft.IsValid || typeLeft.IsUnknown || typeLeft.IsError)
                 {
-                    _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrTypeError);
-                    return false;
+                    errorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrTypeError);
+                    return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                 }
 
-                var typeRight = _txb.GetType(right);
                 if (!typeRight.IsValid || typeRight.IsUnknown || typeRight.IsError)
                 {
-                    _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrTypeError);
-                    return false;
+                    errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrTypeError);
+                    return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                 }
 
                 Contracts.Assert(!typeLeft.IsAggregate || typeLeft.IsTable || typeLeft.IsRecord);
@@ -2612,29 +2614,29 @@ namespace Microsoft.PowerFx.Core.Binding
                             if (typeRight.CoercesTo(DType.String) && DType.String.Accepts(typeLeft))
                             {
                                 // Coerce RHS to a string type.
-                                _txb.SetCoercedType(right, DType.String);
+                                coercions.Add(new BinderCoercionResult() { Node = right, CoercedType = DType.String });
                             }
                             else
                             {
-                                _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrStringExpected);
-                                return false;
+                                errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrStringExpected);
+                                return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                             }
                         }
 
                         if (DType.String.Accepts(typeLeft))
                         {
-                            return true;
+                            return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                         }
 
                         if (!typeLeft.CoercesTo(DType.String))
                         {
-                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), DType.String.GetKindString());
-                            return false;
+                            errorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), DType.String.GetKindString());
+                            return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                         }
 
                         // Coerce LHS to a string type, to facilitate subsequent substring checks.
-                        _txb.SetCoercedType(left, DType.String);
-                        return true;
+                        coercions.Add(new BinderCoercionResult() { Node = left, CoercedType = DType.String });
+                        return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                     }
 
                     // scalar in table: RHS must be a one column table. We'll allow coercion.
@@ -2643,31 +2645,31 @@ namespace Microsoft.PowerFx.Core.Binding
                         var names = typeRight.GetNames(DPath.Root);
                         if (names.Count() != 1)
                         {
-                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrInvalidSchemaNeedCol);
-                            return false;
+                            errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrInvalidSchemaNeedCol);
+                            return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                         }
 
                         var typedName = names.Single();
                         if (typedName.Type.Accepts(typeLeft) || typeLeft.Accepts(typedName.Type))
                         {
-                            return true;
+                            return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                         }
 
                         if (!typeLeft.CoercesTo(typedName.Type))
                         {
-                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
-                            return false;
+                            errorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
+                            return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                         }
 
                         // Coerce LHS to the table column type, to facilitate subsequent comparison.
-                        _txb.SetCoercedType(left, typedName.Type);
-                        return true;
+                        coercions.Add(new BinderCoercionResult() { Node = left, CoercedType = typedName.Type });
+                        return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                     }
 
                     // scalar in record or multiSelectOptionSet table: not supported. Flag an error on the RHS.
                     Contracts.Assert(typeRight.IsRecord);
-                    _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
-                    return false;
+                    errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
+                    return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                 }
 
                 if (typeLeft.IsRecord)
@@ -2675,8 +2677,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     // record in scalar: not supported
                     if (!typeRight.IsAggregate)
                     {
-                        _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
-                        return false;
+                        errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
+                        return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                     }
 
                     // record in table: RHS must be a table with a compatible schema. No coercion is allowed.
@@ -2687,22 +2689,22 @@ namespace Microsoft.PowerFx.Core.Binding
                         if (typeLeftAsTable.Accepts(typeRight, out var typeRightDifferingSchema, out var typeRightDifferingSchemaType) ||
                             typeRight.Accepts(typeLeftAsTable, out var typeLeftDifferingSchema, out var typeLeftDifferingSchemaType))
                         {
-                            return true;
+                            return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                         }
 
-                        _txb.ErrorContainer.Errors(left, typeLeft, typeLeftDifferingSchema, typeLeftDifferingSchemaType);
-                        _txb.ErrorContainer.Errors(right, typeRight, typeRightDifferingSchema, typeRightDifferingSchemaType);
+                        errorContainer.Errors(left, typeLeft, typeLeftDifferingSchema, typeLeftDifferingSchemaType);
+                        errorContainer.Errors(right, typeRight, typeRightDifferingSchema, typeRightDifferingSchemaType);
 
-                        return false;
+                        return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                     }
 
                     // record in record: not supported. Flag an error on the RHS.
                     Contracts.Assert(typeRight.IsRecord);
-                    _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
-                    return false;
+                    errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrBadType_Type, typeRight.GetKindString());
+                    return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                 }
 
-                if (_txb.Document != null && _txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled && typeLeft.IsTable)
+                if (isEnhancedDelegationEnabled && typeLeft.IsTable)
                 {
                     // Table in table: RHS must be a single column table with a compatible schema. No coercion is allowed.
                     if (typeRight.IsTable)
@@ -2710,8 +2712,8 @@ namespace Microsoft.PowerFx.Core.Binding
                         var names = typeRight.GetNames(DPath.Root);
                         if (names.Count() != 1)
                         {
-                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrInvalidSchemaNeedCol);
-                            return false;
+                            errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrInvalidSchemaNeedCol);
+                            return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                         }
 
                         var typedName = names.Single();
@@ -2719,21 +2721,58 @@ namespace Microsoft.PowerFx.Core.Binding
                         // Ensure we error when RHS node of table type cannot be coerced to a multiselectOptionset table node.  
                         if (!typeRight.CoercesTo(typeLeft))
                         {
-                            _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
-                            return false;
+                            errorContainer.EnsureError(DocumentErrorSeverity.Severe, right, TexlStrings.ErrCannotCoerce_SourceType_TargetType, typeLeft.GetKindString(), typedName.Type.GetKindString());
+                            return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
                         }
 
                         // Check if multiselectoptionset column type accepts RHS node of type table. 
                         if (typeLeft.Accepts(typedName.Type))
                         {
-                            return true;
+                            return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
                         }
                     }
                 }
 
                 // Table in scalar or Table in Record or Table in unsupported table: not supported
-                _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrBadType_Type, typeLeft.GetKindString());
-                return false;
+                errorContainer.EnsureError(DocumentErrorSeverity.Severe, left, TexlStrings.ErrBadType_Type, typeLeft.GetKindString());
+                return new BinderCheckTypeResult() { Success = false, Coercions = coercions };
+            }
+
+            private bool CheckType(TexlNode node, DType nodeType, DType typeWant, params DType[] alternateTypes)
+            {
+                var res = CheckTypeCore(_txb.ErrorContainer, node, nodeType, typeWant, alternateTypes);
+
+                if (res.Success)
+                {
+                    foreach (var coercion in res.Coercions)
+                    {
+                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
+                    }
+                }
+
+                return res.Success;
+            }
+
+            // Performs type checking for the arguments passed to the membership "in"/"exactin" operators.
+            private bool CheckInArgTypes(TexlNode left, TexlNode right)
+            {
+                var res = CheckInArgTypesCore(
+                    _txb.ErrorContainer,
+                    left,
+                    right,
+                    _txb.GetType(left),
+                    _txb.GetType(right),
+                    _txb.Document != null && _txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled);
+
+                if (res.Success)
+                {
+                    foreach (var coercion in res.Coercions)
+                    {
+                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
+                    }
+                }
+
+                return res.Success;
             }
 
             private ScopeUseSet JoinScopeUseSets(params TexlNode[] nodes)

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -7,14 +7,17 @@ using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Binding
 {
-    internal class BinderCheckTypeResult
+    internal readonly struct BinderCheckTypeResult
     {
         public bool Success { get; init; }
 
+        // The binder has an imperative function called SetCoercedType,
+        // which may be called multiple times in a given type checking function
+        // This collection represents repeated calls to that function
         public IReadOnlyCollection<BinderCoercionResult> Coercions { get; init; }
     }
 
-    internal class BinderCoercionResult
+    internal readonly struct BinderCoercionResult
     {
         public TexlNode Node { get; init; }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerFx.Core.Binding
+{
+    internal class BinderCheckTypeResult
+    {
+        public bool Success { get; init; }
+
+        public IReadOnlyCollection<BinderCoercionResult> Coercions { get; init; }
+    }
+
+    internal class BinderCoercionResult
+    {
+        public TexlNode Node { get; init; }
+
+        public DType CoercedType { get; init; }
+    }
+}


### PR DESCRIPTION
Small change to CheckType in Binder.cs to move the main logic to a static helper, which is more functional (a mapping of inputs to outputs).