### PR TITLE
Make PostVisitBinaryOpNodeAddition more functional

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4280,9 +4280,12 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     _txb.SetType(res.Node, res.NodeType);
 
-                    foreach (var coercion in res.Coercions)
+                    if (res.Coercions != null)
                     {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
+                        foreach (var coercion in res.Coercions)
+                        {
+                            _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
+                        }
                     }
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4103,26 +4103,23 @@ namespace Microsoft.PowerFx.Core.Binding
                 _txb.SetIsUnliftable(node, _txb.IsUnliftable(node.Left) || _txb.IsUnliftable(node.Right));
             }
 
-            private void PostVisitBinaryOpNodeAddition(BinaryOpNode node)
+            private static BinderCheckTypeResult PostVisitBinaryOpNodeAdditionCore(ErrorContainer errorContainer, BinaryOpNode node, DType leftType, DType rightType)
             {
-                AssertValid();
                 Contracts.AssertValue(node);
                 Contracts.Assert(node.Op == BinaryOp.Add);
 
-                var leftType = _txb.GetType(node.Left);
-                var rightType = _txb.GetType(node.Right);
                 var leftKind = leftType.Kind;
                 var rightKind = rightType.Kind;
 
-                void ReportInvalidOperation()
+                BinderCheckTypeResult ReportInvalidOperation()
                 {
-                    _txb.SetType(node, DType.Error);
-                    _txb.ErrorContainer.EnsureError(
+                    errorContainer.EnsureError(
                         DocumentErrorSeverity.Severe,
                         node,
                         TexlStrings.ErrBadOperatorTypes,
                         leftType.GetKindString(),
                         rightType.GetKindString());
+                    return new BinderCheckTypeResult() { Success = false, Node = node, NodeType = DType.Error };
                 }
 
                 UnaryOpNode unary;
@@ -4139,28 +4136,24 @@ namespace Microsoft.PowerFx.Core.Binding
                                 {
                                     // DateTime - DateTime = Number
                                     // DateTime - Date = Number
-                                    _txb.SetType(node, DType.Number);
+                                    return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Number };
                                 }
                                 else
                                 {
                                     // DateTime + DateTime in any other arrangement is an error
                                     // DateTime + Date in any other arrangement is an error
-                                    ReportInvalidOperation();
+                                    return ReportInvalidOperation();
                                 }
 
-                                break;
                             case DKind.Time:
                                 // DateTime + Time in any other arrangement is an error
-                                ReportInvalidOperation();
-                                break;
+                                return ReportInvalidOperation();
                             default:
                                 // DateTime + number = DateTime
-                                CheckType(node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.DateTime);
-                                break;
+                                var resRight = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = resRight.Success, Node = node, NodeType = DType.DateTime, Coercions = resRight.Coercions };
                         }
 
-                        break;
                     case DKind.Date:
                         switch (rightKind)
                         {
@@ -4170,52 +4163,47 @@ namespace Microsoft.PowerFx.Core.Binding
                                 if (unary != null && unary.Op == UnaryOp.Minus)
                                 {
                                     // Date - Date = Number
-                                    _txb.SetType(node, DType.Number);
+                                    return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Number };
                                 }
                                 else
                                 {
                                     // Date + Date in any other arrangement is an error
-                                    ReportInvalidOperation();
+                                    return ReportInvalidOperation();
                                 }
 
-                                break;
                             case DKind.Time:
                                 unary = node.Right.AsUnaryOpLit();
                                 if (unary != null && unary.Op == UnaryOp.Minus)
                                 {
                                     // Date - Time is an error
-                                    ReportInvalidOperation();
+                                    return ReportInvalidOperation();
                                 }
                                 else
                                 {
                                     // Date + Time = DateTime
-                                    _txb.SetType(node, DType.DateTime);
+                                    return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.DateTime };
                                 }
 
-                                break;
                             case DKind.DateTime:
                                 // Date + DateTime = number but ONLY if its really subtraction Date + '-DateTime'
                                 unary = node.Right.AsUnaryOpLit();
                                 if (unary != null && unary.Op == UnaryOp.Minus)
                                 {
                                     // Date - DateTime = Number
-                                    _txb.SetType(node, DType.Number);
+                                    return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Number };
                                 }
                                 else
                                 {
                                     // Date + DateTime in any other arrangement is an error
-                                    ReportInvalidOperation();
+                                    return ReportInvalidOperation();
                                 }
 
-                                break;
                             default:
                                 // Date + number = Date
-                                CheckType(node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.Date);
-                                break;
+                                var resRight = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = resRight.Success, Node = node, NodeType = DType.Date, Coercions = resRight.Coercions };
                         }
 
-                        break;
                     case DKind.Time:
                         switch (rightKind)
                         {
@@ -4225,68 +4213,77 @@ namespace Microsoft.PowerFx.Core.Binding
                                 if (unary != null && unary.Op == UnaryOp.Minus)
                                 {
                                     // Time - Time = Number
-                                    _txb.SetType(node, DType.Number);
+                                    return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Number };
                                 }
                                 else
                                 {
                                     // Time + Time in any other arrangement is an error
-                                    ReportInvalidOperation();
+                                    return ReportInvalidOperation();
                                 }
 
-                                break;
                             case DKind.Date:
                                 unary = node.Right.AsUnaryOpLit();
                                 if (unary != null && unary.Op == UnaryOp.Minus)
                                 {
                                     // Time - Date is an error
-                                    ReportInvalidOperation();
+                                    return ReportInvalidOperation();
                                 }
                                 else
                                 {
                                     // Time + Date = DateTime
-                                    _txb.SetType(node, DType.DateTime);
+                                    return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.DateTime };
                                 }
 
-                                break;
                             case DKind.DateTime:
                                 // Time + DateTime in any other arrangement is an error
-                                ReportInvalidOperation();
-                                break;
+                                return ReportInvalidOperation();
                             default:
                                 // Time + number = Time
-                                CheckType(node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.Time);
-                                break;
+                                var resRight = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = resRight.Success, Node = node, NodeType = DType.Time, Coercions = resRight.Coercions };
                         }
 
-                        break;
                     default:
                         switch (rightKind)
                         {
                             case DKind.DateTime:
                                 // number + DateTime = DateTime
-                                CheckType(node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.DateTime);
-                                break;
+                                var leftResDateTime = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = leftResDateTime.Success, Node = node, NodeType = DType.DateTime, Coercions = leftResDateTime.Coercions };
                             case DKind.Date:
                                 // number + Date = Date
-                                CheckType(node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.Date);
-                                break;
+                                var leftResDate = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = leftResDate.Success, Node = node, NodeType = DType.Date, Coercions = leftResDate.Coercions };
                             case DKind.Time:
                                 // number + Time = Time
-                                CheckType(node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.Time);
-                                break;
+                                var leftResTime = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = leftResTime.Success, Node = node, NodeType = DType.Time, Coercions = leftResTime.Coercions };
                             default:
                                 // Regular Addition
-                                CheckType(node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                CheckType(node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                _txb.SetType(node, DType.Number);
-                                break;
+                                var leftResAdd = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                var rightResAdd = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
+                                return new BinderCheckTypeResult() { Success = leftResAdd.Success && rightResAdd.Success, Node = node, NodeType = DType.Number, Coercions = leftResAdd.Coercions.Concat(rightResAdd.Coercions).ToList() };
                         }
+                }
+            }
 
-                        break;
+            private void PostVisitBinaryOpNodeAddition(BinaryOpNode node)
+            {
+                AssertValid();
+
+                var leftType = _txb.GetType(node.Left);
+                var rightType = _txb.GetType(node.Right);
+
+                var res = PostVisitBinaryOpNodeAdditionCore(_txb.ErrorContainer, node, leftType, rightType);
+
+                if (res.Success)
+                {
+                    foreach (var coercion in res.Coercions)
+                    {
+                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
+                    }
+
+                    _txb.SetType(res.Node, res.NodeType);
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4151,7 +4151,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             default:
                                 // DateTime + number = DateTime
                                 var resRight = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = resRight.Success, Node = node, NodeType = DType.DateTime, Coercions = resRight.Coercions };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.DateTime, Coercions = resRight.Coercions };
                         }
 
                     case DKind.Date:
@@ -4201,7 +4201,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             default:
                                 // Date + number = Date
                                 var resRight = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = resRight.Success, Node = node, NodeType = DType.Date, Coercions = resRight.Coercions };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Date, Coercions = resRight.Coercions };
                         }
 
                     case DKind.Time:
@@ -4240,7 +4240,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             default:
                                 // Time + number = Time
                                 var resRight = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = resRight.Success, Node = node, NodeType = DType.Time, Coercions = resRight.Coercions };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Time, Coercions = resRight.Coercions };
                         }
 
                     default:
@@ -4249,20 +4249,20 @@ namespace Microsoft.PowerFx.Core.Binding
                             case DKind.DateTime:
                                 // number + DateTime = DateTime
                                 var leftResDateTime = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = leftResDateTime.Success, Node = node, NodeType = DType.DateTime, Coercions = leftResDateTime.Coercions };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.DateTime, Coercions = leftResDateTime.Coercions };
                             case DKind.Date:
                                 // number + Date = Date
                                 var leftResDate = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = leftResDate.Success, Node = node, NodeType = DType.Date, Coercions = leftResDate.Coercions };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Date, Coercions = leftResDate.Coercions };
                             case DKind.Time:
                                 // number + Time = Time
                                 var leftResTime = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = leftResTime.Success, Node = node, NodeType = DType.Time, Coercions = leftResTime.Coercions };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Time, Coercions = leftResTime.Coercions };
                             default:
                                 // Regular Addition
                                 var leftResAdd = CheckTypeCore(errorContainer, node.Left, leftType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
                                 var rightResAdd = CheckTypeCore(errorContainer, node.Right, rightType, DType.Number, /* coerced: */ DType.String, DType.Boolean);
-                                return new BinderCheckTypeResult() { Success = leftResAdd.Success && rightResAdd.Success, Node = node, NodeType = DType.Number, Coercions = leftResAdd.Coercions.Concat(rightResAdd.Coercions).ToList() };
+                                return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Number, Coercions = leftResAdd.Coercions.Concat(rightResAdd.Coercions).ToList() };
                         }
                 }
             }
@@ -4278,12 +4278,15 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (res.Success)
                 {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
-
                     _txb.SetType(res.Node, res.NodeType);
+
+                    if (res.Coercions != null)
+                    {
+                        foreach (var coercion in res.Coercions)
+                        {
+                            _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
+                        }
+                    }
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4280,12 +4280,9 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     _txb.SetType(res.Node, res.NodeType);
 
-                    if (res.Coercions != null)
+                    foreach (var coercion in res.Coercions)
                     {
-                        foreach (var coercion in res.Coercions)
-                        {
-                            _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                        }
+                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                     }
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -18,20 +18,8 @@ namespace Microsoft.PowerFx.Core.Binding
         // This collection represents repeated calls to that function
         public IReadOnlyCollection<BinderCoercionResult> Coercions
         {
-            get
-            {
-                if (_coercions == null)
-                {
-                    return new List<BinderCoercionResult>();
-                }
-
-                return _coercions;
-            }
-
-            init
-            {
-                _coercions = value;
-            }
+            get => _coercions ?? new List<BinderCoercionResult>();
+            init => _coercions = value;
         }
 
         public TexlNode Node { get; init; }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -15,6 +15,10 @@ namespace Microsoft.PowerFx.Core.Binding
         // which may be called multiple times in a given type checking function
         // This collection represents repeated calls to that function
         public IReadOnlyCollection<BinderCoercionResult> Coercions { get; init; }
+
+        public TexlNode Node { get; init; }
+
+        public DType NodeType { get; init; }
     }
 
     internal readonly struct BinderCoercionResult

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -7,28 +7,14 @@ using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Binding
 {
-    internal class BinderCheckTypeResult
+    internal readonly struct BinderCheckTypeResult
     {
-        private IReadOnlyCollection<BinderCoercionResult> _coercions;
-
-        public BinderCheckTypeResult()
-        {
-            _coercions = new List<BinderCoercionResult>();
-        }
-
         public bool Success { get; init; }
 
         // The binder has an imperative function called SetCoercedType,
         // which may be called multiple times in a given type checking function
         // This collection represents repeated calls to that function
-        public IReadOnlyCollection<BinderCoercionResult> Coercions
-        {
-            get => _coercions;
-            init
-            {
-                _coercions = value;
-            }
-        }
+        public IReadOnlyCollection<BinderCoercionResult> Coercions { get; init; }
 
         public TexlNode Node { get; init; }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -7,14 +7,28 @@ using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Binding
 {
-    internal readonly struct BinderCheckTypeResult
+    internal class BinderCheckTypeResult
     {
+        private IReadOnlyCollection<BinderCoercionResult> _coercions;
+
+        public BinderCheckTypeResult()
+        {
+            _coercions = new List<BinderCoercionResult>();
+        }
+
         public bool Success { get; init; }
 
         // The binder has an imperative function called SetCoercedType,
         // which may be called multiple times in a given type checking function
         // This collection represents repeated calls to that function
-        public IReadOnlyCollection<BinderCoercionResult> Coercions { get; init; }
+        public IReadOnlyCollection<BinderCoercionResult> Coercions
+        {
+            get => _coercions;
+            init
+            {
+                _coercions = value;
+            }
+        }
 
         public TexlNode Node { get; init; }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderCheckTypeResult.cs
@@ -9,12 +9,30 @@ namespace Microsoft.PowerFx.Core.Binding
 {
     internal readonly struct BinderCheckTypeResult
     {
+        private readonly IReadOnlyCollection<BinderCoercionResult> _coercions;
+
         public bool Success { get; init; }
 
         // The binder has an imperative function called SetCoercedType,
         // which may be called multiple times in a given type checking function
         // This collection represents repeated calls to that function
-        public IReadOnlyCollection<BinderCoercionResult> Coercions { get; init; }
+        public IReadOnlyCollection<BinderCoercionResult> Coercions
+        {
+            get
+            {
+                if (_coercions == null)
+                {
+                    return new List<BinderCoercionResult>();
+                }
+
+                return _coercions;
+            }
+
+            init
+            {
+                _coercions = value;
+            }
+        }
 
         public TexlNode Node { get; init; }
 


### PR DESCRIPTION
A big one, this changes PostVisitBinaryOpNodeAddition to be a mapping of inputs to outputs. This change also makes BinderCheckTypeResult a class instead of a readonly struct. This allows the Coercions property to default to an empty list instead of defaulting to null, removing the need to check for null when consuming the coercions list.