### PR TITLE
Fix TryGetType DPath overload

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1180,7 +1180,7 @@ namespace Microsoft.PowerFx.Core.Types
                 return true;
             }
 
-            return TryGetTypeCore(path.Name, out type);
+            return type.TryGetTypeCore(path.Name, out type);
         }
 
         // Get the type of a member field specified by path.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DTypeTests.cs
@@ -633,6 +633,21 @@ namespace Microsoft.PowerFx.Tests
             Assert.True(AttachmentRecordType.IsAttachment);
             Assert.NotNull(AttachmentRecordType.AttachmentType);
         }
+
+        [Fact]
+        public void TryGetTypePathTest()
+        {
+            var type = TestUtils.DT("*[A:n, B:*[D:s, E:*[F:b]], C:n]");
+            Assert.True(
+                type.TryGetType(
+                    DPath.Root
+                        .Append(new DName("B"))
+                        .Append(new DName("E"))
+                        .Append(new DName("F")),
+                    out var result));
+
+            Assert.Equal(DType.Boolean, result);
+        }
                 
         [Fact]
         public void RecordAndTableDTypeTests()


### PR DESCRIPTION
This DType overload is rarely used, and appeared untested in this repo. Fixes a recent break caused by #599 and adds test