### PR TITLE
Make outstanding binary op node dependencies more functional

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4054,7 +4054,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                     case BinaryOp.Equal:
                     case BinaryOp.NotEqual:
-                        var resEq = CheckEqualArgTypes(errorContainer, leftNode, rightNode, leftType, rightType);
+                        var resEq = CheckEqualArgTypesCore(errorContainer, leftNode, rightNode, leftType, rightType);
                         return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Boolean, Coercions = resEq.Coercions };
 
                     case BinaryOp.Less:
@@ -4064,7 +4064,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // Excel's type coercion for inequality operators is inconsistent / borderline wrong, so we can't
                         // use it as a reference. For example, in Excel '2 < TRUE' produces TRUE, but so does '2 < FALSE'.
                         // Sticking to a restricted set of numeric-like types for now until evidence arises to support the need for coercion.
-                        var resOrder = CheckComparisonArgTypes(errorContainer, leftNode, rightNode, leftType, rightType);
+                        var resOrder = CheckComparisonArgTypesCore(errorContainer, leftNode, rightNode, leftType, rightType);
                         return new BinderCheckTypeResult() { Success = true, Node = node, NodeType = DType.Boolean, Coercions = resOrder.Coercions };
 
                     case BinaryOp.In:
@@ -4087,15 +4087,12 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 var res = PostVisitCore(_txb.ErrorContainer, node, leftType, rightType, _txb.Document != null && _txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled);
 
-                if (res.Success)
+                foreach (var coercion in res.Coercions)
                 {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
-
-                    _txb.SetType(res.Node, res.NodeType);
+                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                 }
+
+                _txb.SetType(res.Node, res.NodeType);
 
                 _txb.SetSideEffects(node, _txb.HasSideEffects(node.Left) || _txb.HasSideEffects(node.Right));
                 _txb.SetStateful(node, _txb.IsStateful(node.Left) || _txb.IsStateful(node.Right));

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4353,12 +4353,9 @@ namespace Microsoft.PowerFx.Core.Binding
             {
                 var res = CheckComparisonArgTypesCore(_txb.ErrorContainer, left, right, _txb.GetType(left), _txb.GetType(right));
 
-                if (res.Success)
+                foreach (var coercion in res.Coercions)
                 {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
+                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                 }
             }
 
@@ -4366,12 +4363,9 @@ namespace Microsoft.PowerFx.Core.Binding
             {
                 var res = CheckEqualArgTypesCore(_txb.ErrorContainer, left, right, _txb.GetType(left), _txb.GetType(right));
 
-                if (res.Success)
+                foreach (var coercion in res.Coercions)
                 {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
+                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2521,19 +2521,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 return new BinderCheckTypeResult() { Success = false };
             }
 
-            private void CheckComparisonTypeOneOf(TexlNode node, DType type, params DType[] alternateTypes)
-            {
-                var res = CheckComparisonTypeOneOfCore(_txb.ErrorContainer, node, type, alternateTypes);
-
-                if (res.Success)
-                {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
-                }
-            }
-
             // Returns whether the node was of the type wanted, and reports appropriate errors.
             // A list of allowed alternate types specifies what other types of values can be coerced to the wanted type.
             internal static BinderCheckTypeResult CheckTypeCore(ErrorContainer errorContainer, TexlNode node, DType nodeType, DType typeWant, params DType[] alternateTypes)

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2753,24 +2753,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 return res.Success;
             }
 
-            private bool CheckInArgTypes(TexlNode left, TexlNode right)
-            {
-                var res = CheckInArgTypesCore(
-                    _txb.ErrorContainer,
-                    left,
-                    right,
-                    _txb.GetType(left),
-                    _txb.GetType(right),
-                    _txb.Document != null && _txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled);
-
-                foreach (var coercion in res.Coercions)
-                {
-                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                }
-
-                return res.Success;
-            }
-
             private ScopeUseSet JoinScopeUseSets(params TexlNode[] nodes)
             {
                 Contracts.AssertValue(nodes);
@@ -4269,23 +4251,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
             }
 
-            private void PostVisitBinaryOpNodeAddition(BinaryOpNode node)
-            {
-                AssertValid();
-
-                var leftType = _txb.GetType(node.Left);
-                var rightType = _txb.GetType(node.Right);
-
-                var res = PostVisitBinaryOpNodeAdditionCore(_txb.ErrorContainer, node, leftType, rightType);
-
-                _txb.SetType(res.Node, res.NodeType);
-
-                foreach (var coercion in res.Coercions)
-                {
-                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                }
-            }
-
             public override void PostVisit(AsNode node)
             {
                 Contracts.AssertValue(node);
@@ -4352,26 +4317,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 return new BinderCheckTypeResult() { Success = true, Coercions = coercions };
-            }
-
-            private void CheckComparisonArgTypes(TexlNode left, TexlNode right)
-            {
-                var res = CheckComparisonArgTypesCore(_txb.ErrorContainer, left, right, _txb.GetType(left), _txb.GetType(right));
-
-                foreach (var coercion in res.Coercions)
-                {
-                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                }
-            }
-
-            private void CheckEqualArgTypes(TexlNode left, TexlNode right)
-            {
-                var res = CheckEqualArgTypesCore(_txb.ErrorContainer, left, right, _txb.GetType(left), _txb.GetType(right));
-
-                foreach (var coercion in res.Coercions)
-                {
-                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                }
             }
 
             private static BinderCheckTypeResult CheckEqualArgTypesCore(ErrorContainer errorContainer, TexlNode left, TexlNode right, DType typeLeft, DType typeRight)


### PR DESCRIPTION
CheckEqualArgTypes
CheckComparisonArgTypes
CheckComparisonOneOf

These functions are all used by the PostVisit method for Binary op nodes and need to be made functional.

Also makes the PostVisit functions for both Binary and Unary op nodes more functional.