### PR TITLE
Port TexlTest.cs to FxCore.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -391,8 +391,7 @@ namespace Microsoft.PowerFx.Core.Binding
             Contracts.AssertValue(node);
             Contracts.AssertIndex(node.Id, _typeMap.Length);
             
-            // $$$ This assert is failing, which blocks the ability to see the test's assert. 
-            // Contracts.Assert(_typeMap[node.Id].IsValid);
+            Contracts.Assert(_typeMap[node.Id].IsValid);
 
             return _typeMap[node.Id];
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2744,12 +2744,9 @@ namespace Microsoft.PowerFx.Core.Binding
             {
                 var res = CheckTypeCore(_txb.ErrorContainer, node, nodeType, typeWant, alternateTypes);
 
-                if (res.Success)
+                foreach (var coercion in res.Coercions)
                 {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
+                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                 }
 
                 return res.Success;
@@ -2765,12 +2762,9 @@ namespace Microsoft.PowerFx.Core.Binding
                     _txb.GetType(right),
                     _txb.Document != null && _txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled);
 
-                if (res.Success)
+                foreach (var coercion in res.Coercions)
                 {
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
+                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                 }
 
                 return res.Success;
@@ -4278,14 +4272,11 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 var res = PostVisitBinaryOpNodeAdditionCore(_txb.ErrorContainer, node, leftType, rightType);
 
-                if (res.Success)
-                {
-                    _txb.SetType(res.Node, res.NodeType);
+                _txb.SetType(res.Node, res.NodeType);
 
-                    foreach (var coercion in res.Coercions)
-                    {
-                        _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
-                    }
+                foreach (var coercion in res.Coercions)
+                {
+                    _txb.SetCoercedType(coercion.Node, coercion.CoercedType);
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -390,7 +390,6 @@ namespace Microsoft.PowerFx.Core.Binding
         {
             Contracts.AssertValue(node);
             Contracts.AssertIndex(node.Id, _typeMap.Length);
-            
             Contracts.Assert(_typeMap[node.Id].IsValid);
 
             return _typeMap[node.Id];

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -390,7 +390,9 @@ namespace Microsoft.PowerFx.Core.Binding
         {
             Contracts.AssertValue(node);
             Contracts.AssertIndex(node.Id, _typeMap.Length);
-            Contracts.Assert(_typeMap[node.Id].IsValid);
+            
+            // $$$ This assert is failing, which blocks the ability to see the test's assert. 
+            // Contracts.Assert(_typeMap[node.Id].IsValid);
 
             return _typeMap[node.Id];
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Syntax;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{    
+    public class TexlTests : PowerFxTest
+    {
+        [Theory]
+        [InlineData("DateTimeValue(\"1 Jan 2015\") + DateTimeValue(\"1 Jan 2015\")")]
+        [InlineData("DateTimeValue(\"1 Jan 2015\") + Date(2000,1,1)")]
+        [InlineData("DateTimeValue(\"1 Jan 2015\") + Time(2000,1,1)")]
+        [InlineData("Date(2000,1,1) + Date(1999,1,1)")]
+        [InlineData("Date(2000,1,1) + DateTimeValue(\"1 Jan 2015\")")]
+        [InlineData("Time(2000,1,1) + Time(1999,1,1)")]
+        [InlineData("Time(2000,1,1) + DateTimeValue(\"1 Jan 2015\")")]
+        [InlineData("DateTimeValue(\"1 Jan 2015\") - Time(2000,1,1)")]
+        [InlineData("DateValue(\"1 Jan 2015\") - Time(2000,1,1)")]
+        [InlineData("Time(2000,1,1) - DateTimeValue(\"1 Jan 2015\")")]
+        [InlineData("Time(2000,1,1) - Date(2000,1,1)")]
+        public void TexlDateOverloads_Negative(string script)
+        {
+            // TestBindingErrors(script, DType.Error);
+            var engine = new Engine(new PowerFxConfig());
+            var result = engine.Check(script);
+            
+            Assert.Equal(DType.Error, result._binding.ResultType);            
+            Assert.False(result.IsSuccess);
+        }
+    }
+}


### PR DESCRIPTION
This started failing with #610.

Note in debug tests, we hit an Contract assert in binder in _binding.ResultType.

In PAClient, it uses retail FxCore, so contracts are disable, and hence we fail in