### PR TITLE
Updates TryGetFieldType to check for null/empty DNP

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
@@ -71,7 +71,13 @@ namespace Microsoft.PowerFx.Types
         public bool TryGetFieldType(string displayOrLogicalName, out string logical, out FormulaType type)
         {
             Contracts.CheckNonEmpty(displayOrLogicalName, nameof(displayOrLogicalName));
-            if (_type.DisplayNameProvider.TryGetDisplayName(new DName(displayOrLogicalName), out _))
+
+            // checking null and empty case in-case derived types did not provide DisplayNameProvider.
+            if (_type.DisplayNameProvider == null || _type.DisplayNameProvider.LogicalToDisplayPairs.Count() == 0)
+            {
+                logical = displayOrLogicalName;
+            }
+            else if (_type.DisplayNameProvider.TryGetDisplayName(new DName(displayOrLogicalName), out _))
             {
                 logical = displayOrLogicalName;
             }
@@ -86,7 +92,13 @@ namespace Microsoft.PowerFx.Types
                 return false;
             }
 
-            return TryGetFieldType(logical, out type);
+            if (!TryGetFieldType(logical, out type))
+            {
+                logical = null;
+                return false;
+            }
+
+            return true;
         }
 
         public IEnumerable<NamedFormulaType> GetFieldTypes()

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/AggregateType.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
@@ -72,24 +73,20 @@ namespace Microsoft.PowerFx.Types
         {
             Contracts.CheckNonEmpty(displayOrLogicalName, nameof(displayOrLogicalName));
 
-            // checking null and empty case in-case derived types did not provide DisplayNameProvider.
-            if (_type.DisplayNameProvider == null || _type.DisplayNameProvider.LogicalToDisplayPairs.Count() == 0)
+            if (DType.TryGetDisplayNameForColumn(_type, displayOrLogicalName, out _))
             {
                 logical = displayOrLogicalName;
             }
-            else if (_type.DisplayNameProvider.TryGetDisplayName(new DName(displayOrLogicalName), out _))
-            {
-                logical = displayOrLogicalName;
-            }
-            else if (_type.DisplayNameProvider.TryGetLogicalName(new DName(displayOrLogicalName), out var maybeLogical))
+            else if (DType.TryGetLogicalNameForColumn(_type, displayOrLogicalName, out var maybeLogical))
             {
                 logical = maybeLogical;
             }
             else
             {
-                logical = default;
-                type = Blank;
-                return false;
+                // in-case derived types did not provide DisplayNameProvider then above two will be false
+                // but we want to assume that, provided displayOrLogicalName maybe logical name it self
+                // and let TryGetFieldType verify that.
+                logical = displayOrLogicalName;
             }
 
             if (!TryGetFieldType(logical, out type))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TypeTests.cs
@@ -55,6 +55,21 @@ namespace Microsoft.PowerFx.Tests
             Assert.NotNull(formulaType);
         }
 
+        [Theory]
+        [InlineData("F1", true, "F1")]
+        [InlineData("SomethingElse", false, null)]
+        public void TryGetFieldTypeLookupTestWithoutDisplayName(string inputDisplayOrLogical, bool succeeds, string expectedLogical)
+        {
+            var r1 = RecordType.Empty().Add(new NamedFormulaType("F1", FormulaType.Number));
+
+            Assert.Equal(r1.TryGetFieldType(inputDisplayOrLogical, out var actualLogical, out var formulaType), succeeds);
+
+            Assert.Equal(expectedLogical, actualLogical);
+
+            // Since, it returns Blank node on returning false too.
+            Assert.NotNull(formulaType);
+        }
+
         [Fact]
         public void TryGetFieldTypeLookupNullTest()
         {


### PR DESCRIPTION
-Updates TryGetFieldType to check for null/empty DNP in-case derived types did not provide DisplayNameProvider.
