### PR TITLE
Revert "remove max selects limit (#465)"

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -124,6 +124,11 @@ namespace Microsoft.PowerFx.Core.Binding
         public ErrorContainer ErrorContainer { get; } = new ErrorContainer();
 
         /// <summary>
+        /// The maximum number of selects in a table that will be included in data call.
+        /// </summary>
+        public const int MaxSelectsToInclude = 100;
+
+        /// <summary>
         /// Default name used to access a Lambda scope.
         /// </summary>
         internal DName ThisRecordDefaultName => new DName("ThisRecord");
@@ -903,7 +908,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     {
                         if (expandQueryOptions.Value.ExpandInfo.Identity == expandEntityLogicalName)
                         {
-                            if (!expandQueryOptions.Value.SelectsEqualKeyColumns())
+                            if (!expandQueryOptions.Value.SelectsEqualKeyColumns() &&
+                                expandQueryOptions.Value.Selects.Count() <= MaxSelectsToInclude)
                             {
                                 return expandQueryOptions.Value.Selects;
                             }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/QueryOptions/TabularDataQueryOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/QueryOptions/TabularDataQueryOptions.cs
@@ -108,7 +108,8 @@ namespace Microsoft.PowerFx.Core.Entities.QueryOptions
 
             Contracts.Assert(TabularDataSourceInfo.GetKeyColumns().All(x => _selects.Contains(x)));
 
-            return TabularDataSourceInfo.GetKeyColumns().Count() < _selects.Count;
+            return TabularDataSourceInfo.GetKeyColumns().Count() < _selects.Count
+                 && _selects.Count < TexlBinding.MaxSelectsToInclude;
         }
 
         internal bool ReplaceExpandsWithAnnotation(ExpandQueryOptions expand)


### PR DESCRIPTION
This reverts commit 57e2e4bb9d6ce3e4eeb4c113181fe89629671a33.

This change introduced a significant (400%!!) performance regression in Canvas apps for a subset of very, very, very high end complexity apps (p99.99).