### PR TITLE
Remove function initial draft

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -454,6 +454,10 @@ namespace Microsoft.PowerFx.Core.Localization
         public static StringGetter PatchBaseRecordArg = (b) => StringResources.Get("PatchBaseRecordArg", b);
         public static StringGetter PatchChangeRecordsArg = (b) => StringResources.Get("PatchChangeRecordsArg", b);
 
+        public static StringGetter AboutRemove = (b) => StringResources.Get("AboutRemove", b);
+        public static StringGetter RemoveDataSourceArg = (b) => StringResources.Get("RemoveDataSourceArg", b);
+        public static StringGetter RemoveRecordsArg = (b) => StringResources.Get("RemoveRecordsArg", b);
+
         // Previously, errors were listed here in the form of a StringGetter, which would be evaluated to fetch
         // an error message to pass to the BaseError class constructor. We are switching to passing the message key itself
         // to the BaseError class, and the BaseError itself is responsible for fetching the resource. (This allows the
@@ -583,5 +587,7 @@ namespace Microsoft.PowerFx.Core.Localization
         // ErrorResourceKey for creating an error from an arbitrary string message. The key resolves to "{0}", meaning
         // that a single string arg can be supplied representing the entire text of the error.
         public static ErrorResourceKey ErrGeneralError = new ErrorResourceKey("ErrGeneralError");
+
+        public static ErrorResourceKey ErrRemoveAllArg = new ErrorResourceKey("ErrRemoveAllArg");
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
@@ -127,15 +127,15 @@ namespace Microsoft.PowerFx.Types
             {
                 var deleteList = new List<T>();
 
-                foreach (var current in _enumerator)
+                foreach (var item in _enumerator)
                 {
                     cancel.ThrowIfCancellationRequested();
 
-                    var currentRecord = current as RecordValue;
+                    var dRecord = Marshal(item);
 
-                    if (Matches(currentRecord, recordToRemove))
+                    if (Matches(dRecord.Value, recordToRemove))
                     {
-                        deleteList.Add(current);
+                        deleteList.Add(item);
 
                         if (!all)
                         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
@@ -108,6 +108,41 @@ namespace Microsoft.PowerFx.Types
             }
         }
 
+        public override async Task<DValue<BooleanValue>> RemoveAsync(IEnumerable<FormulaValue> recordsToRemove, bool all = false)
+        {
+            var ret = false;
+
+            if (_sourceList == null || _sourceList.IsReadOnly)
+            {
+                return await base.RemoveAsync(recordsToRemove, all);
+            }
+
+            // !JYL! Needs improvement
+            foreach (RecordValue record in recordsToRemove)
+            {
+                while (true)
+                {
+                    var actual = Find(record);
+
+                    if (actual != null)
+                    {
+                        _sourceList.Remove(MarshalInverse(actual));
+
+                        if (!all)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }                    
+                }
+            }
+
+            return DValue<BooleanValue>.Of(New(ret));
+        }
+
         protected override async Task<DValue<RecordValue>> PatchCoreAsync(RecordValue baseRecord, RecordValue changeRecord)
         {
             var actual = Find(baseRecord);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -103,6 +103,11 @@ namespace Microsoft.PowerFx.Types
             return DValue<RecordValue>.Of(NotImplemented(IRContext));
         }
 
+        public virtual async Task<DValue<BooleanValue>> RemoveAsync(IEnumerable<FormulaValue> recordsToRemove, bool all)
+        {
+            return DValue<BooleanValue>.Of(NotImplemented(IRContext));
+        }
+
         /// <summary>
         /// Patch implementation for derived classes.
         /// </summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Utils;
@@ -88,7 +89,7 @@ namespace Microsoft.PowerFx.Types
         {
             return new ErrorValue(irContext, new ExpressionError()
             {
-                Message = $"It is not possible to call {methodName} method from TableValue directly.",
+                Message = $"{methodName} is not supported on this table instance.",
                 Span = irContext.SourceContext,
                 Kind = ErrorKind.Internal
             });
@@ -103,7 +104,7 @@ namespace Microsoft.PowerFx.Types
             return DValue<RecordValue>.Of(NotImplemented(IRContext));
         }
 
-        public virtual async Task<DValue<BooleanValue>> RemoveAsync(IEnumerable<FormulaValue> recordsToRemove, bool all)
+        public virtual async Task<DValue<BooleanValue>> RemoveAsync(IEnumerable<FormulaValue> recordsToRemove, bool all, CancellationToken cancel)
         {
             return DValue<BooleanValue>.Of(NotImplemented(IRContext));
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.PowerFx
             symbolTable.AddFunction(new CollectFunction());
             symbolTable.AddFunction(new PatchRecordFunction());
             symbolTable.AddFunction(new PatchFunction());
+            symbolTable.AddFunction(new RemoveFunction());
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerFx.Functions
                     {
                         var strNode = (StrLitNode)args[i];
 
-                        if (strNode.Value.ToUpper() != "ALL")
+                        if (strNode.Value.ToUpperInvariant() != "ALL")
                         {
                             fValid = false;
                             errors.EnsureError(args[i], ErrRemoveAllArg, args[i]);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -198,7 +198,7 @@ namespace Microsoft.PowerFx.Functions
             {
                 var lastArgValue = (string)lastArg.ToObject();
 
-                if (lastArgValue.ToUpper() == "ALL")
+                if (lastArgValue.ToUpperInvariant() == "ALL")
                 {
                     all = true;
                     toExclude = 2;
@@ -206,11 +206,9 @@ namespace Microsoft.PowerFx.Functions
             }
 
             var datasource = (TableValue)args[0];
-
-            // !JYL! Better approach?
             var recordsToRemove = args.Skip(1).Take(args.Length - toExclude);
 
-            var ret = await datasource.RemoveAsync(recordsToRemove, all);
+            var ret = await datasource.RemoveAsync(recordsToRemove, all, cancel);
 
             return ret.ToFormulaValue();
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -1,0 +1,218 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Functions.DLP;
+using Microsoft.PowerFx.Core.Functions.FunctionArgValidators;
+using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Texl.Builtins;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Types;
+using static Microsoft.PowerFx.Core.Localization.TexlStrings;
+
+namespace Microsoft.PowerFx.Functions
+{
+    internal abstract class RemoveFunctionBase : BuiltinFunction
+    {
+        public override bool IsSelfContained => false;
+
+        public RemoveFunctionBase(DPath theNamespace, string name, StringGetter description, FunctionCategories fc, DType returnType, BigInteger maskLambdas, int arityMin, int arityMax, params DType[] paramTypes)
+            : base(theNamespace, name, /*localeSpecificName*/string.Empty, description, fc, returnType, maskLambdas, arityMin, arityMax, paramTypes)
+        {
+        }
+
+        public RemoveFunctionBase(string name, StringGetter description, FunctionCategories fc, DType returnType, BigInteger maskLambdas, int arityMin, int arityMax, params DType[] paramTypes)
+            : this(DPath.Root, name, description, fc, returnType, maskLambdas, arityMin, arityMax, paramTypes)
+        {
+        }
+
+        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(binding);
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+
+            var isValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+
+            return isValid;
+        }
+
+        protected static bool CheckArgs(FormulaValue[] args, out FormulaValue faultyArg)
+        {
+            // If any args are error, propagate up.
+            foreach (var arg in args)
+            {
+                if (arg is ErrorValue)
+                {
+                    faultyArg = arg;
+
+                    return false;
+                }
+            }
+
+            faultyArg = null;
+
+            return true;
+        }
+    }
+
+    internal class RemoveFunction : RemoveFunctionBase, IAsyncTexlFunction
+    {
+        public override bool IsSelfContained => false;
+
+        public RemoveFunction()
+        : base("Remove", AboutRemove, FunctionCategories.Table | FunctionCategories.Behavior, DType.Boolean, 0, 2, int.MaxValue, DType.EmptyTable, DType.EmptyRecord)
+        {
+        }
+
+        public override IEnumerable<StringGetter[]> GetSignatures()
+        {
+            yield return new[] { RemoveDataSourceArg, RemoveRecordsArg };
+            yield return new[] { RemoveDataSourceArg, RemoveRecordsArg, RemoveRecordsArg };
+        }
+
+        public override IEnumerable<StringGetter[]> GetSignatures(int arity)
+        {
+            if (arity > 2)
+            {
+                return GetGenericSignatures(arity, RemoveDataSourceArg, RemoveRecordsArg, RemoveRecordsArg);
+            }
+
+            return base.GetSignatures(arity);
+        }
+
+        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+            Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
+
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+
+            //Contracts.Assert(returnType.IsTable);
+
+            DType collectionType = argTypes[0];
+            if (!collectionType.IsTable)
+            {
+                fValid = false;
+                errors.EnsureError(args[0], ErrNeedTable_Func, Name);
+            }
+
+            fValid &= DropAttachmentsIfExists(ref collectionType, errors, args[0]);
+
+            var argCount = argTypes.Length;
+
+            for (var i = 1; i < argCount; i++)
+            {
+                DType argType = argTypes[i];
+
+                // The subsequent args should all be records.
+                if (!argType.IsRecord)
+                {
+                    // The last arg may be the optional "ALL" parameter.
+                    if (argCount >= 3 && i == argCount - 1 && DType.String.Accepts(argType))
+                    {
+                        var strNode = (StrLitNode)args[i];
+
+                        if (strNode.Value.ToUpper() != "ALL")
+                        {
+                            fValid = false;
+                            errors.EnsureError(args[i], ErrRemoveAllArg, args[i]);
+                        }
+
+                        continue;
+                    }
+
+                    fValid = false;
+                    errors.EnsureError(args[i], ErrNeedRecord, args[i]);
+                    continue;
+                }
+
+                fValid &= DropAttachmentsIfExists(ref argType, errors, args[i]);
+
+                var collectionAcceptsRecord = collectionType.Accepts(argType.ToTable());
+                var recordAcceptsCollection = argType.ToTable().Accepts(collectionType);
+
+                // The item schema should be compatible with the collection schema.
+                if (!collectionAcceptsRecord && !recordAcceptsCollection)
+                {
+                    fValid = false;
+                    if (!SetErrorForMismatchedColumns(collectionType, argType, args[i], errors))
+                    {
+                        errors.EnsureError(DocumentErrorSeverity.Severe, args[i], ErrTableDoesNotAcceptThisType);
+                    }
+                }
+
+                // Only warn about no-op record inputs if there are no data sources that would use reference identity for comparison.
+                else if (!collectionType.AssociatedDataSources.Any() && !recordAcceptsCollection)
+                {
+                    errors.EnsureError(DocumentErrorSeverity.Warning, args[i], ErrTableDoesNotAcceptThisType);
+                }
+            }
+
+            // Remove returns the new collection, so the return schema is the same as the collection schema.
+            returnType = collectionType;
+
+            return fValid;
+        }
+
+        public async Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancel)
+        {
+            var validArgs = CheckArgs(args, out FormulaValue faultyArg);
+
+            if (!validArgs)
+            {
+                return faultyArg;
+            }
+
+            if (args[0] is BlankValue)
+            {
+                return args[0];
+            }
+
+            var argCount = args.Count();
+            var lastArg = args.Last() as FormulaValue;
+            var all = false;
+            var toExclude = 1;
+
+            if (argCount >= 3 && DType.String.Accepts(lastArg.Type._type))
+            {
+                var lastArgValue = (string)lastArg.ToObject();
+
+                if (lastArgValue.ToUpper() == "ALL")
+                {
+                    all = true;
+                    toExclude = 2;
+                }
+            }
+
+            var datasource = (TableValue)args[0];
+
+            // !JYL! Better approach?
+            var recordsToRemove = args.Skip(1).Take(args.Length - toExclude);
+
+            var ret = await datasource.RemoveAsync(recordsToRemove, all);
+
+            return ret.ToFormulaValue();
+        }
+    }
+}

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -5020,6 +5020,22 @@
     <value>change_record(s)</value>
     <comment>function_parameter - Third parameter for the Patch function. One or more records that contain properties to modify in the BaseRecord. Change records are processed in order from the beginning of the argument list to the end, with later property values overriding earlier ones.</comment>
   </data>
+  <data name="AboutRemove" xml:space="preserve">
+    <value>Removes a specific record or records from a data source</value>
+    <comment>Description of 'Remove' function.</comment>
+  </data>
+  <data name="RemoveDataSourceArg" xml:space="preserve">
+    <value>data_source</value>
+    <comment>function_parameter - First parameter for the Remove function. The data source that contains the records that you want to remove from.</comment>
+  </data>
+  <data name="RemoveRecordsArg" xml:space="preserve">
+    <value>remove_record(s)</value>
+    <comment>function_parameter - One or more records to be removed.</comment>
+  </data>
+  <data name="ErrRemoveAllArg" xml:space="preserve">
+    <value>If provided, last argument must be 'All'. Is there a typo?</value>
+    <comment>Error Message.</comment>
+  </data>
   <data name="PenMode_Draw_DisplayName" xml:space="preserve">
     <value>Draw</value>
     <comment>Display text representing the Draw value of PenMode enum (PenMode_Draw_Name). The possible values for this enumeration are: Draw, Erase.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
@@ -1,0 +1,68 @@
+﻿#SETUP: EnableExpressionChaining,MutationFunctionsTestSetup
+
+// MutationFunctionsTestSetup handle does the following:
+// - Creates a record: r1 => {Field1:1,Field2:"earth",Field3:1/1/2022,Field4:true}
+// - Creates a record: r2 => {Field1:2,Field2:"moon",Field3:2/1/2022,Field4:false} (for convenience)
+// - Creates a record: r_empty => {}
+// - Creates a table: t1(r1) => Type (Field1, Field2, Field3, Field4)
+
+>> Collect(t1, r2);Remove(t1, r1);t1
+Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Collect(t1, r1);Collect(t1, r1);Collect(t1, r1);Collect(t1, r2);Remove(t1, r1, "All");t1
+Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Collect(t1, r2);
+  Collect(t1, {Field1:3,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:4,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Remove(t1, {Field2:"earth"});
+  t1
+Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false},{Field1:3,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false},{Field1:4,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Collect(t1, r2);
+  Collect(t1, {Field1:3,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:4,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Remove(t1, {Field2:"earth"}, "All");
+  t1
+Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Collect(t1, r2);
+  Collect(t1, {Field1:3,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:4,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Remove(t1, {Field4:false});
+  t1
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:3,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false},{Field1:4,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Collect(t1, r2);
+  Collect(t1, {Field1:3,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:4,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Remove(t1, {Field4:false}, "All");
+  t1
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Collect(t1, r2);
+  Collect(t1, {Field1:1/0,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:1/0,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Remove(t1, {Field4:false}, "All");
+  t1
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Collect(t1, {Field1:1/0,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:1/0,Field2:"earth",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+  Collect(t1, {Field1:1/0,Field2:"moon",Field3:DateTime(2030,2,1,0,0,0,0),Field4:true});
+  Remove(t1, {Field2:"earth"}, "All");
+  t1
+Table({Field1:Microsoft.PowerFx.Types.ErrorValue,Field2:"moon",Field3:DateTime(2030,2,1,0,0,0,0),Field4:true})
+
+// Wrong arguments
+>> Remove(t1, r1,"Al");
+Errors: Error 14-18: If provided, last argument must be 'All'. Is there a typo?|Error 0-19: The function 'Remove' has some invalid arguments.
+
+>> Remove(t1, r1,"");
+Errors: Error 14-16: If provided, last argument must be 'All'. Is there a typo?|Error 0-17: The function 'Remove' has some invalid arguments.
+
+>> Remove(t1, r1, r1, r1, r1, r1, r1, "Al");
+Errors: Error 35-39: If provided, last argument must be 'All'. Is there a typo?|Error 0-40: The function 'Remove' has some invalid arguments.
+
+>> Remove(t1, "All");
+Errors: Error 11-16: Invalid argument type (Text). Expecting a Record value instead.|Error 11-16: Cannot use a non-record value in this context.|Error 0-17: The function 'Remove' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TableValueMutationTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TableValueMutationTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var result = await t2.AppendAsync(r2);
 
             Assert.True(result.IsError);
-            Assert.Equal("It is not possible to call AppendAsync method from TableValue directly.", result.Error.Errors[0].Message);
+            Assert.Equal("AppendAsync is not supported on this table instance.", result.Error.Errors[0].Message);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RemoveFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RemoveFunctionTests.cs
@@ -51,24 +51,24 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             // Remode single
             var list = new List<RecordValue>() { rRemove };
 
-            await t1.RemoveAsync(list, false);
+            await t1.RemoveAsync(list, false, CancellationToken.None);
 
             Assert.Equal(2, t1.Count());
 
             var t2 = FormulaValue.NewTable(r1.Type, r1, r2, r3);
 
             // Remove all
-            await t2.RemoveAsync(list, true);
+            await t2.RemoveAsync(list, true, CancellationToken.None);
 
             Assert.Equal(1, t2.Count());
 
             // Immutable
             IEnumerable<RecordValue> source = new RecordValue[] { r1, r2, r3 };
             var t3 = FormulaValue.NewTable(r1.Type, source);
-            var result = await t3.RemoveAsync(list, false);
+            var result = await t3.RemoveAsync(list, false, CancellationToken.None);
 
             Assert.True(result.IsError);
-            Assert.Equal("It is not possible to call RemoveAsync method from TableValue directly.", result.Error.Errors[0].Message);
+            Assert.Equal("RemoveAsync is not supported on this table instance.", result.Error.Errors[0].Message);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RemoveFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RemoveFunctionTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Functions.FunctionArgValidators;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Functions;
+using Microsoft.PowerFx.Interpreter;
+using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Types;
+using Xunit;
+using static Microsoft.PowerFx.Core.Localization.TexlStrings;
+
+namespace Microsoft.PowerFx.Interpreter.Tests
+{
+    public class RemoveFunctionTests : PowerFxTest
+    {
+        [Fact]
+        public async Task RemoveRecordTest()
+        {
+            var r1 = FormulaValue.NewRecordFromFields(
+                new NamedValue("f1", FormulaValue.New(1)),
+                new NamedValue("f2", FormulaValue.New("earth")),
+                new NamedValue("f3", FormulaValue.New(true)));
+
+            var r2 = FormulaValue.NewRecordFromFields(
+                new NamedValue("f1", FormulaValue.New(2)),
+                new NamedValue("f2", FormulaValue.New("moon")),
+                new NamedValue("f3", FormulaValue.New(true)));
+
+            var r3 = FormulaValue.NewRecordFromFields(
+                new NamedValue("f1", FormulaValue.New(3)),
+                new NamedValue("f2", FormulaValue.New("mars")),
+                new NamedValue("f3", FormulaValue.New(false)));
+
+            var rRemove = FormulaValue.NewRecordFromFields(
+                new NamedValue("f3", FormulaValue.New(true)));
+
+            var t1 = FormulaValue.NewTable(r1.Type, r1, r2, r3);
+
+            // Remode single
+            var list = new List<RecordValue>() { rRemove };
+
+            await t1.RemoveAsync(list, false);
+
+            Assert.Equal(2, t1.Count());
+
+            var t2 = FormulaValue.NewTable(r1.Type, r1, r2, r3);
+
+            // Remove all
+            await t2.RemoveAsync(list, true);
+
+            Assert.Equal(1, t2.Count());
+
+            // Immutable
+            IEnumerable<RecordValue> source = new RecordValue[] { r1, r2, r3 };
+            var t3 = FormulaValue.NewTable(r1.Type, source);
+            var result = await t3.RemoveAsync(list, false);
+
+            Assert.True(result.IsError);
+            Assert.Equal("It is not possible to call RemoveAsync method from TableValue directly.", result.Error.Errors[0].Message);
+        }
+    }
+}


### PR DESCRIPTION
Initial push for [**Remove( DataSource, Record1 [, Record2, ... ] [, All ] )**](https://docs.microsoft.com/en-us/power-platform/power-fx/reference/function-remove-removeif#syntax) implementation.

- Still working on a better way to find matching records.
- Working on adding extra test cases for SDK, compiler and interpreter.
- RemoveAsync returns a Boolean. Maybe there is a better way.
- Good approach to get a range of elements from array.
- Any other improvements.