### PR TITLE
Fix 631

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/LogicalNameWrapperRecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/LogicalNameWrapperRecordValue.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.PowerFx.Core;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+
+namespace Microsoft.PowerFx.Types
+{
+    /// <summary>
+    /// Helper for <see cref="RecordType.ResolveToLogicalNames(RecordValue)"/>.
+    /// This creates a lazy record type that converts display names to logical names. 
+    /// The values are based on the inner record, but are using logical names from the template. 
+    /// </summary>
+    internal class LogicalNameWrapperRecordValue : RecordValue
+    {
+        // Fields may have either the display or logical name. 
+        private readonly RecordValue _inner;
+
+        private readonly RecordType _template;
+
+        public LogicalNameWrapperRecordValue(RecordType template, RecordValue inner)
+            : base(new LogicalNameWrapperRecordType(template, inner))
+        {
+            _inner = inner;
+            _template = template;
+        }
+
+        protected override bool TryGetField(FormulaType fieldType, string fieldName, out FormulaValue result)
+        {
+            // If the lookup is by logical name, succeed. 
+            if (_inner.TryGetFieldDirect(fieldType, fieldName, out result))
+            {
+                return true;
+            }
+
+            if (DType.TryGetDisplayNameForColumn(_template._type, fieldName, out var displayName))
+            {
+                fieldName = displayName;
+            }
+
+            result = _inner.GetField(fieldName);
+            return result != null;
+        }
+
+        // Wrap the template so that we can ensure that we only return fields 
+        // that are used by _inner. 
+        internal class LogicalNameWrapperRecordType : RecordType
+        {
+            private readonly RecordValue _inner;
+
+            private readonly RecordType _template;
+
+            public LogicalNameWrapperRecordType(RecordType template, RecordValue inner)
+            {
+                _template = template;
+                _inner = inner;
+            }
+
+            public override IEnumerable<string> FieldNames
+            {
+                get
+                {
+                    // This will have display names
+                    var names = _inner.Type.FieldNames;
+
+                    var names2 = new List<string>();
+                    foreach (var name in names)
+                    {
+                        if (DType.TryGetLogicalNameForColumn(_template._type, name, out var logicalName))
+                        {
+                            names2.Add(logicalName);
+                        }
+                        else
+                        {
+                            names2.Add(name);
+                        }
+                    }
+
+                    return names2;
+                }
+            }
+
+            public override bool TryGetFieldType(string name, out FormulaType type)
+            {
+                var found = _template.TryGetFieldType(name, out type);
+                return found;
+            }
+
+            public override bool Equals(object other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int GetHashCode()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/RecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/RecordType.cs
@@ -104,22 +104,7 @@ namespace Microsoft.PowerFx.Types
         /// <returns>RecordValue containing only logical field names.</returns>
         internal RecordValue ResolveToLogicalNames(RecordValue recordToResolve)
         {
-            var list = new List<NamedValue>();
-            var rType = recordToResolve.Type;
-
-            foreach (var field in recordToResolve.Fields)
-            {
-                var name = field.Name;
-
-                if (DType.TryGetLogicalNameForColumn(_type, field.Name, out var logicalName))
-                {
-                    name = logicalName;
-                }
-
-                list.Add(new NamedValue(name, field.Value));
-            }
-
-            return FormulaValue.NewRecordFromFields(list);
+            return new LogicalNameWrapperRecordValue(this, recordToResolve);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
@@ -141,6 +141,12 @@ namespace Microsoft.PowerFx.Types
         /// <returns>true if field is present, else false.</returns>
         protected abstract bool TryGetField(FormulaType fieldType, string fieldName, out FormulaValue result);
 
+        // Allow internals to access TryGetField.
+        internal bool TryGetFieldDirect(FormulaType fieldType, string fieldName, out FormulaValue result)
+        {
+            return TryGetField(fieldType, fieldName, out result);
+        }
+
         /// <summary>
         /// Return an object, which can be used as 'dynamic' to fetch fields. 
         /// If this RecordValue was created around a host object, the host can override and return the source object.

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -125,9 +125,10 @@ namespace Microsoft.PowerFx.Types
             var recordType = Type.ToRecord();
 
             // Resolve from display names to logical names, if any.            
+            var resolvedBaseRecord = recordType.ResolveToLogicalNames(baseRecord);
             var resolvedChangeRecord = recordType.ResolveToLogicalNames(changeRecord);
 
-            return await PatchCoreAsync(baseRecord, resolvedChangeRecord);
+            return await PatchCoreAsync(resolvedBaseRecord, resolvedChangeRecord);
         }
 
         public override object ToObject()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -74,6 +74,9 @@ Errors: Error 0-15: The function 'Patch' has some invalid arguments.|Error 10-11
 
 
 // Display names
+>> Patch(t1, {DisplayNameField2:"earth"}, {Field2:"mars"});t1
+Table({Field1:1,Field2:"mars",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
 >> Patch(t1, First(t1), {DisplayNameField2:"Saturn"});First(t1)
 {Field1:1,Field2:"Saturn",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
 


### PR DESCRIPTION
Provide a lazy (efficient) impl of Recordtype.ResolveToLogicalNames that does not eagerly enumerate.