### PR TITLE
IR translator update - don't add unneeded AggregateCoercionNode

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -549,7 +549,7 @@ namespace Microsoft.PowerFx.Core.IR
                 }
             }
 
-            private AggregateCoercionNode GetAggregateCoercionNode(UnaryOpKind unaryOpKind, IntermediateNode child, IRTranslatorContext context, DType fromType, DType toType)
+            private IntermediateNode GetAggregateCoercionNode(UnaryOpKind unaryOpKind, IntermediateNode child, IRTranslatorContext context, DType fromType, DType toType)
             {
                 var fieldCoercions = new Dictionary<DName, IntermediateNode>();
                 var scope = GetNewScope();
@@ -567,18 +567,14 @@ namespace Microsoft.PowerFx.Core.IR
                             continue;
                         }
 
-                        var innerCoersion = InjectCoercion(new ScopeAccessNode(IRContext.NotInSource(FormulaType.Build(fromField.Type)), new ScopeAccessSymbol(scope, scope.AddOrGetIndexForField(fromField.Name))), context, fromField.Type, toFieldType);
-
-                        if (innerCoersion != null)
-                        {
-                            fieldCoercions.Add(fromField.Name, innerCoersion);
-                        }
+                        var innerCoersion = InjectCoercion(new ScopeAccessNode(IRContext.NotInSource(FormulaType.Build(fromField.Type)), new ScopeAccessSymbol(scope, scope.AddOrGetIndexForField(fromField.Name))), context, fromField.Type, toFieldType);                        
+                        fieldCoercions.Add(fromField.Name, innerCoersion);                        
                     }
                 }
 
                 if (!fieldCoercions.Any())
                 {
-                    return null;
+                    return child;
                 }
 
                 return new AggregateCoercionNode(IRContext.NotInSource(FormulaType.Build(toType)), unaryOpKind, scope, child, fieldCoercions);
@@ -596,7 +592,7 @@ namespace Microsoft.PowerFx.Core.IR
                 Contracts.Assert(!fromType.IsError);
                 Contracts.Assert(!toType.IsError);
 
-                return InjectCoercion(child, context, fromType, toType) ?? child;                
+                return InjectCoercion(child, context, fromType, toType);             
             }
 
             private IntermediateNode InjectCoercion(IntermediateNode child, IRTranslatorContext context, DType fromType, DType toType)

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PowerFx.Core.IR
                 var kind = BinaryOpMatrix.GetBinaryOpKind(node, context.Binding);
 
                 IntermediateNode binaryOpResult;
-                
+
                 switch (kind)
                 {
                     // Call Node Replacements:
@@ -189,7 +189,7 @@ namespace Microsoft.PowerFx.Core.IR
                         break;
 
                     case BinaryOpKind.Invalid:
-                        if (node.Op == BinaryOp.NotEqual) 
+                        if (node.Op == BinaryOp.NotEqual)
                         {
                             binaryOpResult = new BooleanLiteralNode(context.GetIRContext(node), true);
                         }
@@ -567,8 +567,8 @@ namespace Microsoft.PowerFx.Core.IR
                             continue;
                         }
 
-                        var innerCoersion = InjectCoercion(new ScopeAccessNode(IRContext.NotInSource(FormulaType.Build(fromField.Type)), new ScopeAccessSymbol(scope, scope.AddOrGetIndexForField(fromField.Name))), context, fromField.Type, toFieldType);                        
-                        fieldCoercions.Add(fromField.Name, innerCoersion);                        
+                        var innerCoersion = InjectCoercion(new ScopeAccessNode(IRContext.NotInSource(FormulaType.Build(fromField.Type)), new ScopeAccessSymbol(scope, scope.AddOrGetIndexForField(fromField.Name))), context, fromField.Type, toFieldType);
+                        fieldCoercions.Add(fromField.Name, innerCoersion);
                     }
                 }
 
@@ -592,7 +592,7 @@ namespace Microsoft.PowerFx.Core.IR
                 Contracts.Assert(!fromType.IsError);
                 Contracts.Assert(!toType.IsError);
 
-                return InjectCoercion(child, context, fromType, toType);             
+                return InjectCoercion(child, context, fromType, toType);
             }
 
             private IntermediateNode InjectCoercion(IntermediateNode child, IRTranslatorContext context, DType fromType, DType toType)

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -567,14 +567,18 @@ namespace Microsoft.PowerFx.Core.IR
                             continue;
                         }
 
-                        fieldCoercions.Add(
-                            fromField.Name,
-                            InjectCoercion(
-                                new ScopeAccessNode(IRContext.NotInSource(FormulaType.Build(fromField.Type)), new ScopeAccessSymbol(scope, scope.AddOrGetIndexForField(fromField.Name))),
-                                context,
-                                fromField.Type,
-                                toFieldType));
+                        var innerCoersion = InjectCoercion(new ScopeAccessNode(IRContext.NotInSource(FormulaType.Build(fromField.Type)), new ScopeAccessSymbol(scope, scope.AddOrGetIndexForField(fromField.Name))), context, fromField.Type, toFieldType);
+
+                        if (innerCoersion != null)
+                        {
+                            fieldCoercions.Add(fromField.Name, innerCoersion);
+                        }
                     }
+                }
+
+                if (!fieldCoercions.Any())
+                {
+                    return null;
                 }
 
                 return new AggregateCoercionNode(IRContext.NotInSource(FormulaType.Build(toType)), unaryOpKind, scope, child, fieldCoercions);
@@ -592,7 +596,7 @@ namespace Microsoft.PowerFx.Core.IR
                 Contracts.Assert(!fromType.IsError);
                 Contracts.Assert(!toType.IsError);
 
-                return InjectCoercion(child, context, fromType, toType);
+                return InjectCoercion(child, context, fromType, toType) ?? child;                
             }
 
             private IntermediateNode InjectCoercion(IntermediateNode child, IRTranslatorContext context, DType fromType, DType toType)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Linq;
+using System.Threading;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Types;
+using Xunit;
+
+namespace Microsoft.PowerFx.Interpreter.Tests
+{
+    public class IRTests
+    {
+        [Fact]
+        public void ValidateNoRecordToRecordAggregateCoercion()
+        {
+            var tableType = TableType.Empty().Add(new NamedFormulaType(new TypedName(DType.Currency, new DName("Currency"))));
+
+            var symbols = new SymbolTable();
+            symbols.EnableMutationFunctions();
+            symbols.AddVariable("MyTable", tableType);
+
+            var engine = new RecalcEngine(new PowerFxConfig());
+            var checkResult = engine.Check("Patch(MyTable, { Currency: 1.2 }, { Currency: 1.5 })", new ParserOptions() { AllowsSideEffects = true }, symbolTable: symbols);
+
+            Assert.True(checkResult.IsSuccess, string.Join("\r\n", checkResult.Errors.Select(err => $"{err.Message}")));
+
+            var runtimeConfig = new SymbolValues();
+            runtimeConfig.Add("MyTable", TableValue.NewTable(tableType.ToRecord()));
+            
+            var evalResult = checkResult.GetEvaluator().EvalAsync(CancellationToken.None, runtimeConfig).Result;
+            Assert.IsNotType<ErrorValue>(evalResult);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var engine = new RecalcEngine(new PowerFxConfig());
             var checkResult = engine.Check("Patch(MyTable, { Currency: 1.2 }, { Currency: 1.5 })", new ParserOptions() { AllowsSideEffects = true }, symbolTable: symbols);
 
-            Assert.True(checkResult.IsSuccess, string.Join("\r\n", checkResult.Errors.Select(err => $"{err.Message}")));
+            checkResult.ThrowOnErrors();
 
             var runtimeConfig = new SymbolValues();
             runtimeConfig.Add("MyTable", TableValue.NewTable(tableType.ToRecord()));

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System.Linq;
 using System.Threading;
+using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
@@ -28,9 +28,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             var runtimeConfig = new SymbolValues();
             runtimeConfig.Add("MyTable", TableValue.NewTable(tableType.ToRecord()));
-            
+
             var evalResult = checkResult.GetEvaluator().EvalAsync(CancellationToken.None, runtimeConfig).Result;
             Assert.IsNotType<ErrorValue>(evalResult);
+
+            var ir = IRTranslator.Translate(checkResult._binding).ToString();
+            Assert.DoesNotContain("AggregateCoercionNode", ir);
         }
     }
 }


### PR DESCRIPTION
EvalVisitor is not implemented on AggregateCoercionNode for records, but the coercion matrix frequently produces this node in expressions like 'Patch(MyTable, { Currency: 1.2 }, { Currency: 1.5 })' when the Currency column is a DType.Currency.

We should eventually implement RecordToRecord coercion, but as a first stop, don't emit this coercion node if there actually aren't any coercions used