### PR TITLE
Fix crash in enumbuilder.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx
     /// <summary>
     /// Composition of multiple <see cref="ReadOnlySymbolTable"/> into a single table.
     /// </summary>
-    internal class ComposedReadOnlySymbolTable : ReadOnlySymbolTable, INameResolver, IGlobalSymbolNameResolver
+    internal class ComposedReadOnlySymbolTable : ReadOnlySymbolTable, INameResolver, IGlobalSymbolNameResolver, IEnumStore
     {
         private readonly IEnumerable<ReadOnlySymbolTable> _symbolTables;
 
@@ -41,9 +41,9 @@ namespace Microsoft.PowerFx
                 }
 
                 return hash;
-            }            
+            }
         }
-                
+
         // Expose the list to aide in intellisense suggestions. 
         IEnumerable<TexlFunction> INameResolver.Functions
         {
@@ -81,6 +81,23 @@ namespace Microsoft.PowerFx
                 }
 
                 return map;
+            }
+        }
+
+        IEnumerable<EnumSymbol> IEnumStore.EnumSymbols
+        {
+            get
+            {
+                foreach (var table in _symbolTables)
+                {
+                    if (table is IEnumStore store)
+                    {
+                        foreach (var item in store.EnumSymbols)
+                        {
+                            yield return item;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -28,8 +28,11 @@ namespace Microsoft.PowerFx
         {
             DebugName = "DefaultConfig"
         };
-                
+
+        [Obsolete("Use Config.EnumStore or symboltable directly")]
         internal EnumStoreBuilder EnumStoreBuilder => SymbolTable.EnumStoreBuilder;
+
+        internal IEnumStore EnumStore => ReadOnlySymbolTable.Compose(SymbolTable);
 
         public CultureInfo CultureInfo { get; }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx
     /// </summary>
     [DebuggerDisplay("{_debugName}")]
     [ThreadSafeImmutable]
-    public class ReadOnlySymbolTable : INameResolver, IGlobalSymbolNameResolver
+    public class ReadOnlySymbolTable : INameResolver, IGlobalSymbolNameResolver, IEnumStore
     {
         // Changed on each update. 
         // Host can use to ensure that a symbol table wasn't mutated on us.                 
@@ -103,6 +103,7 @@ namespace Microsoft.PowerFx
 
         // Which enums are available. 
         // These do not compose - only bottom one wins. 
+        // ComposedReadOnlySymbolTable will handle composition by looking up in each symbol table. 
         private protected EnumStoreBuilder _enumStoreBuilder;
         private EnumSymbol[] _enumSymbolCache;
 
@@ -125,6 +126,8 @@ namespace Microsoft.PowerFx
                 return _enumSymbolCache;
             }
         }
+
+        IEnumerable<EnumSymbol> IEnumStore.EnumSymbols => GetEnumSymbolSnapshot;
 
         internal IEnumerable<TexlFunction> Functions => ((INameResolver)this).Functions;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx
 
     /// <summary>
     /// Provides symbols to the engine. This includes variables (locals, globals), enums, options sets, and functions.
-    /// SymbolTables are mutable to support sessionful scenarios and can abe chained together. 
+    /// SymbolTables are mutable to support sessionful scenarios and can be chained together. 
     /// This is a publicly facing class around a <see cref="INameResolver"/>.
     /// </summary>
     [DebuggerDisplay("{DebugName}")]

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerFx.Intellisense
 
         internal static IIntellisense GetIntellisense(PowerFxConfig config)
         {
-            return new Intellisense(config, config.EnumStoreBuilder.Build(), SuggestionHandlers);
+            return new Intellisense(config, config.EnumStore, SuggestionHandlers);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -181,7 +181,13 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             //   https://github.com/nunit/nunit3-vs-adapter/issues/691
 
             Preview.FeatureFlags.StringInterpolation = true;
-            var actualSuggestions = SuggestStrings(expression, Default);
+            var config = Default;
+            var actualSuggestions = SuggestStrings(expression, config);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
+
+            // With adjusted config 
+            AdjustConfig(config);
+            actualSuggestions = SuggestStrings(expression, config);
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }
 
@@ -199,7 +205,13 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         public void TestSuggestEmptyEnumList(string expression, params string[] expectedSuggestions)
         {
             Preview.FeatureFlags.StringInterpolation = true;
-            var actualSuggestions = SuggestStrings(expression, EmptyEverything);
+            var config = EmptyEverything;
+            var actualSuggestions = SuggestStrings(expression, config);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
+
+            // With adjusted config 
+            AdjustConfig(config);
+            actualSuggestions = SuggestStrings(expression, config);
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }
 
@@ -212,8 +224,24 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         public void TestSuggestEmptyAll(string expression, params string[] expectedSuggestions)
         {
             Preview.FeatureFlags.StringInterpolation = true;
-            var actualSuggestions = SuggestStrings(expression, MinimalEnums);
+            var config = MinimalEnums;
+            var actualSuggestions = SuggestStrings(expression, config);
             Assert.Equal(expectedSuggestions, actualSuggestions);
+
+            // With adjusted config 
+            AdjustConfig(config);
+            actualSuggestions = SuggestStrings(expression, config);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
+        }
+
+        // Add an extra (empy) symbol table into the config and ensure we get the same results. 
+        private void AdjustConfig(PowerFxConfig config)
+        {
+            config.SymbolTable = new SymbolTable 
+            {
+                Parent = config.SymbolTable,
+                DebugName = "Extra Table"
+            };
         }
 
         /// <summary>
@@ -239,7 +267,13 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("[@|")]
         public void TestNonEmptySuggest(string expression, string context = null)
         {
+            var config = Default;
             var actualSuggestions = SuggestStrings(expression, Default, context);
+            Assert.True(actualSuggestions.Length > 0);
+
+            // With adjusted config 
+            AdjustConfig(config);
+            actualSuggestions = SuggestStrings(expression, config);
             Assert.True(actualSuggestions.Length > 0);
         }
 
@@ -257,7 +291,13 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         {
             Assert.NotNull(context);
 
-            var actualSuggestions = SuggestStrings(expression, Default, context);
+            var config = Default;
+            var actualSuggestions = SuggestStrings(expression, config, context);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
+
+            // With adjusted config 
+            AdjustConfig(config);
+            actualSuggestions = SuggestStrings(expression, config, context);
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }
         
@@ -281,6 +321,11 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             
             // Intellisense requires iterating the field names for some operations
             Assert.Equal(requiresExpansion, lazyInstance.EnumerableIterated);
+
+            // With adjusted config 
+            AdjustConfig(config);
+            actualSuggestions = SuggestStrings(expression, config, lazyInstance);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
         }
 
         private class LazyRecursiveRecordType : RecordType


### PR DESCRIPTION
If the config has a chained symbol table:

  powerFxConfig.SymbolTable = new SymbolTable() { Parent = dataverseConnection.Symbols };

Then expressions like this get a null ref:
(IEnumStore) config.EnumStoreBuilder.Build(),

because config.EnumStoreBuilder is just config.SymbolTable.EnumStoreBuilder, which is null.

It's not enough to just initialize SymbolTable.EnumStoreBuilder to non-null, we need to ensure the symbols are actually composing.

This runs all Suggest tests in both configurations.

Marking config.EnumStoreBuilder as obsolete.
PowerApps doesn't call config.EnumStoreBuilder.
Dataverse does, but those call should config.EnumStore instead.

This was related to #503. 
