### PR TITLE
Fix error message when record to record coercion might be needed

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -481,36 +481,7 @@ namespace Microsoft.PowerFx
                 }
 
                 return new InMemoryTableValue(node.IRContext, resultRows);
-            }
-
-            if (node.Op == UnaryOpKind.RecordToRecord)
-            {
-                if (arg1 is RecordValue record)
-                {
-                    var fields = new List<NamedValue>();
-                    var scopeContext = context.SymbolContext.WithScope(node.Scope);
-                    foreach (var coercion in node.FieldCoercions)
-                    {
-                        CheckCancel();
-                        var newScope = scopeContext.WithScopeValues(record);
-                        var newValue = await coercion.Value.Accept(this, context.NewScope(newScope));
-
-                        if (newValue is ErrorValue)
-                        {
-                            return newValue;
-                        }
-
-                        var name = coercion.Key;
-                        fields.Add(new NamedValue(name.Value, newValue));
-                    }
-
-                    return new InMemoryRecordValue(node.IRContext, fields);
-                }
-                else if (arg1 is BlankValue bv)
-                {
-                    return new InMemoryRecordValue(node.IRContext, Enumerable.Empty<NamedValue>());
-                }
-            }
+            }            
 
             return CommonErrors.UnreachableCodeError(node.IRContext);
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -228,16 +228,16 @@ namespace Microsoft.PowerFx.Functions
                         continue;
                     }
 
-                    if (!dsNameType.Accepts(type, out var schemaDifference, out var schemaDifferenceType) &&
+                    if (!type.Accepts(dsNameType, out var schemaDifference, out var schemaDifferenceType) &&
                         (!SupportsParamCoercion || !type.CoercesTo(dsNameType, out var coercionIsSafe, aggregateCoercion: false) || !coercionIsSafe))
                     {
-                        if (dsNameType.Kind != type.Kind)
-                        //{
-                        //    errors.Errors(args[i], type, schemaDifference, schemaDifferenceType);
-                        //}
-                        //else
+                        if (dsNameType.Kind == type.Kind)
                         {
-                            errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrTypeError_Arg_Expected_Found, name, dsNameType.GetKindString(), type.GetKindString());
+                            errors.Errors(args[i], type, schemaDifference, schemaDifferenceType);
+                        }
+                        else
+                        {
+                            errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrTypeError_Arg_Expected_Found, name, dsNameType.GetKindString(), type.GetKindString());                            
                         }
 
                         isValid = isSafeToUnion = false;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
@@ -13,10 +11,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Functions.DLP;
-using Microsoft.PowerFx.Core.Functions.FunctionArgValidators;
-using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Localization;
-using Microsoft.PowerFx.Core.Texl.Builtins;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
@@ -201,6 +196,11 @@ namespace Microsoft.PowerFx.Functions
             DType dataSourceType = argTypes[0];
             DType retType = DType.EmptyRecord;
 
+            foreach (var assocDS in dataSourceType.AssociatedDataSources)
+            {
+                retType = DType.AttachDataSourceInfo(retType, assocDS);
+            }
+
             for (var i = 1; i < args.Length; i++)
             {
                 DType curType = argTypes[i];
@@ -218,11 +218,29 @@ namespace Microsoft.PowerFx.Functions
 
                 foreach (var typedName in curType.GetNames(DPath.Root))
                 {
-                    if (!tableType.HasField(typedName.Name))
+                    DName name = typedName.Name;
+                    DType type = typedName.Type;
+
+                    if (!dataSourceType.TryGetType(name, out DType dsNameType))
                     {
                         dataSourceType.ReportNonExistingName(FieldNameKind.Display, errors, typedName.Name, args[i]);
                         isValid = isSafeToUnion = false;
                         continue;
+                    }
+
+                    if (!dsNameType.Accepts(type, out var schemaDifference, out var schemaDifferenceType) &&
+                        (!SupportsParamCoercion || !type.CoercesTo(dsNameType, out var coercionIsSafe, aggregateCoercion: false) || !coercionIsSafe))
+                    {
+                        if (dsNameType.Kind != type.Kind)
+                        //{
+                        //    errors.Errors(args[i], type, schemaDifference, schemaDifferenceType);
+                        //}
+                        //else
+                        {
+                            errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrTypeError_Arg_Expected_Found, name, dsNameType.GetKindString(), type.GetKindString());
+                        }
+
+                        isValid = isSafeToUnion = false;
                     }
                 }
 
@@ -248,6 +266,7 @@ namespace Microsoft.PowerFx.Functions
                 }
             }
 
+            returnType = retType;
             return isValid;
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -125,3 +125,7 @@ Blank()
 
 >> Patch(t1, {DisplayNameField1:1/0}, {DisplayNameField2:"mars"})
 Blank()
+
+// Record to Record coercion
+>> Patch(t1, First(Filter(t1, Field2="earth")), {Field3: "2022-11-14 7:22:06 pm"})
+{Field1:1,Field2:"earth",Field3:DateTime(2022,11,14,19,22,6,0),Field4:true}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -76,8 +76,12 @@ Table({Field1:10,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 >> Patch(t1, 0, 0)
 Errors: Error 0-15: The function 'Patch' has some invalid arguments.|Error 10-11: Invalid argument type (Number). Expecting a Record value instead.|Error 13-14: Invalid argument type (Number). Expecting a Record value instead.|Error 10-11: Cannot use a non-record value in this context.|Error 13-14: Cannot use a non-record value in this context.
 
->> Patch(Table({field1:2,field2:{field21:"earth",field22:"venus"}},{field1:3,field2:{field21:"moon",field22:"phobos"}}),{field2:{field21:"moon"}},{field1:7})
-{field1:7,field2:{field21:"moon",field22:"phobos"}}
+// field22 is missing and this is Ok
+>> Patch(Table({field1:2, field2:{field21:"earth",field22:"venus"}},
+               {field1:3, field2:{field21:"moon",field22:"phobos"}}),
+   {field2:{field21:"moon"}},
+   {field1:7})
+{field1:7, field2:{field21:"moon",field22:"phobos"}}
 
 >> Patch(Table(
   {Planet:"earth",Properties:{Color:"blue",Size:"small",Weight:1000,Moon:{Name:"Moon", Color:"Silver"}}},
@@ -115,7 +119,6 @@ Errors: Error 0-51: The function 'Patch' has some invalid arguments.|Error 21-50
 "mars"
 
 
-
 // Base record not found
 >> Patch(t1, {Field1:55}, {DisplayNameField2:"mars"})
 Blank()
@@ -126,6 +129,7 @@ Blank()
 >> Patch(t1, {DisplayNameField1:1/0}, {DisplayNameField2:"mars"})
 Blank()
 
+
 // Record to Record coercion
 >> Patch(t1, First(Filter(t1, Field2="earth")), {Field3: "2022-11-14 7:22:06 pm"})
-{Field1:1,Field2:"earth",Field3:DateTime(2022,11,14,19,22,6,0),Field4:true}
+Errors: Error 0-79: The function 'Patch' has some invalid arguments.|Error 45-78: The type of this argument 'Field3' does not match the expected type 'DateTime'. Found type 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -20,102 +20,124 @@
 >> Patch(r1, r2)
 {Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
 
->> Patch(t1, r1, r_empty);t1
+>> Patch(t1, r1, r_empty);
+   t1
 Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
->> Patch(t1, r1, {Field2:"mars"});t1
+>> Patch(t1, r1, {Field2:"mars"});
+   t1
 Table({Field1:1,Field2:"mars",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
 >> Patch(t1, r1, {Field2:"mars"})
 {Field1:1,Field2:"mars",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
 
->> Patch(t1, r1, {Field2:"mars"}, Blank());t1
+>> Patch(t1, r1, {Field2:"mars"}, Blank());
+   t1
 Table({Field1:1,Field2:"mars",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
->> Patch(t1, r1, {Field3:DateTime(2022,12,12,0,0,0,0)}, {Field4:false});t1
+>> Patch(t1, r1, {Field3:DateTime(2022,12,12,0,0,0,0)}, {Field4:false});
+   t1
 Table({Field1:1,Field2:"earth",Field3:DateTime(2022,12,12,0,0,0,0),Field4:false})
 
 >> Patch(t1, r1, {Field3:DateTime(2022,12,12,0,0,0,0)}, {Field4:false})
 {Field1:1,Field2:"earth",Field3:DateTime(2022,12,12,0,0,0,0),Field4:false}
 
->> Patch(t1, r1, r2);t1
+>> Patch(t1, r1, r2);
+   t1
 Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
 
 >> Patch(t1, r1, r2)
 {Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
 
->> Patch(t1, r1, {Field5:"Field5"}); t1
+>> Patch(t1, r1, {Field5:"Field5"});
+   t1
 Errors: Error 0-32: The function 'Patch' has some invalid arguments.|Error 14-31: The specified column 'Field5' does not exist.
 
 // This test would fail in PA.
 >> Patch(Table(r1, r2), r1, {Field2:"Venus"})
 {Field1:1,Field2:"Venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
 
->> Patch(t1, r1, {Field1:1/0});t1
+>> Patch(t1, r1, {Field1:1/0});
+   t1
 Table({Field1:Microsoft.PowerFx.Types.ErrorValue,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
 >> Patch(t1, Blank(), {Field1:10})
 Blank()
 
->> Patch(t1, r1, {Field1:1/0}, {Field1:10});t1
+>> Patch(t1, r1, {Field1:1/0}, {Field1:10});
+   t1
 Table({Field1:10,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
 >> Collect(t1,{Field1:3,Field2:"phobos",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
-  Collect(t1,{Field1:2,Field2:"deimos",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
-  Patch(t1,{Field2:"deimos"},{Field3:DateTime(2030,2,1,0,0,0,0)})
+   Collect(t1,{Field1:2,Field2:"deimos",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false});
+   Patch(t1,{Field2:"deimos"},{Field3:DateTime(2030,2,1,0,0,0,0)})
 {Field1:2,Field2:"deimos",Field3:DateTime(2030,2,1,0,0,0,0),Field4:false}
 
 >> Collect(t1,{Field1:3,Field2:"phobos",Field3:DateTime(2024,2,1,0,0,0,0),Field4:false});
-  Collect(t1,{Field1:2,Field2:"deimos",Field3:DateTime(2025,2,1,0,0,0,0),Field4:false});
-  Patch(t1,{Field3:DateTime(2025,2,1,0,0,0,0)},{Field2:"pandora", Field1:55})
+   Collect(t1,{Field1:2,Field2:"deimos",Field3:DateTime(2025,2,1,0,0,0,0),Field4:false});
+   Patch(t1,{Field3:DateTime(2025,2,1,0,0,0,0)},{Field2:"pandora", Field1:55})
 {Field1:55,Field2:"pandora",Field3:DateTime(2025,2,1,0,0,0,0),Field4:false}
 
->> Collect(t1, r2);Patch(t1, {Field4:true}, {Field2:"phobos"});First(t1).DisplayNameField2
+>> Collect(t1, r2);
+   Patch(t1, {Field4:true}, {Field2:"phobos"});
+   First(t1).DisplayNameField2
 "phobos"
 
 >> Patch(t1, 0, 0)
 Errors: Error 0-15: The function 'Patch' has some invalid arguments.|Error 10-11: Invalid argument type (Number). Expecting a Record value instead.|Error 13-14: Invalid argument type (Number). Expecting a Record value instead.|Error 10-11: Cannot use a non-record value in this context.|Error 13-14: Cannot use a non-record value in this context.
 
 // field22 is missing and this is Ok
->> Patch(Table({field1:2, field2:{field21:"earth",field22:"venus"}},
-               {field1:3, field2:{field21:"moon",field22:"phobos"}}),
-   {field2:{field21:"moon"}},
-   {field1:7})
-{field1:7, field2:{field21:"moon",field22:"phobos"}}
+>> Patch(
+     Table(
+       {field1:2, field2:{field21:"earth",field22:"venus"}},
+       {field1:3, field2:{field21:"moon",field22:"phobos"}}),
+     {field2:{field21:"moon"}},
+     {field1:7})
+{field1:7,field2:{field21:"moon",field22:"phobos"}}
 
->> Patch(Table(
-  {Planet:"earth",Properties:{Color:"blue",Size:"small",Weight:1000,Moon:{Name:"Moon", Color:"Silver"}}},
-  {Planet:"Saturn",Properties:{Color:"red-brown",Size:"huge",Weight:99999,Moon:{Name:"Phobos", Color:"yellow"}}}),
-  {Properties:{Moon:{Name:"Phobos"}}},
-  {Planet:"Jupter"})
+>> Patch(
+     Table(
+       {Planet:"earth",Properties:{Color:"blue",Size:"small",Weight:1000,Moon:{Name:"Moon", Color:"Silver"}}},
+       {Planet:"Saturn",Properties:{Color:"red-brown",Size:"huge",Weight:99999,Moon:{Name:"Phobos", Color:"yellow"}}}),
+    {Properties:{Moon:{Name:"Phobos"}}},
+    {Planet:"Jupter"})
 {Planet:"Jupter",Properties:{Color:"red-brown",Moon:{Color:"yellow",Name:"Phobos"},Size:"huge",Weight:99999}}
 
 // Display names
->> Patch(t1, {DisplayNameField2:"earth"}, {Field2:"mars"});t1
+>> Patch(t1, {DisplayNameField2:"earth"}, {Field2:"mars"});
+   t1
 Table({Field1:1,Field2:"mars",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
->> Patch(t1, First(t1), {DisplayNameField2:"Saturn"});First(t1)
+>> Patch(t1, First(t1), {DisplayNameField2:"Saturn"});
+   First(t1)
 {Field1:1,Field2:"Saturn",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
 
->> Patch(t1, r1, {DisplayNameField1:123,DisplayNameField2:"sun",DisplayNameField3:DateTime(2022,12,12,0,0,0,0),DisplayNameField4:false});First(t1)
+>> Patch(t1, r1, {DisplayNameField1:123,DisplayNameField2:"sun",DisplayNameField3:DateTime(2022,12,12,0,0,0,0),DisplayNameField4:false});
+   First(t1)
 {Field1:123,Field2:"sun",Field3:DateTime(2022,12,12,0,0,0,0),Field4:false}
 
->> Patch(t1, First(t1), {DisplayNameField1:1/0});t1
+>> Patch(t1, First(t1), {DisplayNameField1:1/0});
+   t1
 Table({Field1:Microsoft.PowerFx.Types.ErrorValue,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
->> Patch(t1, First(t1), {DisplayNameField1:1/0}, {DisplayNameField1:Blank()}, {DisplayNameField1:0});t1
+>> Patch(t1, First(t1), {DisplayNameField1:1/0}, {DisplayNameField1:Blank()}, {DisplayNameField1:0});
+   t1
 Table({Field1:0,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
->> Patch(t1, First(t1), {DisplayNameField2:"jupter"});First(t1).DisplayNameField2
+>> Patch(t1, First(t1), {DisplayNameField2:"jupter"});
+   First(t1).DisplayNameField2
 "jupter"
 
->> Patch(t1, First(t1), {DisplayNameField2:"jupter"});First(t1).Field2
+>> Patch(t1, First(t1), {DisplayNameField2:"jupter"});
+   First(t1).Field2
 "jupter"
 
->> Patch(t1, First(t1), {DisplayNameField5:"Pandora"});First(t1)
+>> Patch(t1, First(t1), {DisplayNameField5:"Pandora"});
+   First(t1)
 Errors: Error 0-51: The function 'Patch' has some invalid arguments.|Error 21-50: The specified column 'DisplayNameField5' does not exist. The column with the most similar name is 'DisplayNameField1'.
 
->> Patch(t1, {Field1:1}, {DisplayNameField2:"mars"});First(t1).Field2
+>> Patch(t1, {Field1:1}, {DisplayNameField2:"mars"});
+   First(t1).Field2
 "mars"
 
 
@@ -130,6 +152,6 @@ Blank()
 Blank()
 
 
-// Record to Record coercion
+// Record to Record coercion not allowed
 >> Patch(t1, First(Filter(t1, Field2="earth")), {Field3: "2022-11-14 7:22:06 pm"})
 Errors: Error 0-79: The function 'Patch' has some invalid arguments.|Error 45-78: The type of this argument 'Field3' does not match the expected type 'DateTime'. Found type 'Text'.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DatabaseSimulationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DatabaseSimulationTests.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.Entities.Delegation;
+using Microsoft.PowerFx.Core.Entities.QueryOptions;
+using Microsoft.PowerFx.Core.Functions.Delegation;
+using Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata;
+using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.UtilityDataStructures;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Types;
+using Xunit;
+
+namespace Microsoft.PowerFx.Interpreter.Tests
+{
+    public class DatabaseSimulationTests
+    {
+        [Fact]
+        public void DatabaseSimulation_Test()
+        {
+            // var expr = "Patch(Table, First(Filter(Table, MyStr=\"Str3\")), {MyDate: \"2022-11-14 7:22:06 pm\"})";
+            var expr = "Patch(Table, First(Filter(Table, MyStr=\"Str3\")), {MyDate: DateTimeValue(\"2022-11-14 7:22:06 pm\") })";
+
+            var databaseTable = DatabaseTable.CreateTestTable();
+            var symbols = new SymbolTable();
+
+            symbols.AddVariable("Table", DatabaseTable.TestTableType);
+            symbols.EnableMutationFunctions();
+
+            var engine = new RecalcEngine();
+            var runtimeConfig = ReadOnlySymbolValues.New(new Dictionary<string, DatabaseTable>() { { "Table", databaseTable } });
+
+            CheckResult check = engine.Check(expr, symbolTable: symbols, options: new ParserOptions() { AllowsSideEffects = true });
+            Assert.True(check.IsSuccess, string.Join("\r\n", check.Errors.Select(ee => ee.Message)));
+
+            IExpressionEvaluator run = check.GetEvaluator();
+            FormulaValue result = run.EvalAsync(CancellationToken.None, runtimeConfig).Result;
+        }
+
+        internal class DatabaseTable : InMemoryTableValue
+        {
+            internal static TableType TestTableType => DatabaseRecord.TestRecordType.ToTable();
+
+            internal static DatabaseTable CreateTestTable() =>
+                new(
+                    IRContext.NotInSource(TestTableType),
+                    new List<DValue<RecordValue>>()
+                    {
+                        DValue<RecordValue>.Of(DatabaseRecord.CreateTestRecord("Str1", new DateTime(2022, 1, 1, 17, 33, 17), 3.14159265358979)),
+                        DValue<RecordValue>.Of(DatabaseRecord.CreateTestRecord("Str2", new DateTime(2001, 7, 11, 8, 17, 52), 2.71828182845904)),
+                        DValue<RecordValue>.Of(DatabaseRecord.CreateTestRecord("Str3", new DateTime(2019, 6, 28, 0, 45, 15), 1.41421356237309)),
+                        DValue<RecordValue>.Of(DatabaseRecord.CreateTestRecord("Str4", new DateTime(2010, 4, 24, 16, 15, 0), 1.61803398874989)),
+                        DValue<RecordValue>.Of(DatabaseRecord.CreateTestRecord("Str5", new DateTime(1954, 12, 4, 21, 5, 10), 2.15443469003188))
+                    });
+
+            internal DatabaseTable(IRContext irContext, IEnumerable<DValue<RecordValue>> records)
+                : base(irContext, records)
+            {
+            }
+        }
+
+        internal class DatabaseRecord : InMemoryRecordValue
+        {
+            internal static FormulaType TestEntityType => new TestEntityType();
+
+            internal static RecordType TestRecordType => RecordType.Empty()
+                .Add("logicStr", FormulaType.String, "MyStr")
+                .Add("logicDate", FormulaType.Date, "MyDate")
+                .Add("logicNum", FormulaType.Number, "MyNum")
+                .Add("logicEnt", TestEntityType, "MyEntity");
+
+            internal static DatabaseRecord CreateTestRecord(string myStr, DateTime myDate, double myNum) =>
+                new(
+                    IRContext.NotInSource(TestRecordType),
+                    new List<NamedValue>()
+                    {
+                        new NamedValue("MyStr", New(myStr)),
+                        new NamedValue("MyDate", New(myDate)),
+                        new NamedValue("MyNum", New(myNum)),
+                        new NamedValue("MyEntity", new TestEntityValue(IRContext.NotInSource(TestEntityType)))
+                    });
+
+            internal DatabaseRecord(IRContext irContext, IEnumerable<NamedValue> fields)
+                : base(irContext, fields)
+            {
+            }
+
+            internal DatabaseRecord(IRContext irContext, IReadOnlyDictionary<string, FormulaValue> fields)
+                : base(irContext, fields)
+            {
+            }
+
+            protected override bool TryGetField(FormulaType fieldType, string fieldName, out FormulaValue result)
+            {
+                if (Environment.StackTrace.Contains("Microsoft.PowerFx.SymbolContext.GetScopeVar"))
+                {
+                    return base.TryGetField(fieldType, fieldName, out result);
+                }
+
+                throw new NotImplementedException("Cannot call TryGetField");
+            }
+        }
+
+        internal class TestEntityType : FormulaType
+        {
+            internal TestEntityType()
+                : base(DType.CreateExpandType(new TestExpandInfo()))
+            {
+            }
+
+            public override void Visit(ITypeVisitor vistor)
+            {
+                throw new NotImplementedException("TestEntityType.Visit");
+            }
+        }
+
+        internal class TestEntityValue : ValidFormulaValue
+        {
+            public TestEntityValue(IRContext irContext) 
+                : base(irContext)
+            {
+            }
+
+            public override object ToObject()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(IValueVisitor visitor)
+            {
+                throw new NotImplementedException("TestEntityValue.Visit");
+            }
+        }
+
+        internal class ExternalDataEntityMetadataProvider : IExternalDataEntityMetadataProvider
+        {
+            public bool TryGetEntityMetadata(string expandInfoIdentity, out IDataEntityMetadata entityMetadata)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        internal class TestDelegationMetadata : IDelegationMetadata
+        {
+            public DType Schema => new TestEntityType()._type;
+
+            public DelegationCapability TableAttributes => throw new NotImplementedException();
+
+            public DelegationCapability TableCapabilities => throw new NotImplementedException();
+
+            public Core.Functions.Delegation.DelegationMetadata.SortOpMetadata SortDelegationMetadata => throw new NotImplementedException();
+
+            public Core.Functions.Delegation.DelegationMetadata.FilterOpMetadata FilterDelegationMetadata => throw new NotImplementedException();
+
+            public Core.Functions.Delegation.DelegationMetadata.GroupOpMetadata GroupDelegationMetadata => throw new NotImplementedException();
+
+            public Dictionary<DPath, DPath> ODataPathReplacementMap => throw new NotImplementedException();
+        }
+
+        internal class DataEntityMetadata : IDataEntityMetadata
+        {
+            public string EntityName => throw new NotImplementedException();
+
+            public DType Schema => throw new NotImplementedException();
+
+            public BidirectionalDictionary<string, string> DisplayNameMapping => throw new NotImplementedException();
+
+            public BidirectionalDictionary<string, string> PreviousDisplayNameMapping => throw new NotImplementedException();
+
+            public bool IsConvertingDisplayNameMapping { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public IDelegationMetadata DelegationMetadata => new TestDelegationMetadata();
+
+            public IExternalTableDefinition EntityDefinition => throw new NotImplementedException();
+
+            public string DatasetName => throw new NotImplementedException();
+
+            public bool IsValid => throw new NotImplementedException();
+
+            public string OriginalDataDescriptionJson => throw new NotImplementedException();
+
+            public string InternalRepresentationJson => throw new NotImplementedException();
+
+            public void ActualizeTemplate(string datasetName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ActualizeTemplate(string datasetName, string entityName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void LoadClientSemantics(bool isPrimaryTable = false)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SetClientSemantics(IExternalTableDefinition tableDefinition)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string ToJsonDefinition()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        internal class TestDataSource : IExternalDataSource, IExternalTabularDataSource
+        {
+            internal IExternalDataEntityMetadataProvider ExternalDataEntityMetadataProvider;
+
+            internal TestDataSource()
+            {
+                ExternalDataEntityMetadataProvider = new ExternalDataEntityMetadataProvider();
+            }
+
+            public string Name => throw new NotImplementedException();
+
+            public bool IsSelectable => throw new NotImplementedException();
+
+            public bool IsDelegatable => throw new NotImplementedException();
+
+            public bool RequiresAsync => throw new NotImplementedException();
+
+            public IExternalDataEntityMetadataProvider DataEntityMetadataProvider => ExternalDataEntityMetadataProvider;
+
+            public DataSourceKind Kind => throw new NotImplementedException();
+
+            public IExternalTableMetadata TableMetadata => throw new NotImplementedException();
+
+            public DelegationMetadata DelegationMetadata => throw new NotImplementedException();
+
+            public DName EntityName => throw new NotImplementedException();
+
+            public DType Type => throw new NotImplementedException();
+
+            public bool IsPageable => throw new NotImplementedException();
+
+            public TabularDataQueryOptions QueryOptions => throw new NotImplementedException();
+
+            public bool IsConvertingDisplayNameMapping => throw new NotImplementedException();
+
+            public BidirectionalDictionary<string, string> DisplayNameMapping => throw new NotImplementedException();
+
+            public BidirectionalDictionary<string, string> PreviousDisplayNameMapping => throw new NotImplementedException();
+
+            IDelegationMetadata IExternalDataSource.DelegationMetadata => throw new NotImplementedException();
+
+            public bool CanIncludeExpand(IExpandInfo expandToAdd)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool CanIncludeExpand(IExpandInfo parentExpandInfo, IExpandInfo expandToAdd)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool CanIncludeSelect(string selectColumnName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool CanIncludeSelect(IExpandInfo expandInfo, string selectColumnName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadOnlyList<string> GetKeyColumns()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<string> GetKeyColumns(IExpandInfo expandInfo)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        internal class TestExpandInfo : IExpandInfo
+        {
+            internal TestDataSource DataSource;
+
+            internal  TestExpandInfo()
+            {
+                DataSource = new TestDataSource();
+            }
+
+            public string Identity => "Some Identity";
+
+            public bool IsTable => true;
+
+            public string Name => throw new NotImplementedException();
+
+            public string PolymorphicParent => throw new NotImplementedException();
+
+            public IExternalDataSource ParentDataSource => DataSource;
+
+            public ExpandPath ExpandPath => throw new NotImplementedException();
+
+            public IExpandInfo Clone()
+            {
+                return new TestExpandInfo();
+            }
+
+            public string ToDebugString()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UpdateEntityInfo(IExternalDataSource dataSource, string relatedEntityPath)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Such expression requires record to record coercion which wasn't implemented
Patch(Table2, Lookup(Table2, Table2=GUID("802dcedc-492f-ed11-9db2-0022482aea8f")), {MyDate:  "2022-9-14 7:11:04 pm" })

Before this fix, the error message we were returning was "unknown error", now, it will provide a clear error message, asking for MyDate to be a DateTime and not a string.