### PR TITLE
Added GetTableNodes() to binder

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -1874,6 +1874,17 @@ namespace Microsoft.PowerFx.Core.Binding
             }
         }
 
+        public IEnumerable<TableNode> GetTableNodes()
+        {
+            for (var id = 0; id < IdLim; id++)
+            {
+                if (_nodeMap[id] is TableNode tableNode)
+                {
+                    yield return tableNode;
+                }
+            }
+        }
+
         public bool TryGetCall(int nodeId, out CallInfo callInfo)
         {
             Contracts.AssertIndex(nodeId, IdLim);


### PR DESCRIPTION
As a part of the feature I am working on , I need to modify the script as below for all the tables, for that I will need all the table nodes.
`[{a: 1}, {a: 2}] -> [{value: {a:1}}, {value: {a:2}}]`