### PR TITLE
Initial work on UntypedObject ForAll

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4215,6 +4215,13 @@ namespace Microsoft.PowerFx.Core.Binding
                             var nodeInp = node.Args.Children[0];
                             nodeInp.Accept(this);
 
+                            // At this point we know the type of the first argument, so we can check for untyped objects
+                            if (overloadWithUntypedObjectLambda != null && _txb.GetType(nodeInp) == DType.UntypedObject)
+                            {
+                                maybeFunc = overloadWithUntypedObjectLambda;
+                                scopeInfo = maybeFunc.ScopeInfo;
+                            }
+
                             // Determine the Scope Identifier using the 1st arg
                             required = _txb.GetScopeIdent(nodeInp, _txb.GetType(nodeInp), out scopeIdentifier);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4163,7 +4163,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     Contracts.Assert(overloadsWithUntypedObjectLambdas.Count() == 1, "Incorrect multiple overloads with both UntypedObject and lambdas.");
                     overloadWithUntypedObjectLambda = overloadsWithUntypedObjectLambdas.Single();
-                    Contracts.Assert(overloadWithUntypedObjectLambda.HasLambdas);
 
                     // As an extraordinarily special case, we ignore untype object lambdas for now, and type check as normal
                     // using the function without untyped object params. This only works if both functions have exactly

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4157,7 +4157,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 var numOverloads = overloads.Count();
 
-                var overloadsWithUntypedObjectLambdas = overloadsWithLambdas.Where(func => func.ParamTypes[0] == DType.UntypedObject);
+                var overloadsWithUntypedObjectLambdas = overloadsWithLambdas.Where(func => func.ParamTypes.Any() && func.ParamTypes[0] == DType.UntypedObject);
                 TexlFunction overloadWithUntypedObjectLambda = null;
                 if (overloadsWithUntypedObjectLambdas.Any())
                 {
@@ -4169,7 +4169,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // using the function without untyped object params. This only works if both functions have exactly
                     // the same arity (this is enforced below). We can't simply check the type of the first argument
                     // because the argument list might be empty. Arity checks below require that we already picked an override.
-                    overloadsWithLambdas = overloadsWithLambdas.Where(func => func.ParamTypes[0] != DType.UntypedObject);
+                    overloadsWithLambdas = overloadsWithLambdas.Where(func => func.ParamTypes.Any() && func.ParamTypes[0] != DType.UntypedObject);
                     numOverloads -= 1;
                 }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4215,7 +4215,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             // Determine the Scope Identifier using the 1st arg
                             required = _txb.GetScopeIdent(nodeInp, _txb.GetType(nodeInp), out scopeIdentifier);
 
-                            if (scopeInfo.CheckInput(nodeInp, scopeInfo.ScopeType, out scope))
+                            if (scopeInfo.CheckInput(nodeInp, _txb.GetType(nodeInp), out scope))
                             {
                                 if (_txb.TryGetEntityInfo(nodeInp, out expandInfo))
                                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -122,9 +122,7 @@ namespace Microsoft.PowerFx.Core.Functions
             }
             else if (_function.ParamTypes[0].IsUntypedObject)
             {
-                var fError = false;
                 typeScope = DType.UntypedObject;
-                fArgsValid &= !fError;
             }
             else
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerFx.Core.Functions
             else if (_function.ParamTypes[0].IsUntypedObject)
             {
                 var fError = false;
-                typeScope = DType.UntypedObject;
+                typeScope = DType.CreateRecord(new TypedName(DType.UntypedObject, BuiltinFunction.ColumnName_Value));
                 fArgsValid &= !fError;
             }
             else

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerFx.Core.Functions
             else if (_function.ParamTypes[0].IsUntypedObject)
             {
                 var fError = false;
-                typeScope = DType.CreateRecord(new TypedName(DType.UntypedObject, BuiltinFunction.ColumnName_Value));
+                typeScope = DType.UntypedObject;
                 fArgsValid &= !fError;
             }
             else

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -120,6 +120,12 @@ namespace Microsoft.PowerFx.Core.Functions
                 typeScope = typeScope.ToRecord(ref fError);
                 fArgsValid &= !fError;
             }
+            else if (_function.ParamTypes[0].IsUntypedObject)
+            {
+                var fError = false;
+                typeScope = DType.UntypedObject;
+                fArgsValid &= !fError;
+            }
             else
             {
                 Contracts.Assert(_function.ParamTypes[0].IsRecord);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -75,8 +75,6 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if the function expects lambda arguments, false otherwise.
         public virtual bool HasLambdas => !_maskLambdas.IsZero;
 
-        public virtual bool HasUntypedObjectLambdas => false;
-
         // Return true if lambda args should affect ECS, false otherwise.
         public virtual bool HasEcsExcemptLambdas => false;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -75,6 +75,8 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if the function expects lambda arguments, false otherwise.
         public virtual bool HasLambdas => !_maskLambdas.IsZero;
 
+        public virtual bool HasUntypedObjectLambdas => false;
+
         // Return true if lambda args should affect ECS, false otherwise.
         public virtual bool HasEcsExcemptLambdas => false;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -88,6 +88,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction First = _library.Append(new FirstLastFunction(isFirst: true));
         public static readonly TexlFunction FirstN = _library.Append(new FirstLastNFunction(isFirst: true));
         public static readonly TexlFunction ForAll = _library.Append(new ForAllFunction());
+        public static readonly TexlFunction ForAll_UO = _library.Append(new ForAllFunction_UO());
         public static readonly TexlFunction GUIDPure = _library.Append(new GUIDPureFunction());
         public static readonly TexlFunction GUID_UO = _library.Append(new GUIDPureFunction_UO());
         public static readonly TexlFunction Hour = _library.Append(new HourFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -83,8 +83,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool HasUntypedObjectLambdas => true;
-
         public ForAllFunction_UO()
             : base(ForAllFunction.ForAllInvariantFunctionName, TexlStrings.AboutForAll, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.UntypedObject)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -18,6 +18,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // ForAll(source:*, formula)
     internal sealed class ForAllFunction : FunctionWithTableInput
     {
+        public const string ForAllInvariantFunctionName = "ForAll";
+
         public override bool SkipScopeForInlineRecords => true;
 
         public override bool IsSelfContained => true;
@@ -25,7 +27,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => false;
 
         public ForAllFunction()
-            : base("ForAll", TexlStrings.AboutForAll, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.EmptyTable)
+            : base(ForAllInvariantFunctionName, TexlStrings.AboutForAll, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.EmptyTable)
         {
             ScopeInfo = new FunctionScopeInfo(this);
         }
@@ -72,6 +74,65 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {
             return GetUniqueTexlRuntimeName(suffix: isPrefetching ? "_ParallelPrefetching" : string.Empty);
+        }
+    }
+
+    internal sealed class ForAllFunction_UO : BuiltinFunction
+    {
+        public override bool IsSelfContained => true;
+
+        public override bool SupportsParamCoercion => false;
+
+        public override bool HasUntypedObjectLambdas => true;
+
+        public ForAllFunction_UO()
+            : base(ForAllFunction.ForAllInvariantFunctionName, TexlStrings.AboutForAll, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.UntypedObject)
+        {
+            ScopeInfo = new FunctionScopeInfo(this);
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.ForAllArg1, TexlStrings.ForAllArg2 };
+        }
+
+        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+
+            if (argTypes[1].IsRecord)
+            {
+                returnType = argTypes[1].ToTable();
+            }
+            else if (argTypes[1].IsPrimitive || argTypes[1].IsTable)
+            {
+                returnType = DType.CreateTable(new TypedName(argTypes[1], ColumnName_Value));
+            }
+            else
+            {
+                returnType = DType.Error;
+                fArgsValid = false;
+            }
+
+            return fArgsValid;
+        }
+
+        public override bool HasSuggestionsForParam(int index)
+        {
+            Contracts.Assert(index >= 0);
+
+            return index == 0;
+        }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -100,6 +100,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
+            Contracts.AssertAllValues(argTypes);
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 returnType = argTypes[1].ToTable();
             }
-            else if (argTypes[1].IsPrimitive || argTypes[1].IsTable)
+            else if (argTypes[1].IsPrimitive || argTypes[1].IsTable || argTypes[1].IsUntypedObject)
             {
                 returnType = DType.CreateTable(new TypedName(argTypes[1], ColumnName_Value));
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -42,6 +42,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
+            Contracts.AssertAllValues(argTypes);
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 returnType = argTypes[1].ToTable();
             }
-            else if (argTypes[1].IsPrimitive || argTypes[1].IsTable)
+            else if (argTypes[1].IsPrimitive || argTypes[1].IsTable || argTypes[1].IsUntypedObject)
             {
                 returnType = DType.CreateTable(new TypedName(argTypes[1], ColumnName_Value));
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -514,8 +514,14 @@ namespace Microsoft.PowerFx
             if (node.Value is ScopeSymbol s2)
             {
                 var r = context.SymbolContext.ScopeValues[s2.Id];
-                var r2 = (RecordScope)r;
-                return r2._context;
+                if (r is RecordScope r2)
+                {
+                    return r2._context;
+                }
+                else if (r is ThisItemScope r3)
+                {
+                    return r3._thisItem;
+                }
             }
 
             return CommonErrors.UnreachableCodeError(node.IRContext);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -598,6 +598,7 @@ namespace Microsoft.PowerFx.Functions
             {
                 BuiltinFunctionsCore.ForAll_UO,
                 StandardErrorHandlingAsync<FormulaValue>(
+                    BuiltinFunctionsCore.ForAll_UO.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactSequence(

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Texl;
@@ -1873,7 +1874,24 @@ namespace Microsoft.PowerFx.Functions
                     childContext = context.SymbolContext.WithScopeValues(RecordValue.Empty());
                 }
 
-                // Filter evals to a boolean 
+                // Filter evals to a boolean
+                var result = filter.EvalAsync(runner, context.NewScope(childContext)).AsTask();
+
+                yield return result;
+            }
+        }
+
+        private static IEnumerable<Task<FormulaValue>> LazyForAll(
+            EvalVisitor runner,
+            EvalVisitorContext context,
+            IEnumerable<DValue<UntypedObjectValue>> sources,
+            LambdaFormulaValue filter)
+        {
+            foreach (var row in sources)
+            {
+                SymbolContext childContext = context.SymbolContext.WithThisItem(row.ToFormulaValue());
+
+                // Filter evals to a boolean
                 var result = filter.EvalAsync(runner, context.NewScope(childContext)).AsTask();
 
                 yield return result;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -595,6 +595,20 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: ForAll)
             },
             {
+                BuiltinFunctionsCore.ForAll_UO,
+                StandardErrorHandlingAsync<FormulaValue>(
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactSequence(
+                        ExactValueTypeOrBlank<UntypedObjectValue>,
+                        ExactValueTypeOrBlank<LambdaFormulaValue>),
+                    checkRuntimeValues: ExactSequence(
+                        UntypedObjectArrayChecker,
+                        DeferRuntimeValueChecking),
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: ForAll_UO)
+            },
+            {
                 BuiltinFunctionsCore.GUIDPure,
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.GUIDPure.Name,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -231,8 +231,7 @@ namespace Microsoft.PowerFx.Functions
             var arg0 = (UntypedObjectValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
 
-            var inputItemType = RecordType.Empty().Add(new NamedFormulaType(BuiltinFunction.ColumnName_ValueStr, FormulaType.UntypedObject));
-            var inputTableType = inputItemType.ToTable();
+            var itemType = RecordType.Empty().Add(new NamedFormulaType(BuiltinFunction.ColumnName_ValueStr, FormulaType.UntypedObject));
 
             var resultRows = new List<DValue<RecordValue>>();
 
@@ -243,11 +242,10 @@ namespace Microsoft.PowerFx.Functions
                 var element = arg0.Impl[i];
 
                 var namedValue = new NamedValue(BuiltinFunction.ColumnName_ValueStr, new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), element));
-                var record = new InMemoryRecordValue(IRContext.NotInSource(inputItemType), new List<NamedValue>() { namedValue });
+                var record = new InMemoryRecordValue(IRContext.NotInSource(itemType), new List<NamedValue>() { namedValue });
                 resultRows.Add(DValue<RecordValue>.Of(record));
             }
 
-            var input = new InMemoryTableValue(IRContext.NotInSource(inputTableType), resultRows);
             var rowsAsync = LazyForAll(runner, context, resultRows, arg1);
 
             var rows = await Task.WhenAll(rowsAsync);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
@@ -253,6 +254,12 @@ namespace Microsoft.PowerFx.Functions
             var rowsAsync = LazyForAll(runner, context, items, arg1);
 
             var rows = await Task.WhenAll(rowsAsync);
+
+            var errorRows = rows.OfType<ErrorValue>();
+            if (errorRows.Any())
+            {
+                return ErrorValue.Combine(irContext, errorRows);
+            }
 
             return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows, forceSingleColumn: false));
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -231,22 +231,19 @@ namespace Microsoft.PowerFx.Functions
             var arg0 = (UntypedObjectValue)args[0];
             var arg1 = (LambdaFormulaValue)args[1];
 
-            var itemType = RecordType.Empty().Add(new NamedFormulaType(BuiltinFunction.ColumnName_ValueStr, FormulaType.UntypedObject));
-
-            var resultRows = new List<DValue<RecordValue>>();
+            var items = new List<DValue<UntypedObjectValue>>();
 
             var len = arg0.Impl.GetArrayLength();
 
             for (var i = 0; i < len; i++)
             {
                 var element = arg0.Impl[i];
+                var item = new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), element);
 
-                var namedValue = new NamedValue(BuiltinFunction.ColumnName_ValueStr, new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), element));
-                var record = new InMemoryRecordValue(IRContext.NotInSource(itemType), new List<NamedValue>() { namedValue });
-                resultRows.Add(DValue<RecordValue>.Of(record));
+                items.Add(DValue<UntypedObjectValue>.Of(item));
             }
 
-            var rowsAsync = LazyForAll(runner, context, resultRows, arg1);
+            var rowsAsync = LazyForAll(runner, context, items, arg1);
 
             var rows = await Task.WhenAll(rowsAsync);
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -108,6 +108,11 @@ namespace Microsoft.PowerFx.Functions
         {
             if (arg is UntypedObjectValue cov)
             {
+                if (cov.Impl.Type == FormulaType.Blank)
+                {
+                    return new BlankValue(irContext);
+                }
+
                 if (!(cov.Impl.Type is ExternalType et && et.Kind == ExternalTypeKind.Array))
                 {
                     return new ErrorValue(irContext, new ExpressionError()

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -237,6 +237,8 @@ namespace Microsoft.PowerFx.Functions
 
             for (var i = 0; i < len; i++)
             {
+                runner.CheckCancel();
+
                 var element = arg0.Impl[i];
                 var item = new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), element);
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -93,24 +93,26 @@ namespace Microsoft.PowerFx.Functions
                     return ErrorValue.Combine(irContext, errors);
                 }
 
+                var anyValueBlank = runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank));
+
                 switch (returnBehavior)
                 {
                     case ReturnBehavior.ReturnBlankIfAnyArgIsBlank:
-                        if (runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank)))
+                        if (anyValueBlank)
                         {
                             return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
                         }
 
                         break;
                     case ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank:
-                        if (runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank)))
+                        if (anyValueBlank)
                         {
                             return new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty);
                         }
 
                         break;
                     case ReturnBehavior.ReturnFalseIfAnyArgIsBlank:
-                        if (runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank)))
+                        if (anyValueBlank)
                         {
                             return new BooleanValue(IRContext.NotInSource(FormulaType.Boolean), false);
                         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -96,21 +96,21 @@ namespace Microsoft.PowerFx.Functions
                 switch (returnBehavior)
                 {
                     case ReturnBehavior.ReturnBlankIfAnyArgIsBlank:
-                        if (runtimeValuesChecked.Any(arg => arg is BlankValue))
+                        if (runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank)))
                         {
                             return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
                         }
 
                         break;
                     case ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank:
-                        if (runtimeValuesChecked.Any(arg => arg is BlankValue))
+                        if (runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank)))
                         {
                             return new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty);
                         }
 
                         break;
                     case ReturnBehavior.ReturnFalseIfAnyArgIsBlank:
-                        if (runtimeValuesChecked.Any(arg => arg is BlankValue))
+                        if (runtimeValuesChecked.Any(arg => arg is BlankValue || (arg is UntypedObjectValue uov && uov.Impl.Type == FormulaType.Blank)))
                         {
                             return new BooleanValue(IRContext.NotInSource(FormulaType.Boolean), false);
                         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/IScope.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/IScope.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx
@@ -23,7 +24,7 @@ namespace Microsoft.PowerFx
 
         public virtual FormulaValue Resolve(string name)
         {
-            return _context.GetField(name);            
+            return _context.GetField(name);
         }
     }
 
@@ -38,7 +39,28 @@ namespace Microsoft.PowerFx
 
         public virtual FormulaValue Resolve(string name)
         {
+
             return _context;
+        }
+    }
+
+    internal class ThisItemScope : IScope
+    {
+        public readonly FormulaValue _thisItem;
+
+        public ThisItemScope(FormulaValue thisItem)
+        {
+            _thisItem = thisItem;
+        }
+
+        public virtual FormulaValue Resolve(string name)
+        {
+            if (name == TexlBinding.ThisItemDefaultName.Value)
+            {
+                return _thisItem;
+            }
+
+            return null;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/IScope.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/IScope.cs
@@ -39,7 +39,6 @@ namespace Microsoft.PowerFx
 
         public virtual FormulaValue Resolve(string name)
         {
-
             return _context;
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/SymbolContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/SymbolContext.cs
@@ -62,6 +62,11 @@ namespace Microsoft.PowerFx
             return WithScopeValues(new ErrorScope(scopeValues));
         }
 
+        public SymbolContext WithThisItem(FormulaValue value)
+        {
+            return WithScopeValues(new ThisItemScope(value));
+        }
+
         // Called by evaluator to fetch a runtime value in the given scope. 
         public FormulaValue GetScopeVar(ScopeSymbol scope, string name)
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -227,3 +227,7 @@ Blank()
 
 >> Text(Index(ParseJSON("[ { ""a"" : 10 }, { ""b"" : ""str"" } ]"),2).a)
 Blank()
+
+// ForAll
+>> ForAll(ParseJSON("[5, 6, 7]"), Value(Value))
+[5, 6, 7]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -118,7 +118,7 @@ Blank()
 [GUID("5cc45615-f759-4a53-b225-d3a2497f60ad"),Blank()]
 
 >> ForAll(ParseJSON("[1]"), Value(ThisItem) / 0)
-[Microsoft.PowerFx.Types.ErrorValue]
+#Error
 
 >> CountRows(ForAll(ParseJSON("[1,2,3]"), Value(ThisItem)))
 3
@@ -133,7 +133,7 @@ Blank()
 ["1","false","hello"]
 
 >> ForAll(ParseJSON("[1,true,3,false]"), Value(ThisItem))
-[1,Microsoft.PowerFx.Types.ErrorValue,3,Microsoft.PowerFx.Types.ErrorValue]
+#Error
 
 >> ForAll(ParseJSON("[1,2,3]"), If(Value(ThisItem) < 2, Value(ThisItem), ThisItem))
 Errors: Error 70-78: Invalid argument type (UntypedObject). Expecting a Number value instead.|Error 29-79: The function 'If' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -93,7 +93,7 @@ Blank()
 >> ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem))
 [5,6,7]
 
->> Sum(ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem)))
+>> Sum(ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem)), Value)
 18
 
 >> ParseJSON("5") + ParseJSON("5")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -120,6 +120,9 @@ Blank()
 >> ForAll(ParseJSON("[1]"), Value(ThisItem) / 0)
 [Microsoft.PowerFx.Types.ErrorValue]
 
+>> CountRows(ForAll(ParseJSON("[1,2,3]"), Value(ThisItem)))
+3
+
 >> Sum(ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem)), Value)
 18
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -96,9 +96,26 @@ Blank()
 >> ForAll(ParseJSON("null"), Value(ThisItem))
 Blank()
 
-// We currently do not support null in any of the constructor functions, so this is an error
->> ForAll(ParseJSON("[null, null, null]"), Abs(Value(ThisItem)))
-[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+>> ForAll(ParseJSON("[null, null, null]"), Value(ThisItem))
+[Blank(),Blank(),Blank()]
+
+>> ForAll(ParseJSON("[5, null, 7]"), Value(ThisItem))
+[5,Blank(),7]
+
+>> ForAll(ParseJSON("[""hi"", null, ""hello""]"), Text(ThisItem))
+["hi",Blank(),"hello"]
+
+>> ForAll(ParseJSON("[true, null, false]"), Boolean(ThisItem))
+[true,Blank(),false]
+
+>> ForAll(ParseJSON("[""2011-01-15"", null]"), Text(DateValue(ThisItem), "yyyy-MM-dd"))
+["2011-01-15",""]
+
+>> ForAll(ParseJSON("[""08:03:05.000"", null]"), Text(TimeValue(ThisItem), "HH:mm:ss"))
+["08:03:05",""]
+
+>> ForAll(ParseJSON("[""5cc45615-f759-4a53-b225-d3a2497f60ad"", null]"), GUID(ThisItem))
+[GUID("5cc45615-f759-4a53-b225-d3a2497f60ad"),Blank()]
 
 >> ForAll(ParseJSON("[1]"), Value(ThisItem) / 0)
 [Microsoft.PowerFx.Types.ErrorValue]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -93,8 +93,30 @@ Blank()
 >> ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem))
 [5,6,7]
 
+>> ForAll(ParseJSON("null"), Value(ThisItem))
+Blank()
+
+// We currently do not support null in any of the constructor functions, so this is an error
+>> ForAll(ParseJSON("[null, null, null]"), Abs(Value(ThisItem)))
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> ForAll(ParseJSON("[1]"), Value(ThisItem) / 0)
+[Microsoft.PowerFx.Types.ErrorValue]
+
 >> Sum(ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem)), Value)
 18
+
+>> Sum(ForAll(ParseJSON("[5, 6, 7]"), ThisItem), Value(Value))
+18
+
+>> ForAll(ParseJSON("[1,{""a"":false},""hello""]"), IfError(Text(ThisItem), IfError(Text(Value(ThisItem)), Text(Boolean(ThisItem.a)))))
+["1","false","hello"]
+
+>> ForAll(ParseJSON("[1,true,3,false]"), Value(ThisItem))
+[1,Microsoft.PowerFx.Types.ErrorValue,3,Microsoft.PowerFx.Types.ErrorValue]
+
+>> ForAll(ParseJSON("[1,2,3]"), If(Value(ThisItem) < 2, Value(ThisItem), ThisItem))
+Errors: Error 70-78: Invalid argument type (UntypedObject). Expecting a Number value instead.|Error 29-79: The function 'If' has some invalid arguments.
 
 >> ParseJSON("5") + ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -229,5 +229,5 @@ Blank()
 Blank()
 
 // ForAll
->> ForAll(ParseJSON("[5, 6, 7]"), Value(Value))
+>> ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem))
 [5,6,7]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -230,4 +230,4 @@ Blank()
 
 // ForAll
 >> ForAll(ParseJSON("[5, 6, 7]"), Value(Value))
-[5, 6, 7]
+[5,6,7]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -90,6 +90,12 @@ Blank()
 >> Sum(Table(ParseJSON("[1, 2, 3, 4, 5]")), Value(Value))
 15
 
+>> ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem))
+[5,6,7]
+
+>> Sum(ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem)))
+18
+
 >> ParseJSON("5") + ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
@@ -227,7 +233,3 @@ Blank()
 
 >> Text(Index(ParseJSON("[ { ""a"" : 10 }, { ""b"" : ""str"" } ]"),2).a)
 Blank()
-
-// ForAll
->> ForAll(ParseJSON("[5, 6, 7]"), Value(ThisItem))
-[5,6,7]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -138,6 +138,9 @@ Blank()
 >> ForAll(ParseJSON("[1,2,3]"), If(Value(ThisItem) < 2, Value(ThisItem), ThisItem))
 Errors: Error 70-78: Invalid argument type (UntypedObject). Expecting a Number value instead.|Error 29-79: The function 'If' has some invalid arguments.
 
+>> ForAll(ParseJSON("[1,2,3]"), ThisRecord)
+Errors: Error 29-39: Name isn't valid. 'ThisRecord' isn't recognized.|Error 0-40: The function 'ForAll' has some invalid arguments.
+
 >> ParseJSON("5") + ParseJSON("5")
 Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 


### PR DESCRIPTION
Adds the ForAll function for UntypedObjects. A very bizarre change with some hacky type checking.

The problem is that overloaded functions with lambdas are not evaluated bottom-up. This is because some of the arguments may be lambdas. It leads to a chicken and egg problem: you need to know the override before you can determine that an argument is a lambda, but you need to know which arguments are lambdas in order to pick an override.

Thus we enforce that only a single override is allowed to have a lambda. It is assumed to be a table, and we type check the first argument quite late.

This implementation piggybacks off of all existing code paths by "tricking" the type checker into thinking that there is only 1 override. It will then "switch" the selected override at the last second if it's discovered that the first argument is an untyped object.

Not ideal for a code maintenance standpoint. However, our other option is to rename ForAll function to something else specifically for untyped objects.