### PR TITLE
Fix delegation warning to be only if Async Nodes when In operator is used.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
@@ -56,7 +56,9 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
 
             var leftType = binding.GetType(binaryOpNode.Left);
             var rightType = binding.GetType(binaryOpNode.Right);
-            if ((leftType.IsMultiSelectOptionSet() && !rightType.IsAggregate) || (rightType.IsMultiSelectOptionSet() && !leftType.IsAggregate))
+            var isLeftNodeAsync = binding.IsAsync(binaryOpNode.Left);
+            var isRightNodeAsync = binding.IsAsync(binaryOpNode.Right);
+            if ((leftType.IsMultiSelectOptionSet() && isRightNodeAsync) || (rightType.IsMultiSelectOptionSet() && isLeftNodeAsync))
             {
                 SuggestDelegationHint(node, binding);
                 return false;


### PR DESCRIPTION
A recent change to prevent delegation of Filter(TableA.Optionsetcolumn in multiselectOptionset) (https://github.com/microsoft/Power-Fx/pull/522 ) regressed a delegable scenario for singleSelectOptionSet in Collection to be non delegable, adding an explicit check to not delegate if the in operator is used on a async node instead of checking for !IsAggregate.

TestCases added in Client repo 