### PR TITLE
Check invocation result fail prior to get tabular result

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -484,10 +484,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // for DateTime alone is sufficient.
                 fValid &= CheckDateColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                var resultColumnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
-                    ? ColumnName_Value
-                    : type0.GetNames(DPath.Root).Single().Name;
-                returnType = DType.CreateTable(new TypedName(DType.DateTime, resultColumnType));
+                if (fValid)
+                {
+                    var resultColumnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                        ? ColumnName_Value
+                        : type0.GetNames(DPath.Root).Single().Name;
+                    returnType = DType.CreateTable(new TypedName(DType.DateTime, resultColumnType));
+                }
             }
             else
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -104,5 +104,18 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(expectedDType, result._binding.ResultType);
             Assert.True(result.IsSuccess);
         }
+
+        [Theory]
+        [InlineData("DateAdd(Table({v:Date(2022,1,1),s:9},{v:Date(2022,2,2),s:25}), 2, TimeUnit.Days)")]
+        [InlineData("DateAdd(DropColumns([Date(2022,1,1),Date(2022,2,2)],\"Value\"), 2, TimeUnit.Days)")]
+        [InlineData("DateDiff(Table({v:Date(2022,1,1),s:9},{v:Date(2022,2,2),s:25}), Date(2022,12,12), TimeUnit.Days)")]
+        [InlineData("DateDiff(DropColumns([Date(2022,1,1),Date(2022,2,2)],\"Value\"), Date(2022,2,2), TimeUnit.Days)")]
+        public void TexlDateTableFunctions_Negative(string expression)
+        {
+            var engine = new Engine(new PowerFxConfig());
+            var result = engine.Check(expression);
+
+            Assert.False(result.IsSuccess);
+        }
     }
 }


### PR DESCRIPTION
A recent change caused an exception to be thrown if an invalid tabular DateAdd function was used. This fixes it and adds a new test to check this scenario.