### PR TITLE
Fix IsNumeric implementation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1568,10 +1568,22 @@ namespace Microsoft.PowerFx.Functions
             return false;
         }
 
-        public static FormulaValue IsNumeric(IRContext irContext, FormulaValue[] args)
+        public static FormulaValue IsNumeric(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
             var arg0 = args[0];
-            return new BooleanValue(irContext, arg0 is NumberValue);
+            switch (arg0)
+            {
+                case NumberValue _:
+                case DateValue _:
+                case DateTimeValue _:
+                case TimeValue _:
+                    return new BooleanValue(irContext, true);
+                case StringValue _:
+                    var nv = Value(runner, context, IRContext.NotInSource(FormulaType.Number), args);
+                    return new BooleanValue(irContext, nv is NumberValue);
+                default:
+                    return new BooleanValue(irContext, false);
+            }
         }
 
         public static async ValueTask<FormulaValue> With(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsNumeric.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsNumeric.txt
@@ -1,6 +1,9 @@
 >>IsNumeric("A")
 false
 
+>>IsNumeric("123")
+true
+
 >>IsNumeric(123)
 true
 
@@ -17,7 +20,7 @@ true
 true
 
 >>IsNumeric(1/0)
-#Error
+#Error(Kind=Div0)
 
 >>IsNumeric(Blank())
 false
@@ -28,3 +31,17 @@ false
 >>IsNumeric([1,2,3,4])
 false
 
+>> IsNumeric(Date(2022,1,2))
+true
+
+>> IsNumeric(DateTime(2022,1,2,12,34,56))
+true
+
+>> IsNumeric(Time(2022,1,2))
+true
+
+>> IsNumeric(false)
+false
+
+>> IsNumeric(true)
+false


### PR DESCRIPTION
The IsNumeric function should return true for string values that represent, as well as to date, time and date/time values (which has a natural conversion to numbers)