### PR TITLE
Inconsistent result with ConsistentOneColumnTableResult flag enabled.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/BuiltinFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/BuiltinFunction.cs
@@ -15,7 +15,6 @@ namespace Microsoft.PowerFx.Core.Functions
         public const string OneColumnTableResultNameStrOld = "Result";
         public const string ColumnName_NameStr = "Name";
         public const string ColumnName_AddressStr = "Address";
-        public const string ColumnName_ValueStr = "Value";
         public const string ColumnName_FullMatchStr = "FullMatch";
         public const string ColumnName_SubMatchesStr = "SubMatches";
         public const string ColumnName_StartMatchStr = "StartMatch";

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -71,8 +71,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of colors.
                 fValid &= CheckColorColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                // Borrow the return type from the 1st arg.
-                returnType = type0;
+                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    : type0;
 
                 // Check arg1 below.
                 otherArg = args[1];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 fValid &= CheckColorColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
                 returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
-                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    ? DType.CreateTable(new TypedName(DType.Color, new DName(ColumnName_ValueStr)))
                     : type0;
 
                 // Check arg1 below.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -74,7 +74,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Typecheck the input table
             fValid &= CheckStringColumnType(argTypes[0], args[0], errors, ref nodeToCoercedTypeMap);
 
-            returnType = argTypes[0];
+            returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                : argTypes[0];
 
             return fValid;
         }
@@ -125,7 +127,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Typecheck the count table
             fValid &= CheckNumericColumnType(argTypes[1], args[1], errors, ref nodeToCoercedTypeMap);
 
-            returnType = argTypes[0];
+            returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                : argTypes[0];
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
@@ -56,7 +57,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -64,8 +65,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(binding, DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
@@ -77,7 +77,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
                 // Borrow the return type from the 1st arg
-                returnType = type0;
+                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    : type0;
             }
             else
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
@@ -53,7 +54,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.PowerTFuncArg1, TexlStrings.PowerTFuncArg2 };
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -61,8 +62,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(binding, DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
@@ -76,8 +76,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of strings
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                // Borrow the return type from the 1st arg
-                returnType = type0;
+                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    : type0;
             }
             else
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -76,8 +76,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of numerics
                 fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                // Borrow the return type from the 1st arg
-                returnType = type0;
+                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    : type0;
 
                 // Check arg1 below.
                 otherArg = args[1];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -89,7 +89,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of numerics
                 fValid &= CheckNumericColumnType(type1, args[1], errors, ref nodeToCoercedTypeMap);
 
-                // Since the 1st arg is not a table, make a new table return type *[Result:n]
+                // Since the 1st arg is not a table, make a new table return type *[Result:n] or
+                // *[Value:n] if the consistent return schema flag is enabled
                 returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
 
                 // Check arg0 below.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
                 returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
-                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                     : type0;
 
                 // Check arg1 below.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -128,7 +128,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
             else
             {
-                returnType = argTypes[0];
+                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                : argTypes[0];
             }
 
             return fValid;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
@@ -77,8 +77,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of strings
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                // Borrow the return type from the 1st arg
-                returnType = type0;
+                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    : type0;
             }
             else
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -142,8 +142,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Ensure we have a one-column table of numerics
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                    // Borrow the return type from the 1st arg
-                    returnType = type0;
+                    returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                        ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
+                        : type0;
                 }
                 else
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -81,8 +81,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
                     returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
-                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
-                    : type0;
+                        ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
+                        : type0;
 
                     // Check arg1 below.
                     otherArg = args[1];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -80,8 +80,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Ensure we have a one-column table of numerics
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                    // Borrow the return type from the 1st arg
-                    returnType = type0;
+                    returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
+                    : type0;
 
                     // Check arg1 below.
                     otherArg = args[1];

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -588,6 +588,27 @@ namespace Microsoft.PowerFx.Core.Tests
                 symbol);
         }
 
+        [Theory]
+        [InlineData("Left(T, 3)")]
+        [InlineData("Left(\"foo\", T2)")]
+        [InlineData("Left(T, T2)")]
+        public void TexlFunctionTypeSemanticsLeft_ConsistentOneColumnTableResult(string script)
+        {
+            TestSimpleBindingSuccess(
+                "Left(\"foo\", 3)",
+                DType.String);
+
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+            symbol.AddVariable("T2", new TableType(TestUtils.DT("*[Count:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:s]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
         [Fact]
         public void TexlFunctionTypeSemanticsLen()
         {
@@ -646,6 +667,18 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TexlFunctionTypeSemanticsLower_ConsistentOneColumnTableResult()
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+            TestSimpleBindingSuccess(
+                "Lower(T)",
+                TestUtils.DT("*[Value:s]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Fact]
         public void TexlFunctionTypeSemanticsMid()
         {
             TestSimpleBindingSuccess(
@@ -683,18 +716,24 @@ namespace Microsoft.PowerFx.Core.Tests
                 symbol);
         }
 
-        [Fact]
-        public void TexlFunctionTypeSemanticsMid_ConsistentOneColumnTableResult()
+        [Theory]
+        [InlineData("Mid(T, 2, 3)")]
+        [InlineData("Mid(T, T2, 3)")]
+        [InlineData("Mid(T, 2, T3)")]
+        [InlineData("Mid(T, T2, T3)")]
+        [InlineData("Mid(\"hello\", T2, T3)")]
+        public void TexlFunctionTypeSemanticsMid_ConsistentOneColumnTableResult(string script)
         {
             var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
             symbol.AddVariable("T2", new TableType(TestUtils.DT("*[Start:n]")));
             symbol.AddVariable("T3", new TableType(TestUtils.DT("*[Count:n]")));
 
             TestSimpleBindingSuccess(
-                "Mid(\"hello\", T2, T3)",
-                TestUtils.DT("*[Value:s]"),
-                symbol,
-                Features.ConsistentOneColumnTableResult);
+               script,
+               TestUtils.DT("*[Value:s]"),
+               symbol,
+               Features.ConsistentOneColumnTableResult);
         }
 
         [Theory]
@@ -823,7 +862,11 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("Replace(T, 2, 3, \"X\")", "*[Name:s]")]
+        [InlineData("Replace(T, 2, 3, \"X\")", "*[Value:s]")]
+        [InlineData("Replace(T, T2, 3, \"X\")", "*[Value:s]")]
+        [InlineData("Replace(T, 2, T3, \"X\")", "*[Value:s]")]
+        [InlineData("Replace(T, T2, T3, \"X\")", "*[Value:s]")]
+        [InlineData("Replace(T, T2, T3, TX)", "*[Value:s]")]
         [InlineData("Replace(\"hello\", T2, T3, TX)", "*[Value:s]")]
         public void TexlFunctionTypeSemanticsReplace_ConsistentOneColumnTableResult(string script, string expectedType)
         {
@@ -879,6 +922,22 @@ namespace Microsoft.PowerFx.Core.Tests
             {
                 TestSimpleBindingSuccess(script, TestUtils.DT(expectedType));
             }
+        }
+
+        [Theory]
+        [InlineData("Int(T)", "*[Booleans:b]")]
+        [InlineData("Int(T)", "*[Strings:s]")]
+        [InlineData("Int(T)", "*[Number:n]")]
+        public void TexlFunctionTypeSemanticsIntWithCoercion__ConsistentOneColumnTableResult(string script, string typedGlobal)
+        {
+            var symbol = new SymbolTable();
+
+            symbol.AddVariable("T", new TableType(TestUtils.DT(typedGlobal)));
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
         }
 
         [Fact]
@@ -2126,6 +2185,22 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
+        [InlineData("Log(3, numtable)")]
+        [InlineData("Log(numtable, 3)")]
+        [InlineData("Log(numtable, numtable)")]
+        public void TexlFunctionTypeSemanticsLog_T_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("numtable", new TableType(TestUtils.DT("*[Num:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
         [InlineData("Log(errortable)")]
         [InlineData("Log(errortable, 3)")]
         [InlineData("Log(numbertable, errortable)")]
@@ -2262,6 +2337,440 @@ namespace Microsoft.PowerFx.Core.Tests
                 script, 
                 TestUtils.DT(typeSpec),
                 symbol);
+        }
+
+        [Theory]
+        [InlineData("Abs(1)", "n")]
+        [InlineData("Abs(A)", "n")]
+        [InlineData("Abs(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsAbs(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Abs(Table)")]
+        public void TexlFunctionTypeSemanticsAbs_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Acos(1)", "n")]
+        [InlineData("Acos(A)", "n")]
+        [InlineData("Acos(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsAcos(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Acos(Table)")]
+        public void TexlFunctionTypeSemanticsAcos_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Acot(1)", "n")]
+        [InlineData("Acot(A)", "n")]
+        [InlineData("Acot(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsAcot(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Acot(Table)")]
+        public void TexlFunctionTypeSemanticsAcot_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Asin(1)", "n")]
+        [InlineData("Asin(A)", "n")]
+        [InlineData("Asin(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsAsin(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Asin(Table)")]
+        public void TexlFunctionTypeSemanticsAsin_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Atan(1)", "n")]
+        [InlineData("Atan(A)", "n")]
+        [InlineData("Atan(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsAtan(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Atan(Table)")]
+        public void TexlFunctionTypeSemanticsAtan_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Boolean(1)", "b")]
+        [InlineData("Boolean(A)", "b")]
+        [InlineData("Boolean(Table)", "*[Value:b]")]
+        [InlineData("Boolean(TableS)", "*[Value:b]")]
+        public void TexlFunctionTypeSemanticsBoolean(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("TableS", new TableType(TestUtils.DT("*[input:s]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Boolean(Table)")]
+        [InlineData("Boolean(TableS)")]
+        public void TexlFunctionTypeSemanticsBoolean_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("TableS", new TableType(TestUtils.DT("*[input:s]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:b]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("ColorFade(Color.Red, 0.5)", "c")]
+        [InlineData("ColorFade(Table, 0.5)", "*[input:c]")]
+        [InlineData("ColorFade(Color.Red, TableN)", "*[Result:c]")]
+        [InlineData("ColorFade(Table, TableN)", "*[input:c]")]
+        public void TexlFunctionTypeSemanticsColorFade(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:c]")));
+            symbol.AddVariable("TableN", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("ColorFade(Table, 0.5)")]
+        [InlineData("ColorFade(Color.Red, TableN)")]
+        [InlineData("ColorFade(Table, TableN)")]
+        public void TexlFunctionTypeSemanticsColorFade_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:c]")));
+            symbol.AddVariable("TableN", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:c]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        //[Theory]
+        //[InlineData("cos(1)", "n")]
+        //[InlineData("cos(A)", "n")]
+        //[InlineData("cos(Table)", "*[input:n]")]
+        //public void TexlFunctionTypeSemanticsCos(string script, string expectedType)
+        //{
+        //    var symbol = new SymbolTable();
+        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+        //    symbol.AddVariable("A", FormulaType.Number);
+
+        //    TestSimpleBindingSuccess(
+        //        script,
+        //        TestUtils.DT(expectedType),
+        //        symbol);
+        //}
+
+        //[Theory]
+        //[InlineData("cos(Table)")]
+        //public void TexlFunctionTypeSemanticsCos_ConsistentOneColumnTableResult(string script)
+        //{
+        //    var symbol = new SymbolTable();
+        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+        //    TestSimpleBindingSuccess(
+        //        script,
+        //        TestUtils.DT("*[Value:n]"),
+        //        symbol,
+        //        Features.ConsistentOneColumnTableResult);
+        //}
+
+        //[Theory]
+        //[InlineData("cot(1)", "n")]
+        //[InlineData("cot(A)", "n")]
+        //[InlineData("cot(Table)", "*[input:n]")]
+        //public void TexlFunctionTypeSemanticsCot(string script, string expectedType)
+        //{
+        //    var symbol = new SymbolTable();
+        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+        //    symbol.AddVariable("A", FormulaType.Number);
+
+        //    TestSimpleBindingSuccess(
+        //        script,
+        //        TestUtils.DT(expectedType),
+        //        symbol);
+        //}
+
+        //[Theory]
+        //[InlineData("cot(Table)")]
+        //public void TexlFunctionTypeSemanticsCot_ConsistentOneColumnTableResult(string script)
+        //{
+        //    var symbol = new SymbolTable();
+        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+        //    TestSimpleBindingSuccess(
+        //        script,
+        //        TestUtils.DT("*[Value:n]"),
+        //        symbol,
+        //        Features.ConsistentOneColumnTableResult);
+        //}
+
+        [Theory]
+        [InlineData("Degrees(1)", "n")]
+        [InlineData("Degrees(A)", "n")]
+        [InlineData("Degrees(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsDegrees(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Degrees(Table)")]
+        public void TexlFunctionTypeSemanticsDegrees_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Exp(1)", "n")]
+        [InlineData("Exp(A)", "n")]
+        [InlineData("Exp(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsExp(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Exp(Table)")]
+        public void TexlFunctionTypeSemanticsExp_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Ln(1)", "n")]
+        [InlineData("Ln(A)", "n")]
+        [InlineData("Ln(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsLn(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Ln(Table)")]
+        public void TexlFunctionTypeSemanticsLn_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Power(4,3)", "n")]
+        [InlineData("Power(Table,3)", "*[input:n]")]
+        [InlineData("Power(4, Table2)", "*[input:n]")]
+        [InlineData("Power(Table, Table2)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsPower(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("Table2", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Power(Table,3)")]
+        [InlineData("Power(4, Table2)")]
+        [InlineData("Power(Table, Table2)")]
+        public void TexlFunctionTypeSemanticsPower_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("Table2", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Radians(1)", "n")]
+        [InlineData("Radians(A)", "n")]
+        [InlineData("Radians(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsRadians(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Radians(Table)")]
+        public void TexlFunctionTypeSemanticsRadians_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
         }
 
         private void TestBindingPurity(string script, bool isPure, SymbolTable symbolTable = null)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -2994,6 +2994,27 @@ namespace Microsoft.PowerFx.Core.Tests
                 symbol);
         }
 
+        [Theory]
+        [InlineData("Substitute(T, T2, T3, TN)")]
+        [InlineData("Substitute(T,\"S1\", \"S2\", 1)")]
+        [InlineData("Substitute(\"S1\",T, \"S2\", 1)")]
+        [InlineData("Substitute(\"S1\",\"S2\", T, 1)")]
+        [InlineData("Substitute(\"S1\",\"S2\", \"S3\", TN)")]
+        public void TexlFunctionTypeSemanticsSubstitute_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+            symbol.AddVariable("T2", new TableType(TestUtils.DT("*[Name2:s]")));
+            symbol.AddVariable("T3", new TableType(TestUtils.DT("*[Name3:s]")));
+            symbol.AddVariable("TN", new TableType(TestUtils.DT("*[Number:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value: s]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
         private void TestBindingPurity(string script, bool isPure, SymbolTable symbolTable = null)
         {
             var config = new PowerFxConfig

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -862,13 +862,13 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("Replace(T, 2, 3, \"X\")", "*[Value:s]")]
-        [InlineData("Replace(T, T2, 3, \"X\")", "*[Value:s]")]
-        [InlineData("Replace(T, 2, T3, \"X\")", "*[Value:s]")]
-        [InlineData("Replace(T, T2, T3, \"X\")", "*[Value:s]")]
-        [InlineData("Replace(T, T2, T3, TX)", "*[Value:s]")]
-        [InlineData("Replace(\"hello\", T2, T3, TX)", "*[Value:s]")]
-        public void TexlFunctionTypeSemanticsReplace_ConsistentOneColumnTableResult(string script, string expectedType)
+        [InlineData("Replace(T, 2, 3, \"X\")")]
+        [InlineData("Replace(T, T2, 3, \"X\")")]
+        [InlineData("Replace(T, 2, T3, \"X\")")]
+        [InlineData("Replace(T, T2, T3, \"X\")")]
+        [InlineData("Replace(T, T2, T3, TX)")]
+        [InlineData("Replace(\"hello\", T2, T3, TX)")]
+        public void TexlFunctionTypeSemanticsReplace_ConsistentOneColumnTableResult(string script)
         {
             var symbol = new SymbolTable();
             symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
@@ -878,7 +878,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
             TestSimpleBindingSuccess(
                 script,
-                TestUtils.DT(expectedType),
+                TestUtils.DT("*[Value:s]"),
                 symbol,
                 Features.ConsistentOneColumnTableResult);
         }
@@ -1022,11 +1022,11 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("Round(1234.567, T)", "*[Value:n]")]
-        [InlineData("Round(4, X)", "*[Value:n]")]
-        [InlineData("Round(X, 4)", "*[Value:n]")]
-        [InlineData("Round(X, T)", "*[Value:n]")]
-        public void TexlFunctionTypeSemanticsRound_ConsistentOneColumnTableResult(string expression, string expectedType)
+        [InlineData("Round(1234.567, T)")]
+        [InlineData("Round(4, X)")]
+        [InlineData("Round(X, 4)")]
+        [InlineData("Round(X, T)")]
+        public void TexlFunctionTypeSemanticsRound_ConsistentOneColumnTableResult(string expression)
         {
             var symbol = new SymbolTable();
             symbol.AddVariable("T", new TableType(TestUtils.DT("*[digits:n]")));
@@ -1034,18 +1034,9 @@ namespace Microsoft.PowerFx.Core.Tests
 
             TestSimpleBindingSuccess(
                 expression,
-                TestUtils.DT(expectedType),
+                TestUtils.DT("*[Value:n]"),
                 symbol,
                 Features.ConsistentOneColumnTableResult);
-
-            var config = new PowerFxConfig(Features.ConsistentOneColumnTableResult)
-            {
-                SymbolTable = symbol,
-            };
-            var engine = new Engine(config);
-            var result = engine.Check(expression);
-            Assert.Equal(TestUtils.DT(expectedType), result._binding.ResultType);
-            Assert.True(result.IsSuccess);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -2765,10 +2765,48 @@ namespace Microsoft.PowerFx.Core.Tests
         {
             var symbol = new SymbolTable();
             symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
-
+            
             TestSimpleBindingSuccess(
                 script,
                 TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Right(\"foo\", 3)", "s")]
+        [InlineData("Right(T, 3)", "*[Name:s]")]
+        [InlineData("Right(T, T2)", "*[Name:s]")]
+        [InlineData("Right(\"foo\", T2)", "*[Result:s]")]
+        public void TexlFunctionTypeSemanticsRight(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+            symbol.AddVariable("T2", new TableType(TestUtils.DT("*[Count:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Right(T, 3)")]
+        [InlineData("Right(\"foo\", T2)")]
+        [InlineData("Right(T, T2)")]
+        public void TexlFunctionTypeSemanticsRight_ConsistentOneColumnTableResult(string script)
+        {
+            TestSimpleBindingSuccess(
+                "Right(\"foo\", 3)",
+                DType.String);
+
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+            symbol.AddVariable("T2", new TableType(TestUtils.DT("*[Count:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:s]"),
                 symbol,
                 Features.ConsistentOneColumnTableResult);
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -956,6 +956,18 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TexlFunctionTypeSemanticsTruncOneParam_ConsistentOneColumnTableResult()
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[A:n]")));
+            TestSimpleBindingSuccess(
+                "Trunc(T)",
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Fact]
         public void TexlFunctionTypeSemanticsTruncTwoParams()
         {
             var symbol = new SymbolTable();
@@ -1063,6 +1075,23 @@ namespace Microsoft.PowerFx.Core.Tests
                 symbol);
         }
 
+        [Theory]
+        [InlineData("RoundUp(1234.567, T)")]
+        [InlineData("RoundUp(X, 4)")]
+        [InlineData("RoundUp(X, T)")]
+        public void TexlFunctionTypeSemanticsRoundUp_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[digits:n]")));
+            symbol.AddVariable("X", new TableType(TestUtils.DT("*[Nnnuuummm:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
         [Fact]
         public void TexlFunctionTypeSemanticsRoundDown()
         {
@@ -1088,6 +1117,23 @@ namespace Microsoft.PowerFx.Core.Tests
                 "RoundDown(X, 4)",
                 TestUtils.DT("*[Nnnuuummm:n]"),
                 symbol);
+        }
+
+        [Theory]
+        [InlineData("RoundDown(1234.567, T)")]
+        [InlineData("RoundDown(X, T)")]
+        [InlineData("RoundDown(X, 4)")]
+        public void TexlFunctionTypeSemanticsRoundDown_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[digits:n]")));
+            symbol.AddVariable("X", new TableType(TestUtils.DT("*[Nnnuuummm:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
         }
 
         [Theory]
@@ -1152,6 +1198,22 @@ namespace Microsoft.PowerFx.Core.Tests
             {
                 TestSimpleBindingSuccess(script, TestUtils.DT(expectedType));
             }
+        }
+
+        [Theory]
+        [InlineData("Sqrt(T)", "*[Booleans:b]")]
+        [InlineData("Sqrt(T)", "*[Number:n]")]
+        [InlineData("Sqrt(T)", "*[Strings:s]")]
+        public void TexlFunctionTypeSemanticsSqrtWithCoercion_ConsistentOneColumnTableResult(string script, string typedGlobal)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT(typedGlobal)));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value: n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
         }
 
         [Theory]
@@ -1378,6 +1440,19 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TexlFunctionTypeSemanticsTrim_ConsistentOneColumnTableResult()
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+
+            TestSimpleBindingSuccess(
+                "Trim(T)",
+                TestUtils.DT("*[Value:s]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Fact]
         public void TexlFunctionTypeSemanticsTrimEnds()
         {
             var symbol = new SymbolTable();
@@ -1394,6 +1469,19 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TexlFunctionTypeSemanticsTrimEnds_ConsistentOneColumnTableResult()
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+
+            TestSimpleBindingSuccess(
+                "TrimEnds(T)",
+                TestUtils.DT("*[Value:s]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Fact]
         public void TexlFunctionTypeSemanticsUpper()
         {
             var symbol = new SymbolTable();
@@ -1407,6 +1495,19 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Upper(T)",
                 TestUtils.DT("*[Name:s]"),
                 symbol);
+        }
+
+        [Fact]
+        public void TexlFunctionTypeSemanticsUpper_ConsistentOneColumnTableResult()
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+
+            TestSimpleBindingSuccess(
+                "Upper(T)",
+                TestUtils.DT("*[Value:s]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
         }
 
         [Fact]
@@ -2560,65 +2661,65 @@ namespace Microsoft.PowerFx.Core.Tests
                 Features.ConsistentOneColumnTableResult);
         }
 
-        //[Theory]
-        //[InlineData("cos(1)", "n")]
-        //[InlineData("cos(A)", "n")]
-        //[InlineData("cos(Table)", "*[input:n]")]
-        //public void TexlFunctionTypeSemanticsCos(string script, string expectedType)
-        //{
-        //    var symbol = new SymbolTable();
-        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
-        //    symbol.AddVariable("A", FormulaType.Number);
+        [Theory]
+        [InlineData("Cos(1)", "n")]
+        [InlineData("Cos(A)", "n")]
+        [InlineData("Cos(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsCos(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
 
-        //    TestSimpleBindingSuccess(
-        //        script,
-        //        TestUtils.DT(expectedType),
-        //        symbol);
-        //}
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
 
-        //[Theory]
-        //[InlineData("cos(Table)")]
-        //public void TexlFunctionTypeSemanticsCos_ConsistentOneColumnTableResult(string script)
-        //{
-        //    var symbol = new SymbolTable();
-        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+        [Theory]
+        [InlineData("Cos(Table)")]
+        public void TexlFunctionTypeSemanticsCos_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
 
-        //    TestSimpleBindingSuccess(
-        //        script,
-        //        TestUtils.DT("*[Value:n]"),
-        //        symbol,
-        //        Features.ConsistentOneColumnTableResult);
-        //}
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
 
-        //[Theory]
-        //[InlineData("cot(1)", "n")]
-        //[InlineData("cot(A)", "n")]
-        //[InlineData("cot(Table)", "*[input:n]")]
-        //public void TexlFunctionTypeSemanticsCot(string script, string expectedType)
-        //{
-        //    var symbol = new SymbolTable();
-        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
-        //    symbol.AddVariable("A", FormulaType.Number);
+        [Theory]
+        [InlineData("Cot(1)", "n")]
+        [InlineData("Cot(A)", "n")]
+        [InlineData("Cot(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsCot(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
 
-        //    TestSimpleBindingSuccess(
-        //        script,
-        //        TestUtils.DT(expectedType),
-        //        symbol);
-        //}
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
 
-        //[Theory]
-        //[InlineData("cot(Table)")]
-        //public void TexlFunctionTypeSemanticsCot_ConsistentOneColumnTableResult(string script)
-        //{
-        //    var symbol = new SymbolTable();
-        //    symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+        [Theory]
+        [InlineData("Cot(Table)")]
+        public void TexlFunctionTypeSemanticsCot_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
 
-        //    TestSimpleBindingSuccess(
-        //        script,
-        //        TestUtils.DT("*[Value:n]"),
-        //        symbol,
-        //        Features.ConsistentOneColumnTableResult);
-        //}
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
 
         [Theory]
         [InlineData("Degrees(1)", "n")]
@@ -2811,6 +2912,86 @@ namespace Microsoft.PowerFx.Core.Tests
                 TestUtils.DT("*[Value:s]"),
                 symbol,
                 Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Sin(1)", "n")]
+        [InlineData("Sin(A)", "n")]
+        [InlineData("Sin(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsSin(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Sin(Table)")]
+        public void TexlFunctionTypeSemanticsSin_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Tan(1)", "n")]
+        [InlineData("Tan(A)", "n")]
+        [InlineData("Tan(Table)", "*[input:n]")]
+        public void TexlFunctionTypeSemanticsTan(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+            symbol.AddVariable("A", FormulaType.Number);
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
+        }
+
+        [Theory]
+        [InlineData("Tan(Table)")]
+        public void TexlFunctionTypeSemanticsTan_ConsistentOneColumnTableResult(string script)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("Table", new TableType(TestUtils.DT("*[input:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT("*[Value:n]"),
+                symbol,
+                Features.ConsistentOneColumnTableResult);
+        }
+
+        [Theory]
+        [InlineData("Substitute(T, T2, T3, TN)", "*[Name:s]")]
+        [InlineData("Substitute(T,\"S1\", \"S2\", 1)", "*[Name:s]")]
+        [InlineData("Substitute(\"S1\",T, \"S2\", 1)", "*[Result:s]")]
+        [InlineData("Substitute(\"S1\",\"S2\", T, 1)", "*[Result:s]")]
+        [InlineData("Substitute(\"S1\",\"S2\", \"S3\", TN)", "*[Result:s]")]
+        public void TexlFunctionTypeSemanticsSubstitute(string script, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("T", new TableType(TestUtils.DT("*[Name:s]")));
+            symbol.AddVariable("T2", new TableType(TestUtils.DT("*[Name2:s]")));
+            symbol.AddVariable("T3", new TableType(TestUtils.DT("*[Name3:s]")));
+            symbol.AddVariable("TN", new TableType(TestUtils.DT("*[Number:n]")));
+
+            TestSimpleBindingSuccess(
+                script,
+                TestUtils.DT(expectedType),
+                symbol);
         }
 
         private void TestBindingPurity(string script, bool isPure, SymbolTable symbolTable = null)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -1012,6 +1012,8 @@ namespace Microsoft.PowerFx.Core.Tests
         [Theory]
         [InlineData("Round(1234.567, T)", "*[Value:n]")]
         [InlineData("Round(4, X)", "*[Value:n]")]
+        [InlineData("Round(X, 4)", "*[Value:n]")]
+        [InlineData("Round(X, T)", "*[Value:n]")]
         public void TexlFunctionTypeSemanticsRound_ConsistentOneColumnTableResult(string expression, string expectedType)
         {
             var symbol = new SymbolTable();


### PR DESCRIPTION
- Fixes #709 where multiple functions did not return consistent result even with  ConsistentOneColumnTableResult flag enabled.
- Fixes #710 Added tests for checking the same in TexlTests.