### PR TITLE
Fixes Multi arg table function to be compatible with Excel

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerFx
         Numeric = 24,
         InvalidArgument = 25,
         Internal = 26,
-        Custom = 1000,
         NotApplicable = 27,
+        Custom = 1000,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
@@ -36,6 +36,7 @@ namespace Microsoft.PowerFx
         Numeric = 24,
         InvalidArgument = 25,
         Internal = 26,
-        Custom = 1000
+        Custom = 1000,
+        NotApplicable = 27,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => true;
 
         public ConcatenateFunction()
-            : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Text, DType.String, 0, 0, int.MaxValue)
+            : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Text, DType.String, 0, 1, int.MaxValue)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStoreBuilder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/EnumStoreBuilder.cs
@@ -191,7 +191,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                     "%n[None:0, Sync:1, MissingRequired:2, CreatePermission:3, EditPermission:4, DeletePermission:5, Conflict:6, NotFound:7, " +
                     "ConstraintViolated:8, GeneratedValue:9, ReadOnlyValue:10, Validation: 11, Unknown: 12, Div0: 13, BadLanguageCode: 14, " +
                     "BadRegex: 15, InvalidFunctionUsage: 16, FileNotFound: 17, AnalysisError: 18, ReadPermission: 19, NotSupported: 20, " +
-                    "InsufficientMemory: 21, QuotaExceeded: 22, Network: 23, Numeric: 24, InvalidArgument: 25, Internal: 26, Custom: 1000]"
+                    "InsufficientMemory: 21, QuotaExceeded: 22, Network: 23, Numeric: 24, InvalidArgument: 25, Internal: 26, NotApplicable: 27, Custom: 1000]"
                 },
                 {
                     EnumConstants.ZoomEnumString,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -51,6 +51,12 @@ namespace Microsoft.PowerFx.Functions
                 allFunctions.Add(func.Key, func.Value);
             }
 
+            foreach (var func in SimpleFunctionMultiArgsTabularOverloadImplementations)
+            {
+                Contracts.Assert(allFunctions.Any(f => f.Key.Name == func.Key.Name), "It needs to be an overload");
+                allFunctions.Add(func.Key, func.Value);
+            }
+
             FunctionImplementations = allFunctions;
         }
 
@@ -1452,19 +1458,10 @@ namespace Microsoft.PowerFx.Functions
                 BuiltinFunctionsCore.SqrtT,
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Sqrt])
             },
-            {
-                BuiltinFunctionsCore.ConcatenateT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.ConcatenateT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<StringValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate],
-                            transposeEmptyTable: true))
-            },
+        };
+
+        private static IReadOnlyDictionary<TexlFunction, AsyncFunctionPtr> SimpleFunctionMultiArgsTabularOverloadImplementations { get; } = new Dictionary<TexlFunction, AsyncFunctionPtr>
+        {
             {
                 BuiltinFunctionsCore.FindT,
                 StandardErrorHandlingAsync<FormulaValue>(
@@ -1479,7 +1476,22 @@ namespace Microsoft.PowerFx.Functions
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: MultiSingleColumnTable(
                             SimpleFunctionImplementations[BuiltinFunctionsCore.Find],
-                            transposeEmptyTable: false))
+                            transposeEmptyTable: false),
+                    isMultiArgTabularOverload: true)
+            },
+            {
+                BuiltinFunctionsCore.ConcatenateT,
+                StandardErrorHandlingAsync(
+                    BuiltinFunctionsCore.ConcatenateT.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<StringValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: MultiSingleColumnTable(
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate],
+                            transposeEmptyTable: true),
+                    isMultiArgTabularOverload: true)
             },
             {
                 BuiltinFunctionsCore.RoundT,
@@ -1492,7 +1504,8 @@ namespace Microsoft.PowerFx.Functions
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: MultiSingleColumnTable(
                             SimpleFunctionImplementations[BuiltinFunctionsCore.Round],
-                            transposeEmptyTable: true))
+                            transposeEmptyTable: true),
+                    isMultiArgTabularOverload: true)
             },
         };
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1475,8 +1475,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Find],
-                            transposeEmptyTable: false),
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Find]),
                     isMultiArgTabularOverload: true)
             },
             {
@@ -1489,8 +1488,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate],
-                            transposeEmptyTable: true),
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate]),
                     isMultiArgTabularOverload: true)
             },
             {
@@ -1503,8 +1501,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Round],
-                            transposeEmptyTable: true),
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Round]),
                     isMultiArgTabularOverload: true)
             },
         };

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -240,26 +240,6 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Concatenate)
             },
             {
-                BuiltinFunctionsCore.ConcatenateT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.ConcatenateT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<StringValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            StandardErrorHandling<StringValue>(
-                                BuiltinFunctionsCore.Concatenate.Name,
-                                expandArguments: NoArgExpansion,
-                                replaceBlankValues: ReplaceBlankWithEmptyString,
-                                checkRuntimeTypes: ExactValueType<StringValue>,
-                                checkRuntimeValues: DeferRuntimeValueChecking,
-                                returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                                targetFunction: Concatenate),
-                            transposeEmptyTable: true))
-            },
-            {
                 BuiltinFunctionsCore.Cos,
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Cos.Name,
@@ -525,38 +505,6 @@ namespace Microsoft.PowerFx.Functions
                         StrictArgumentPositiveNumberChecker),
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Find)
-            },
-            {
-                BuiltinFunctionsCore.FindT,
-                StandardErrorHandlingAsync<FormulaValue>(
-                    BuiltinFunctionsCore.FindT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactSequence(
-                        ExactValueTypeOrTableOrBlank<StringValue>,
-                        ExactValueTypeOrTableOrBlank<StringValue>,
-                        ExactValueTypeOrTableOrBlank<NumberValue>),
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            StandardErrorHandling<FormulaValue>(
-                                BuiltinFunctionsCore.Find.Name,
-                                expandArguments: InsertDefaultValues(outputArgsCount: 3, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
-                                replaceBlankValues: ReplaceBlankWith(
-                                    new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                                    new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                                    new BlankValue(IRContext.NotInSource(FormulaType.Blank))),
-                                checkRuntimeTypes: ExactSequence(
-                                    ExactValueType<StringValue>,
-                                    ExactValueType<StringValue>,
-                                    ExactValueTypeOrBlank<NumberValue>),
-                                checkRuntimeValues: ExactSequence(
-                                    DeferRuntimeValueChecking,
-                                    DeferRuntimeValueChecking,
-                                    StrictArgumentPositiveNumberChecker),
-                                returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                                targetFunction: Find),
-                            transposeEmptyTable: false))
             },
             {
                 BuiltinFunctionsCore.First,
@@ -1072,26 +1020,6 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: Round)
             },
             {
-                BuiltinFunctionsCore.RoundT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.RoundT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            StandardErrorHandling<NumberValue>(
-                                BuiltinFunctionsCore.Round.Name,
-                                expandArguments: NoArgExpansion,
-                                replaceBlankValues: ReplaceBlankWithEmptyString,
-                                checkRuntimeTypes: ExactValueType<NumberValue>,
-                                checkRuntimeValues: DeferRuntimeValueChecking,
-                                returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                                targetFunction: Round),
-                            transposeEmptyTable: true))
-            },
-            {
                 BuiltinFunctionsCore.RoundUp,
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.RoundUp.Name,
@@ -1523,6 +1451,48 @@ namespace Microsoft.PowerFx.Functions
             {
                 BuiltinFunctionsCore.SqrtT,
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Sqrt])
+            },
+            {
+                BuiltinFunctionsCore.ConcatenateT,
+                StandardErrorHandlingAsync(
+                    BuiltinFunctionsCore.ConcatenateT.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<StringValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: MultiSingleColumnTable(
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate],
+                            transposeEmptyTable: true))
+            },
+            {
+                BuiltinFunctionsCore.FindT,
+                StandardErrorHandlingAsync<FormulaValue>(
+                    BuiltinFunctionsCore.FindT.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactSequence(
+                        ExactValueTypeOrTableOrBlank<StringValue>,
+                        ExactValueTypeOrTableOrBlank<StringValue>,
+                        ExactValueTypeOrTableOrBlank<NumberValue>),
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: MultiSingleColumnTable(
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Find],
+                            transposeEmptyTable: false))
+            },
+            {
+                BuiltinFunctionsCore.RoundT,
+                StandardErrorHandlingAsync(
+                    BuiltinFunctionsCore.RoundT.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: MultiSingleColumnTable(
+                            SimpleFunctionImplementations[BuiltinFunctionsCore.Round],
+                            transposeEmptyTable: true))
             },
         };
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -61,7 +61,8 @@ namespace Microsoft.PowerFx.Functions
                 {
                     (var maxSize, var minsSize, var emptyTablePresent) = AnalyzeTableArguments(args);
 
-                    // In case Tabular overload has one scalar error arg and another Table arg.
+                    // In case Tabular overload has one scalar error arg and another Table arg we want to
+                    // return table of error.
                     if (isMultiArgTabularOverload && maxSize > 0)
                     {
                         var tableType = (TableType)irContext.ResultType;
@@ -470,6 +471,8 @@ namespace Microsoft.PowerFx.Functions
                     resultRows.Add(DValue<RecordValue>.Of(record));
                 }
 
+                // Add error nodes for different table length
+                // e.g. Concatenate(["a"],["1","2"] => ["a1", <error>]
                 var namedErrorValue = new NamedValue(tableType.SingleColumnFieldName, FormulaValue.NewError(new ExpressionError()
                 {
                     Kind = ErrorKind.NotSupported,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -324,42 +324,6 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        private static ExpandToSizeResult ExpandToSize(FormulaValue arg, int size)
-        {
-            if (arg is TableValue tv)
-            {
-                var tvType = (TableType)tv.Type;
-                var name = tvType.SingleColumnFieldName;
-
-                var count = tv.Rows.Count();
-                if (count < size)
-                {
-                    var inputRecordType = tvType.ToRecord();
-                    var inputRecordNamedValue = new NamedValue(name, new BlankValue(IRContext.NotInSource(FormulaType.Blank)));
-                    var inputRecord = new InMemoryRecordValue(IRContext.NotInSource(inputRecordType), new List<NamedValue>() { inputRecordNamedValue });
-                    var inputDValue = DValue<RecordValue>.Of(inputRecord);
-
-                    var repeated = Enumerable.Repeat(inputDValue, size - count);
-                    var rows = tv.Rows.Concat(repeated);
-                    return new ExpandToSizeResult(name, rows);
-                }
-                else
-                {
-                    return new ExpandToSizeResult(name, tv.Rows);
-                }
-            }
-            else
-            {
-                var name = BuiltinFunction.ColumnName_ValueStr;
-                var inputRecordType = RecordType.Empty().Add(name, arg.Type);
-                var inputRecordNamedValue = new NamedValue(name, arg);
-                var inputRecord = new InMemoryRecordValue(IRContext.NotInSource(inputRecordType), new List<NamedValue>() { inputRecordNamedValue });
-                var inputDValue = DValue<RecordValue>.Of(inputRecord);
-                var rows = Enumerable.Repeat(inputDValue, size);
-                return new ExpandToSizeResult(name, rows);
-            }
-        }
-
         private static ExpandToSizeResult ShrinkToSize(FormulaValue arg, int size)
         {
             if (arg is TableValue tv)
@@ -473,7 +437,7 @@ namespace Microsoft.PowerFx.Functions
 
                 // Add error nodes for different table length
                 // e.g. Concatenate(["a"],["1","2"] => ["a1", <error>]
-                var namedErrorValue = new NamedValue(tableType.SingleColumnFieldName, FormulaValue.NewError(new ExpressionError()
+                var namedErrorValue = new NamedValue(columnNameStr, FormulaValue.NewError(new ExpressionError()
                 {
                     Kind = ErrorKind.NotSupported,
                     Severity = ErrorSeverity.Critical,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -309,7 +309,7 @@ namespace Microsoft.PowerFx.Functions
                     emptyTablePresent |= tableSize == 0;
                 }
 
-                if (arg is BlankValue bv)
+                if (arg is BlankValue bv && bv.IRContext.ResultType._type.IsTable)
                 {
                     blankTablePresent = true;
                 }
@@ -404,9 +404,9 @@ namespace Microsoft.PowerFx.Functions
 
                 (var maxSize, var minSize, var emptyTablePresent, var blankTablePresent) = AnalyzeTableArguments(args);
 
-                // If one arg is blank and among all other args one is empty Table or all other args are scaler or blank.
+                // If one arg is blank table and among all other args, return blank.
                 // e.g. Concatenate(Blank(), []), Concatenate(Blank(), "test"), Concatenate(Blank(), ["test"], []) => Blank()
-                if (blankTablePresent && (emptyTablePresent || maxSize == 0))
+                if (blankTablePresent)
                 {
                     return FormulaValue.NewBlank();
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -309,9 +309,7 @@ namespace Microsoft.PowerFx.Functions
                 {
                     var tableSize = tv.Rows.Count();
                     maxTableSize = Math.Max(maxTableSize, tableSize);
-
-                    // Empty tables are not considered for count.
-                    minTableSize = tableSize != 0 ? Math.Min(minTableSize, tableSize) : minTableSize;
+                    minTableSize = Math.Min(minTableSize, tableSize);
 
                     emptyTablePresent |= tableSize == 0;
                 }
@@ -411,8 +409,7 @@ namespace Microsoft.PowerFx.Functions
          * As a concrete example, Concatenate(["a", "b"], ["1", "2"]) => ["a1", "b2"]
         */
         public static Func<EvalVisitor, EvalVisitorContext, IRContext, FormulaValue[], ValueTask<FormulaValue>> MultiSingleColumnTable(
-            AsyncFunctionPtr targetFunction,
-            bool transposeEmptyTable)
+            AsyncFunctionPtr targetFunction)
         {
             return async (runner, context, irContext, args) =>
             {
@@ -427,11 +424,10 @@ namespace Microsoft.PowerFx.Functions
                     return FormulaValue.NewBlank();
                 }
 
-                if (maxSize == 0 || (emptyTablePresent && !transposeEmptyTable))
+                if (maxSize == 0)
                 {
                     // maxSize == 0 means there are no tables with rows. This can happen when we expect a Table at compile time but we recieve Blank() at runtime,
-                    // or all tables in args are empty. Additionally, among non-empty tables (in which case maxSize > 0) there may be an empty table,
-                    // which also means empty result if transposeEmptyTable == false.
+                    // or all tables in args are empty. Additionally, 
                     // Return an empty table (with the correct type).
                     // e.g. Concatenate([], "test") => []
                     return new InMemoryTableValue(irContext, resultRows);

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -3452,6 +3452,10 @@
     <value>Internal</value>
     <comment>{Locked} Enum value</comment>
   </data>
+  <data name="ErrorKind_NotApplicable_Name" xml:space="preserve">
+    <value>NotApplicable</value>
+    <comment>{Locked} Enum value</comment>
+  </data>
   <data name="Post" xml:space="preserve">
     <value>Post</value>
     <comment>Button text to post comment</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate.txt
@@ -2,7 +2,7 @@
 Table({Result:"777abc1"},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate("777", Filter(["empty table"], Value <> Value), ["1", "2"])
-Table({Result:"7771"},{Result:"7772"})
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 // ******** VALID STRING PARAMETERS ********
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate.txt
@@ -1,5 +1,5 @@
 ﻿>> Concatenate("777", ["abc"], ["1", "2"])
-Table({Result:"777abc1"},{Result:"7772"})
+Table({Result:"777abc1"},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate("777", Filter(["empty table"], Value <> Value), ["1", "2"])
 Table({Result:"7771"},{Result:"7772"})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate_ConsistentOneColumnTableResult.txt
@@ -4,4 +4,4 @@
 ["777abc1",Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate("777", Filter(["empty table"], Value <> Value), ["1", "2"])
-["7771","7772"]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concatenate_ConsistentOneColumnTableResult.txt
@@ -1,7 +1,7 @@
 ﻿#SETUP: ConsistentOneColumnTableResult
 
 >> Concatenate("777", ["abc"], ["1", "2"])
-["777abc1","7772"]
+["777abc1",Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate("777", Filter(["empty table"], Value <> Value), ["1", "2"])
 ["7771","7772"]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT.txt
@@ -5,37 +5,37 @@ Errors: Error 0-24: The function 'Find' has some invalid arguments.|Error 14-18:
 Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: Invalid argument type (Table). Expecting a Text value instead.|Error 11-15: Invalid argument type (Table). Expecting a Text value instead.
 
 >> Find(If(false, ["blank table"], Blank()), If(false, ["blank table"], Blank()), [1])
-Table({Result:1})
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), If(false, ["blank table"], Blank()), [2])
-Table({Result:Microsoft.PowerFx.Types.ErrorValue})
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), "textToBeSearchedIn", [5])
-Table({Result:5})
+Blank()
 
 >> Find("textToSearch", If(false, ["blank table"], Blank()), [1])
-Table({Result:Blank()})
+Blank()
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()), 1)
-Table({Result:1},{Result:1},{Result:Blank()})
+Blank()
 
 >> Find(["b"], ["abc", "cde"])
 Table({Result:2},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(["b"], ["abc", "cde"], If(false, [0], Blank()))
-Table({Result:Blank()},{Result:Microsoft.PowerFx.Types.ErrorValue})
+Blank()
 
 >> Find(["b"], ["abc", "cde"], Filter([0], Value <> Value))
 Table()
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()), [1, 2, 3])
-Table({Result:1},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), [Blank(), "", "textToBeSearchedIn"], 1)
-Table({Result:1},{Result:1},{Result:1})
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), [Blank(), "", "textToBeSearchedIn"], [1, 2, 3])
-Table({Result:1},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:3})
+Blank()
 
 >> Find([Blank(), "", ","], "textToBeSearchedIn,textToBeSearchedIn", 1)
 Table({Result:1},{Result:1},{Result:19})
@@ -56,10 +56,10 @@ Table({Result:1},{Result:10},{Result:19})
 Table({Result:19},{Result:19},{Result:19},{Result:Blank()})
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()))
-Table({Result:1},{Result:1},{Result:Blank()})
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), [Blank(), "", "textToBeSearchedIn"])
-Table({Result:1},{Result:1},{Result:1})
+Blank()
 
 >> Find([Blank(), "", ","], "textToBeSearchedIn,textToBeSearchedIn")
 Table({Result:1},{Result:1},{Result:19})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT.txt
@@ -20,10 +20,10 @@ Table({Result:Blank()})
 Table({Result:1},{Result:1},{Result:Blank()})
 
 >> Find(["b"], ["abc", "cde"])
-Table({Result:2},{Result:1})
+Table({Result:2},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(["b"], ["abc", "cde"], If(false, [0], Blank()))
-Table({Result:Blank()},{Result:Blank()})
+Table({Result:Blank()},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(["b"], ["abc", "cde"], Filter([0], Value <> Value))
 Table()
@@ -71,10 +71,10 @@ Table({Result:19})
 Table({Result:1},{Result:1},{Result:19})
 
 >> Find([Blank(), ","], ["lastName,firstName", "lastName,firstName,", "lastName,firstName", Blank()])
-Table({Result:1},{Result:9},{Result:1},{Result:1})
+Table({Result:1},{Result:9},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find([Blank(), ",", "", "findMe"], [Blank(), "lastName,firstName"])
-Table({Result:1},{Result:9},{Result:1},{Result:Blank()})
+Table({Result:1},{Result:9},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find([Blank(), ","], ["lastName,firstName",], [9, 2, 3])
 Table({Result:9},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
@@ -83,10 +83,10 @@ Table({Result:9},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.P
 Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Blank()},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find([",", Blank()], "lastName,firstName", [1, 2, 3])
-Table({Result:9},{Result:2},{Result:3})
+Table({Result:9},{Result:2},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(",", [Blank(), "lastName,firstName", "lastName,firstName"], [1, 2])
-Table({Result:Blank()},{Result:9},{Result:Blank()})
+Table({Result:Blank()},{Result:9},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(Filter(["empty table"], Value <> Value), "", 1)
 Table()
@@ -138,7 +138,7 @@ Table({Result:1},Microsoft.PowerFx.Types.ErrorValue,{Result:Microsoft.PowerFx.Ty
 //actual: Microsoft.PowerFx.Types.ErrorValue
 
 >> Find(Table({ find: "a" }, { find: "b" }, { find: "c" }), If(1/0>2,"abcdef"))
-#Error(Kind=Div0)
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(If(Sqrt(-1)<0,"First second third"), Table({ within: "First" }, { within: "Second" }))
-#Error(Kind=Numeric)
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT.txt
@@ -26,7 +26,7 @@ Table({Result:2},{Result:Microsoft.PowerFx.Types.ErrorValue})
 Blank()
 
 >> Find(["b"], ["abc", "cde"], Filter([0], Value <> Value))
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()), [1, 2, 3])
 Blank()
@@ -104,22 +104,22 @@ Table()
 Table()
 
 >> Find(Filter(["empty table"], Value <> Value), [Blank(), "lastName,firstName", "lastName,firstName"], 2)
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(Filter(["empty table"], Value <> Value), "textToSearch", [1, 2])
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find([",", Blank(), ""], Filter(["empty table"], Value <> Value), 2)
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(",", Filter(["empty table"], Value <> Value), [1, 1])
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find([Blank(), ",", "", "findMe"], [Blank(), "lastName,firstName", "lastName,firstName"], Filter(["empty table"], Value <> Value))
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find(",", [Blank(), "lastName,firstName"], Filter(["empty table"], Value <> Value))
-Table()
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Find("c", Table({ within: "abc" }, { within: Error({Kind: ErrorKind.Validation}) }, { within: "cde" }))
 Table({Result:3},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:1})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT_ConsistentOneColumnTableResult.txt
@@ -22,10 +22,10 @@ Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: I
 [1,1,Blank()]
 
 >> Find(["b"], ["abc", "cde"])
-[2,1]
+[2,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(["b"], ["abc", "cde"], If(false, [0], Blank()))
-[Blank(),Blank()]
+[Blank(),Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(["b"], ["abc", "cde"], Filter([0], Value <> Value))
 []
@@ -73,10 +73,10 @@ Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: I
 [1,1,19]
 
 >> Find([Blank(), ","], ["lastName,firstName", "lastName,firstName,", "lastName,firstName", Blank()])
-[1,9,1,1]
+[1,9,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find([Blank(), ",", "", "findMe"], [Blank(), "lastName,firstName"])
-[1,9,1,Blank()]
+[1,9,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find([Blank(), ","], ["lastName,firstName",], [9, 2, 3])
 [9,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
@@ -85,10 +85,10 @@ Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: I
 [Microsoft.PowerFx.Types.ErrorValue,Blank(),Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find([",", Blank()], "lastName,firstName", [1, 2, 3])
-[9,2,3]
+[9,2,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(",", [Blank(), "lastName,firstName", "lastName,firstName"], [1, 2])
-[Blank(),9,Blank()]
+[Blank(),9,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(Filter(["empty table"], Value <> Value), "", 1)
 []
@@ -139,7 +139,7 @@ Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: I
 Table({Value:1},Microsoft.PowerFx.Types.ErrorValue,{Value:Microsoft.PowerFx.Types.ErrorValue},Microsoft.PowerFx.Types.ErrorValue,{Value:3})
 
 >> Find(Table({ find: "a" }, { find: "b" }, { find: "c" }), If(1/0>2,"abcdef"))
-#Error(Kind=Div0)
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(If(Sqrt(-1)<0,"First second third"), Table({ within: "First" }, { within: "Second" }))
-#Error(Kind=Numeric)
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT_ConsistentOneColumnTableResult.txt
@@ -7,37 +7,37 @@ Errors: Error 0-24: The function 'Find' has some invalid arguments.|Error 14-18:
 Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: Invalid argument type (Table). Expecting a Text value instead.|Error 11-15: Invalid argument type (Table). Expecting a Text value instead.
 
 >> Find(If(false, ["blank table"], Blank()), If(false, ["blank table"], Blank()), [1])
-[1]
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), If(false, ["blank table"], Blank()), [2])
-[Microsoft.PowerFx.Types.ErrorValue]
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), "textToBeSearchedIn", [5])
-[5]
+Blank()
 
 >> Find("textToSearch", If(false, ["blank table"], Blank()), [1])
-[Blank()]
+Blank()
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()), 1)
-[1,1,Blank()]
+Blank()
 
 >> Find(["b"], ["abc", "cde"])
 [2,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(["b"], ["abc", "cde"], If(false, [0], Blank()))
-[Blank(),Microsoft.PowerFx.Types.ErrorValue]
+Blank()
 
 >> Find(["b"], ["abc", "cde"], Filter([0], Value <> Value))
 []
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()), [1, 2, 3])
-[1,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), [Blank(), "", "textToBeSearchedIn"], 1)
-[1,1,1]
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), [Blank(), "", "textToBeSearchedIn"], [1, 2, 3])
-[1,Microsoft.PowerFx.Types.ErrorValue,3]
+Blank()
 
 >> Find([Blank(), "", ","], "textToBeSearchedIn,textToBeSearchedIn", 1)
 [1,1,19]
@@ -58,10 +58,10 @@ Errors: Error 0-25: The function 'Find' has some invalid arguments.|Error 5-9: I
 [19,19,19,Blank()]
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()))
-[1,1,Blank()]
+Blank()
 
 >> Find(If(false, ["blank table"], Blank()), [Blank(), "", "textToBeSearchedIn"])
-[1,1,1]
+Blank()
 
 >> Find([Blank(), "", ","], "textToBeSearchedIn,textToBeSearchedIn")
 [1,1,19]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FindT_ConsistentOneColumnTableResult.txt
@@ -28,7 +28,7 @@ Blank()
 Blank()
 
 >> Find(["b"], ["abc", "cde"], Filter([0], Value <> Value))
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find([Blank(), "", ","], If(false, ["blank table"], Blank()), [1, 2, 3])
 Blank()
@@ -106,22 +106,22 @@ Blank()
 []
 
 >> Find(Filter(["empty table"], Value <> Value), [Blank(), "lastName,firstName", "lastName,firstName"], 2)
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(Filter(["empty table"], Value <> Value), "textToSearch", [1, 2])
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find([",", Blank(), ""], Filter(["empty table"], Value <> Value), 2)
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(",", Filter(["empty table"], Value <> Value), [1, 1])
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find([Blank(), ",", "", "findMe"], [Blank(), "lastName,firstName", "lastName,firstName"], Filter(["empty table"], Value <> Value))
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find(",", [Blank(), "lastName,firstName"], Filter(["empty table"], Value <> Value))
-[]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Find("c", Table({ within: "abc" }, { within: Error({Kind: ErrorKind.Validation}) }, { within: "cde" }))
 [3,Microsoft.PowerFx.Types.ErrorValue,1]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RoundTable.txt
@@ -24,14 +24,14 @@ Table({Result:1200},{Result:1234.6},{Result:1235},{Result:1234.6},{Result:1234.5
 
 // Blank values
 >> Round( If(1<0,[1]), 1 )
-[]
+Blank()
 
 // Errors
 >> Round( If(1/0<2, [1]), 1 )
 #Error(Kind=Div0)
 
 >> Round( [1.2, 2.3, 3.4], 1/0 )
-#Error(Kind=Div0)
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Round( [1.23, Sqrt(-1), 7.89], 1)
 [1.2,Microsoft.PowerFx.Types.ErrorValue,7.9]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
@@ -19,13 +19,13 @@ Blank()
 Table({Value:"aone"},Microsoft.PowerFx.Types.ErrorValue,{Value:"athree"})
 
 >> Concatenate(Blank(), ["hello", Mid("great", -1), "world"])
-["hello",Microsoft.PowerFx.Types.ErrorValue,"world"]
+Blank()
 
 >> Concatenate(Blank(), Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}))
-["one","","three"]
+Blank()
 
 >> Concatenate(Blank(), Table({a:"one"},If(1/0<2,{a:"two"}),{a:"three"}))
-Table({Value:"one"},Microsoft.PowerFx.Types.ErrorValue,{Value:"three"})
+Blank()
 
 >> Concatenate(Table({b:"1"},{b:"2"}), "a")
 ["1a","2a"]
@@ -43,13 +43,13 @@ Table({Value:"one"},Microsoft.PowerFx.Types.ErrorValue,{Value:"three"})
 Table({Value:"onea"},Microsoft.PowerFx.Types.ErrorValue,{Value:"threea"})
 
 >> Concatenate(["hello", Mid("great", -1), "world"], Blank())
-["hello",Microsoft.PowerFx.Types.ErrorValue,"world"]
+Blank()
 
 >> Concatenate(Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}), Blank())
-["one","","three"]
+Blank()
 
 >> Concatenate(Table({a:"one"},If(1/0<2,{a:"two"}),{a:"three"}), Blank())
-Table({Value:"one"},Microsoft.PowerFx.Types.ErrorValue,{Value:"three"})
+Blank()
 
 // Table + Table
 >> Concatenate(["one", "two"], [1, 2, 3, 4])
@@ -59,7 +59,7 @@ Table({Value:"one"},Microsoft.PowerFx.Types.ErrorValue,{Value:"three"})
 ["one","two"]
 
 >> Concatenate(["one", "two"], If(1<0, ["txt"]))
-["one","two"]
+Blank()
 
 >> Concatenate(["one", "two"], If(1/0<2, ["txt"]))
 [Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
@@ -7,7 +7,7 @@
 []
 
 >> Concatenate("a", If(1<0, ["txt"]))
-[]
+Blank()
 
 >> Concatenate("a", ["hello", Mid("great", -1), "world"])
 ["ahello",Microsoft.PowerFx.Types.ErrorValue,"aworld"]
@@ -53,7 +53,7 @@ Table({Value:"one"},Microsoft.PowerFx.Types.ErrorValue,{Value:"three"})
 
 // Table + Table
 >> Concatenate(["one", "two"], [1, 2, 3, 4])
-["one1","two2","3","4"]
+["one1","two2",Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate(["one", "two"], LastN(Table({b:"1"},{b:"2"}), 0))
 ["one","two"]
@@ -62,13 +62,13 @@ Table({Value:"one"},Microsoft.PowerFx.Types.ErrorValue,{Value:"three"})
 ["one","two"]
 
 >> Concatenate(["one", "two"], If(1/0<2, ["txt"]))
-Microsoft.PowerFx.Types.ErrorValue
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate(["one", "two"], Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}))
-["oneone","two","three"]
+["oneone","two",Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate(["one", "two"], ["hello", Mid("great", -1), "world"])
-["onehello",Microsoft.PowerFx.Types.ErrorValue,"world"]
+["onehello",Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate(["a","b","c","d"], "-", ["1", "2"], "-", ["x", "y", "z"], "!")
-["a-1-x!","b-2-y!","c--z!","d--!"]
+["a-1-x!","b-2-y!",Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
@@ -62,7 +62,7 @@ Blank()
 Blank()
 
 >> Concatenate(["one", "two"], If(1/0<2, ["txt"]))
-[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+#Error(Kind=Div0)
 
 >> Concatenate(["one", "two"], Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}))
 ["oneone","two",Microsoft.PowerFx.Types.ErrorValue]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringFuncs_ConsistentOneColumnTableResult.txt
@@ -56,7 +56,7 @@ Blank()
 ["one1","two2",Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate(["one", "two"], LastN(Table({b:"1"},{b:"2"}), 0))
-["one","two"]
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
 
 >> Concatenate(["one", "two"], If(1<0, ["txt"]))
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
@@ -21,13 +21,13 @@ Table({Result:"aone"},{Result:"a"},{Result:"athree"})
 Table({Result:"aone"},Microsoft.PowerFx.Types.ErrorValue,{Result:"athree"})
 
 >> Concatenate(Blank(), ["hello", Mid("great", -1), "world"])
-Table({Result:"hello"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:"world"})
+Blank()
 
 >> Concatenate(Blank(), Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}))
-Table({Result:"one"},{Result:""},{Result:"three"})
+Blank()
 
 >> Concatenate(Blank(), Table({a:"one"},If(1/0<2,{a:"two"}),{a:"three"}))
-Table({Result:"one"},Microsoft.PowerFx.Types.ErrorValue,{Result:"three"})
+Blank()
 
 // Table + Scalar (Reverse Arguments)
 >> Concatenate(Table({b:"1"},{b:"2"}), "a")
@@ -52,13 +52,13 @@ Table({Result:"onea"},{Result:"a"},{Result:"threea"})
 Table({Result:"onea"},Microsoft.PowerFx.Types.ErrorValue,{Result:"threea"})
 
 >> Concatenate(["hello", Mid("great", -1), "world"], Blank())
-Table({Result:"hello"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:"world"})
+Blank()
 
 >> Concatenate(Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}), Blank())
-Table({Result:"one"},{Result:""},{Result:"three"})
+Blank()
 
 >> Concatenate(Table({a:"one"},If(1/0<2,{a:"two"}),{a:"three"}), Blank())
-Table({Result:"one"},Microsoft.PowerFx.Types.ErrorValue,{Result:"three"})
+Blank()
 
 // Table + Table
 >> Concatenate(["one", "two"], [1, 2, 3, 4])
@@ -68,7 +68,7 @@ Table({Result:"one1"},{Result:"two2"},{Result:Microsoft.PowerFx.Types.ErrorValue
 Table({Result:"one"},{Result:"two"})
 
 >> Concatenate(["one", "two"], If(1<0, ["txt"]))
-Table({Result:"one"},{Result:"two"})
+Blank()
 
 >> Concatenate(["one", "two"], If(1/0<2, ["txt"]))
 Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
@@ -65,7 +65,7 @@ Blank()
 Table({Result:"one1"},{Result:"two2"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate(["one", "two"], LastN(Table({b:"1"},{b:"2"}), 0))
-Table({Result:"one"},{Result:"two"})
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate(["one", "two"], If(1<0, ["txt"]))
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
@@ -6,7 +6,7 @@ Table({Result:"a1"},{Result:"a2"})
 Table()
 
 >> Concatenate("a", If(1<0, ["txt"]))
-Table()
+Blank()
 
 >> Concatenate("a", If(1/0<2, ["txt"]))
 #Error
@@ -37,7 +37,7 @@ Table({Result:"1a"},{Result:"2a"})
 Table()
 
 >> Concatenate(If(1<0, ["txt"]), "a")
-Table()
+Blank()
 
 >> Concatenate(If(1/0<2, ["txt"]), "a")
 #Error
@@ -62,7 +62,7 @@ Table({Result:"one"},Microsoft.PowerFx.Types.ErrorValue,{Result:"three"})
 
 // Table + Table
 >> Concatenate(["one", "two"], [1, 2, 3, 4])
-Table({Result:"one1"},{Result:"two2"},{Result:"3"},{Result:"4"})
+Table({Result:"one1"},{Result:"two2"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate(["one", "two"], LastN(Table({b:"1"},{b:"2"}), 0))
 Table({Result:"one"},{Result:"two"})
@@ -71,13 +71,13 @@ Table({Result:"one"},{Result:"two"})
 Table({Result:"one"},{Result:"two"})
 
 >> Concatenate(["one", "two"], If(1/0<2, ["txt"]))
-Microsoft.PowerFx.Types.ErrorValue
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate(["one", "two"], Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}))
-Table({Result:"oneone"},{Result:"two"},{Result:"three"})
+Table({Result:"oneone"},{Result:"two"},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate(["one", "two"], ["hello", Mid("great", -1), "world"])
-Table({Result:"onehello"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:"world"})
+Table({Result:"onehello"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
 
 >> Concatenate(["a","b","c","d"], "-", ["1", "2"], "-", ["x", "y", "z"], "!")
-Table({Result:"a-1-x!"},{Result:"b-2-y!"},{Result:"c--z!"},{Result:"d--!"})
+Table({Result:"a-1-x!"},{Result:"b-2-y!"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableStringfuncs.txt
@@ -71,7 +71,7 @@ Table({Result:"one"},{Result:"two"})
 Blank()
 
 >> Concatenate(["one", "two"], If(1/0<2, ["txt"]))
-Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+#Error(Kind=Div0)
 
 >> Concatenate(["one", "two"], Table({a:"one"},If(1<0,{a:"two"}),{a:"three"}))
 Table({Result:"oneone"},{Result:"two"},{Result:Microsoft.PowerFx.Types.ErrorValue})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -233,3 +233,12 @@ Blank()
 
 >> Concatenate(If(1<0,["a","b"]), If(1/0<2,["abcdef", "ghijkl"]))
 #Error(Kind=Div0)
+
+>> Concatenate( If(Sqrt(-1)<0,["Hi", "hello"]), If(1/0<2, " world") )
+#Error(Kind=Numeric)
+
+>> Concatenate( If(Sqrt(-1)<0,"Hello"), If(1/0<2, [" world", "people"]) )
+#Error(Kind=Div0)
+
+>> Concatenate( If(Sqrt(-1)<0,["Hi", "hello"]), If(1/0<2, [" world", "people"]) )
+#Error(Kind=Numeric, Div0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -218,3 +218,18 @@ Blank()
 
 >> Find(If(1<0,["a","b"]), Filter(["abcdef", "ghijkl"], Len(Value)>10))
 Blank()
+
+>> Concatenate(["a","b"], If(1/0<2,["abcdef", "ghijkl"]))
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Find(If(1/0<2,["a","b"]), ["abcdef", "ghijkl"])
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Concatenate(["a","b"], If(1<0,["abcdef", "ghijkl"]))
+Blank()
+
+>> Find(If(1<0,["a","b"]), ["abcdef", "ghijkl"])
+Blank()
+
+>> Concatenate(If(1<0,["a","b"]), If(1/0<2,["abcdef", "ghijkl"]))
+#Error(Kind=Div0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -242,3 +242,6 @@ Blank()
 
 >> Concatenate( If(Sqrt(-1)<0,["Hi", "hello"]), If(1/0<2, [" world", "people"]) )
 #Error(Kind=Numeric, Div0)
+
+>> Concatenate(Filter([1,2], Value<>Value), If(1/0<0, "test"))
+Table()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -1,0 +1,214 @@
+﻿// *********** Single-argument functions ***********
+
+>> Abs(If(1/0<2,[1]))
+#Error(Kind=Div0)
+
+>> Abs(If(1<0,[1]))
+Blank()
+
+>> Abs(Filter([1,2,3], Value > 10))
+[]
+
+>> Boolean(If(1/0<2,["true"]))
+#Error(Kind=Div0)
+
+>> Boolean(If(1<0,["true"]))
+Blank()
+
+>> Boolean(Filter(["true","false"], Len(Value) > 10))
+[]
+
+>> Boolean(If(1/0<2,[1]))
+#Error(Kind=Div0)
+
+>> Boolean(If(1<0,[1]))
+Blank()
+
+>> Boolean(Filter([1,2,3], Value > 10))
+[]
+
+>> Char(If(1/0<2,[61]))
+#Error(Kind=Div0)
+
+>> Char(If(1<0,[61]))
+Blank()
+
+>> Char(Filter([61,62,63], Value > 100))
+Table()
+
+>> Exp(If(1/0<2,[1]))
+#Error(Kind=Div0)
+
+>> Exp(If(1<0,[1]))
+Blank()
+
+>> Exp(Filter([1,2,3], Value > 10))
+[]
+
+>> Int(If(1/0<2,[1]))
+#Error(Kind=Div0)
+
+>> Int(If(1<0,[1]))
+Blank()
+
+>> Int(Filter([1,2,3], Value > 10))
+[]
+
+>> Len(If(1/0<2,["true"]))
+#Error(Kind=Div0)
+
+>> Len(If(1<0,["true"]))
+Blank()
+
+>> Len(Filter(["true","false"], Len(Value) > 10))
+Table()
+
+>> Ln(If(1/0<2,[1]))
+#Error(Kind=Div0)
+
+>> Ln(If(1<0,[1]))
+Blank()
+
+>> Ln(Filter([1,2,3], Value > 10))
+[]
+
+>> Sqrt(If(1/0<2,[1]))
+#Error(Kind=Div0)
+
+>> Sqrt(If(1<0,[1]))
+Blank()
+
+>> Sqrt(Filter([1,2,3], Value > 10))
+[]
+
+// *********** 2+-argument functions, errors ***********
+
+>> Concatenate(If(1/0<2,["hello", "hi"]), " world")
+#Error(Kind=Div0)
+
+>> Concatenate("hello ", If(Sqrt(-1)<0,["world", "day"]))
+#Error(Kind=Numeric)
+
+>> Concatenate(["hello", "hi"], If(1/0<2," world"))
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Concatenate(Char(0), ["hello", "great", "world"])
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Concatenate(["hello", "hi"], " ", ["John", "Jane", "Jim", "Joan"])
+Table({Result:"hello John"},{Result:"hi Jane"},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Concat(Concatenate(["one", "two"], Text(1/0)), IfError(Result, $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=13), Error(Kind=13)"
+
+>> Concat(Concatenate(Char(0), ["hello", "great", "world"]), IfError(Result, $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=25), Error(Kind=25), Error(Kind=25)"
+
+>> Concat(Concatenate(["hello", "hi"], " ", ["John", "Jane", "Jim", "Joan"]), IfError(Result, $"Error(Kind={FirstError.Kind})"), ", ")
+"hello John, hi Jane, Error(Kind=20), Error(Kind=20)"
+
+>> Find(If(1/0<2,["hello", "hi"]), " world")
+#Error(Kind=Div0)
+
+>> Find("a", If(Sqrt(-1)<0,["world", "day"]))
+#Error(Kind=Numeric)
+
+>> Find(["a", "b"], If(1/0<2,"abcdefg"))
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Find(Char(0), ["hello", "great", "world"])
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Find(["a", "b", "c"], "The quick brown fox jumped over the lazy dog", [1, 2, 3, 4, 5])
+Table({Result:38},{Result:11},{Result:8},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Concat(Find(["a", "b"], If(1/0<2,"abcdefg")), IfError(Text(Result), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=13), Error(Kind=13)"
+
+>> Concat(Find(Char(0), ["hello", "great", "world"]), IfError(Text(Result), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=25), Error(Kind=25), Error(Kind=25)"
+
+>> Concat(Find(["a", "b", "c"], "The quick brown fox jumped over the lazy dog", [1, 2, 3, 4, 5]), IfError(Text(Result), $"Error(Kind={FirstError.Kind})"), ", ")
+"38, 11, 8, Error(Kind=20), Error(Kind=20)"
+
+>> Round(If(1/0<2,[12.34, 56.78]), 1)
+#Error(Kind=Div0)
+
+>> Round(1234.5678, If(Sqrt(-1)<0,[1, 2, 3]))
+#Error(Kind=Numeric)
+
+>> Round([12.34, 56.78], 1/0)
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Round(Sqrt(-1), [1, 2, 3])
+Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+
+>> Round([123.456, 234.567], [1, 2, 3])
+[123.5,234.57,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Concat(Round([12.34, 56.78], 1/0), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=13), Error(Kind=13)"
+
+>> Concat(Round(Sqrt(-1), [1, 2, 3]), IfError(Text(Result), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=24), Error(Kind=24), Error(Kind=24)"
+
+>> Concat(Round([123.456, 234.567], [1, 2, 3]), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
+"123.5, 234.57, Error(Kind=20)"
+
+// *********** 2+-argument functions, blanks ***********
+
+>> Concatenate(If(1<0,["hello", "hi"]), " world")
+Blank()
+
+>> Concatenate("hello ", If(1<0,["world", "day"]))
+Blank()
+
+>> Concatenate(["hello", "hi"], If(1<0," world"))
+Table({Result:"hello"},{Result:"hi"})
+
+>> Concatenate(If(1<0,"hi"), ["hello", "great", "world"])
+Table({Result:"hello"},{Result:"great"},{Result:"world"})
+
+>> Find(If(1<0,["hello", "hi"]), " world")
+Blank()
+
+>> Find("a", If(1<0,["world", "day"]))
+Blank()
+
+>> Find(["a", "b"], If(1<0,"abcdefg"))
+Table({Result:Blank()},{Result:Blank()})
+
+>> Find(If(1<0,"a"), ["hello", "great", "world"])
+Table({Result:1},{Result:1},{Result:1})
+
+>> Round(If(1<0,[12.34, 56.78]), 1)
+Blank()
+
+>> Round(1234.5678, If(1<0,[1, 2, 3]))
+Blank()
+
+>> Round([12.34, 56.78], If(1<0,1))
+[12,57]
+
+>> Round(If(1<0,2), [1, 2, 3])
+Table({Result:0},{Result:0},{Result:0})
+
+// *********** 2+-argument functions, empty tables ***********
+
+>> Concatenate(Filter(["hello", "hi"], Len(Value)>10), " world")
+Table()
+
+>> Concatenate("hello ", Filter(["world", "day"],Len(Value)>10))
+Table()
+
+>> Find(Filter(["hello", "hi"], Len(Value)>10), " world")
+Table()
+
+>> Find("a", Filter(["world", "day"],Len(Value)>10))
+Table()
+
+>> Round(Filter([12.34, 56.78], Value > 100), 1)
+[]
+
+>> Round(1234.5678, Filter([1, 2, 3], Value > 10))
+Table()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -105,7 +105,7 @@ Table({Result:"hello John"},{Result:"hi Jane"},{Result:Microsoft.PowerFx.Types.E
 "Error(Kind=25), Error(Kind=25), Error(Kind=25)"
 
 >> Concat(Concatenate(["hello", "hi"], " ", ["John", "Jane", "Jim", "Joan"]), IfError(Result, $"Error(Kind={FirstError.Kind})"), ", ")
-"hello John, hi Jane, Error(Kind=20), Error(Kind=20)"
+"hello John, hi Jane, Error(Kind=27), Error(Kind=27)"
 
 >> Find(If(1/0<2,["hello", "hi"]), " world")
 #Error(Kind=Div0)
@@ -129,7 +129,7 @@ Table({Result:38},{Result:11},{Result:8},{Result:Microsoft.PowerFx.Types.ErrorVa
 "Error(Kind=25), Error(Kind=25), Error(Kind=25)"
 
 >> Concat(Find(["a", "b", "c"], "The quick brown fox jumped over the lazy dog", [1, 2, 3, 4, 5]), IfError(Text(Result), $"Error(Kind={FirstError.Kind})"), ", ")
-"38, 11, 8, Error(Kind=20), Error(Kind=20)"
+"38, 11, 8, Error(Kind=27), Error(Kind=27)"
 
 >> Round(If(1/0<2,[12.34, 56.78]), 1)
 #Error(Kind=Div0)
@@ -153,7 +153,7 @@ Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Type
 "Error(Kind=24), Error(Kind=24), Error(Kind=24)"
 
 >> Concat(Round([123.456, 234.567], [1, 2, 3]), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
-"123.5, 234.57, Error(Kind=20)"
+"123.5, 234.57, Error(Kind=27)"
 
 // *********** 2+-argument functions, blanks ***********
 
@@ -212,3 +212,9 @@ Table()
 
 >> Round(1234.5678, Filter([1, 2, 3], Value > 10))
 Table()
+
+>> Concatenate(Filter(["a","b"], Len(Value)>10), If(1<0,["abcdef", "ghijkl"]))
+Blank()
+
+>> Find(If(1<0,["a","b"]), Filter(["abcdef", "ghijkl"], Len(Value)>10))
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -220,10 +220,10 @@ Blank()
 Blank()
 
 >> Concatenate(["a","b"], If(1/0<2,["abcdef", "ghijkl"]))
-Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+#Error(Kind=Div0)
 
 >> Find(If(1/0<2,["a","b"]), ["abcdef", "ghijkl"])
-Table({Result:Microsoft.PowerFx.Types.ErrorValue},{Result:Microsoft.PowerFx.Types.ErrorValue})
+#Error(Kind=Div0)
 
 >> Concatenate(["a","b"], If(1<0,["abcdef", "ghijkl"]))
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors_ConsistentOneColumnTableResult.txt
@@ -16,7 +16,7 @@
 "Error(Kind=25), Error(Kind=25), Error(Kind=25)"
 
 >> Concat(Concatenate(["hello", "hi"], " ", ["John", "Jane", "Jim", "Joan"]), IfError(Value, $"Error(Kind={FirstError.Kind})"), ", ")
-"hello John, hi Jane, Error(Kind=20), Error(Kind=20)"
+"hello John, hi Jane, Error(Kind=27), Error(Kind=27)"
 
 >> Find(["a", "b"], If(1/0<2,"abcdefg"))
 [Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
@@ -34,7 +34,7 @@
 "Error(Kind=25), Error(Kind=25), Error(Kind=25)"
 
 >> Concat(Find(["a", "b", "c"], "The quick brown fox jumped over the lazy dog", [1, 2, 3, 4, 5]), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
-"38, 11, 8, Error(Kind=20), Error(Kind=20)"
+"38, 11, 8, Error(Kind=27), Error(Kind=27)"
 
 >> Round(Sqrt(-1), [1, 2, 3])
 [Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
@@ -71,3 +71,15 @@
 
 >> Round(1234.5678, Filter([1, 2, 3], Value > 10))
 []
+
+>> Concatenate(Filter([1], Value > 10), "test")
+[]
+
+>> Concatenate(Blank(), Filter([1], Value > 10))
+Blank()
+
+>> Concatenate(Blank(), "test")
+"test"
+
+>> Concatenate(Blank(), ["test"], Filter([1], Value > 10))
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors_ConsistentOneColumnTableResult.txt
@@ -1,0 +1,73 @@
+﻿#SETUP: ConsistentOneColumnTableResult
+
+>> Concatenate(["hello", "hi"], If(1/0<2," world"))
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Concatenate(Char(0), ["hello", "great", "world"])
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Concatenate(["hello", "hi"], " ", ["John", "Jane", "Jim", "Joan"])
+["hello John","hi Jane",Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Concat(Concatenate(["one", "two"], Text(1/0)), IfError(Value, $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=13), Error(Kind=13)"
+
+>> Concat(Concatenate(Char(0), ["hello", "great", "world"]), IfError(Value, $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=25), Error(Kind=25), Error(Kind=25)"
+
+>> Concat(Concatenate(["hello", "hi"], " ", ["John", "Jane", "Jim", "Joan"]), IfError(Value, $"Error(Kind={FirstError.Kind})"), ", ")
+"hello John, hi Jane, Error(Kind=20), Error(Kind=20)"
+
+>> Find(["a", "b"], If(1/0<2,"abcdefg"))
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Find(Char(0), ["hello", "great", "world"])
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Find(["a", "b", "c"], "The quick brown fox jumped over the lazy dog", [1, 2, 3, 4, 5])
+[38,11,8,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Concat(Find(["a", "b"], If(1/0<2,"abcdefg")), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=13), Error(Kind=13)"
+
+>> Concat(Find(Char(0), ["hello", "great", "world"]), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=25), Error(Kind=25), Error(Kind=25)"
+
+>> Concat(Find(["a", "b", "c"], "The quick brown fox jumped over the lazy dog", [1, 2, 3, 4, 5]), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
+"38, 11, 8, Error(Kind=20), Error(Kind=20)"
+
+>> Round(Sqrt(-1), [1, 2, 3])
+[Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue,Microsoft.PowerFx.Types.ErrorValue]
+
+>> Concat(Round(Sqrt(-1), [1, 2, 3]), IfError(Text(Value), $"Error(Kind={FirstError.Kind})"), ", ")
+"Error(Kind=24), Error(Kind=24), Error(Kind=24)"
+
+>> Concatenate(["hello", "hi"], If(1<0," world"))
+["hello","hi"]
+
+>> Concatenate(If(1<0,"hi"), ["hello", "great", "world"])
+["hello","great","world"]
+
+>> Find(["a", "b"], If(1<0,"abcdefg"))
+[Blank(),Blank()]
+
+>> Find(If(1<0,"a"), ["hello", "great", "world"])
+[1,1,1]
+
+>> Round(If(1<0,2), [1, 2, 3])
+[0,0,0]
+
+>> Concatenate(Filter(["hello", "hi"], Len(Value)>10), " world")
+[]
+
+>> Concatenate("hello ", Filter(["world", "day"],Len(Value)>10))
+[]
+
+>> Find(Filter(["hello", "hi"], Len(Value)>10), " world")
+[]
+
+>> Find("a", Filter(["world", "day"],Len(Value)>10))
+[]
+
+>> Round(1234.5678, Filter([1, 2, 3], Value > 10))
+[]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -131,13 +131,13 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("true &|", "&", "&&")]
 
         // UnaryOpNodeSuggestionHandler
-        [InlineData("Not| false", "Not", "NotificationType", "NotificationType.Error", "NotificationType.Information", "NotificationType.Success", "NotificationType.Warning", "ErrorKind.FileNotFound", "ErrorKind.NotFound", "ErrorKind.NotSupported", "Icon.Note", "Icon.Notebook")]
+        [InlineData("Not| false", "Not", "NotificationType", "NotificationType.Error", "NotificationType.Information", "NotificationType.Success", "NotificationType.Warning", "ErrorKind.FileNotFound", "ErrorKind.NotApplicable", "ErrorKind.NotFound", "ErrorKind.NotSupported", "Icon.Note", "Icon.Notebook")]
         [InlineData("| Not false")]
         [InlineData("Not |")]
 
         // StrInterpSuggestionHandler
-        [InlineData("With( {Apples:3}, $\"We have {appl|", "Apples")]
-        [InlineData("With( {Apples:3}, $\"We have {appl|} apples.", "Apples")]
+        [InlineData("With( {Apples:3}, $\"We have {appl|", "Apples", "ErrorKind.NotApplicable")]
+        [InlineData("With( {Apples:3}, $\"We have {appl|} apples.", "Apples", "ErrorKind.NotApplicable")]
         [InlineData("$\"This is a randomly generated number: {rand|", "Rand", "RandBetween")]
 
         // StrNumLitNodeSuggestionHandler

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FunctionDefinitionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FunctionDefinitionTests.cs
@@ -25,7 +25,16 @@ namespace Microsoft.PowerFx.Tests
             var tabularOverloads = type.GetProperty("SimpleFunctionTabularOverloadImplementations", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null)
                 as IReadOnlyDictionary<TexlFunction, AsyncFunctionPtr>;
             Assert.NotNull(tabularOverloads);
+            var tabularMultiArgsOverloads = type.GetProperty("SimpleFunctionMultiArgsTabularOverloadImplementations", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null)
+                as IReadOnlyDictionary<TexlFunction, AsyncFunctionPtr>;
+            Assert.NotNull(tabularMultiArgsOverloads);
 
+            ValidateOverloads(simpleFunctions, tabularOverloads, isMultiArg: false);
+            ValidateOverloads(simpleFunctions, tabularMultiArgsOverloads, isMultiArg: true);
+        }
+
+        private void ValidateOverloads(IReadOnlyDictionary<TexlFunction, AsyncFunctionPtr> simpleFunctions, IReadOnlyDictionary<TexlFunction, AsyncFunctionPtr> tabularOverloads, bool isMultiArg) 
+        {
             foreach (var tabularOverload in tabularOverloads.Keys)
             {
                 var simpleFunction = simpleFunctions.First(f => f.Key.Name == tabularOverload.Name).Key;
@@ -35,9 +44,15 @@ namespace Microsoft.PowerFx.Tests
                 Assert.NotEqual(DKind.Table, simpleFunction.ReturnType.Kind);
                 Assert.DoesNotContain(simpleFunction.ParamTypes, t => t.Kind == DKind.Table); // No tabular inputs
 
-                // Validate input / output types - tabular function should take at least one table / return table
+                // Validate tabular function should return table
                 Assert.Equal(DKind.Table, tabularOverload.ReturnType.Kind); // Returns table
-                Assert.Contains(tabularOverload.ParamTypes, t => t.Kind == DKind.Table); // At least one table input
+
+                // Validate input types - Single arg Tabular function should take at lease one table
+                // Multi arg Tabular Function can have scaler/tabular as arg hence skip this test.
+                if (!isMultiArg)
+                {
+                    Assert.Contains(tabularOverload.ParamTypes, t => t.Kind == DKind.Table); // At least one table input
+                }
 
                 // Validate similar arity
                 Assert.Equal(tabularOverload.MinArity, simpleFunction.MinArity);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FunctionDefinitionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FunctionDefinitionTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerFx.Tests
                 Assert.Equal(DKind.Table, tabularOverload.ReturnType.Kind); // Returns table
 
                 // Validate input types - Single arg Tabular function should take at lease one table
-                // Multi arg Tabular Function can have scaler/tabular as arg hence skip this test.
+                // Multi arg Tabular Function can have scalar/tabular as arg hence skip this test.
                 if (!isMultiArg)
                 {
                     Assert.Contains(tabularOverload.ParamTypes, t => t.Kind == DKind.Table); // At least one table input


### PR DESCRIPTION
```
Semantics of tabular overloads of scalar functions with errors / blanks / empty tables (and examples)

•	Functions with single arguments:
o	F(<err>) ==> <err>
	Sqrt(If(1/0<2,[1,2,3])) ==> #Error(Kind=Div0)
o	F(<blank>) ==> <blank>
	Sqrt(If(1<0,[1,2,3])) ==> Blank()
o	F(<empty table>) = <empty table>
	Sqrt(Filter([1,2,3], Value > 10)) ==> []

•	Functions with multiple arguments, errors
o	F(<error table>, <scalar>) ==> <error table>
	Power(If(1/0<2,[1,2,3,4]), 2) ==> #Error(Kind=Div0)
o	F(<table>, <error scalar>) ==> ForAll(<table>, F(<value>, <error scalar>))
	Power([2,3,4], 1/0) ==> [<div0>, <div0>, <div0>]
o	F(<error scalar>, <table>) ==> ForAll(<table>, F(<error scalar>, <value>))
	Power(1/0, [2,3,4]) ==> [<div0>, <div0>, <div0>]

•	Functions with multiple arguments, blanks
o	F(<blank table>, <scalar>) ==> <blank table>
	Power(If(1<0,[1,2,3,4]), 2) ==> Blank()
o	F(<table>, <blank scalar>) ==> ForAll(<table>, F(<value>, <blank scalar>))
	Power([2,3,4], If(1<0,2)) ==> [1, 1, 1]
o	F(<blank scalar>, <table>) ==> ForAll(<table>, F(<blank scalar>, <value>))
	Power(If(1<0,2), [2,3,4]) ==> [0, 0, 0]

•	Functions with multiple arguments, different table lengths
o	Take length of smaller table, fill it with errors records up to length of larger table
o	F(<table1,len=4>,<table2,len=2>,<table3,len=3>) = [F(v1_1, v2_1, v3_1), F(v1_1, v2_1, v3_1), <err>, <err>]
	Power([2, 3, 4, 5], [3, 4]) ==> Table({Value:8},{Value:81},<err>,<err>)
	Substitute(["John Doe", "Joan Coe", "Jim Poe", "Jane Roe"], ["oe","oe"], ["OE", "Oe", "oE"]) ==> Table({Value:"John DOE"},{Value:"Joan COe"},<err>,<err>)

```