### PR TITLE
CheckInvocation Prerequisite Work

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -133,6 +133,8 @@ namespace Microsoft.PowerFx.Core.Binding
         /// </summary>
         internal static DName ThisRecordDefaultName => new DName("ThisRecord");
 
+        public Features Features { get; }
+
         // Property to which current rule is being bound to. It could be null in the absence of NameResolver.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0025:Use expression body for properties", Justification = "n/a")]
         public IExternalControlProperty Property
@@ -268,6 +270,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
             BindingConfig = bindingConfig;
             QueryOptions = queryOptions;
+            Features = features;
             _glue = glue;
             Top = node;
             NameResolver = resolver;

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -133,8 +133,6 @@ namespace Microsoft.PowerFx.Core.Binding
         /// </summary>
         internal static DName ThisRecordDefaultName => new DName("ThisRecord");
 
-        public Features Features { get; }
-
         // Property to which current rule is being bound to. It could be null in the absence of NameResolver.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0025:Use expression body for properties", Justification = "n/a")]
         public IExternalControlProperty Property
@@ -204,6 +202,8 @@ namespace Microsoft.PowerFx.Core.Binding
 
         public BindingConfig BindingConfig { get; }
 
+        public CheckTypesContext CheckTypesContext { get; }
+
         public IExternalDocument Document => NameResolver?.Document;
 
         public bool AffectsAliases { get; private set; }
@@ -268,7 +268,6 @@ namespace Microsoft.PowerFx.Core.Binding
 
             BindingConfig = bindingConfig;
             QueryOptions = queryOptions;
-            Features = features;
             _glue = glue;
             Top = node;
             NameResolver = resolver;
@@ -327,6 +326,14 @@ namespace Microsoft.PowerFx.Core.Binding
 
             resolver?.TryGetCurrentControlProperty(out _property);
             _control = resolver?.CurrentEntity as IExternalControl;
+
+            CheckTypesContext = new CheckTypesContext(
+                features,
+                resolver,
+                entityName: EntityName,
+                propertyName: Property?.InvariantName ?? string.Empty,
+                isEnhancedDelegationEnabled: Document?.Properties?.EnabledFeatures?.IsEnhancedDelegationEnabled ?? false,
+                allowsSideEffects: bindingConfig.AllowsSideEffects);
         }
 
         // Binds a Texl parse tree.

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/BuiltinFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/BuiltinFunction.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx.Core.Functions
         public const string ColumnName_SubMatchesStr = "SubMatches";
         public const string ColumnName_StartMatchStr = "StartMatch";
 
-        public static DName GetOneColumnTableResultName(TexlBinding binding) => GetOneColumnTableResultName(binding.Features);
+        public static DName GetOneColumnTableResultName(TexlBinding binding) => GetOneColumnTableResultName(binding.CheckTypesContext.Features);
 
         public static DName GetOneColumnTableResultName(Features f) => f.HasFlag(Features.ConsistentOneColumnTableResult) 
             ? new DName(ColumnName_ValueStr) 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/BuiltinFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/BuiltinFunction.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Functions
         public const string ColumnName_SubMatchesStr = "SubMatches";
         public const string ColumnName_StartMatchStr = "StartMatch";
 
-        public static DName GetOneColumnTableResultName(TexlBinding binding) => GetOneColumnTableResultName(binding.CheckTypesContext.Features);
-
         public static DName GetOneColumnTableResultName(Features f) => f.HasFlag(Features.ConsistentOneColumnTableResult) 
             ? new DName(ColumnName_ValueStr) 
             : new DName(OneColumnTableResultNameStrOld);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/CheckTypesContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/CheckTypesContext.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Core.Binding;
+
+namespace Microsoft.PowerFx.Core.Functions
+{
+    internal class CheckTypesContext
+    {
+        public Features Features { get; }
+
+        public INameResolver NameResolver { get; }
+
+        public string EntityName { get; }
+
+        public string PropertyName { get; }
+
+        public bool IsEnhancedDelegationEnabled { get; }
+
+        public bool AllowsSideEffects { get; }
+
+        public CheckTypesContext(Features features, INameResolver nameResolver, string entityName, string propertyName, bool isEnhancedDelegationEnabled, bool allowsSideEffects)
+        {
+            Features = features;
+            NameResolver = nameResolver;
+            EntityName = entityName;
+            PropertyName = propertyName;
+            IsEnhancedDelegationEnabled = isEnhancedDelegationEnabled;
+            AllowsSideEffects = allowsSideEffects;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1277,7 +1277,7 @@ namespace Microsoft.PowerFx.Core.Functions
                 {
                     if (fValid && nodeToCoercedTypeMap.Any())
                     {
-                        var resultColumnName = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                        var resultColumnName = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                             ? new DName(ColumnName_ValueStr)
                             : argTypes[i].GetNames(DPath.Root).Single().Name;
 
@@ -1285,7 +1285,7 @@ namespace Microsoft.PowerFx.Core.Functions
                     }
                     else
                     {
-                        returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                        returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                             ? DType.CreateTable(new TypedName(desiredType, new DName(ColumnName_ValueStr)))
                             : argTypes[i];
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -394,7 +394,7 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if everything aligns even with coercion, false otherwise.
         // By default, the out returnType will be the one advertised via the constructor. If this.ReturnType
         // is either Unknown or an aggregate type, this method needs to be specialized.
-        public virtual bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected virtual bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             return CheckInvocationCore(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1259,7 +1259,7 @@ namespace Microsoft.PowerFx.Core.Functions
             return false;
         }
 
-        protected bool CheckAllParamsAreTypeOrSingleColumnTable(TexlBinding binding, DType desiredType, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected bool CheckAllParamsAreTypeOrSingleColumnTable(CheckTypesContext context, DType desiredType, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -1282,7 +1282,7 @@ namespace Microsoft.PowerFx.Core.Functions
                 {
                     if (fValid && nodeToCoercedTypeMap.Any())
                     {
-                        var resultColumnName = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                        var resultColumnName = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                             ? new DName(ColumnName_ValueStr)
                             : argTypes[i].GetNames(DPath.Root).Single().Name;
 
@@ -1290,7 +1290,7 @@ namespace Microsoft.PowerFx.Core.Functions
                     }
                     else
                     {
-                        returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                        returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                             ? DType.CreateTable(new TypedName(desiredType, new DName(ColumnName_ValueStr)))
                             : argTypes[i];
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -387,6 +387,11 @@ namespace Microsoft.PowerFx.Core.Functions
 
         public virtual bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
+            return CheckInvocation(binding.CheckTypesContext, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+        }
+
+        protected virtual bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
             return CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerFx.Core.IR
                 var children = node.Children.Select(child => child.Accept(this, context)).ToArray();
                 var irContext = context.GetIRContext(node);
 
-                if (!context.Binding.Features.HasTableSyntaxDoesntWrapRecords() || (children.Any() && children.First() is not RecordNode))
+                if (!context.Binding.CheckTypesContext.Features.HasTableSyntaxDoesntWrapRecords() || (children.Any() && children.First() is not RecordNode))
                 {
                     // Let's add "Value:" here                    
                     children = children.Select(childNode =>

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AddColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AddColumns.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -63,7 +63,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             // The first arg determines the scope type for the lambda params, and the return type.
             fArgsValid &= ScopeInfo.CheckInput(args[0], argTypes[0], errors, out var typeScope);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
@@ -135,7 +135,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "N_T");
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -65,14 +65,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = base.CheckInvocation(binding, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             // Typecheck the input table
             fValid &= CheckNumericColumnType(argTypes[0], args[0], errors, ref nodeToCoercedTypeMap);
 
             // Synthesize a new return type
-            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -71,7 +71,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of colors.
                 fValid &= CheckColorColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.Color, new DName(ColumnName_ValueStr)))
                     : type0;
 
@@ -90,7 +90,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 fValid &= CheckNumericColumnType(type1, args[1], errors, ref nodeToCoercedTypeMap);
 
                 // Since the 1st arg is not a table, make a new table return type *[Result:c]
-                returnType = DType.CreateTable(new TypedName(DType.Color, GetOneColumnTableResultName(binding)));
+                returnType = DType.CreateTable(new TypedName(DType.Color, GetOneColumnTableResultName(context.Features)));
 
                 // Check arg0 below.
                 otherArg = args[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of colors.
                 fValid &= CheckColorColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.Color, new DName(ColumnName_ValueStr)))
                     : type0;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -148,7 +148,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 nodeToCoercedTypeMap = null;
             }
 
-            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
 
             return hasTableArg && fArgsValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.CountArg1 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             // The argument should be a table of one column.
             var argType = argTypes[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.CountArg1 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             // The argument should be a table of one column.
             var argType = argTypes[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType == DType.Number);
 
             // Ensure that all the args starting at index 1 are booleans or coerece to boolean if they are OptionSetValues.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -486,7 +486,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                 if (fValid)
                 {
-                    var resultColumnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    var resultColumnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                         ? ColumnName_Value
                         : type0.GetNames(DPath.Root).Single().Name;
                     returnType = DType.CreateTable(new TypedName(DType.DateTime, resultColumnType));

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -410,7 +410,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType == DType.DateTime);
 
             var type0 = argTypes[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -401,7 +401,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return argumentIndex == 2;
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -462,7 +462,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -486,7 +486,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                 if (fValid)
                 {
-                    var resultColumnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    var resultColumnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                         ? ColumnName_Value
                         : type0.GetNames(DPath.Root).Single().Name;
                     returnType = DType.CreateTable(new TypedName(DType.DateTime, resultColumnType));
@@ -496,7 +496,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 if (type0.Kind == DKind.DateTime || type0.Kind == DKind.Date)
                 {
-                    returnType = DType.CreateTable(new TypedName(DType.DateTime, GetOneColumnTableResultName(binding)));
+                    returnType = DType.CreateTable(new TypedName(DType.DateTime, GetOneColumnTableResultName(context.Features)));
                 }
                 else if (type0.CoercesTo(DType.DateTime))
                 {
@@ -609,7 +609,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -623,7 +623,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var type0 = argTypes[0];
             var type1 = argTypes[1];
 
-            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features)));
 
             // Arg0 should be either a date or a column of dates.
             if (type0.IsTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DropColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DropColumns.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             if (!argTypes[0].IsTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return new List<string>() { EnumConstants.ErrorKindEnumString };
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -110,7 +110,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
             }
 
-            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features)));
 
             var hasStartIndex = argTypes.Length == 3;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
@@ -45,14 +45,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.FirstLastArg1 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             var arg0Type = argTypes[0];
             if (arg0Type.IsTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.FirstLastNArg1, TexlStrings.FirstLastNArg2 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             var arg0Type = argTypes[0];
             if (arg0Type.IsTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.ForAllArg1, TexlStrings.ForAllArg2 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -46,7 +46,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             if (argTypes[1].IsRecord)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.ForAllArg1, TexlStrings.ForAllArg2 };
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -60,9 +60,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return index >= 1;
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
+            Contracts.AssertValue(context);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
@@ -88,7 +88,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var type = ReturnType;
 
             // Are we on a behavior property?
-            var isBehavior = binding.BindingConfig.AllowsSideEffects;
+            var isBehavior = context.AllowsSideEffects;
 
             // Compute the result type by joining the types of all non-predicate args.
             Contracts.Assert(type == DType.Unknown);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -56,9 +56,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
+            Contracts.AssertValue(context);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
@@ -73,7 +73,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var fArgsValid = true;
             var type = ReturnType;
 
-            var isBehavior = binding.BindingConfig.AllowsSideEffects;
+            var isBehavior = context.AllowsSideEffects;
 
             Contracts.Assert(type == DType.Unknown);
             for (var i = 0; i < count;)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.IndexArg1, TexlStrings.IndexArg2 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -45,7 +45,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             var arg0Type = argTypes[0];
             if (arg0Type.IsTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsError.cs
@@ -29,9 +29,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.IsErrorArg };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
             Contracts.Assert(args.Length == argTypes.Length);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsToday.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsToday.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return EnumerableUtils.Yield(new[] { TexlStrings.IsTodayFuncArg1 });
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             var type0 = argTypes[0];
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsUTCToday.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsUTCToday.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return EnumerableUtils.Yield(new[] { TexlStrings.IsUTCTodayFuncArg1 });
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -41,7 +41,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             var type0 = argTypes[0];
 
             // Arg0 should not be a Time

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_TS");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -74,7 +74,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Typecheck the input table
             fValid &= CheckStringColumnType(argTypes[0], args[0], errors, ref nodeToCoercedTypeMap);
 
-            returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+            returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                 ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                 : argTypes[0];
 
@@ -108,7 +108,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_TT");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -127,7 +127,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Typecheck the count table
             fValid &= CheckNumericColumnType(argTypes[1], args[1], errors, ref nodeToCoercedTypeMap);
 
-            returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+            returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                 ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                 : argTypes[0];
 
@@ -161,7 +161,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_ST");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -178,7 +178,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             fValid &= CheckNumericColumnType(argTypes[1], args[1], errors, ref nodeToCoercedTypeMap);
 
             // Synthesize a new return type
-            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Typecheck the input table
             fValid &= CheckStringColumnType(argTypes[0], args[0], errors, ref nodeToCoercedTypeMap);
 
-            returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+            returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                 ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                 : argTypes[0];
 
@@ -127,7 +127,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Typecheck the count table
             fValid &= CheckNumericColumnType(argTypes[1], args[1], errors, ref nodeToCoercedTypeMap);
 
-            returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+            returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                 ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                 : argTypes[0];
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -77,7 +77,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             fValid &= CheckStringColumnType(argTypes[0], args[0], errors, ref nodeToCoercedTypeMap);
 
             // Synthesize a new return type
-            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features)));
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -66,7 +66,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
 
             var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(binding, DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(context, DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.LookUpArg1, TexlStrings.LookUpArg2, TexlStrings.LookUpArg3 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length >= 2 && args.Length <= 3);
             Contracts.AssertValue(errors);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             // The return type is dictated by the last argument (projection) if one exists. Otherwise it's based on first argument (source).
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -78,7 +78,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 returnType = argType;
             }
 
-            returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult) ? DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding))) : returnType;
+            returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult) ? DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features))) : returnType;
 
             if (!fValid)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 returnType = argType;
             }
 
-            returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult) ? DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding))) : returnType;
+            returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult) ? DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding))) : returnType;
 
             if (!fValid)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -77,13 +77,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
                 // Borrow the return type from the 1st arg
-                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                     : type0;
             }
             else
             {
-                returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+                returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
                 if (!DType.String.Accepts(type0))
                 {
                     if (type0.CoercesTo(DType.String))

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
                 // Borrow the return type from the 1st arg
-                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                     : type0;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             _delegationCapability = isMin ? DelegationCapability.Min : DelegationCapability.Max;
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -108,7 +108,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 errors.EnsureError(DocumentErrorSeverity.Severe, arg1, TexlStrings.ErrNumberExpected);
             }
 
-            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features)));
 
             // At least one arg has to be a table.
             if (!(type0.IsTable || type1.IsTable))

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.PowerTFuncArg1, TexlStrings.PowerTFuncArg2 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -63,7 +63,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
 
             var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(binding, DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            fValid &= CheckAllParamsAreTypeOrSingleColumnTable(context, DType.Number, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             return fValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -76,13 +76,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of strings
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                     : type0;
             }
             else
             {
-                returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+                returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
                 if (!DType.String.Accepts(type0))
                 {
                     if (type0.CoercesTo(DType.String))

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of strings
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                     : type0;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of numerics
                 fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                     : type0;
 
@@ -91,7 +91,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                 // Since the 1st arg is not a table, make a new table return type *[Result:n] or
                 // *[Value:n] if the consistent return schema flag is enabled
-                returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
+                returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features)));
 
                 // Check arg0 below.
                 otherArg = args[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of numerics
                 fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                     : type0;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowColumns.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertValue(argTypes);
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var isValidInvocation = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var isValidInvocation = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             if (!argTypes[0].IsTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Shuffle.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Shuffle.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.ShuffleArg1 };
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return new List<string>() { LanguageConstants.SortOrderEnumString };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             returnType = argTypes[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -69,7 +69,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             returnType = argTypes[0];
@@ -384,7 +384,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return new List<string>() { LanguageConstants.SortOrderEnumString };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -393,7 +393,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             returnType = argTypes[0];

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
@@ -24,7 +25,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.SplitArg1, TexlStrings.SplitArg2 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -36,7 +37,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var fValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
-            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+            returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
             return fValid;
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
             else
             {
-                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                 ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                 : argTypes[0];
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -128,7 +128,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
             else
             {
-                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                 ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                 : argTypes[0];
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -77,13 +77,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of strings
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                     : type0;
             }
             else
             {
-                returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(binding)));
+                returnType = DType.CreateTable(new TypedName(DType.String, GetOneColumnTableResultName(context.Features)));
                 if (!DType.String.Accepts(type0))
                 {
                     if (type0.CoercesTo(DType.String))

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure we have a one-column table of strings
                 fValid &= CheckStringColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                     ? DType.CreateTable(new TypedName(DType.String, new DName(ColumnName_ValueStr)))
                     : type0;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
@@ -83,9 +83,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         // Type check an invocation of the function with the specified args (and their corresponding types).
         // Return true if everything aligns, false otherwise.
         // This override does not post any document errors (i.e. it performs the typechecks quietly).
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
+            Contracts.AssertValue(context);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
@@ -117,7 +117,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             nodeToCoercedTypeMap = null;
 
             // Are we on a behavior property?
-            var isBehavior = binding.BindingConfig.AllowsSideEffects;
+            var isBehavior = context.AllowsSideEffects;
 
             // Compute the result type by joining the types of all non-predicate args.
             Contracts.Assert(type == DType.Unknown);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
 
         // Typecheck an invocation of Table.
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var isValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var isValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             // Ensure that all args (if any) are records with compatible schemas.
@@ -103,9 +103,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
 
         // Typecheck an invocation of Table.
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            var isValid = CheckInvocation(args, argTypes, errors, out _, out nodeToCoercedTypeMap);
+            var isValid = base.CheckInvocation(args, argTypes, errors, out _, out nodeToCoercedTypeMap);
 
             var rowType = DType.EmptyRecord.Add(new TypedName(DType.UntypedObject, ColumnName_Value));
             returnType = rowType.ToTable();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.TextArg1, TexlStrings.TextArg2, TexlStrings.TextArg3 };
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Ensure we have a one-column table of numerics
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                    returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                         ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                         : type0;
 
@@ -142,7 +142,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Ensure we have a one-column table of numerics
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                    returnType = binding.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                         ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                         : type0;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_T");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -80,7 +80,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Ensure we have a one-column table of numerics
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                    returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                         ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                         : type0;
 
@@ -94,7 +94,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     fValid &= CheckNumericColumnType(type1, args[1], errors, ref nodeToCoercedTypeMap);
 
                     // Since the 1st arg is not a table, make a new table return type *[Result:n]
-                    returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(binding)));
+                    returnType = DType.CreateTable(new TypedName(DType.Number, GetOneColumnTableResultName(context.Features)));
 
                     // Check arg0 below.
                     otherArg = args[0];
@@ -142,7 +142,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Ensure we have a one-column table of numerics
                     fValid &= CheckNumericColumnType(type0, args[0], errors, ref nodeToCoercedTypeMap);
 
-                    returnType = binding.CheckTypesContext.Features.HasFlag(Features.ConsistentOneColumnTableResult)
+                    returnType = context.Features.HasFlag(Features.ConsistentOneColumnTableResult)
                         ? DType.CreateTable(new TypedName(DType.Number, new DName(ColumnName_ValueStr)))
                         : type0;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.ValueArg1, TexlStrings.ValueArg2 };
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
@@ -36,9 +36,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return GetUniqueTexlRuntimeName(suffix: "_R");
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
@@ -46,7 +45,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(errors);
 
             // Base call yields unknown return type, so we set it accordingly below
-            var fArgsValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             // Return type determined by second argument (function)
             // Since CheckInvocation is called on partial functions, return type should be error when a second argument is undefined

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CollectFunction.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerFx.Interpreter
         }
 
         // Typecheck an invocation of Collect.
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Interpreter
             Contracts.AssertValue(errors);
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
-            var fValid = base.CheckInvocation(binding, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
             Contracts.Assert(returnType.IsTable);
 
             DType dataSourceType = argTypes[0];

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -39,16 +39,15 @@ namespace Microsoft.PowerFx.Functions
         {
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var isValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var isValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             return isValid;
         }
@@ -182,16 +181,15 @@ namespace Microsoft.PowerFx.Functions
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var isValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var isValid = base.CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
             DType dataSourceType = argTypes[0];
             DType retType = DType.EmptyRecord;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerFx.Functions
             return base.GetSignatures(arity);
         }
 
-        public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -39,20 +39,6 @@ namespace Microsoft.PowerFx.Functions
         {
         }
 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
-        {
-            Contracts.AssertValue(binding);
-            Contracts.AssertValue(args);
-            Contracts.AssertAllValues(args);
-            Contracts.AssertValue(argTypes);
-            Contracts.Assert(args.Length == argTypes.Length);
-            Contracts.AssertValue(errors);
-
-            var isValid = CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-
-            return isValid;
-        }
-
         protected static bool CheckArgs(FormulaValue[] args, out FormulaValue faultyArg)
         {
             // If any args are error, propagate up.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
@@ -50,9 +50,8 @@ namespace Microsoft.PowerFx.Interpreter
         }
 
         // 2nd argument should be same type as 1st argument. 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -84,9 +84,8 @@ namespace Microsoft.PowerFx
         }
 
         // 2nd argument should be same type as 1st argument. 
-        public override bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.AssertValue(binding);
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
             Contracts.AssertValue(argTypes);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
                 yield break;
             }
 
-            public override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> coercedArgs)
+            protected override bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> coercedArgs)
             {
                 var isValid = base.CheckInvocation(args, argTypes, errors, out returnType, out coercedArgs);
 


### PR DESCRIPTION
CheckInvocation does too much, and it has too much power since it has access to TexlBinding. In the future, we will split this method into 2 methods. This change is a prerequisite change, much more modest in scope. It adds an override of CheckInvocation that does not accept binding.