### PR TITLE
Updated serialization to properly escape record property values

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Types
 {
@@ -233,7 +234,8 @@ namespace Microsoft.PowerFx.Types
 
                 flag = false;
 
-                sb.Append($"'{CharacterUtils.Escape(field.Name)}':");
+                sb.Append(IdentToken.MakeValidIdentifier(field.Name));
+                sb.Append(':');
 
                 field.Value.ToExpression(sb, settings);
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Escaping.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Escaping.txt
@@ -1,5 +1,11 @@
 ﻿>> {'abc \ " \0 \b \t \n \v \f \r \u0085 \u2028 \u2029def':1}
-{abc \\ \" \\0 \\b \\t \\n \\v \\f \\r \\u0085 \\u2028 \\u2029def:1}
+{'abc \ " \0 \b \t \n \v \f \r \u0085 \u2028 \u2029def':1}
 
 >> {'abc \ " \0 \b \t \n \v \f \r \u0085 \u2028 \u2029def':1}.'abc \ " \0 \b \t \n \v \f \r \u0085 \u2028 \u2029def'
 1
+
+>> {'hello " world':"hello world"}
+{'hello " world':"hello world"}
+
+>> ForAll(Table({'hello " world':"hello world", a:1}), {'needs '' escaping':$"{a} - {'hello " world'}"})
+Table({'needs '' escaping':"1 - hello world"})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TestRunner.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Core.Tests
@@ -345,7 +346,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 foreach (var field in fields)
                 {
                     sb.Append(dil);
-                    sb.Append(field.Name);
+                    var escapedName = IdentToken.MakeValidIdentifier(field.Name);
+                    sb.Append(escapedName);
                     sb.Append(':');
                     TestToString(field.Value, sb);
 


### PR DESCRIPTION
The record serialization was escaping property names incorrectly. This fixes it.