### PR TITLE
Make ReadOnlySymbolValues.NewRowScope be lazy.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolTableValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolTableValues.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+    /// <summary>
+    /// Helper to compose multiple symbol values into a single one. 
+    /// Corresponds to <see cref="ReadOnlySymbolTable.Compose(ReadOnlySymbolTable[])"/>.
+    /// </summary>
+    internal class ComposedReadOnlySymbolTableValues : ReadOnlySymbolValues
+    {
+        private readonly IEnumerable<ReadOnlySymbolValues> _tables;
+
+        public ComposedReadOnlySymbolTableValues(IEnumerable<ReadOnlySymbolValues> tables)            
+        {
+            _tables = tables;
+            DebugName = string.Join(",", tables.Select(t => t.DebugName));
+        }
+
+        public override object GetService(Type serviceType)
+        {
+            foreach (var table in _tables)
+            {
+                var service = table.GetService(serviceType);
+                if (service != null)
+                {
+                    return service;
+                }
+            }
+
+            return null;
+        }
+
+        public override bool TryGetValue(string name, out FormulaValue value)
+        {
+            foreach (var table in _tables)
+            {
+                if (table.TryGetValue(name, out value))
+                {
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        protected override ReadOnlySymbolTable GetSymbolTableSnapshotWorker()
+        {
+            var symTables = _tables.Select(table => table.GetSymbolTableSnapshot());
+
+            return ReadOnlySymbolTable.Compose(symTables.ToArray());
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RowScopeSymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RowScopeSymbolValues.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+    /// <summary>
+    /// Create Symbol values around a RecordValue. 
+    /// Ensure lazy evaluation semantics, just like RecordValue/RecordType.
+    /// </summary>
+    internal class RowScopeSymbolValues : ReadOnlySymbolValues
+    {
+        private readonly RecordValue _parameter;
+        private readonly bool _allowThisRecord;
+
+        public RowScopeSymbolValues(RecordValue parameter, bool allowThisRecord)
+        {
+            _parameter = parameter;
+            _allowThisRecord = allowThisRecord;
+        }
+
+        public override bool TryGetValue(string name, out FormulaValue value)
+        {
+            if (_allowThisRecord && name == "ThisRecord")
+            {
+                value = _parameter;
+                return true;
+            }
+
+            if (!_parameter.Type.HasField(name))
+            {
+                // If it's not in this table. Be sure to not claim it so that 
+                // we can still check a parent scope. 
+                value = null;
+                return false;
+            }
+
+            value = _parameter.GetField(name);
+            return value != null;
+        }
+
+        protected override ReadOnlySymbolTable GetSymbolTableSnapshotWorker()
+        {
+            SymbolTable table1 = null;
+            if (_allowThisRecord)
+            {
+                table1 = new SymbolTable();
+                table1.AddVariable("ThisRecord", _parameter.Type);
+            }
+
+            var table = ReadOnlySymbolTable.NewFromRecord(_parameter.Type, table1);
+            return table;
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -252,11 +252,13 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     return new RunResult(check);
                 }
 
-                var rtConfig = SymbolValues.NewFromRecord(parameters) as SymbolValues;
-
+                var rtConfig = SymbolValues.NewFromRecord(parameters);
+                                
                 if (iSetup.TimeZoneInfo != null)
                 {
-                    rtConfig.AddService(iSetup.TimeZoneInfo);
+                    var commonSymbols = new SymbolValues();
+                    commonSymbols.AddService(iSetup.TimeZoneInfo);
+                    rtConfig = ReadOnlySymbolValues.Compose(rtConfig, commonSymbols);
                 }
 
                 var newValue = await check.GetEvaluator().EvalAsync(CancellationToken.None, rtConfig);


### PR DESCRIPTION
This is critical in dataverse scenarios, since those are lazy RecordType/RecordValues, and loading all the fields is expensive.

Also includes Compose() functionality for chaining symbol tables. 