### PR TITLE
No longer drop attachments in DType

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1654,13 +1654,6 @@ namespace Microsoft.PowerFx.Core.Types
                 fValid &= !fError;
             }
 
-            if (type.ContainsAttachmentType(DPath.Root))
-            {
-                var fError = false;
-                type = type.DropAllMatching(ref fError, DPath.Root, type => type.IsAttachment);
-                fValid &= !fError;
-            }
-
             if (!fValid)
             {
                 type = Unknown;


### PR DESCRIPTION
Breaking internals, as part of a PR in PAClient to no longer drop attachments in Update/UpdateIf, etc. Interestingly, we do not appear to have code coverage for this code path.