### PR TITLE
Removed support for row-scope disambiguation syntax.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -573,6 +573,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrInvalidControlReference = new ErrorResourceKey("ErrInvalidControlReference");
         public static ErrorResourceKey ErrInvalidStringInterpolation = new ErrorResourceKey("ErrInvalidStringInterpolation");
         public static ErrorResourceKey ErrEmptyIsland = new ErrorResourceKey("ErrEmptyIsland");
+        public static ErrorResourceKey ErrDeprecated = new ErrorResourceKey("ErrDeprecated");
 
         public static ErrorResourceKey ErrErrorIrrelevantField = new ErrorResourceKey("ErrErrorIrrelevantField");
         public static ErrorResourceKey ErrAsNotInContext = new ErrorResourceKey("ErrAsNotInContext");

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
@@ -19,14 +19,19 @@ namespace Microsoft.PowerFx
         /// If true, allow parsing a chaining operator. This is only used for side-effecting operations.
         /// </summary>
         public bool AllowsSideEffects { get; set; }
-                
+
         public CultureInfo Culture { get; set; }
 
         internal ParseResult Parse(string script)
         {
+            return Parse(script, Features.None);
+        }
+
+        internal ParseResult Parse(string script, Features features)
+        {
             var flags = AllowsSideEffects ? TexlParser.Flags.EnableExpressionChaining : TexlParser.Flags.None;
 
-            return TexlParser.ParseScript(script, Culture, flags);
+            return TexlParser.ParseScript(script, features, Culture, flags);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -713,7 +713,7 @@ namespace Microsoft.PowerFx.Core.Parser
                             
                             if (_features.HasFlag(Features.DisableRowScopeDisambiguationSyntax))
                             {
-                                PostError(_curs.TokCur, errKey: TexlStrings.ErrBadToken);
+                                PostError(_curs.TokCur, errKey: TexlStrings.ErrDeprecated);
                             }
 
                             node = ParseScopeField(first);

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -44,13 +44,14 @@ namespace Microsoft.PowerFx.Core.Parser
         private SourceList _before;
         private SourceList _after;
         private readonly CultureInfo _locale;
+        private readonly Features _features;
 
         // Represents temporary extra trivia, for when a parsing method
         // had to parse tailing trivia to do 1-lookahead. Will be
         // collected by the next call to ParseTrivia.
         private ITexlSource _extraTrivia;
 
-        private TexlParser(IReadOnlyList<Token> tokens, Flags flags, CultureInfo locale)
+        private TexlParser(IReadOnlyList<Token> tokens, Flags flags, CultureInfo locale, Features features = Features.None)
         {
             Contracts.AssertValue(tokens);
 
@@ -59,6 +60,7 @@ namespace Microsoft.PowerFx.Core.Parser
             _flagsMode = new Stack<Flags>();
             _flagsMode.Push(flags);
             _locale = locale;
+            _features = features;
         }
 
         public static ParseUDFsResult ParseUDFsScript(string script, CultureInfo loc)
@@ -216,11 +218,16 @@ namespace Microsoft.PowerFx.Core.Parser
         // caller, so precedenceTokens provide a list of stripped tokens.
         internal static ParseResult ParseScript(string script, CultureInfo loc = null, Flags flags = Flags.None)
         {
+            return ParseScript(script, Features.None, loc, flags);
+        }
+
+        internal static ParseResult ParseScript(string script, Features features, CultureInfo loc = null, Flags flags = Flags.None)
+        {
             Contracts.AssertValue(script);
             Contracts.AssertValueOrNull(loc);
 
             var tokens = TokenizeScript(script, loc, flags);
-            var parser = new TexlParser(tokens, flags, loc);
+            var parser = new TexlParser(tokens, flags, loc, features);
             List<TexlError> errors = null;
             var parsetree = parser.Parse(ref errors);
 
@@ -702,6 +709,11 @@ namespace Microsoft.PowerFx.Core.Parser
                             if (node is not FirstNameNode first || first.Ident.AtToken != null || _curs.TidPeek() != TokKind.At)
                             {
                                 goto default;
+                            }
+                            
+                            if (_features.HasFlag(Features.DisableRowScopeDisambiguationSyntax))
+                            {
+                                PostError(_curs.TokCur, errKey: TexlStrings.ErrBadToken);
                             }
 
                             node = ParseScopeField(first);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -27,6 +27,6 @@ namespace Microsoft.PowerFx
         /// instead of
         /// Filter(A, A[@Value] = 2)
         /// </summary>
-        DisableRowScopeDisambiguationSyntax
+        DisableRowScopeDisambiguationSyntax = 0x4,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -19,6 +19,14 @@ namespace Microsoft.PowerFx
         /// <summary>
         /// Enable functions to consistently return one dimension tables with a "Value" column rather than some other name like "Result"
         /// </summary>
-        ConsistentOneColumnTableResult = 0x2
+        ConsistentOneColumnTableResult = 0x2,
+
+        /// <summary>
+        /// Disables support for row-scope disambiguation syntax.
+        /// Now,for example user would need to use Filter(A, ThisRecord.Value = 2) or Filter(A As Foo, Foo.Value = 2)
+        /// instead of
+        /// Filter(A, A[@Value] = 2)
+        /// </summary>
+        DisableRowScopeDisambiguationSyntax
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -90,12 +90,22 @@ namespace Microsoft.PowerFx
         /// </summary>
         internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder)
         {
-            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, Core.Texl.BuiltinFunctionsCore.BuiltinFunctionsLibrary);
+            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, Features.None); 
+        }
+
+        internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, Features features)
+        {
+            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, Core.Texl.BuiltinFunctionsCore.BuiltinFunctionsLibrary, features: features);
         }
 
         internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, IEnumerable<TexlFunction> coreFunctions)
         {
-            var config = new PowerFxConfig(cultureInfo, enumStoreBuilder);
+            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, coreFunctions, Features.None);
+        }
+
+        internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, IEnumerable<TexlFunction> coreFunctions, Features features)
+        {
+            var config = new PowerFxConfig(cultureInfo, enumStoreBuilder, features);
 
             foreach (var func in coreFunctions)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerFx
         /// <returns></returns>
         public ParseResult Parse(string expressionText, ParserOptions options = null)
         {
-            return Parse(expressionText, options, Config.CultureInfo);
+            return Parse(expressionText, Config.Features, options, Config.CultureInfo);
         }
 
         /// <summary>
@@ -138,12 +138,25 @@ namespace Microsoft.PowerFx
         /// <returns></returns>
         public static ParseResult Parse(string expressionText, ParserOptions options = null, CultureInfo cultureInfo = null)
         {
+            return Parse(expressionText, Features.None, options, cultureInfo);
+        }
+
+        /// <summary>
+        /// Parse the expression without doing any binding.
+        /// </summary>
+        /// <param name="expressionText"></param>
+        /// <param name="features"></param>
+        /// <param name="options"></param>
+        /// <param name="cultureInfo"></param>
+        /// <returns></returns>
+        public static ParseResult Parse(string expressionText, Features features, ParserOptions options = null, CultureInfo cultureInfo = null)
+        {
             options ??= new ParserOptions();
 
             // If culture isn't explicitly set, use the one from PowerFx Config
             options.Culture ??= cultureInfo;
 
-            var result = options.Parse(expressionText);
+            var result = options.Parse(expressionText, features);
             return result;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -144,11 +144,6 @@ namespace Microsoft.PowerFx
         /// <summary>
         /// Parse the expression without doing any binding.
         /// </summary>
-        /// <param name="expressionText"></param>
-        /// <param name="features"></param>
-        /// <param name="options"></param>
-        /// <param name="cultureInfo"></param>
-        /// <returns></returns>
         public static ParseResult Parse(string expressionText, Features features, ParserOptions options = null, CultureInfo cultureInfo = null)
         {
             options ??= new ParserOptions();

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -19,6 +19,8 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
         // $$$ This should probably be symbol and not just config. 
         protected readonly PowerFxConfig _powerFxConfig;
 
+        internal Features Features => _powerFxConfig.Features;
+
         private readonly IEnumStore _enumStore;
 
         public IntellisenseData(PowerFxConfig powerFxConfig, IEnumStore enumStore, IIntellisenseContext context, DType expectedType, TexlBinding binding, TexlFunction curFunc, TexlNode curNode, int argIndex, int argCount, IsValidSuggestion isValidSuggestionFunc, IList<DType> missingTypes, List<CommentToken> comments)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/FirstNameNodeSuggestionHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/FirstNameNodeSuggestionHandler.cs
@@ -71,7 +71,8 @@ namespace Microsoft.PowerFx.Intellisense
 
                     intellisenseData.AddAdditionalSuggestionsForKeywordSymbols(curNode);
                 }
-                else if (IsBracketOpen(tok.Span.Lim, cursorPos, intellisenseData.Script))
+                else if (IsBracketOpen(tok.Span.Lim, cursorPos, intellisenseData.Script) && 
+                    !intellisenseData.Features.HasFlag(Features.DisableRowScopeDisambiguationSyntax))
                 {
                     AddSuggestionsForScopeFields(intellisenseData, intellisenseData.Binding.GetType(firstNameNode));
                 }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -6611,4 +6611,8 @@
     <value>A column of hexadecimal strings to convert to decimals.</value>
     <comment>Description of 'Hex2DecTArg1' function parameter.</comment>
   </data>
+  <data name="ErrDeprecated" xml:space="preserve">
+    <value>This feature is deprecated and is no longer supported.</value>
+    <comment>An error message for deprecated features.</comment>
+  </data>
 </root>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FlagTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FlagTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Parser;
 using Microsoft.PowerFx.Preview;
 using Microsoft.PowerFx.Types;
@@ -34,12 +36,13 @@ namespace Microsoft.PowerFx.Core.Tests
             TableValue val = FormulaValue.NewSingleColumnTable(r1, r2, r3);
 
             engine.UpdateVariable("A", val);
-            var resultWithFlag = engine.Check(expression);
+            var resultWithFlag = engine.Parse(expression);
 
             engineWithoutFlag.UpdateVariable("A", val);
-            var resultWithoutFlag = engineWithoutFlag.Check(expression);
+            var resultWithoutFlag = engineWithoutFlag.Parse(expression);
 
             Assert.False(resultWithFlag.IsSuccess);
+            Assert.NotNull(resultWithFlag.Errors.First(error => error.MessageKey.Equals(TexlStrings.ErrDeprecated.Key)));
 
             Assert.True(resultWithoutFlag.IsSuccess);
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FlagTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FlagTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Core.Parser;
+using Microsoft.PowerFx.Preview;
+using Microsoft.PowerFx.Types;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    public class FlagTests
+    {
+        /// <summary>
+        /// "@ syntax is deprecated. Now, users should write 
+        /// Filter(A, ThisRecord.Value = 2) or Filter(A As Foo, Foo.Value = 2)
+        /// instead of
+        /// Filter(A, A[@Value] = 2).
+        /// </summary>
+        /// <param name="expression"></param>
+        [Theory]
+        [InlineData("Sum(A, A[@Value])")]
+        [InlineData("Filter(A, A[@Value] = 2)")]
+        public void Parser_DisableRowScopeDisambiguationSyntax(string expression)
+        {
+            var engine = new RecalcEngine(new PowerFxConfig(features: Features.DisableRowScopeDisambiguationSyntax));
+            var engineWithoutFlag = new RecalcEngine(new PowerFxConfig());
+            
+            NumberValue r1 = FormulaValue.New(1);
+            NumberValue r2 = FormulaValue.New(2);
+            NumberValue r3 = FormulaValue.New(3);
+            TableValue val = FormulaValue.NewSingleColumnTable(r1, r2, r3);
+
+            engine.UpdateVariable("A", val);
+            var resultWithFlag = engine.Check(expression);
+
+            engineWithoutFlag.UpdateVariable("A", val);
+            var resultWithoutFlag = engineWithoutFlag.Check(expression);
+
+            Assert.False(resultWithFlag.IsSuccess);
+
+            Assert.True(resultWithoutFlag.IsSuccess);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #698 
- Removed support for row-scope disambiguation syntax.
- Removed support from intellisense for the same.

Now, user would need to use
 `Filter(A, ThisRecord.Value = 2)` or `Filter(A As Foo, Foo.Value = 2)`
instead of 
`Filter(A, A[@Value] = 2)`