### PR TITLE
Do not drop attachments in Remove, Collect

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1125,37 +1125,6 @@ namespace Microsoft.PowerFx.Core.Functions
                     dataSource.DelegationMetadata.VerifyValue().TableCapabilities.HasCapability(expectedCapability.Capabilities);
         }
 
-        /// <summary>
-        /// Removes the Attachments field from <paramref name="itemType"/> if it is defined and returns true if
-        /// successful and false if an error was present.  If the Attachments field is not defined, does nothing
-        /// and returns true.
-        /// </summary>
-        /// <remarks>
-        /// We ignore the Attachments field on all types in the invocation because it is a special column that
-        /// is delay loaded.  It is stripped from the type when used in functions like Set and is ignored in
-        /// Collect.CheckInvocation.
-        /// </remarks>
-        /// <param name="itemType">Type that may define Attachments.</param>
-        /// <param name="errors">Errors.</param>
-        /// <param name="node">Node to which <paramref name="itemType"/> is associated.</param>
-        /// <returns>
-        /// True if operation succeeded, if no Attachments field is defined or the Attachments field
-        /// has been successfully removed from <paramref name="itemType"/>, false otherwise.
-        /// </returns>
-        protected bool DropAttachmentsIfExists(ref DType itemType, IErrorContainer errors, TexlNode node)
-        {
-            Contracts.AssertValid(itemType);
-            Contracts.AssertValue(errors);
-            Contracts.AssertValue(node);
-
-            if (itemType.ContainsAttachmentType(DPath.Root))
-            {
-                return DropAllMatchingNested(ref itemType, errors, node, type => type.IsAttachment);
-            }
-
-            return true;
-        }
-
         // Helper to drop all of a single types from a result type
         protected bool DropAllOfKindNested(ref DType itemType, IErrorContainer errors, TexlNode node, DKind kind)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CollectFunction.cs
@@ -149,8 +149,6 @@ namespace Microsoft.PowerFx.Interpreter
                 {
                     fValid &= DropAllOfKindNested(ref itemType, errors, args[i], DKind.DataEntity);
                 }
-
-                fValid &= DropAttachmentsIfExists(ref itemType, errors, args[i]);
             }
 
             Contracts.Assert(!itemType.IsValid || itemType.IsTable);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -117,8 +117,6 @@ namespace Microsoft.PowerFx.Functions
                 errors.EnsureError(args[0], ErrNeedTable_Func, Name);
             }
 
-            fValid &= DropAttachmentsIfExists(ref collectionType, errors, args[0]);
-
             var argCount = argTypes.Length;
 
             for (var i = 1; i < argCount; i++)
@@ -146,8 +144,6 @@ namespace Microsoft.PowerFx.Functions
                     errors.EnsureError(args[i], ErrNeedRecord, args[i]);
                     continue;
                 }
-
-                fValid &= DropAttachmentsIfExists(ref argType, errors, args[i]);
 
                 var collectionAcceptsRecord = collectionType.Accepts(argType.ToTable());
                 var recordAcceptsCollection = argType.ToTable().Accepts(collectionType);


### PR DESCRIPTION
Removes the other places where Attachments were being dropped. Once again, these did not have code coverage.