### PR TITLE
Update blank value handling for text functions in the C# interpreter

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -667,7 +667,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Index.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
+                    replaceBlankValues: ReplaceBlankWithZeroForSpecificIndices(1),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueTypeOrBlank<TableValue>,
                         ExactValueTypeOrBlank<NumberValue>),
@@ -731,7 +731,7 @@ namespace Microsoft.PowerFx.Functions
                 BuiltinFunctionsCore.IsNumeric,
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.IsNumeric.Name,
-                    expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
+                    expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
@@ -778,10 +778,12 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Left.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
+                    replaceBlankValues: ReplaceBlankWith(
+                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
+                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
                     checkRuntimeTypes: ExactSequence(
-                        ExactValueTypeOrBlank<StringValue>,
-                        ExactValueTypeOrBlank<NumberValue>),
+                        ExactValueType<StringValue>,
+                        ExactValueType<NumberValue>),
                     checkRuntimeValues: PositiveNumericNumberChecker,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Left)
@@ -1048,10 +1050,12 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Right.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
+                    replaceBlankValues: ReplaceBlankWith(
+                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
+                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
                     checkRuntimeTypes: ExactSequence(
-                        ExactValueTypeOrBlank<StringValue>,
-                        ExactValueTypeOrBlank<NumberValue>),
+                        ExactValueType<StringValue>,
+                        ExactValueType<NumberValue>),
                     checkRuntimeValues: PositiveNumericNumberChecker,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Right)
@@ -1126,7 +1130,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Sequence.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 3, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
                     replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Sequence)
@@ -1148,7 +1152,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Sin.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: SingleArgTrig(Math.Sin))
@@ -1184,7 +1188,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Sqrt.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeTypeChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Sqrt)
@@ -1195,7 +1199,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.StartsWith.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithEmptyString,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
+                    checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: StartsWith)
@@ -1292,7 +1296,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Tan.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: SingleArgTrig(Math.Tan))
@@ -1325,7 +1329,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Time.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 4, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
                     replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Time)
@@ -1372,10 +1376,10 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Trim.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
+                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Trim)
             },
             {
@@ -1383,10 +1387,10 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.TrimEnds.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
+                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: TrimEnds)
             },
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -465,10 +465,10 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.EndsWith.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
+                    replaceBlankValues: ReplaceBlankWithEmptyString,
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnFalseIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: EndsWith)
             },
             {
@@ -514,16 +514,16 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: ReplaceBlankWith(
                         new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
                         new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                        new BlankValue(IRContext.NotInSource(FormulaType.Blank))),
+                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueType<StringValue>,
                         ExactValueType<StringValue>,
-                        ExactValueTypeOrBlank<NumberValue>),
+                        ExactValueType<NumberValue>),
                     checkRuntimeValues: ExactSequence(
                         DeferRuntimeValueChecking,
                         DeferRuntimeValueChecking,
                         StrictArgumentPositiveNumberChecker),
-                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Find)
             },
             {
@@ -1031,15 +1031,15 @@ namespace Microsoft.PowerFx.Functions
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWith(
                         new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                        new BlankValue(IRContext.NotInSource(FormulaType.Blank)),
+                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0),
                         new NumberValue(IRContext.NotInSource(FormulaType.Number), 0),
                         new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty)),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueType<StringValue>,
-                        ExactValueTypeOrBlank<NumberValue>,
+                        ExactValueType<NumberValue>,
                         ExactValueType<NumberValue>,
                         ExactValueType<StringValue>),
-                    checkRuntimeValues: ReplaceChecker,
+                    checkRuntimeValues: DeferRuntimeTypeChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Replace)
             },
@@ -1194,10 +1194,10 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.StartsWith.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
+                    replaceBlankValues: ReplaceBlankWithEmptyString,
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnFalseIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: StartsWith)
             },
             {
@@ -1228,17 +1228,17 @@ namespace Microsoft.PowerFx.Functions
                 BuiltinFunctionsCore.Substitute,
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Substitute.Name,
-                    expandArguments: InsertDefaultValues(outputArgsCount: 4, fillWith: new BlankValue(IRContext.NotInSource(FormulaType.Blank))),
+                    expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWith(
                         new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                        new BlankValue(IRContext.NotInSource(FormulaType.Blank)),
                         new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                        new BlankValue(IRContext.NotInSource(FormulaType.Blank))),
+                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
+                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueType<StringValue>,
-                        ExactValueTypeOrBlank<StringValue>,
                         ExactValueType<StringValue>,
-                        ExactValueTypeOrBlank<NumberValue>),
+                        ExactValueType<StringValue>,
+                        ExactValueType<NumberValue>),
                     checkRuntimeValues: StrictArgumentPositiveNumberChecker,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Substitute)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -408,6 +408,11 @@ namespace Microsoft.PowerFx.Functions
             var count = ((NumberValue)args[2]).Value;
             var replacement = ((StringValue)args[3]).Value;
 
+            if (start <= 0 || count < 0)
+            {
+                return CommonErrors.ArgumentOutOfRange(irContext);
+            }
+
             if (start >= int.MaxValue)
             {
                 start = source.Length + 1;
@@ -439,19 +444,19 @@ namespace Microsoft.PowerFx.Functions
         private static FormulaValue Substitute(IRContext irContext, FormulaValue[] args)
         {
             var source = (StringValue)args[0];
+            var match = (StringValue)args[1];
+            var replacement = (StringValue)args[2];
 
-            if (args[1] is BlankValue || (args[1] is StringValue sv && string.IsNullOrEmpty(sv.Value)))
+            if (string.IsNullOrEmpty(match.Value))
             {
                 return source;
             }
 
-            var match = (StringValue)args[1];
-            var replacement = (StringValue)args[2];
-
             var instanceNum = -1;
-            if (args[3] is NumberValue nv)
+            if (args.Length > 3)
             {
-                if (nv.Value >= int.MaxValue)
+                var nv = (NumberValue)args[3];
+                if (nv.Value > source.Value.Length)
                 {
                     return source;
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -654,20 +654,6 @@ namespace Microsoft.PowerFx.Functions
             return arg;
         }
 
-        private static FormulaValue PositiveArgumentNumberChecker(IRContext irContext, int index, FormulaValue arg)
-        {
-            if (arg is NumberValue numberArg)
-            {
-                var number = numberArg.Value;
-                if (number < 0)
-                {
-                    return CommonErrors.ArgumentOutOfRange(irContext);
-                }
-            }
-
-            return arg;
-        }
-
         private static FormulaValue StrictArgumentPositiveNumberChecker(IRContext irContext, int index, FormulaValue arg)
         {
             if (arg is NumberValue numberArg)
@@ -691,31 +677,6 @@ namespace Microsoft.PowerFx.Functions
                 {
                     return CommonErrors.ArgumentOutOfRange(irContext);
                 }
-            }
-
-            return arg;
-        }
-
-        private static FormulaValue ReplaceChecker(IRContext irContext, int index, FormulaValue arg)
-        {
-            if (index == 1)
-            {
-                if (arg is BlankValue)
-                {
-                    return new ErrorValue(irContext, new ExpressionError()
-                    {
-                        Message = "The second parameter to the Replace function cannot be Blank()",
-                        Span = irContext.SourceContext,
-                        Kind = ErrorKind.InvalidFunctionUsage
-                    });
-                }
-
-                return StrictArgumentPositiveNumberChecker(irContext, index, arg);
-            }
-
-            if (index == 2)
-            {
-                return PositiveArgumentNumberChecker(irContext, index, arg);
             }
 
             return arg;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/EndsWith.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/EndsWith.txt
@@ -146,6 +146,10 @@ false
 >> EndsWith("Hello",Blank())
 true
 
+//Null end case - coerced to ""
+>> EndsWith("",Blank())
+true
+
 //Null both case - both coerced to ""
 >> EndsWith(Blank(),Blank())
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/EndsWith.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/EndsWith.txt
@@ -142,13 +142,13 @@ true
 >> EndsWith(Blank(),"ok")
 false
 
-//Null end case
+//Null end case - coerced to ""
 >> EndsWith("Hello",Blank())
-false
+true
 
-//Null both case
+//Null both case - both coerced to ""
 >> EndsWith(Blank(),Blank())
-false
+true
 
 
 // ******** BOOLEAN PARAMETERS ********

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Find.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Find.txt
@@ -95,16 +95,16 @@ Blank()
 Blank()
 
 >> Find("textToFind", Blank(), 3)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Find(",", "LastName,FirstName", -1)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Find(",", "LastName,FirstName", 0)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Find(",", "LastName,FirstName", Blank())
-Blank()
+#Error(Kind=InvalidArgument)
 
 >> Find("B", "LastNameisBlah")
 11

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Index.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Index.txt
@@ -7,8 +7,11 @@
 >> Index([1, 2, 3, 4, 5], -1)
 #Error(Kind=InvalidArgument)
 
+>> Index([1, 2, 3, 4, 5], 0)
+#Error(Kind=InvalidArgument)
+
 >> Index([1, 2, 3, 4, 5], Blank())
-Blank()
+#Error(Kind=InvalidArgument)
 
 >> Index(Blank(), 2)
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Replace.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Replace.txt
@@ -151,7 +151,7 @@
 
 //Error message: The second argument to the "Value" function should be greater than or equal to 1
 >> Replace("abcabcabc", -1, -2, "mm")
-#Error(Kind=InvalidArgument, InvalidArgument)
+#Error(Kind=InvalidArgument)
 
 //Error message: The second argument to the "Value" function should be greater than or equal to 1
 >> Replace("", 0, 0, "")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StartsWith.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StartsWith.txt
@@ -140,17 +140,17 @@ true
 >> StartsWith(1/0,"hello")
 #Error(Kind=Div0)
 
-// Null text case
+// Null text case - coerced to ""
 >> StartsWith(Blank(),"ok")
 false
 
-// Null end case
+// Null start case - coerced to ""
 >> StartsWith("Hello",Blank())
-false
+true
 
-// Null both case
+// Null both case - coerced to ""
 >> StartsWith(Blank(),Blank())
-false
+true
 
 
 // ******** BOOLEAN PARAMETERS ********

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StartsWith.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StartsWith.txt
@@ -148,6 +148,10 @@ false
 >> StartsWith("Hello",Blank())
 true
 
+// Null start case - coerced to ""
+>> StartsWith("",Blank())
+true
+
 // Null both case - coerced to ""
 >> StartsWith(Blank(),Blank())
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Substitute.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Substitute.txt
@@ -119,9 +119,9 @@
 >> Substitute("HelloHelloHello", Blank(), "Je", 2)
 "HelloHelloHello"
 
-//Excel doesn't support Blank() in the forth argument and throws error
+// Blank() is coerced to 0, which is invalid
 >> Substitute("HelloHelloHello", "He", "Je", Blank())
-"JelloJelloJello"
+#Error(Kind=InvalidArgument)
 
 >> Substitute("HelloHelloHello", "He", "")
 "llollollo"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/string.txt
@@ -17,10 +17,10 @@
 ""
 
 >> Left("foo", -1)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Left("foo", 1/0)
-#Error
+#Error(Kind=Div0)
 
 >> Left(Blank(), 1)
 ""
@@ -41,10 +41,10 @@
 ""
 
 >> Right("bar", -1)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Right("foo", 1/0)
-#Error
+#Error(Kind=Div0)
 
 >> Right(Blank(), 1)
 ""
@@ -69,22 +69,22 @@
 ""
 
 >> Mid("bar", -1)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> IsError(Mid("bar", -1))
 true
 
 >> Mid("bar", 2, -1)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> IsError(Mid("bar", 2, -1))
 true
 
 >> Mid("foo", 0)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Mid(Text(1/0, "#.000"), 1)
-#Error
+#Error(Kind=Div0)
 
 >> IsError(Mid("foo", 0))
 true
@@ -108,7 +108,7 @@ false
 0
 
 >> Len(Text(1/0, "#.000"))
-#Error
+#Error(Kind=Div0)
 
 >> "f" in "foo"
 true
@@ -143,8 +143,9 @@ false
 >> StartsWith("foo", "")
 true
 
+// Blank is coerced to ""
 >> StartsWith("foo", Blank())
-false
+true
 
 >> StartsWith("foobar", Text(1/0))
 #Error
@@ -158,11 +159,12 @@ false
 >> EndsWith("foobar", "")
 true
 
+// Blank is coerced to ""
 >> EndsWith("foobar", Blank())
-false
+true
 
 >> EndsWith("foobar", Text(1/0))
-#Error
+#Error(Kind=Div0)
 
 >> TrimEnds("   Hello     World   ")
 "Hello     World"
@@ -171,7 +173,7 @@ false
 ""
 
 >> TrimEnds(Text(1/0))
-#Error
+#Error(Kind=Div0)
 
 >> Trim("   Hello     World   ")
 "Hello World"
@@ -180,7 +182,7 @@ false
 ""
 
 >> Trim(Text(1/0))
-#Error
+#Error(Kind=Div0)
 
 >> Lower("E. E. Cummings")
 "e. e. cummings"
@@ -189,7 +191,7 @@ false
 ""
 
 >> Lower(Text(1/0, "000"))
-#Error
+#Error(Kind=Div0)
 
 >> Upper("Important!")
 "IMPORTANT!"
@@ -198,7 +200,7 @@ false
 ""
 
 >> Upper(Text(1/0, "000"))
-#Error
+#Error(Kind=Div0)
 
 >> Substitute("abcabcabc", "ab", "xx")
 "xxcxxcxxc"
@@ -216,13 +218,13 @@ false
 "abcabcabc"
 
 >> Substitute("abcabcabc", "ab", "xx", 1/0)
-#Error
+#Error(Kind=Div0)
 
 >> Substitute("abcabcabc", "ab", "xx", 0)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> Substitute("abcabcabc", "ab", "xx", Blank())
-"xxcxxcxxc"
+#Error(Kind=InvalidArgument)
 
 >> Substitute("abcabcabc", Blank(), "xx")
 "abcabcabc"
@@ -243,7 +245,7 @@ false
 true
 
 >> Substitute("abcabcabc", "ab", "xx", -2)
-#Error
+#Error(Kind=InvalidArgument)
 
 >> IsError(Substitute("abcabcabc", "ab", "xx", -2))
 true
@@ -261,19 +263,19 @@ true
 "abcxx"
 
 >> Replace("abcabcabc", 0, 0, "xx")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> IsError(Replace("abcabcabc", 0, 0, "xx"))
 true
 
 >> Replace("abcabcabc", 1, -2, "xx")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> IsError(Replace("abcabcabc", 1, -2, "xx"))
 true
 
 >> Replace("abcabcabc", -1, -2, "xx")
-#Error
+#Error(Kind=InvalidArgument)
 
 >> IsError(Replace("abcabcabc", -1, -2, "xx"))
 true
@@ -285,5 +287,4 @@ true
 "ab"
 
 >> Concatenate(Text(1/0, "000"), "b", Text(7))
-#Error
-
+#Error(Kind=Div0)


### PR DESCRIPTION
Blank values should be coerced to empty strings (`""`) or zero (`0`) when passed as inputs to string or numeric arguments in functions. This change updates text functions to do so.