### PR TITLE
Fixes Nullable fields cause symbol generation to fail when using marshaller

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/PrimitiveValueConversions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/PrimitiveValueConversions.cs
@@ -24,6 +24,11 @@ namespace Microsoft.PowerFx.Types
             { typeof(decimal), FormulaType.Number },
             { typeof(long), FormulaType.Number },
             { typeof(float), FormulaType.Number },
+            { typeof(double?), FormulaType.Number },
+            { typeof(int?), FormulaType.Number },
+            { typeof(decimal?), FormulaType.Number },
+            { typeof(long?), FormulaType.Number },
+            { typeof(float?), FormulaType.Number },
                         
             // Non-numeric types:
             { typeof(Guid), FormulaType.Guid },
@@ -31,7 +36,12 @@ namespace Microsoft.PowerFx.Types
             { typeof(DateTime), FormulaType.DateTime },
             { typeof(DateTimeOffset), FormulaType.DateTime },
             { typeof(TimeSpan), FormulaType.Time },
-            { typeof(string), FormulaType.String }
+            { typeof(string), FormulaType.String },
+            { typeof(Guid?), FormulaType.Guid },
+            { typeof(bool?), FormulaType.Boolean },
+            { typeof(DateTime?), FormulaType.DateTime },
+            { typeof(DateTimeOffset?), FormulaType.DateTime },
+            { typeof(TimeSpan?), FormulaType.Time },
         };
 
         /// <summary>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MarshalTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MarshalTests.cs
@@ -102,6 +102,32 @@ namespace Microsoft.PowerFx.Tests
         }
 
         [Fact]
+        public void TestNullableType()
+        {
+            var typeMarshallerCache = new TypeMarshallerCache();
+            var typeMarshaller = typeMarshallerCache.GetMarshaller(typeof(TestNullableObj));
+
+            var fxObj = typeMarshallerCache.Marshal(new TestNullableObj());
+            var fxObj2 = typeMarshallerCache.Marshal(new TestNullableObj { IntField = 12 });
+
+            var engine = new RecalcEngine();
+
+            engine.UpdateVariable("fxObj", fxObj);
+            engine.UpdateVariable("fxObj2", fxObj2);
+
+            var result = engine.Eval("fxObj.IntField");
+            var result2 = engine.Eval("fxObj2.IntField");
+
+            Assert.IsType<BlankValue>(result);
+            Assert.IsType<NumberType>(result.Type);
+            Assert.Null(result.ToObject());
+
+            Assert.IsType<NumberValue>(result2);
+            Assert.IsType<NumberType>(result2.Type);
+            Assert.Equal(12D, result2.ToObject());
+        }
+
+        [Fact]
         public void TestBlank()
         {
             var node1 = new TestNode
@@ -247,6 +273,11 @@ namespace Microsoft.PowerFx.Tests
             var cache = TypeMarshallerCache.New(new CollideObjectMarshallerProvider());
 
             Assert.Throws<NameCollisionException>(() => cache.GetMarshaller(obj.GetType()));
+        }
+
+        private class TestNullableObj
+        {
+            public int? IntField { get; set; }
         }
 
         private class TestObj


### PR DESCRIPTION
- fixes #737 .
- Added test for the same.