### PR TITLE
Exposing anonymized method for logging 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseResult.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerFx
         }));
 
         /// <summary>
-        /// Converts the current formula into an anonymized format.
+        /// Converts the current formula into an anonymized format suitable for logging.
         /// </summary>
         public string GetAnonymizedFormula()
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseResult.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Logging;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Syntax.SourceInformation;
@@ -72,5 +73,13 @@ namespace Microsoft.PowerFx
             err.FormatCore(sb);            
             return $"Err#{++i} {sb}";
         }));
+
+        /// <summary>
+        /// Converts the current formula into an anonymized format.
+        /// </summary>
+        public string GetAnonymizedFormula()
+        {
+            return StructuralPrint.Print(Root);
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
@@ -35,7 +35,6 @@ namespace Microsoft.PowerFx.Tests
                 _defaultLocale,
                 flags: Flags.EnableExpressionChaining);
 
-            //Assert.Equal(expected, StructuralPrint.Print(result.Root));
             Assert.Equal(expected, result.GetAnonymizedFormula());
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
@@ -35,7 +35,8 @@ namespace Microsoft.PowerFx.Tests
                 _defaultLocale,
                 flags: Flags.EnableExpressionChaining);
 
-            Assert.Equal(expected, StructuralPrint.Print(result.Root));
+            //Assert.Equal(expected, StructuralPrint.Print(result.Root));
+            Assert.Equal(expected, result.GetAnonymizedFormula());
         }
 
         private class TestSanitizer : ISanitizedNameProvider


### PR DESCRIPTION
Issue #766.
New **ParseResult.GetAnonymizedFormula()** method is public but interfaced used to inject behavior to **StructuralPrint** aren't:
- **TexlBinding**
- **ISanitizedNameProvider**

What's the best approach?

Update: checked internally. Injection classes won't be exposed (for now).