### PR TITLE
RemoveFlags.All should be locked in error string

### DIFF
--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -5037,8 +5037,8 @@
     <comment>function_parameter - One or more records to be removed.</comment>
   </data>
   <data name="ErrRemoveAllArg" xml:space="preserve">
-    <value>If provided, last argument must be 'All'. Is there a typo?</value>
-    <comment>Error Message.</comment>
+    <value>If provided, last argument must be 'RemoveFlags.All'. Is there a typo?</value>
+    <comment>{Locked=RemoveFlags.All} Error Message, RemoveFlags.All is an enum value that does not get localized.</comment>
   </data>
   <data name="PenMode_Draw_DisplayName" xml:space="preserve">
     <value>Draw</value>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
@@ -120,13 +120,13 @@ Table()
 
 // Wrong arguments
 >> Remove(t1, r1,"Al");
-Errors: Error 14-18: If provided, last argument must be 'All'. Is there a typo?|Error 0-19: The function 'Remove' has some invalid arguments.
+Errors: Error 14-18: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-19: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, r1,"");
-Errors: Error 14-16: If provided, last argument must be 'All'. Is there a typo?|Error 0-17: The function 'Remove' has some invalid arguments.
+Errors: Error 14-16: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-17: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, r1, r1, r1, r1, r1, r1, "Al");
-Errors: Error 35-39: If provided, last argument must be 'All'. Is there a typo?|Error 0-40: The function 'Remove' has some invalid arguments.
+Errors: Error 35-39: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-40: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, "All");
 Errors: Error 11-16: Invalid argument type (Text). Expecting a Record value instead.|Error 11-16: Cannot use a non-record value in this context.|Error 0-17: The function 'Remove' has some invalid arguments.


### PR DESCRIPTION
Locks `All` in the error string. Also, changes this to use the fully qualified enum in the error message. 