### PR TITLE
Custom function error handling. Fixes #777

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -364,11 +364,17 @@ namespace Microsoft.PowerFx
                 }
                 else if (arg is BlankValue)
                 {
+                    if (errors == null)
+                    {
+                        errors = new List<ErrorValue>();
+                    }
+
                     errors.Add(CommonErrors.RuntimeTypeMismatch(IRContext.NotInSource(FormulaType.Blank)));
                 }
                 else if (arg is LambdaFormulaValue lambda)
                 {
-                    arg = async () => (BooleanValue)await lambda.EvalAsync();
+                    Func<Task<BooleanValue>> argLambda = async () => (BooleanValue)await lambda.EvalAsync();
+                    arg = argLambda;
                 }
 
                 args2.Add(arg);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -15,6 +15,7 @@ using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 using static Microsoft.PowerFx.Core.Localization.TexlStrings;
@@ -361,6 +362,10 @@ namespace Microsoft.PowerFx
                 {
                     arg = FormulaValue.New(string.Empty);
                 }
+                else if (arg is BlankValue)
+                {
+                    errors.Add(CommonErrors.RuntimeTypeMismatch(IRContext.NotInSource(FormulaType.Blank)));
+                }
                 else if (arg is LambdaFormulaValue lambda)
                 {
                     arg = async () => (BooleanValue)await lambda.EvalAsync();
@@ -372,11 +377,6 @@ namespace Microsoft.PowerFx
             if (errors != null)
             {
                 return ErrorValue.Combine(IRContext.NotInSource(_info.RetType), errors);
-            }
-
-            if (errors != null)
-            {
-                return ErrorValue.Combine(IRContext.NotInSource(FormulaType.BindingError), errors);
             }
 
             if (_info._isAsync)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Values/LambdaFormulaValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Values/LambdaFormulaValue.cs
@@ -41,12 +41,6 @@ namespace Microsoft.PowerFx.Types
             return result;
         }
 
-        public async ValueTask<FormulaValue> EvalInRowScopeAsync(EvalVisitorContext context)
-        {
-            Context = context;
-            return await EvalAsync();
-        }
-
         public override object ToObject()
         {
             return "<Lambda>";

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Values/LambdaFormulaValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Values/LambdaFormulaValue.cs
@@ -41,6 +41,12 @@ namespace Microsoft.PowerFx.Types
             return result;
         }
 
+        public async ValueTask<FormulaValue> EvalInRowScopeAsync(EvalVisitorContext context)
+        {
+            Context = context;
+            return await EvalAsync();
+        }
+
         public override object ToObject()
         {
             return "<Lambda>";

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Tests
 
             // With error as arg.
             var result = engine.Eval("TestCustom(1/0,true)");
-            Assert.Equal(FormulaType.BindingError, result.Type);
+            Assert.Equal(FormulaType.String, result.Type);
             Assert.Equal(1, ((ErrorValue)result).Errors.Count);
             Assert.Equal("Invalid operation: division by zero.", ((ErrorValue)result).Errors[0].Message);
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -2,16 +2,12 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Tests;
-using Microsoft.PowerFx.Core.Tests.Helpers;
 using Microsoft.PowerFx.Types;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Microsoft.PowerFx.Tests
 {
@@ -29,17 +25,44 @@ namespace Microsoft.PowerFx.Tests
             Assert.NotNull(func);
 
             // Can be invoked. 
-            var result = engine.Eval("TestCustom(3,true)");
-            Assert.Equal("3,True", result.ToObject());
+            var result = engine.Eval("TestCustom(3,\"a\")");
+            Assert.Equal("3,a", result.ToObject());
+        }
+
+        [Fact]
+        public void CustomFunctionErrorOrBlank()
+        {
+            var config = new PowerFxConfig(null);
+            config.AddFunction(new TestCustomFunction());
+            var engine = new RecalcEngine(config);
+
+            // Shows up in enumeration
+            var func = engine.GetAllFunctionNames().First(name => name == "TestCustom");
+            Assert.NotNull(func);
+
+            // With error as arg.
+            var result = engine.Eval("TestCustom(1/0,true)");
+            Assert.Equal(FormulaType.BindingError, result.Type);
+            Assert.Equal(1, ((ErrorValue)result).Errors.Count);
+            Assert.Equal("Invalid operation: division by zero.", ((ErrorValue)result).Errors[0].Message);
+
+            // With Blanks as arg.
+            // For number Blank() will be converted to 0.
+            var result2 = engine.Eval("TestCustom(If(false,12), \"a\")");
+            Assert.Equal("0,a", result2.ToObject());
+
+            // For String Blank() will be converted to empty string.
+            var result3 = engine.Eval("TestCustom(0, If(false,\"a\"))");
+            Assert.Equal("0,", result3.ToObject());
         }
 
         // Must have "Function" suffix. 
         private class TestCustomFunction : ReflectionFunction
         {
             // Must have "Execute" method. 
-            public static StringValue Execute(NumberValue x, BooleanValue b)
+            public static StringValue Execute(NumberValue x, StringValue s)
             {
-                var val = x.Value.ToString() + "," + b.Value.ToString();
+                var val = x.Value.ToString() + "," + s.Value.ToString();
                 return FormulaValue.New(val);
             }
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -25,12 +25,22 @@ namespace Microsoft.PowerFx.Tests
             Assert.NotNull(func);
 
             // Can be invoked. 
-            var result = engine.Eval("TestCustom(3,\"a\")");
-            Assert.Equal("3,a", result.ToObject());
+            var result = engine.Eval("TestCustom(3,true,\"a\")");
+            Assert.Equal("3,True,a", result.ToObject());
         }
 
-        [Fact]
-        public void CustomFunctionErrorOrBlank()
+        [Theory]
+        [InlineData("TestCustom(1/0,true,\"test\")", null, true, "Invalid operation: division by zero.")]
+
+        // With Blanks() as arg where expected arg is not a number or a string, Blank() will generate type mismatch error.
+        [InlineData("TestCustom(0, If(false,true), \"test\")", null, true, "Runtime type mismatch")]
+
+        // With Blanks() as arg where expected arg is number, Blank() will be coerced to 0.
+        [InlineData("TestCustom(If(false,12),true,\"test\")", "0,True,test", false, null)]
+
+        // With Blanks() as arg where expected arg is string, Blank() will be coerced to empty string.
+        [InlineData("TestCustom(0,true,If(false,\"test\"))", "0,True,", false, null)]
+        public void CustomFunctionErrorOrBlank(string script, string expectedResult, bool isErrorExpected, string errorMessage)
         {
             var config = new PowerFxConfig(null);
             config.AddFunction(new TestCustomFunction());
@@ -41,28 +51,27 @@ namespace Microsoft.PowerFx.Tests
             Assert.NotNull(func);
 
             // With error as arg.
-            var result = engine.Eval("TestCustom(1/0,true)");
-            Assert.Equal(FormulaType.String, result.Type);
-            Assert.Equal(1, ((ErrorValue)result).Errors.Count);
-            Assert.Equal("Invalid operation: division by zero.", ((ErrorValue)result).Errors[0].Message);
+            var result = engine.Eval(script);
 
-            // With Blanks as arg.
-            // For number Blank() will be converted to 0.
-            var result2 = engine.Eval("TestCustom(If(false,12), \"a\")");
-            Assert.Equal("0,a", result2.ToObject());
-
-            // For String Blank() will be converted to empty string.
-            var result3 = engine.Eval("TestCustom(0, If(false,\"a\"))");
-            Assert.Equal("0,", result3.ToObject());
+            if (isErrorExpected)
+            {
+                Assert.IsType<ErrorValue>(result);
+                Assert.Equal(1, ((ErrorValue)result).Errors.Count);
+                Assert.Equal(errorMessage, ((ErrorValue)result).Errors[0].Message);
+            }
+            else
+            {
+                Assert.Equal(expectedResult, result.ToObject());
+            }
         }
 
         // Must have "Function" suffix. 
         private class TestCustomFunction : ReflectionFunction
         {
             // Must have "Execute" method. 
-            public static StringValue Execute(NumberValue x, StringValue s)
+            public static StringValue Execute(NumberValue x, BooleanValue b, StringValue s)
             {
-                var val = x.Value.ToString() + "," + s.Value.ToString();
+                var val = x.Value.ToString() + "," + b.Value.ToString() + "," + s.Value.ToString();
                 return FormulaValue.New(val);
             }
         }


### PR DESCRIPTION
- Fixes #777 
- When Custom function will have error as Arg we would report those errors before trying to invoke the function.
- If Custom function has Blank() as arg and expected type is NumberValue then we would treat it as 0, if expected type is StringValue then we would treat it as empty string.
- Added test to demo the same.