### PR TITLE
Add record and replay feature to LimitedSeverityErrorContainer

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/LimitedSeverityErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/LimitedSeverityErrorContainer.cs
@@ -19,6 +19,105 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
         private readonly IErrorContainer _errors;
         private readonly DocumentErrorSeverity _maximumSeverity;
 
+        #region Record and Replay
+        private readonly List<FrozenInvocation> _frozenInvocations = new List<FrozenInvocation>();
+
+        private abstract class FrozenInvocation
+        {
+            public abstract void Invoke(IErrorContainer errors);
+        }
+
+        private sealed class EnsureErrorFrozenInvocation : FrozenInvocation
+        {
+            private readonly TexlNode _node;
+            private readonly ErrorResourceKey _errKey;
+            private readonly object[] _args;
+
+            public EnsureErrorFrozenInvocation(TexlNode node, ErrorResourceKey errKey, params object[] args)
+            {
+                _node = node;
+                _errKey = errKey;
+                _args = args;
+            }
+
+            public override void Invoke(IErrorContainer errors)
+            {
+                errors.EnsureError(_node, _errKey, _args);
+            }
+        }
+
+        private sealed class EnsureErrorSeverityFrozenInvocation : FrozenInvocation
+        {
+            private readonly DocumentErrorSeverity _severity;
+            private readonly TexlNode _node;
+            private readonly ErrorResourceKey _errKey;
+            private readonly object[] _args;
+
+            public EnsureErrorSeverityFrozenInvocation(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, params object[] args)
+            {
+                _severity = severity;
+                _node = node;
+                _errKey = errKey;
+                _args = args;
+            }
+
+            public override void Invoke(IErrorContainer errors)
+            {
+                errors.EnsureError(_severity, _node, _errKey, _args);
+            }
+        }
+
+        private sealed class ErrorFrozenInvocation : FrozenInvocation
+        {
+            private readonly TexlNode _node;
+            private readonly ErrorResourceKey _errKey;
+            private readonly object[] _args;
+
+            public ErrorFrozenInvocation(TexlNode node, ErrorResourceKey errKey, params object[] args)
+            {
+                _node = node;
+                _errKey = errKey;
+                _args = args;
+            }
+
+            public override void Invoke(IErrorContainer errors)
+            {
+                errors.Error(_node, _errKey, _args);
+            }
+        }
+
+        private sealed class ErrorSeverityFrozenInvocation : FrozenInvocation
+        {
+            private readonly DocumentErrorSeverity _severity;
+            private readonly TexlNode _node;
+            private readonly ErrorResourceKey _errKey;
+            private readonly object[] _args;
+
+            public ErrorSeverityFrozenInvocation(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, params object[] args)
+            {
+                _severity = severity;
+                _node = node;
+                _errKey = errKey;
+                _args = args;
+            }
+
+            public override void Invoke(IErrorContainer errors)
+            {
+                errors.Error(_severity, _node, _errKey, _args);
+            }
+        }
+
+        public void Undiscard()
+        {
+            foreach (var invocation in _frozenInvocations)
+            {
+                invocation.Invoke(_errors);
+            }
+
+            _frozenInvocations.Clear();
+        }
+        #endregion
+
         public DocumentErrorSeverity DefaultSeverity => _errors.DefaultSeverity;
 
         public LimitedSeverityErrorContainer(IErrorContainer errors, DocumentErrorSeverity maximumSeverity)
@@ -34,6 +133,7 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
                 return _errors.EnsureError(node, errKey, args);
             }
 
+            _frozenInvocations.Add(new EnsureErrorFrozenInvocation(node, errKey, args));
             return null;
         }
 
@@ -44,6 +144,7 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
                 return _errors.EnsureError(severity, node, errKey, args);
             }
 
+            _frozenInvocations.Add(new EnsureErrorSeverityFrozenInvocation(severity, node, errKey, args));
             return null;
         }
 
@@ -54,6 +155,7 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
                 return _errors.Error(node, errKey, args);
             }
 
+            _frozenInvocations.Add(new ErrorFrozenInvocation(node, errKey, args));
             return null;
         }
 
@@ -64,6 +166,7 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
                 return _errors.Error(severity, node, errKey, args);
             }
 
+            _frozenInvocations.Add(new ErrorSeverityFrozenInvocation(severity, node, errKey, args));
             return null;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4941,8 +4941,14 @@ namespace Microsoft.PowerFx.Core.Binding
                 var carg = args.Length;
                 var argTypes = args.Select(_txb.GetType).ToArray();
 
-                if (TryGetBestOverload(_txb, node, argTypes, overloads, out var function, out var nodeToCoercedTypeMap, out var returnType))
+                if (TryGetBestOverload(_txb, node, argTypes, overloads, out var function, out var nodeToCoercedTypeMap, out var returnType, out var warnings))
                 {
+                    if (function.CheckTypesAndSemanticsOnly)
+                    {
+                        // CheckSemantics may produce errors that are being ignored.
+                        warnings.Undiscard();
+                    }
+
                     _txb.SetInfo(node, new CallInfo(function, node));
                     _txb.SetType(node, returnType);
 


### PR DESCRIPTION
Adds a "record and replay" feature to the error container that is being used by TryGetBestOverload. This is so that, when functions want to use CheckTypes/CheckSemantics instead of CheckInvocation, semantic errors that do not contribute to a type checking error can be "replayed" in the case where type checking succeeds.

A new error container is created per-function, so only the errors generated for a single function are added to the list.

This should greatly reduce the number of failures in PAClient test labs as we migrate functions to use the new methods.