### PR TITLE
Delegation support for named formula rules

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -571,6 +571,14 @@ namespace Microsoft.PowerFx.Core.Binding
             return false;
         }
 
+        private bool SupportsDelegation(FirstNameNode node)
+        {
+            Contracts.AssertValue(node);
+
+            var info = GetInfo(node).VerifyValue();
+            return info.Data is IExternalDelegable delegableSymbol && delegableSymbol.IsDelegable;
+        }
+
         private bool SupportsPaging(TexlNode node)
         {
             Contracts.AssertValue(node);
@@ -1135,8 +1143,7 @@ namespace Microsoft.PowerFx.Core.Binding
             Contracts.AssertValue(node);
             Contracts.AssertIndex(node.Id, _typeMap.Length);
 
-            var info = GetInfo(node).VerifyValue();
-            if (info.Kind == BindKind.PowerFxResolvedObject && SupportsPaging(node))
+            if (SupportsDelegation(node))
             {
                 _isDelegatable.Set(node.Id, true);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -1130,6 +1130,24 @@ namespace Microsoft.PowerFx.Core.Binding
             }
         }
 
+        public void CheckAndMarkAsDelegatable(FirstNameNode node)
+        {
+            Contracts.AssertValue(node);
+            Contracts.AssertIndex(node.Id, _typeMap.Length);
+
+            var info = GetInfo(node).VerifyValue();
+            if (info.Kind == BindKind.PowerFxResolvedObject && SupportsPaging(node))
+            {
+                _isDelegatable.Set(node.Id, true);
+
+                // Mark this as async, as this may result in async invocation.
+                FlagPathAsAsync(node);
+
+                // Pageable nodes are also stateful as data is always pulled from outside.
+                SetStateful(node, isStateful: true);
+            }
+        }
+
         public void CheckAndMarkAsDelegatable(DottedNameNode node)
         {
             Contracts.AssertValue(node);
@@ -2900,6 +2918,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 _txb.CheckAndMarkAsPageable(node);
+                _txb.CheckAndMarkAsDelegatable(node);
 
                 if ((lookupInfo.Kind == BindKind.WebResource || lookupInfo.Kind == BindKind.QualifiedValue) && !(node.Parent is DottedNameNode))
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -576,7 +576,7 @@ namespace Microsoft.PowerFx.Core.Binding
             Contracts.AssertValue(node);
 
             var info = GetInfo(node).VerifyValue();
-            return info.Data is IExternalDelegable delegableSymbol && delegableSymbol.IsDelegable;
+            return info.Data is IExternalDelegatableSymbol delegableSymbol && delegableSymbol.IsDelegatable;
         }
 
         private bool SupportsPaging(TexlNode node)

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDataSource.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDataSource.cs
@@ -25,9 +25,4 @@ namespace Microsoft.PowerFx.Core.Entities
 
         IDelegationMetadata DelegationMetadata { get; }
     }
-
-    internal interface IExternalNamedFormula : IExternalPageableSymbol
-    {
-        bool TryGetExternalDataSource(out IExternalDataSource dataSource);
-    }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDataSource.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDataSource.cs
@@ -25,4 +25,9 @@ namespace Microsoft.PowerFx.Core.Entities
 
         IDelegationMetadata DelegationMetadata { get; }
     }
+
+    internal interface IExternalNamedFormula : IExternalPageableSymbol
+    {
+        bool TryGetExternalDataSource(out IExternalDataSource dataSource);
+    }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDelegable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDelegable.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerFx.Core.Entities
+{
+    internal interface IExternalDelegable
+    {
+        bool IsDelegable { get; }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDelegable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDelegable.cs
@@ -3,8 +3,8 @@
 
 namespace Microsoft.PowerFx.Core.Entities
 {
-    internal interface IExternalDelegable
+    internal interface IExternalDelegatableSymbol
     {
-        bool IsDelegable { get; }
+        bool IsDelegatable { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Core.Entities.Delegation;
+using Microsoft.PowerFx.Core.Functions.Delegation;
+using Microsoft.PowerFx.Core.Types;
+
+namespace Microsoft.PowerFx.Core.Entities
+{
+    internal interface IExternalNamedFormula : IExternalPageableSymbol
+    {
+        bool TryGetExternalDataSource(out IExternalDataSource dataSource);
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
@@ -7,7 +7,7 @@ using Microsoft.PowerFx.Core.Types;
 
 namespace Microsoft.PowerFx.Core.Entities
 {
-    internal interface IExternalNamedFormula : IExternalPageableSymbol
+    internal interface IExternalNamedFormula : IExternalPageableSymbol, IExternalDelegable
     {
         bool TryGetExternalDataSource(out IExternalDataSource dataSource);
     }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
@@ -7,7 +7,7 @@ using Microsoft.PowerFx.Core.Types;
 
 namespace Microsoft.PowerFx.Core.Entities
 {
-    internal interface IExternalNamedFormula : IExternalPageableSymbol, IExternalDelegable
+    internal interface IExternalNamedFormula : IExternalPageableSymbol, IExternalDelegatableSymbol
     {
         bool TryGetExternalDataSource(out IExternalDataSource dataSource);
     }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionArgValidators/ConnectedDataSourceInfoArgValidator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionArgValidators/ConnectedDataSourceInfoArgValidator.cs
@@ -73,13 +73,22 @@ namespace Microsoft.PowerFx.Core.Functions.FunctionArgValidators
             }
 
             var firstNameInfo = binding.GetInfo(firstName);
-            if (firstNameInfo == null || firstNameInfo.Kind != BindKind.Data)
+            if (firstNameInfo == null)
             {
                 return false;
             }
 
-            return binding.EntityScope != null &&
-                binding.EntityScope.TryGetEntity(firstNameInfo.Name, out dsInfo);
+            if (firstNameInfo.Kind == BindKind.Data)
+            {
+                return binding.EntityScope != null &&
+                    binding.EntityScope.TryGetEntity(firstNameInfo.Name, out dsInfo);
+            }
+            else if (firstNameInfo.Kind == BindKind.PowerFxResolvedObject && firstNameInfo.Data is IExternalNamedFormula formula)
+            {
+                return formula.TryGetExternalDataSource(out dsInfo);
+            }
+
+            return false;
         }
 
         private bool TryGetDsInfo(DottedNameNode dottedNameNode, TexlBinding binding, out IExternalDataSource dsInfo)


### PR DESCRIPTION
This change adds ability for named formula rules to participate in pageability/delegable checks. This will provide support for extending pageable support for named formula rules. I will have the unit tests added on PaClient once I have that change ready for PR.