### PR TITLE
Draft - Binder errors translate to locale

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
@@ -106,12 +107,27 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
             return Error(DefaultSeverity, node, errKey, args);
         }
 
+        public TexlError Error(TexlNode node, ErrorResourceKey errKey, CultureInfo locale, params object[] args)
+        {
+            return Error(DefaultSeverity, node, errKey, locale: locale, args);
+        }
+
         public TexlError Error(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, params object[] args)
         {
             Contracts.AssertValue(node);
             Contracts.AssertValue(args);
 
             var err = new TexlError(node, severity, null, errKey, args);
+            CollectionUtils.Add(ref _errors, err);
+            return err;
+        }
+
+        public TexlError Error(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, CultureInfo locale, params object[] args)
+        {
+            Contracts.AssertValue(node);
+            Contracts.AssertValue(args);
+
+            var err = new TexlError(node, severity, locale: locale, errKey, args);
             CollectionUtils.Add(ref _errors, err);
             return err;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
@@ -15,6 +15,8 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
     {
         private List<TexlError> _errors;
 
+        public CultureInfo Locale { get; set; }
+
         public DocumentErrorSeverity DefaultSeverity => DocumentErrorSeverity.Critical;
 
         public bool HasErrors()
@@ -107,27 +109,12 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
             return Error(DefaultSeverity, node, errKey, args);
         }
 
-        public TexlError Error(TexlNode node, ErrorResourceKey errKey, CultureInfo locale, params object[] args)
-        {
-            return Error(DefaultSeverity, node, errKey, locale: locale, args);
-        }
-
         public TexlError Error(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, params object[] args)
         {
             Contracts.AssertValue(node);
             Contracts.AssertValue(args);
 
-            var err = new TexlError(node, severity, null, errKey, args);
-            CollectionUtils.Add(ref _errors, err);
-            return err;
-        }
-
-        public TexlError Error(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, CultureInfo locale, params object[] args)
-        {
-            Contracts.AssertValue(node);
-            Contracts.AssertValue(args);
-
-            var err = new TexlError(node, severity, locale: locale, errKey, args);
+            var err = new TexlError(node, severity, Locale, errKey, args);
             CollectionUtils.Add(ref _errors, err);
             return err;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -337,6 +337,8 @@ namespace Microsoft.PowerFx.Core.Binding
                 propertyName: Property?.InvariantName ?? string.Empty,
                 isEnhancedDelegationEnabled: Document?.Properties?.EnabledFeatures?.IsEnhancedDelegationEnabled ?? false,
                 allowsSideEffects: bindingConfig.AllowsSideEffects);
+
+            ErrorContainer.Locale = bindingConfig.Locale;
         }
 
         // Binds a Texl parse tree.
@@ -2780,7 +2782,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // App variable name cannot conflict with any existing global entity name, eg. control/data/table/enum.
                         if (scopedControl.IsAppInfoControl && _nameResolver.LookupGlobalEntity(node.Ident.Name, out lookupInfo))
                         {
-                            _txb.ErrorContainer.Error(node, TexlStrings.ErrExpectedFound_Ex_Fnd, _txb.BindingConfig.CultureInfo, lookupInfo.Kind, TokKind.Ident);
+                            _txb.ErrorContainer.Error(node, TexlStrings.ErrExpectedFound_Ex_Fnd, lookupInfo.Kind, TokKind.Ident);
                         }
 
                         _txb.SetAppScopedVariable(node, scopedControl.IsAppInfoControl);
@@ -2810,7 +2812,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!haveNameResolver || !_nameResolver.Lookup(node.Ident.Name, out lookupInfo, preferences: lookupPrefs))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, _txb.BindingConfig.CultureInfo, node.Ident.Name.Value);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, node.Ident.Name.Value);
                     _txb.SetType(node, DType.Error);
                     _txb.SetInfo(node, FirstNameInfo.Create(node, default(NameLookupInfo)));
                     return;
@@ -2838,7 +2840,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // Internal control references are not allowed in component input properties.
                 if (CheckComponentProperty(lookupInfo.Data as IExternalControl))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInternalControlInInputProperty, locale: _txb.BindingConfig.CultureInfo);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInternalControlInInputProperty);
                     _txb.SetType(node, DType.Error);
                     _txb.SetInfo(node, fnInfo ?? FirstNameInfo.Create(node, default(NameLookupInfo)));
                     return;
@@ -3048,7 +3050,7 @@ namespace Microsoft.PowerFx.Core.Binding
                                     }
                                     else
                                     {
-                                        _txb.ErrorContainer.Error(node, TexlStrings.ErrColumnNotAccessibleInCurrentContext, locale: _txb.BindingConfig.CultureInfo);
+                                        _txb.ErrorContainer.Error(node, TexlStrings.ErrColumnNotAccessibleInCurrentContext);
                                         _txb.SetType(node, DType.Error);
                                         fError = true;
                                         return true;
@@ -3125,14 +3127,14 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (_nameResolver == null || _nameResolver.CurrentEntity == null)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier, locale: _txb.BindingConfig.CultureInfo);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
 
                 if (!(_nameResolver.CurrentEntity is IExternalControl) || !_nameResolver.LookupParent(out var lookupInfo))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidParentUse, locale: _txb.BindingConfig.CultureInfo);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidParentUse);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
@@ -3152,14 +3154,14 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (_nameResolver == null || _nameResolver.CurrentEntity == null)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier, locale: _txb.BindingConfig.CultureInfo);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
 
                 if (!_nameResolver.LookupSelf(out var lookupInfo))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier, locale: _txb.BindingConfig.CultureInfo);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
@@ -3695,7 +3697,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 Contracts.AssertValue(args);
 
                 _txb.SetInfo(node, new DottedNameInfo(node));
-                _txb.ErrorContainer.Error(node, errKey, locale: _txb.BindingConfig.CultureInfo, args);
+                _txb.ErrorContainer.Error(node, errKey, args);
                 _txb.SetType(node, DType.Error);
             }
 
@@ -4126,7 +4128,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                     else
                     {
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrUnknownFunction, _txb.BindingConfig.CultureInfo, node.Head.Name.Value);
+                        _txb.ErrorContainer.Error(node, TexlStrings.ErrUnknownFunction, node.Head.Name.Value);
                     }
 
                     _txb.SetInfo(node, new CallInfo(node));
@@ -4349,7 +4351,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // If there is a single function with this name, and the first arg is not
                         // a good match, then we have an erroneous invocation.
                         _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, nodeInput, TexlStrings.ErrBadType);
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, maybeFunc.Name);
+                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
                         _txb.SetInfo(node, new CallInfo(maybeFunc, node, typeScope, scopeIdent, identRequired, _currentScope.Nest));
                         _txb.SetType(node, maybeFunc.ReturnType);
                     }
@@ -4414,7 +4416,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     if (_txb.IsAsync(args[i]) && !scopeInfo.SupportsAsyncLambdas)
                     {
                         fArgsValid = false;
-                        _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrAsyncLambda, locale: _txb.BindingConfig.CultureInfo);
+                        _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrAsyncLambda);
                     }
 
                     // Accept should leave the scope as it found it.
@@ -4441,7 +4443,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // on their argument types.
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, maybeFunc.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
                 }
 
                 // Set the inferred return type for the node.
@@ -4641,7 +4643,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidStringInterpolation, locale: _txb.BindingConfig.CultureInfo);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidStringInterpolation);
                 }
 
                 if (fArgsValid && nodeToCoercedTypeMap != null)
@@ -4759,7 +4761,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 fArgsValid = func.HandleCheckInvocation(_txb, args, argTypes, _txb.ErrorContainer, out returnType, out _);
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, func.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, func.Name);
                 }
 
                 _txb.SetType(node, returnType);
@@ -4890,7 +4892,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                     else
                     {
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, locale: _txb.BindingConfig.CultureInfo, node.Head.Name.Value);
+                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, node.Head.Name.Value);
                         _txb.SetInfo(node, new CallInfo(node));
                         _txb.SetType(node, DType.Error);
                         return;
@@ -4926,7 +4928,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!fArgsValid && !func.HasPreciseErrors)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, func.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, func.Name);
                 }
 
                 _txb.SetType(node, returnType);
@@ -5007,7 +5009,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // We exhausted the overloads without finding an exact match, so post a document error.
                 if (!someFunc.HasPreciseErrors)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, someFunc.Name);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, someFunc.Name);
                 }
 
                 // The final CheckInvocation call will post all the necessary document errors.

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2780,7 +2780,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // App variable name cannot conflict with any existing global entity name, eg. control/data/table/enum.
                         if (scopedControl.IsAppInfoControl && _nameResolver.LookupGlobalEntity(node.Ident.Name, out lookupInfo))
                         {
-                            _txb.ErrorContainer.Error(node, TexlStrings.ErrExpectedFound_Ex_Fnd, lookupInfo.Kind, TokKind.Ident);
+                            _txb.ErrorContainer.Error(node, TexlStrings.ErrExpectedFound_Ex_Fnd, _txb.BindingConfig.CultureInfo, lookupInfo.Kind, TokKind.Ident);
                         }
 
                         _txb.SetAppScopedVariable(node, scopedControl.IsAppInfoControl);
@@ -2810,7 +2810,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!haveNameResolver || !_nameResolver.Lookup(node.Ident.Name, out lookupInfo, preferences: lookupPrefs))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, node.Ident.Name.Value);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, _txb.BindingConfig.CultureInfo, node.Ident.Name.Value);
                     _txb.SetType(node, DType.Error);
                     _txb.SetInfo(node, FirstNameInfo.Create(node, default(NameLookupInfo)));
                     return;
@@ -2838,7 +2838,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // Internal control references are not allowed in component input properties.
                 if (CheckComponentProperty(lookupInfo.Data as IExternalControl))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInternalControlInInputProperty);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInternalControlInInputProperty, locale: _txb.BindingConfig.CultureInfo);
                     _txb.SetType(node, DType.Error);
                     _txb.SetInfo(node, fnInfo ?? FirstNameInfo.Create(node, default(NameLookupInfo)));
                     return;
@@ -3048,7 +3048,7 @@ namespace Microsoft.PowerFx.Core.Binding
                                     }
                                     else
                                     {
-                                        _txb.ErrorContainer.Error(node, TexlStrings.ErrColumnNotAccessibleInCurrentContext);
+                                        _txb.ErrorContainer.Error(node, TexlStrings.ErrColumnNotAccessibleInCurrentContext, locale: _txb.BindingConfig.CultureInfo);
                                         _txb.SetType(node, DType.Error);
                                         fError = true;
                                         return true;
@@ -3125,14 +3125,14 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (_nameResolver == null || _nameResolver.CurrentEntity == null)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier, locale: _txb.BindingConfig.CultureInfo);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
 
                 if (!(_nameResolver.CurrentEntity is IExternalControl) || !_nameResolver.LookupParent(out var lookupInfo))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidParentUse);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidParentUse, locale: _txb.BindingConfig.CultureInfo);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
@@ -3152,14 +3152,14 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (_nameResolver == null || _nameResolver.CurrentEntity == null)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier, locale: _txb.BindingConfig.CultureInfo);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
 
                 if (!_nameResolver.LookupSelf(out var lookupInfo))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier, locale: _txb.BindingConfig.CultureInfo);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
@@ -3695,7 +3695,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 Contracts.AssertValue(args);
 
                 _txb.SetInfo(node, new DottedNameInfo(node));
-                _txb.ErrorContainer.Error(node, errKey, args);
+                _txb.ErrorContainer.Error(node, errKey, locale: _txb.BindingConfig.CultureInfo, args);
                 _txb.SetType(node, DType.Error);
             }
 
@@ -4126,7 +4126,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                     else
                     {
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrUnknownFunction, node.Head.Name.Value);
+                        _txb.ErrorContainer.Error(node, TexlStrings.ErrUnknownFunction, _txb.BindingConfig.CultureInfo, node.Head.Name.Value);
                     }
 
                     _txb.SetInfo(node, new CallInfo(node));
@@ -4349,7 +4349,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // If there is a single function with this name, and the first arg is not
                         // a good match, then we have an erroneous invocation.
                         _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, nodeInput, TexlStrings.ErrBadType);
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
+                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, maybeFunc.Name);
                         _txb.SetInfo(node, new CallInfo(maybeFunc, node, typeScope, scopeIdent, identRequired, _currentScope.Nest));
                         _txb.SetType(node, maybeFunc.ReturnType);
                     }
@@ -4414,7 +4414,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     if (_txb.IsAsync(args[i]) && !scopeInfo.SupportsAsyncLambdas)
                     {
                         fArgsValid = false;
-                        _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrAsyncLambda);
+                        _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrAsyncLambda, locale: _txb.BindingConfig.CultureInfo);
                     }
 
                     // Accept should leave the scope as it found it.
@@ -4441,7 +4441,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // on their argument types.
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, maybeFunc.Name);
                 }
 
                 // Set the inferred return type for the node.
@@ -4641,7 +4641,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidStringInterpolation);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidStringInterpolation, locale: _txb.BindingConfig.CultureInfo);
                 }
 
                 if (fArgsValid && nodeToCoercedTypeMap != null)
@@ -4759,7 +4759,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 fArgsValid = func.HandleCheckInvocation(_txb, args, argTypes, _txb.ErrorContainer, out returnType, out _);
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, func.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, func.Name);
                 }
 
                 _txb.SetType(node, returnType);
@@ -4890,7 +4890,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                     else
                     {
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, node.Head.Name.Value);
+                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidName, locale: _txb.BindingConfig.CultureInfo, node.Head.Name.Value);
                         _txb.SetInfo(node, new CallInfo(node));
                         _txb.SetType(node, DType.Error);
                         return;
@@ -4926,7 +4926,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!fArgsValid && !func.HasPreciseErrors)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, func.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, func.Name);
                 }
 
                 _txb.SetType(node, returnType);
@@ -5001,7 +5001,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // We exhausted the overloads without finding an exact match, so post a document error.
                 if (!someFunc.HasPreciseErrors)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, someFunc.Name);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, locale: _txb.BindingConfig.CultureInfo, someFunc.Name);
                 }
 
                 // The final CheckInvocation call will post all the necessary document errors.

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BindingConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BindingConfig.cs
@@ -20,13 +20,20 @@ namespace Microsoft.PowerFx.Core.Binding
 
         public bool UseThisRecordForRuleScope { get; }
 
-        public CultureInfo CultureInfo { get; }
+        public CultureInfo Locale { get; }
 
-        public BindingConfig(bool allowsSideEffects = false, bool useThisRecordForRuleScope = false, CultureInfo locale = null)
+        public BindingConfig(bool allowsSideEffects = false, bool useThisRecordForRuleScope = false)
         {
             AllowsSideEffects = allowsSideEffects;
             UseThisRecordForRuleScope = useThisRecordForRuleScope;
-            CultureInfo = locale;
+            Locale = null;
+        }
+
+        public BindingConfig(CultureInfo locale, bool allowsSideEffects = false, bool useThisRecordForRuleScope = false)
+        {
+            AllowsSideEffects = allowsSideEffects;
+            UseThisRecordForRuleScope = useThisRecordForRuleScope;
+            Locale = locale;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BindingConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BindingConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace Microsoft.PowerFx.Core.Binding
@@ -19,10 +20,13 @@ namespace Microsoft.PowerFx.Core.Binding
 
         public bool UseThisRecordForRuleScope { get; }
 
-        public BindingConfig(bool allowsSideEffects = false, bool useThisRecordForRuleScope = false)
+        public CultureInfo CultureInfo { get; }
+
+        public BindingConfig(bool allowsSideEffects = false, bool useThisRecordForRuleScope = false, CultureInfo locale = null)
         {
             AllowsSideEffects = allowsSideEffects;
             UseThisRecordForRuleScope = useThisRecordForRuleScope;
+            CultureInfo = locale;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PowerFx
             ParserOptions options = null,
             ReadOnlySymbolTable symbolTable = null)
         {
-            var bindingConfig = new BindingConfig(allowsSideEffects: options?.AllowsSideEffects == true);
+            var bindingConfig = new BindingConfig(allowsSideEffects: options?.AllowsSideEffects == true, locale: Config.CultureInfo);
 
             return CheckInternal(parse, bindingConfig, symbolTable);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PowerFx
             ParserOptions options = null,
             ReadOnlySymbolTable symbolTable = null)
         {
-            var bindingConfig = new BindingConfig(allowsSideEffects: options?.AllowsSideEffects == true, locale: Config.CultureInfo);
+            var bindingConfig = new BindingConfig(Config.CultureInfo, allowsSideEffects: options?.AllowsSideEffects == true);
 
             return CheckInternal(parse, bindingConfig, symbolTable);
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -145,6 +145,19 @@ namespace Microsoft.PowerFx.Tests
             AssertContainsError(result, "Error 2-5: Name isn't valid. 'foo' isn't recognized");
         }
 
+        [Theory]
+        [InlineData("3+foo+2", "Error 2-5: Il nome non è valido. \"foo\" non riconosciuto.", "it-IT")]
+        [InlineData("Foo()", "Error 0-5: 'Foo' est une fonction inconnue ou non prise en charge.", "fr-FR")]
+        [InlineData("AAA", "Error 0-3: O nome não é válido. 'AAA' não é reconhecido.", "pt-BR")]
+        public void CheckBindError2(string expression, string expected, string locale)
+        {
+            var engine = new Engine(new PowerFxConfig(CultureInfo.GetCultureInfo(locale)));
+            var result = engine.Check(expression);
+
+            Assert.False(result.IsSuccess);
+            AssertContainsError(result, expected);
+        }
+
         [Fact]
         public void CheckBadFunctionError()
         {


### PR DESCRIPTION
Issue #800.

A few comments:

- To avoid breaking internals, new overloads were created.
- New binding config locale is populated from PowerFxConfig.