### PR TITLE
Fix TZI tests

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_Seattle.txt
@@ -4,15 +4,18 @@
 // ******************************** TIMEZONEOFFSET FUNCTION - CONVERTING TO AND FROM UTC TIME TESTCASES ********************************
 
 //Convert to UTC time - No DST - Difference of 8 hours (480 minutes) from UTC time (i.e. UTC-8:00)
->> DateAdd( DateTime(2000,1,1,0,0,0), TimeZoneOffset(), TimeUnit.Minutes)
-DateTime(2000,1,1,7,0,0,0)
+>> DateAdd( DateTime(2000,1,1,0,0,0), TimeZoneOffset(DateTime(2000,1,1,0,0,0)), TimeUnit.Minutes)
+DateTime(2000,1,1,8,0,0,0)
+
+>> DateAdd( DateTime(2000,7,1,0,0,0), TimeZoneOffset(DateTime(2000,7,1,0,0,0)), TimeUnit.Minutes)
+DateTime(2000,7,1,7,0,0,0)
 
 //Converting from UTC time
 >> DateAdd( DateTime(2000,1,1,7,0,0), -TimeZoneOffset(DateTime(2000,1,1,7,0,0)), TimeUnit.Minutes)
 DateTime(1999,12,31,23,0,0,0)
 
 //Convert to UTC time during DST - Difference of 7 hours (420 minutes) from UTC time (i.e. UTC-7:00)
->> DateAdd( DateTime(2013,7,15,13,0,0), TimeZoneOffset(), TimeUnit.Minutes)
+>> DateAdd( DateTime(2013,7,15,13,0,0), TimeZoneOffset(DateTime(2013,7,15,13,0,0)), TimeUnit.Minutes)
 DateTime(2013,7,15,20,0,0,0)
 
 //Converting from UTC time during DST


### PR DESCRIPTION
The use of TimeZoneOffset() is only valid when associated with Now()
If not used with Now(), we need to specify the date/time to which it applies
