### PR TITLE
Updated error messages for unresolved Self & Parent usages

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3048,7 +3048,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!(_nameResolver.CurrentEntity is IExternalControl) || !_nameResolver.LookupParent(out var lookupInfo))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidParentUse);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrParentInvalidReference);
                     _txb.SetType(node, DType.Error);
                     return;
                 }
@@ -3075,7 +3075,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!_nameResolver.LookupSelf(out var lookupInfo))
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidIdentifier);
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrSelfInvalidReference);
                     _txb.SetType(node, DType.Error);
                     return;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -574,6 +574,8 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrInvalidStringInterpolation = new ErrorResourceKey("ErrInvalidStringInterpolation");
         public static ErrorResourceKey ErrEmptyIsland = new ErrorResourceKey("ErrEmptyIsland");
         public static ErrorResourceKey ErrDeprecated = new ErrorResourceKey("ErrDeprecated");
+        public static ErrorResourceKey ErrParentInvalidReference = new ErrorResourceKey("ErrParentInvalidReference");
+        public static ErrorResourceKey ErrSelfInvalidReference = new ErrorResourceKey("ErrSelfInvalidReference");
 
         public static ErrorResourceKey ErrErrorIrrelevantField = new ErrorResourceKey("ErrErrorIrrelevantField");
         public static ErrorResourceKey ErrAsNotInContext = new ErrorResourceKey("ErrAsNotInContext");

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -6615,4 +6615,12 @@
     <value>This feature is deprecated and is no longer supported.</value>
     <comment>An error message for deprecated features.</comment>
   </data>
+  <data name="ErrSelfInvalidReference" xml:space="preserve">
+    <value>Self is not a valid reference in this expression.</value>
+    <comment>An error message for invalid self keyword usage.</comment>
+  </data>
+  <data name="ErrParentInvalidReference" xml:space="preserve">
+    <value>Parent is not a valid reference in this expression.</value>
+    <comment>An error message for invalid parent keyword usage.</comment>
+  </data>
 </root>


### PR DESCRIPTION
'Self/Parent is not a valid reference in this expression' will be shown if CheckSelf()/CheckParent() failed to resolve.