### PR TITLE
Fix issue with IsRowScope check in  delegation with "in" operator (#825)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -77,28 +77,31 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             Contracts.AssertValue(binding);
             Contracts.AssertValue(opDelStrategy);
 
-            // Check whether this is -
-            //  1) in operator delegation and
-            //  2) it is verifying if RHS node is supported and
-            //  3) it is not an async node and
-            //  4) it is a single column table and
-            //  5) metadata belongs to cds datasource that supports delegation of CdsIn
-            // If this check fails, verify if it is simply a valid node..
-            // Eg of valid delegation functions -
-            // Filter(Accounts, 'Account Name' in ["Foo", Bar"]) - Direct table use
-            // Set(Names, ["Foo", Bar"]); Filter(Accounts, 'Account Name' in Names) - Using variable of type table
-            // ClearCollect(Names, Accounts); Filter(Accounts, 'Account Name' in Names.'Account Name') - using column from collection.
-            // This won't be delegated - Filter(Accounts, 'Account Name' in Accounts.'Account Name') as Accounts.'Account Name' is async.
-            if (isRHSNode && binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled
-                && (opDelStrategy as BinaryOpDelegationStrategy)?.Op == BinaryOp.In && !binding.IsAsync(node) && binding.GetType(node).IsTable && binding.GetType(node).IsColumn &&
-                opDelStrategy.IsOpSupportedByTable(metadata, node, binding))
+            if (!binding.IsRowScope(node))
             {
-                return true;
-            }
+                // Check whether this is -
+                //  1) in operator delegation and
+                //  2) it is verifying if RHS node is supported and
+                //  3) it is not an async node and
+                //  4) it is a single column table and
+                //  5) metadata belongs to cds datasource that supports delegation of CdsIn
+                // If this check fails, verify if it is simply a valid node..
+                // Eg of valid delegation functions -
+                // Filter(Accounts, 'Account Name' in ["Foo", Bar"]) - Direct table use
+                // Set(Names, ["Foo", Bar"]); Filter(Accounts, 'Account Name' in Names) - Using variable of type table
+                // ClearCollect(Names, Accounts); Filter(Accounts, 'Account Name' in Names.'Account Name') - using column from collection.
+                // This won't be delegated - Filter(Accounts, 'Account Name' in Accounts.'Account Name') as Accounts.'Account Name' is async.
+                if (isRHSNode && binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled
+                    && (opDelStrategy as BinaryOpDelegationStrategy)?.Op == BinaryOp.In && !binding.IsAsync(node) && binding.GetType(node).IsTable && binding.GetType(node).IsColumn &&
+                    opDelStrategy.IsOpSupportedByTable(metadata, node, binding))
+                {
+                    return true;
+                }
 
-            if (!binding.IsRowScope(node) && IsValidNode(node, binding))
-            {
-                return true;
+                if (!binding.IsRowScope(node) && IsValidNode(node, binding))
+                {
+                    return true;
+                }
             }
 
             switch (node.Kind)


### PR DESCRIPTION
There was a regression related to the change
:https://github.com/microsoft/Power-Fx/pull/638 , that caused NullreferenceException with the FilterFunctionTranslator when using formula's like : Filter(Table,ColA in Trim(Split(ColB, ",")))

Co-authored-by: Kartik K R <karr@microsoft.com>
Co-authored-by: McCall Saltzman <69215460+lesaltzm@users.noreply.github.com>