### PR TITLE
Delete CheckInvocation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
@@ -57,7 +57,6 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
         public override Capabilities Capabilities => Capabilities.OutboundInternetAccess | Capabilities.EnterpriseAuthentication | Capabilities.PrivateNetworkAccess;
         public override bool IsHidden => _isHidden;
         public override bool IsSelfContained => !_isBehaviorOnly;
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public ServiceFunction(IService parentService, DPath theNamespace, string name, string localeSpecificName, string description,
             DType returnType, BigInteger maskLambdas, int arityMin, int arityMax, bool isBehaviorOnly, bool isAutoRefreshable, bool isDynamic, bool isCacheEnabled, int cacheTimetoutMs, bool isHidden,

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4885,11 +4885,8 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (TryGetBestOverload(_txb, node, argTypes, overloads, out var function, out var nodeToCoercedTypeMap, out var returnType, out var warnings))
                 {
-                    if (function.CheckTypesAndSemanticsOnly)
-                    {
-                        // CheckSemantics may produce errors that are being ignored.
-                        warnings.Undiscard();
-                    }
+                    // CheckSemantics may produce errors that are being ignored.
+                    warnings.Undiscard();
 
                     _txb.SetInfo(node, new CallInfo(function, node));
                     _txb.SetType(node, returnType);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Core.Functions
         // and the specific return type will depend on the argument types.
         // If the function can return some shape of record, which depends on the argument types,
         // DType.EmptyRecord should be used. Similarly for tables and DType.EmptyTable.
-        // CheckInvocation can be used to infer the exact return type of a specific invocation.
+        // CheckTypes can be used to infer the exact return type of a specific invocation.
         public DType ReturnType { get; }
 
         // Function arity (expected min/max number of arguments).
@@ -118,7 +118,7 @@ namespace Microsoft.PowerFx.Core.Functions
         public virtual bool CanBeUsedInTests => !CreatesImplicitScreenDependency;
 
         /// <summary>
-        /// Whether the function always produces a visible error if CheckInvocation returns invalid.
+        /// Whether the function always produces a visible error if CheckTypes returns invalid.
         /// This can be used to prevent the overall "Function has invalid arguments" error.
         /// </summary>
         public virtual bool HasPreciseErrors => false;
@@ -385,92 +385,24 @@ namespace Microsoft.PowerFx.Core.Functions
             return char.ToLowerInvariant(name[0]).ToString() + name.Substring(1) + suffix + (IsAsync && !suppressAsync ? "Async" : string.Empty);
         }
 
-        [Obsolete("Override CheckTypes instead. If binder access is needed to generate errors, override CheckSemantics. Override the bool property CheckTypesAndSemanticsOnly and set it to true if you override either of these methods.", false)]
-        protected virtual bool CheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
-        {
-            return CheckInvocation(binding.CheckTypesContext, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-        }
-
-        [Obsolete("Override CheckTypes instead. If binder access is needed to generate errors, override CheckSemantics. Override the bool property CheckTypesAndSemanticsOnly and set it to true if you override either of these methods.", false)]
-        protected virtual bool CheckInvocation(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
-        {
-            return CheckInvocation(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-        }
-
-        // Type check an invocation of the function with the specified args (and their corresponding types).
-        // Return true if everything aligns even with coercion, false otherwise.
-        // By default, the out returnType will be the one advertised via the constructor. If this.ReturnType
-        // is either Unknown or an aggregate type, this method needs to be specialized.
-        protected virtual bool CheckInvocation(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
-        {
-            return CheckTypesCore(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-        }
-
         #region CheckInvocation Replacement Project
         public bool HandleCheckInvocation(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            if (CheckTypesAndSemanticsOnly)
-            {
-                Contracts.Assert(!CompareLegacyCheckInvocation);
-
-                var result = CheckTypes(binding.CheckTypesContext, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-                CheckSemantics(binding, args, argTypes, errors, ref nodeToCoercedTypeMap);
-                return result;
-            }
-
-            if (CompareLegacyCheckInvocation)
-            {
-                Contracts.Assert(!CheckTypesAndSemanticsOnly);
-
-                var checkTypesErrors = new ErrorContainer();
-                var checkTypesResult = CheckTypes(binding.CheckTypesContext, args, argTypes, checkTypesErrors, out var checkTypesReturnType, out var checkTypesNodeMap);
-                CheckSemantics(binding, args, argTypes, checkTypesErrors, ref checkTypesNodeMap);
-
-                var legacyErrors = new ErrorContainer();
-#pragma warning disable CS0618 // Type or member is obsolete
-                var legacyResult = CheckInvocation(binding, args, argTypes, legacyErrors, out var legacyReturnType, out var legacyNodeMap);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                CompareResultToLegacyCheckInvocation(
-                    checkTypesResult,
-                    checkTypesErrors,
-                    checkTypesReturnType,
-                    checkTypesNodeMap,
-                    legacyResult,
-                    legacyErrors,
-                    legacyReturnType,
-                    legacyNodeMap);
-            }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            return CheckInvocation(binding, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
-#pragma warning restore CS0618 // Type or member is obsolete
+            var result = CheckTypes(binding.CheckTypesContext, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            CheckSemantics(binding, args, argTypes, errors, ref nodeToCoercedTypeMap);
+            return result;
         }
 
         /// <summary>
-        /// Opt-in to using the new CheckTypes/CheckSemantics and then compare the results to legacy CheckInvocation.
-        /// </summary>
-        public virtual bool CompareLegacyCheckInvocation => false;
-
-        /// <summary>
-        /// Opt-in to using the new CheckTypes/CheckSemantics methods without calling CheckInvocation.
-        /// </summary>
-        public virtual bool CheckTypesAndSemanticsOnly => false;
-
-        /// <summary>
-        /// Perform sub-expression type checking and produce a return type. This method will eventually replace CheckInvocation.
+        /// Perform sub-expression type checking and produce a return type.
         /// </summary>
         protected virtual bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.Assert(CheckTypesAndSemanticsOnly || CompareLegacyCheckInvocation);
-
             return CheckTypes(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
         }
 
         protected virtual bool CheckTypes(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.Assert(CheckTypesAndSemanticsOnly || CompareLegacyCheckInvocation);
-
             return CheckTypesCore(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
         }
 
@@ -479,29 +411,11 @@ namespace Microsoft.PowerFx.Core.Functions
         /// </summary>
         protected virtual void CheckSemantics(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors, ref Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
-            Contracts.Assert(CheckTypesAndSemanticsOnly || CompareLegacyCheckInvocation);
-
             CheckSemantics(binding, args, argTypes, errors);
         }
 
         protected virtual void CheckSemantics(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors)
         {
-            Contracts.Assert(CheckTypesAndSemanticsOnly || CompareLegacyCheckInvocation);
-        }
-
-        // This method can be overridden in a derived class and then a breakpoint can be used to inspect the
-        // output of both methods.
-        protected virtual void CompareResultToLegacyCheckInvocation(
-            bool result,
-            IErrorContainer errors,
-            DType returnType,
-            Dictionary<TexlNode, DType> nodeToCoercedTypeMap,
-            bool legacyResult,
-            IErrorContainer legacyErrors,
-            DType legacyReturnType,
-            Dictionary<TexlNode, DType> legacyNodeToCoercedTypeMap)
-        {
-            Contracts.Assert(CompareLegacyCheckInvocation);
         }
         #endregion
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AddColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AddColumns.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public AddColumnsFunction()
             : base("AddColumns", TexlStrings.AboutAddColumns, FunctionCategories.Table, DType.EmptyTable, 0, 3, int.MaxValue, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
@@ -33,8 +33,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public AsTypeFunction()
             : base(AsTypeInvariantFunctionName, TexlStrings.AboutAsType, FunctionCategories.Table, DType.EmptyRecord, 0, 2, 2, DType.Error /* Polymorphic type is checked in override */, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -43,8 +43,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public BooleanFunction_T()
             : base(BooleanFunction.BooleanInvariantFunctionName, TexlStrings.AboutBooleanT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)
         {
@@ -121,8 +119,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public BooleanNFunction_T()
             : base(BooleanFunction.BooleanInvariantFunctionName, TexlStrings.AboutBooleanNT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -41,8 +41,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public CharTFunction()
             : base("Char", TexlStrings.AboutCharT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public CoalesceFunction()
             : base("Coalesce", TexlStrings.AboutCoalesce, FunctionCategories.Information, DType.Unknown, 0, 1, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -26,8 +26,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ColorFadeTFunction()
             : base("ColorFade", TexlStrings.AboutColorFadeT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ConcatenateFunction()
             : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Text, DType.String, 0, 1, int.MaxValue)
         {
@@ -94,8 +92,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public ConcatenateTableFunction()
             : base("Concatenate", TexlStrings.AboutConcatenateT, FunctionCategories.Table | FunctionCategories.Text, DType.EmptyTable, 0, 1, int.MaxValue)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public CountFunction()
             : base("Count", TexlStrings.AboutCount, FunctionCategories.Table | FunctionCategories.MathAndStat, DType.Number, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public CountAFunction()
             : base("CountA", TexlStrings.AboutCountA, FunctionCategories.Table | FunctionCategories.MathAndStat, DType.Number, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -27,8 +27,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Filter | DelegationCapability.Count;
 
         public CountIfFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -375,8 +375,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         internal static readonly List<string> SubDayStringList = new List<string>() { "Hours", "Minutes", "Seconds", "Milliseconds" };
 
         public DateAddFunction()
@@ -442,8 +440,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public DateAddTFunction()
             : base("DateAdd", TexlStrings.AboutDateAddT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)
@@ -591,8 +587,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public DateDiffTFunction()
             : base("DateDiff", TexlStrings.AboutDateDiffT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -46,8 +46,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         private static readonly DType TabularReturnType = DType.CreateTable(new TypedName(DType.String, ColumnName_Value));
 
         public Dec2HexTFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DropColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DropColumns.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public DropColumnsFunction()
             : base("DropColumns", TexlStrings.AboutDropColumns, FunctionCategories.Table, DType.EmptyTable, 0, 2, int.MaxValue, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -28,8 +28,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ErrorFunction()
             : base("Error", TexlStrings.AboutError, FunctionCategories.Logical, DType.ObjNull, 0, 1, 1)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
@@ -31,8 +31,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             // Enumerate just the base overloads (the first 3 possibilities).

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
@@ -43,8 +43,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public FindTFunction()
             : base("Find", TexlStrings.AboutFindT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
@@ -25,8 +25,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         private readonly bool _isFirst;
 
         public FirstLastFunction(bool isFirst)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public FirstLastNFunction(bool isFirst)
             : base(
                   isFirst ? "FirstN" : "LastN",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -26,8 +26,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ForAllFunction()
             : base(ForAllInvariantFunctionName, TexlStrings.AboutForAll, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.EmptyTable)
         {
@@ -85,8 +83,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public ForAllFunction_UO()
             : base(ForAllFunction.ForAllInvariantFunctionName, TexlStrings.AboutForAll, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.UntypedObject)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -30,8 +30,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public IfFunction()
             : base("If", TexlStrings.AboutIf, FunctionCategories.Logical, DType.Unknown, 0, 2, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -26,8 +26,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public IfErrorFunction()
             : base("IfError", TexlStrings.AboutIfError, FunctionCategories.Logical, DType.Unknown, 0, 2, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public IndexFunction()
             : base(
                   "Index",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Null | DelegationCapability.Filter;
 
         public IsBlankFunctionBase(string name, TexlStrings.StringGetter description, FunctionCategories functionCategories, DType returnType, BigInteger maskLambdas, int arityMin, int arityMax)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsError.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public IsErrorFunction()
             : base("IsError", TexlStrings.AboutIsError, FunctionCategories.Logical, DType.Boolean, 0, 1, 1)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsToday.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsToday.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public IsTodayFunction()
             : base("IsToday", TexlStrings.AboutIsToday, FunctionCategories.Information, DType.Boolean, 0, 1, 1, DType.DateTime)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsUTCToday.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsUTCToday.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public IsUTCTodayFunction()
             : base("IsUTCToday", TexlStrings.AboutIsUTCToday, FunctionCategories.Information, DType.Boolean, 0, 1, 1, DType.DateTime)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -41,8 +41,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public LeftRightTableScalarFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeftT : TexlStrings.AboutRightT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2, DType.EmptyTable, DType.Number)
         {
@@ -92,8 +90,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public LeftRightTableTableFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeftT : TexlStrings.AboutRightT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2, DType.EmptyTable, DType.EmptyTable)
@@ -147,8 +143,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public LeftRightScalarTableFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeftT : TexlStrings.AboutRightT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2, DType.String, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
@@ -46,8 +46,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public LenTFunction()
             : base("Len", TexlStrings.AboutLenT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -42,8 +42,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public LogTFunction()
             : base("Log", TexlStrings.AboutLogT, FunctionCategories.MathAndStat, DType.EmptyTable, 0, 1, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
@@ -25,8 +25,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         internal readonly bool _isAnd;
 
         public VariadicLogicalFunction(bool isAnd)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public LookUpFunction()
             : base("LookUp", TexlStrings.AboutLookUp, FunctionCategories.Table, DType.Unknown, 0x6, 2, 3, DType.EmptyTable, DType.Boolean)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -37,8 +37,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public MathOneArgTableFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc)
             : base(name, description, fc, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public MidTFunction()
             : base("Mid", TexlStrings.AboutMidT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public MinMaxFunction(bool isMin)
             : base(isMin ? "Min" : "Max", isMin ? TexlStrings.AboutMin : TexlStrings.AboutMax, FunctionCategories.MathAndStat, DType.Number, 0, 1, int.MaxValue, DType.Number)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override DelegationCapability FunctionDelegationCapability => _delegationCapability;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public MinMaxTableFunction(bool isMin)
             : base(isMin ? "Min" : "Max", isMin ? TexlStrings.AboutMinT : TexlStrings.AboutMaxT, FunctionCategories.Table)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -38,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ModTFunction()
             : base("Mod", TexlStrings.AboutModT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public PowerTFunction()
             : base("Power", TexlStrings.AboutPowerT, FunctionCategories.MathAndStat, DType.EmptyTable, 0, 2, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
@@ -38,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ReplaceTFunction()
             : base("Replace", TexlStrings.AboutReplaceT, FunctionCategories.Table, DType.EmptyTable, 0, 4, 4)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -38,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public TableRoundingFunction(string name, TexlStrings.StringGetter description)
             : base(name, description, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowColumns.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ShowColumnsFunction()
             : base("ShowColumns", TexlStrings.AboutShowColumns, FunctionCategories.Table, DType.EmptyTable, 0, 2, int.MaxValue, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Shuffle.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Shuffle.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ShuffleFunction()
             : base("Shuffle", TexlStrings.AboutShuffle, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public SortFunction()
             : base("Sort", TexlStrings.AboutSort, FunctionCategories.Table, DType.EmptyTable, 0x02, 2, 3, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public SortByColumnsFunction()
             : base("SortByColumns", TexlStrings.AboutSortByColumns, FunctionCategories.Table, DType.EmptyTable, 0, 2, int.MaxValue, DType.EmptyTable, DType.String)
         {
@@ -365,8 +363,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public SortByColumnsOrderTableFunction()
             : base("SortByColumns", TexlStrings.AboutSortByColumnsWithOrderValues, FunctionCategories.Table, DType.EmptyTable, 0, 3, 3, DType.EmptyTable, DType.String, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
@@ -15,8 +15,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Split(text:s, separator:s)
     internal class SplitFunction : StringTwoArgFunction
     {
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public SplitFunction()
             : base("Split", TexlStrings.AboutSplit, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public StatisticalFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc)
             : base(name, description, fc, DType.Number, 0, 1, int.MaxValue, DType.Number)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -91,8 +91,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public StringOneArgTableFunction(string name, TexlStrings.StringGetter description, FunctionCategories functionCategories)
             : base(name, description, functionCategories, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public SubstituteTFunction()
             : base("Substitute", TexlStrings.AboutSubstituteT, FunctionCategories.Table, DType.EmptyTable, 0, 3, 4)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
@@ -31,8 +31,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         // We do not support coercion for the 1st param, or the match params, only the result params. 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public SwitchFunction()
             : base("Switch", TexlStrings.AboutSwitch, FunctionCategories.Logical, DType.Unknown, 0, 3, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public TableFunction()
             : base("Table", TexlStrings.AboutTable, FunctionCategories.Table, DType.EmptyTable, 0, 0, int.MaxValue)
         {
@@ -93,8 +91,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => false;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public TableFunction_UO()
             : base("Table", TexlStrings.AboutTable, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.UntypedObject)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public TextFunction()
             : base("Text", TexlStrings.AboutText, FunctionCategories.Table | FunctionCategories.Text | FunctionCategories.DateTime, DType.String, 0, 1, 3, DType.Number, DType.String, DType.String)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public TruncTableFunction()
             : base("Trunc", TexlStrings.AboutTruncT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public ValueFunction()
             : base(ValueInvariantFunctionName, TexlStrings.AboutValue, FunctionCategories.Text, DType.Number, 0, 1, 2, DType.String, DType.String)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public WithFunction()
             : base("With", TexlStrings.AboutWith, FunctionCategories.Table, DType.Unknown, 0x2, 2, 2, DType.EmptyRecord)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CollectFunction.cs
@@ -39,8 +39,6 @@ namespace Microsoft.PowerFx.Interpreter
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public override bool ArgMatchesDatasourceType(int argNum)
         {
             return argNum >= 1;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Functions
     {
         public override bool RequiresDataSourceScope => true;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public override bool ArgMatchesDatasourceType(int argNum)
         {
             return argNum >= 1;
@@ -160,8 +158,6 @@ namespace Microsoft.PowerFx.Functions
     internal class PatchFunction : PatchAndValidateRecordFunctionBase, IAsyncTexlFunction
     {
         public override bool IsSelfContained => false;
-
-        public override bool CheckTypesAndSemanticsOnly => true;
 
         public PatchFunction()
             : base("Patch", AboutPatch, FunctionCategories.Table | FunctionCategories.Behavior, DType.EmptyRecord, 0, 3, int.MaxValue, DType.EmptyTable, DType.EmptyRecord, DType.EmptyRecord)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -62,8 +62,6 @@ namespace Microsoft.PowerFx.Functions
     {
         public override bool IsSelfContained => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public RemoveFunction()
         : base("Remove", AboutRemove, FunctionCategories.Table | FunctionCategories.Behavior, DType.Boolean, 0, 2, int.MaxValue, DType.EmptyTable, DType.EmptyRecord)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
@@ -30,8 +30,6 @@ namespace Microsoft.PowerFx.Interpreter
         // Set() is a behavior function. 
         public override bool IsSelfContained => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public override IEnumerable<StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.SetArg1, TexlStrings.SetArg2 };

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -79,8 +79,6 @@ namespace Microsoft.PowerFx
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool CheckTypesAndSemanticsOnly => true;
-
         public Func<FormulaValue[], Task<FormulaValue>> _impl;
 
         public CustomSetPropertyFunction(string name)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
@@ -118,8 +118,6 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
             public override bool IsSelfContained => true;
 
-            public override bool CheckTypesAndSemanticsOnly => true;
-
             public bool CheckNumericTableOverload { get; set; }
 
             public bool CheckStringTableOverload { get; set; }


### PR DESCRIPTION
Delete the CheckInvocation virtual function in TexlFunction.

This PR cannot be completed until the final functions in PAClient have been migrated to CheckTypes/Semantics.