### PR TITLE
Accept on Custom Records was failing due to incorrect equals method.

### DIFF
--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/CustomRecordTypeWithUndefinedFields.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/CustomRecordTypeWithUndefinedFields.cs
@@ -17,6 +17,15 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         private readonly RecordType _customRecordType;
         private readonly TestObj _testObj;
 
+        [Fact]
+        public void TestAccept()
+        {
+            var t = _customRecordType._type;
+            var ok = t.Accepts(t);
+
+            Assert.True(ok);
+        }
+
         public CustomRecordTypeWithUndefinedFields()
         {
             _originalRecordType = RecordType
@@ -162,7 +171,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     return false;
                 }
 
-                return RealRecordType.Equals(otherRecordType);
+                return RealRecordType.Equals(otherRecordType.RealRecordType);
             }
 
             public override int GetHashCode()


### PR DESCRIPTION
- Fixes #833 
- Fixed Equals method on `TreatMissingFieldAsUntypedRecordType`
- Added the test as mentioned in #833 