### PR TITLE
suppress error from latest analyzer.

### DIFF
--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/Helpers/LoggingTestServer.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/Helpers/LoggingTestServer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -29,7 +30,9 @@ namespace Microsoft.PowerFx.Tests
         }
 
         // Set the response, returned by SendAsync
+#pragma warning disable CA2213 // Disposable fields should be disposed
         public HttpResponseMessage _nextResponse;
+#pragma warning restore CA2213 // Disposable fields should be disposed
 
         public void SetResponseFromFile(string filename, HttpStatusCode status = HttpStatusCode.OK)
         {


### PR DESCRIPTION
Suppress the error from latest .NET code analyzer so builds can succeed.