### PR TITLE
Update error kind for accessing field in untyped object

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -425,7 +425,7 @@ namespace Microsoft.PowerFx
                     {
                         Message = "Accessing a field is not valid on this value",
                         Span = node.IRContext.SourceContext,
-                        Kind = ErrorKind.BadLanguageCode
+                        Kind = ErrorKind.InvalidArgument
                     });
                 }
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -36,7 +36,7 @@ Blank()
 Blank()
 
 >> Value(ParseJSON("""s""").a)
-Error({Kind:ErrorKind.BadLanguageCode})
+Error({Kind:ErrorKind.InvalidArgument})
 
 >> Value(ParseJSON("This "" Is , "" Invalid ").a)
 Error({Kind:ErrorKind.InvalidArgument})


### PR DESCRIPTION
Accessing a field in an untyped object which is not a record is currently returning an error with kind BadLanguageCode. That kind is used when an argument is the language/locale to functions such as Value and Text. The correct error kind should be InvalidArgument.