### PR TITLE
Update static format check for Text function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -911,7 +911,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     var dottedNameNode = node.AsDottedName();
                     if (dottedNameNode.Left.Kind == NodeKind.FirstName)
                     {
-                        if (context.NameResolver.EntityScope.TryGetNamedEnum(dottedNameNode.Left.AsFirstName().Ident.Name, out var enumType))
+                        DType enumType = null;
+                        if (context.NameResolver.EntityScope?.TryGetNamedEnum(dottedNameNode.Left.AsFirstName().Ident.Name, out enumType) == true)
                         {
                             if (enumType.TryGetEnumValue(dottedNameNode.Right.Name, out var enumValue))
                             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
@@ -34,7 +36,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.TextArg1, TexlStrings.TextArg2, TexlStrings.TextArg3 };
         }
 
-        public override bool CheckTypes(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        public override bool CheckTypes(CheckTypesContext checkTypesContext, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -103,6 +105,38 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrStringExpected);
                 isValid = false;
+            }
+            else if (BinderUtils.TryGetConstantValue(checkTypesContext, args[1], out var formatArg))
+            {
+                // Verify statically that the format string doesn't contain BOTH numeric and date/time
+                // format specifiers. If it does, that's an error according to Excel and our spec.
+
+                // But firstly skip any locale-prefix
+                if (formatArg.StartsWith("[$-"))
+                {
+                    var end = formatArg.IndexOf(']', 3);
+                    if (end > 0)
+                    {
+                        formatArg = formatArg.Substring(end + 1);
+                    }
+                }
+
+                var hasDateTimeFmt = formatArg.IndexOfAny(new char[] { 'm', 'd', 'y', 'h', 'H', 's', 'a', 'A', 'p', 'P' }) >= 0;
+                var hasNumericFmt = formatArg.IndexOfAny(new char[] { '0', '#' }) >= 0;
+                if (hasDateTimeFmt && hasNumericFmt)
+                {
+                    // Check if the date time format contains '0's after the seconds specifier, which
+                    // is used for fractional seconds - in which case it is valid
+                    var formatWithoutZeroSubseconds = Regex.Replace(formatArg, @"[sS]\.?(0+)",
+                        m => m.Groups[1].Success ? "" : m.Groups[1].Value);
+                    hasNumericFmt = formatWithoutZeroSubseconds.IndexOfAny(new char[] { '0', '#' }) >= 0;
+                }
+
+                if (hasDateTimeFmt && hasNumericFmt)
+                {
+                    errors.EnsureError(DocumentErrorSeverity.Moderate, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
+                    isValid = false;
+                }
             }
 
             if (args.Length > 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -99,35 +99,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return isValid;
             }
 
-            StrLitNode formatNode;
             if (!DType.String.Accepts(argTypes[1]))
             {
                 errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrStringExpected);
                 isValid = false;
-            }
-            else if ((formatNode = args[1].AsStrLit()) != null)
-            {
-                // Verify statically that the format string doesn't contain BOTH numeric and date/time
-                // format specifiers. If it does, that's an error accd to Excel and our spec.
-                var fmt = formatNode.Value;
-
-                // But firstly skip any locale-prefix
-                if (fmt.StartsWith("[$-"))
-                {
-                    var end = fmt.IndexOf(']', 3);
-                    if (end > 0)
-                    {
-                        fmt = fmt.Substring(end + 1);
-                    }
-                }
-
-                var hasDateTimeFmt = fmt.IndexOfAny(new char[] { 'm', 'd', 'y', 'h', 'H', 's', 'a', 'A', 'p', 'P' }) >= 0;
-                var hasNumericFmt = fmt.IndexOfAny(new char[] { '0', '#' }) >= 0;
-                if (hasDateTimeFmt && hasNumericFmt)
-                {
-                    errors.EnsureError(DocumentErrorSeverity.Moderate, formatNode, TexlStrings.ErrIncorrectFormat_Func, Name);
-                    isValid = false;
-                }
             }
 
             if (args.Length > 2)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Value.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Value.txt
@@ -474,6 +474,17 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> Value("false")
 Error({Kind:ErrorKind.InvalidArgument})
 
+// ******** DATE/TIME PARAMETERS ********
+
+>> Value(Date(2022,11,21))
+44886
+
+>> Value(DateTime(2022,11,21,6,0,0))
+44886.25
+
+>> Value(Time(12,0,0))
+0.5
+
 // ******** INVALID, NULL and ERROR PARAMETERS ********
 
 //Alphabetical String passed as parameter

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -1354,16 +1354,6 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
-        public void TexlFunctionTypeSemanticsText_Negative()
-        {
-            // Can't use both numeric formatting and date/time formatting within the same format string.
-            TestBindingErrors(
-                "Text(123, \"###.####    dddd, mm/dd/yy, at hh:mm:ss am/pm\")",
-                DType.String,
-                expectedErrorCount: 2);
-        }
-
-        [Fact]
         public void TexlFunctionTypeSemanticsToday()
         {
             TestSimpleBindingSuccess("Today()", DType.Date);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -1346,6 +1346,8 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Text(123, \"dddd, mm/dd/yy, at hh:mm:ss am/pm\")")]
         [InlineData("Text(\"hello world\")")]
         [InlineData("Text(\"hello world\", \"mm/dd/yyyy\")")]
+        [InlineData("Text(1.23, \"[$-en-us]0.00\")")]
+        [InlineData("Text(1.23, \"[$-fr-fr]0,00\")")]
         [InlineData("Text(123, \"yyyy-mm-dd hh:mm:ss.000\") // 0 is valid if after seconds")]
         [InlineData("Text(Now(), \"yyyy-mm-dd hh:mm:ss.000\") // 0 is valid if after seconds")]
         public void TexlFunctionTypeSemanticsText(string script)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -1346,11 +1346,26 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Text(123, \"dddd, mm/dd/yy, at hh:mm:ss am/pm\")")]
         [InlineData("Text(\"hello world\")")]
         [InlineData("Text(\"hello world\", \"mm/dd/yyyy\")")]
+        [InlineData("Text(123, \"yyyy-mm-dd hh:mm:ss.000\") // 0 is valid if after seconds")]
+        [InlineData("Text(Now(), \"yyyy-mm-dd hh:mm:ss.000\") // 0 is valid if after seconds")]
         public void TexlFunctionTypeSemanticsText(string script)
         {
             TestSimpleBindingSuccess(
                 script,
                 DType.String);
+        }
+
+        [Theory]
+        [InlineData("Text(123, \"###.####    dddd, mm/dd/yy, at hh:mm:ss am/pm\")")]
+        [InlineData("Text(123, \"###.#### \" & \"   dddd, mm/dd/yy, at hh:mm:ss am/pm\")")]
+        [InlineData("Text(Now(), \"yyyy-mm-dd 0 hh:mm:ss.000\") // 0 is only valid after seconds")]
+        public void TexlFunctionTypeSemanticsText_Negative(string script)
+        {
+            // Can't use both numeric formatting and date/time formatting within the same format string.
+            TestBindingErrors(
+                script,
+                DType.String,
+                expectedErrorCount: 2);
         }
 
         [Fact]


### PR DESCRIPTION
The Text function has a static check that the format argument should not have both numeric and date/time specifiers. This logic will change (once we support `0` as the specifier for fractional seconds, as Excel does), and it isn't implemented correctly. This change updates it to cover more constant values. Notice that this should not be a replacement for a runtime check, since the format can come from expressions, variables, which are not captured by a static check.