### PR TITLE
Update expected error kind for Dec2Hex function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -934,7 +934,12 @@ namespace Microsoft.PowerFx.Functions
             // places need to be greater or equal to length of hexadecimal when number is positive
             if (places != 0 && result.Length > places && number > 0)
             {
-                return CommonErrors.GenericInvalidArgument(irContext);
+                return new ErrorValue(irContext, new ExpressionError()
+                {
+                    Message = $"Places argument must be big enough to hold the result",
+                    Span = irContext.SourceContext,
+                    Kind = ErrorKind.Numeric
+                });
             }
 
             return new StringValue(irContext, result);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Dec2Hex.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Dec2Hex.txt
@@ -47,7 +47,7 @@
 "B2D4"
 
 >> Dec2Hex(45780, 3)
-Error({Kind:ErrorKind.InvalidArgument})
+Error({Kind:ErrorKind.Numeric})
 
 >> Dec2Hex(45780, 4)
 "B2D4"


### PR DESCRIPTION
`#NUM` errors from Excel should map to Numeric error kinds. The new Dec2Hex function doesn't follow that. This change updates it.