### PR TITLE
Allow coercions in the Concat function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concat.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concat.cs
@@ -18,10 +18,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public ConcatFunction()
-            : base("Concat", TexlStrings.AboutConcat, FunctionCategories.Table, DType.String, 0x02, 2, 3, DType.EmptyTable, DType.String)
+            : base("Concat", TexlStrings.AboutConcat, FunctionCategories.Table, DType.String, 0x02, 2, 3, DType.EmptyTable, DType.String, DType.String)
         {
             ScopeInfo = new FunctionScopeInfo(this, usesAllFieldsInScope: false);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -45,6 +45,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var fValid = base.CheckTypes(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
+            if (!fValid)
+            {
+                return false;
+            }
+
             // The return type is dictated by the last argument (projection) if one exists. Otherwise it's based on first argument (source).
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -45,11 +45,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var fValid = base.CheckTypes(args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
-            if (!fValid)
-            {
-                return false;
-            }
-
             // The return type is dictated by the last argument (projection) if one exists. Otherwise it's based on first argument (source).
             returnType = args.Length == 2 ? argTypes[0].ToRecord() : argTypes[2];
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
@@ -111,3 +111,11 @@ Errors: Error 43-48: Name isn't valid. 'Value' isn't recognized.
 // Errors in the lambda
 >> Concat([2, 1, 0, -1, -2], Text(1 / Value), ",")
 Error({Kind:ErrorKind.Div0})
+
+// Coercion on lambda
+>> Concat([1, 2, 3], Value, ",")
+"1,2,3"
+
+// Coercion on separator
+>> Concat([1, 2, 3], "a" & Value, 0)
+"a10a20a3"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
@@ -112,10 +112,23 @@ Errors: Error 43-48: Name isn't valid. 'Value' isn't recognized.
 >> Concat([2, 1, 0, -1, -2], Text(1 / Value), ",")
 Error({Kind:ErrorKind.Div0})
 
-// Coercion on lambda
+// Coercions on lambda
 >> Concat([1, 2, 3], Value, ",")
 "1,2,3"
+
+>> Concat([1, 2, 3], Mod(Value, 2) = 0, ",")
+"false,true,false"
+
+>> Concat([1, 2, 3], Date(2020 + Value,1,1), ",")
+"1/1/2021,1/1/2022,1/1/2023"
+
+>> Concat([1, 2, 3], Time(10 + Value, Value * 10, 0), ",")
+"11:10 AM,12:20 PM,1:30 PM"
 
 // Coercion on separator
 >> Concat([1, 2, 3], "a" & Value, 0)
 "a10a20a3"
+
+// Coercion on separator
+>> Concat([1, 2, 3], $"-a{Value}-", false)
+"-a1-false-a2-false-a3-"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -241,30 +241,6 @@ namespace Microsoft.PowerFx.Core.Tests
                 Features.ConsistentOneColumnTableResult);
         }
 
-        [Theory]
-        [InlineData("Concat([], \"\")")]
-        [InlineData("Concat([1, 2, 3], Text(Value))")]
-        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), b)")]
-        [InlineData("Concat([1, 2, 3], Text(Value), \",\")")]
-        [InlineData("Concat([1, 2, 3], Text(Value), Text(Today()))")]
-        [InlineData("Concat([], 1)")]
-        [InlineData("Concat([1, 2, 3], Value)")]
-        [InlineData("Concat([], 1)")]
-        [InlineData("Concat([\"a\", \"b\", \"C\"], Value, 1)")]
-        public void TexlFunctionTypeSemanticsConcat(string script)
-        {
-            TestSimpleBindingSuccess(script, DType.String);
-        }
-
-        [Theory]
-        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), [\"hello\", \"world\"])")]
-        [InlineData("Concat([1, 2, 3], {Value:Value})")]
-        [InlineData("Concat([1, 2, 3], Value, {a:1})")]
-        public void TexlFunctionTypeSemanticsConcat_Negative(string script)
-        {
-            TestBindingErrors(script, DType.String);
-        }
-
         [Fact]
         public void TexlFunctionTypeSemanticsCount()
         {
@@ -1859,29 +1835,28 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("Concat([], \"\")", "s")]
-        [InlineData("Concat([1, 2, 3], Text(Value))", "s")]
-        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), b)", "s")]
-        [InlineData("Concat([1, 2, 3], Text(Value), \",\")", "s")]
-        [InlineData("Concat([1, 2, 3], Text(Value), Text(Today()))", "s")]
-        public void TexlFunctionTypeSemanticsConcat(string script, string expectedType)
+        [InlineData("Concat([], \"\")")]
+        [InlineData("Concat([1, 2, 3], Text(Value))")]
+        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), b)")]
+        [InlineData("Concat([1, 2, 3], Text(Value), \",\")")]
+        [InlineData("Concat([1, 2, 3], Text(Value), Text(Today()))")]
+        [InlineData("Concat([], 1)")]
+        [InlineData("Concat([1, 2, 3], Value)")]
+        [InlineData("Concat([], 1)")]
+        [InlineData("Concat([\"a\", \"b\", \"C\"], Value, 1)")]
+        public void TexlFunctionTypeSemanticsConcat(string script)
         {
-            Assert.True(DType.TryParse(expectedType, out DType type));
-            Assert.True(type.IsValid);
-            TestSimpleBindingSuccess(script, type);
+            TestSimpleBindingSuccess(script, DType.String);
         }
 
         [Theory]
-        [InlineData("Concat([], 1)", "s")]
-        [InlineData("Concat([1, 2, 3], Value)", "s")]
-        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), [\"hello\", \"world\"])", "s")]
-        [InlineData("Concat([1, 2, 3], Value, Today())", "s")]
-        [InlineData("Concat([1, 2, 3], Value, 1)", "s")]
-        public void TexlFunctionTypeSemanticsConcat_Negative(string script, string expectedType)
+        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), [\"hello\", \"world\"])")]
+        [InlineData("Concat([1, 2, 3], {Value:Value})")]
+        [InlineData("Concat([1, 2, 3], Value, {a:1})")]
+        [InlineData("Concat({a:1,b:\"hello\"}, b)")]
+        public void TexlFunctionTypeSemanticsConcat_Negative(string script)
         {
-            Assert.True(DType.TryParse(expectedType, out DType type));
-            Assert.True(type.IsValid);
-            TestBindingErrors(script, type);
+            TestBindingErrors(script, DType.String);
         }
 
         [Theory]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -241,6 +241,30 @@ namespace Microsoft.PowerFx.Core.Tests
                 Features.ConsistentOneColumnTableResult);
         }
 
+        [Theory]
+        [InlineData("Concat([], \"\")")]
+        [InlineData("Concat([1, 2, 3], Text(Value))")]
+        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), b)")]
+        [InlineData("Concat([1, 2, 3], Text(Value), \",\")")]
+        [InlineData("Concat([1, 2, 3], Text(Value), Text(Today()))")]
+        [InlineData("Concat([], 1)")]
+        [InlineData("Concat([1, 2, 3], Value)")]
+        [InlineData("Concat([], 1)")]
+        [InlineData("Concat([\"a\", \"b\", \"C\"], Value, 1)")]
+        public void TexlFunctionTypeSemanticsConcat(string script)
+        {
+            TestSimpleBindingSuccess(script, DType.String);
+        }
+
+        [Theory]
+        [InlineData("Concat(Table({a:1, b:\"hello\"}, {b:\"world\"}), [\"hello\", \"world\"])")]
+        [InlineData("Concat([1, 2, 3], {Value:Value})")]
+        [InlineData("Concat([1, 2, 3], Value, {a:1})")]
+        public void TexlFunctionTypeSemanticsConcat_Negative(string script)
+        {
+            TestBindingErrors(script, DType.String);
+        }
+
         [Fact]
         public void TexlFunctionTypeSemanticsCount()
         {


### PR DESCRIPTION
Currently the Concat function disallows coercions to its parameters, but there is nothing that should prevent that from happening. This change removes that restriction, and adds tests to validate that coercions work as intended.