### PR TITLE
More test coverage on SymbolValues

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/ResolvedObjectNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/ResolvedObjectNode.cs
@@ -24,6 +24,10 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
 
         public override string ToString()
         {
+            if (Value is ISymbolSlot slot)
+            {
+                return $"ResolvedObject({slot.DebugName()})";
+            }
             return $"ResolvedObject({Value})";
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Microsoft.PowerFx.Core.Binding;
@@ -45,7 +46,27 @@ namespace Microsoft.PowerFx
             // These take precedence and are all added first. 
             foreach (var symValues in existing)
             {
-                symValues.AddSymbolMap(map);
+                if (symValues is ComposedReadOnlySymbolValues composed)
+                {
+                    foreach (var kv in composed._map)
+                    {
+                        // quick Integrity checks - these should never fail. 
+                        if (!Object.ReferenceEquals(kv.Key, kv.Value.SymbolTable))
+                        {
+                            throw new InvalidOperationException($"Table doesn't match");
+                        }
+                        if (kv.Value is ComposedReadOnlySymbolValues)
+                        {
+                            throw new InvalidOperationException($"ComposedSymbolValues should have been flattened ");
+                        }
+                        
+                        Add(map, kv.Value);
+                    }
+                }
+                else
+                {
+                    Add(map, symValues);
+                }                
             }
             
             CreateValues(map, symbolTable);
@@ -58,6 +79,23 @@ namespace Microsoft.PowerFx
             }
 
             return new ComposedReadOnlySymbolValues(symbolTable, map, existing);
+        }
+
+        private static void Add(Dictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map, ReadOnlySymbolValues symValues)
+        {
+            var symTable = symValues.SymbolTable;
+            try
+            {
+                map.Add(symTable, symValues);
+            }
+            catch
+            {
+                // Give better error.
+                if (map.TryGetValue(symTable, out var existingSymValues))
+                {
+                    throw new InvalidOperationException($"SymbolTable {symTable.DebugName()} already has SymbolValues '{existingSymValues.DebugName}' associated with it. Can't add '{symValues.DebugName}'");
+                }
+            }
         }
 
         // Walk the symbolTable tree and for each node, create the corresponding symbol values. 
@@ -105,14 +143,6 @@ namespace Microsoft.PowerFx
             else
             {
                 throw new NotImplementedException($"Unhandled symbol table kind: {symbolTable.DebugName} of type {symbolTable.GetType().FullName} ");
-            }
-        }
-
-        internal override void AddSymbolMap(IDictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map)
-        {
-            foreach (var kv in _map)
-            {
-                map[kv.Key] = kv.Value;
             }
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
@@ -47,12 +47,6 @@ namespace Microsoft.PowerFx
             _symbolTable = symbolTable;
         }
 
-        internal virtual void AddSymbolMap(IDictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map)
-        {
-            // If a derived class supports multiple symbols tables, then override this to add them. 
-            map[_symbolTable] = this;
-        }
-
         /// <summary>
         /// Get value of a slot previously provided by <see cref="Set(ISymbolSlot, FormulaValue)"/>. 
         /// </summary>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -428,8 +428,13 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var result = engine.EvalAsync("a + b + global", CancellationToken.None, runtimeConfig: r2).Result;
 
             Assert.Equal(111.0, result.ToObject());
-        }
 
+            // Without a parent
+            var r3 = ReadOnlySymbolValues.New(dict);
+            var result3 = engine.EvalAsync("a + b", CancellationToken.None, runtimeConfig: r2).Result;
+            Assert.Equal(11.0, result3.ToObject());
+        }
+             
         [Fact]
         public void Test1()
         {
@@ -616,6 +621,44 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             // can't assign a string to a number
             var symValues = new SymbolValues(symTable1);
             Assert.Throws<InvalidOperationException>(() => symValues.Set(slot, FormulaValue.New("abc")));
+        }
+
+
+        [Fact]
+        public void CreateSingle()
+        {
+            // Compose on a single item is an identity
+            var s1 = new SymbolValues();
+            var s2 = ReadOnlySymbolValues.Compose(s1);
+
+            Assert.Same(s2, s1);
+        }
+
+        // Trying to provide Multiple Values for the same SymbolTable is an error 
+        // That could lead to an ambiguity about which values to use. 
+        [Fact]
+        public void MultipleValues()
+        {
+            var symTable1 = new SymbolTable { DebugName = "L1" };
+            var slot = symTable1.AddVariable("x", FormulaType.Number);
+
+            // can't assign a string to a number
+            var values1 = new SymbolValues(symTable1) { DebugName = "V1" };
+            var values2 = new SymbolValues(symTable1) { DebugName = "V1" };
+
+            symTable1.CreateValues(values1); // ok 
+
+            try
+            {
+                symTable1.CreateValues(values1, values2); // error
+            }
+            catch(InvalidOperationException e)
+            {
+                // Message should be useful. 
+                Assert.Contains(symTable1.DebugName, e.Message);
+                Assert.Contains(values1.DebugName, e.Message);
+                Assert.Contains(values2.DebugName, e.Message);
+            }
         }
 
         // Get a convenient string representation of a SymbolValue


### PR DESCRIPTION
Ran through Codecoverage and caught some missing blocks. 

Notably enforce that we can't try to associate 2 SymValues with the same SymTable - and that we give a helpful error mssage. 
