### PR TITLE
Add support for display name for top level variables.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2749,6 +2749,10 @@ namespace Microsoft.PowerFx.Core.Binding
                     {
                         _txb.NodesToReplace.Add(new KeyValuePair<Token, string>(node.Token, entity.EntityName));
                     }
+                    else if(lookupInfo.Data is NameSymbol nameSymbol)
+                    {
+                        _txb.NodesToReplace.Add(new KeyValuePair<Token, string>(node.Token, nameSymbol.Name));
+                    }
                 }
 
                 // Internal control references are not allowed in component input properties.

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -126,7 +126,10 @@ namespace Microsoft.PowerFx
             }
         }
 
-        internal IEnumerable<NameLookupInfo> GetSymbols() => SymbolTable._variables.Values;
+        internal bool GetSymbols(string name, out NameLookupInfo symbol) => SymbolTable._variables.TryGetValue(name, out symbol);
+
+        internal IEnumerable<string> GetSuggestableSymbolName() => SymbolTable._variables.Keys;
+
 
         internal void AddEntity(IExternalEntity entity, DName displayName = default)
             => SymbolTable.AddEntity(entity, displayName);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.PowerFx.Core;
+using Microsoft.PowerFx.Core.Binding.BindInfo;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Texl;
@@ -125,10 +126,7 @@ namespace Microsoft.PowerFx
             }
         }
 
-        internal IEnumerable<IExternalEntity> GetSymbols() => SymbolTable._environmentSymbols.Values;
-
-        internal string GetSuggestableSymbolName(IExternalEntity entity)
-            => SymbolTable.GetSuggestableSymbolName(entity);
+        internal IEnumerable<NameLookupInfo> GetSymbols() => SymbolTable._variables.Values;
 
         internal void AddEntity(IExternalEntity entity, DName displayName = default)
             => SymbolTable.AddEntity(entity, displayName);
@@ -151,7 +149,7 @@ namespace Microsoft.PowerFx
             AddEntity(optionSet, optionalDisplayName);
         }
 
-        internal bool TryGetSymbol(DName name, out IExternalEntity symbol, out DName displayName)
-            => SymbolTable.TryGetSymbol(name, out symbol, out displayName);
+        internal bool TryGetVariable(DName name, out DName displayName)
+            => SymbolTable.TryGetVariable(name, out _, out displayName); 
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -197,13 +197,7 @@ namespace Microsoft.PowerFx
             return s;
         }
 
-        // https://github.com/microsoft/Power-Fx/issues/779
-        // _environmentSymbols have the display name support (they update the _environmentSymbolDisplayNameProvider)
-        // Merge _variables with _environmentSymbols to provide display name support for variables.. 
-        // Both ultimately serve in INameResolver.Lookup 
         internal readonly Dictionary<string, NameLookupInfo> _variables = new Dictionary<string, NameLookupInfo>();
-
-        internal readonly Dictionary<DName, IExternalEntity> _environmentSymbols = new Dictionary<DName, IExternalEntity>();
 
         internal DisplayNameProvider _environmentSymbolDisplayNameProvider = new SingleSourceDisplayNameProvider();
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/SingleSourceDisplayNameProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/SingleSourceDisplayNameProvider.cs
@@ -77,5 +77,24 @@ namespace Microsoft.PowerFx.Core
         {
             return _logicalToDisplay.TryGetValue(logicalName, out displayName);
         }
+
+        public DisplayNameProvider RemoveField(DName lookupName)
+        {
+            if (_logicalToDisplay.TryGetValue(lookupName, out var displayName))
+            {
+                var logicalToDisplay = _logicalToDisplay.Remove(lookupName);
+                var displayToLogic = _displayToLogical.Remove(displayName);
+                return new SingleSourceDisplayNameProvider(logicalToDisplay, displayToLogic);
+
+            }
+            else if (_displayToLogical.TryGetValue(lookupName, out var logicalName))
+            {
+                var displayToLogic = _displayToLogical.Remove(lookupName);
+                var logicalToDisplay = _logicalToDisplay.Remove(logicalName);
+                return new SingleSourceDisplayNameProvider(logicalToDisplay, displayToLogic);
+            }
+
+            return this;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/SingleSourceDisplayNameProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/SingleSourceDisplayNameProvider.cs
@@ -78,7 +78,12 @@ namespace Microsoft.PowerFx.Core
             return _logicalToDisplay.TryGetValue(logicalName, out displayName);
         }
 
-        public DisplayNameProvider RemoveField(DName lookupName)
+        /// <summary>
+        /// Removes field based on given <paramref name="lookupName"/>.
+        /// </summary>
+        /// <param name="lookupName"> logical or display name of the field.</param>
+        /// <returns></returns>
+        public SingleSourceDisplayNameProvider RemoveField(DName lookupName)
         {
             if (_logicalToDisplay.TryGetValue(lookupName, out var displayName))
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -314,7 +314,7 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
         {
             foreach (var global in _powerFxConfig.GetSymbols())
             {
-                IntellisenseHelper.AddSuggestion(this, _powerFxConfig.GetSuggestableSymbolName(global), SuggestionKind.Global, SuggestionIconKind.Other, global.Type, requiresSuggestionEscaping: true);
+                IntellisenseHelper.AddSuggestion(this, global.DisplayName, SuggestionKind.Global, SuggestionIconKind.Other, global.Type, requiresSuggestionEscaping: true);
             }
         }
 
@@ -342,7 +342,7 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
         /// <returns>
         /// Sequence of suggestions for first name node context.
         /// </returns>
-        internal virtual IEnumerable<string> SuggestableFirstNames => _powerFxConfig.GetSymbols().Select(_powerFxConfig.GetSuggestableSymbolName);
+        internal virtual IEnumerable<string> SuggestableFirstNames => _powerFxConfig.GetSymbols().Select( symbol => symbol.DisplayName.Value);
 
         /// <summary>
         /// Invokes <see cref="AddSuggestionsForConstantKeywords"/> to supply suggestions for constant

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -312,9 +312,14 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
         /// </summary>
         internal virtual void AddCustomSuggestionsForGlobals()
         {
-            foreach (var global in _powerFxConfig.GetSymbols())
+            foreach (var global in _powerFxConfig.GetSuggestableSymbolName())
             {
-                IntellisenseHelper.AddSuggestion(this, global.DisplayName, SuggestionKind.Global, SuggestionIconKind.Other, global.Type, requiresSuggestionEscaping: true);
+                DType type = default;
+                if(_powerFxConfig.GetSymbols(global, out var nameInfo))
+                {
+                    type = nameInfo.Type;
+                }
+                IntellisenseHelper.AddSuggestion(this, global, SuggestionKind.Global, SuggestionIconKind.Other, type, requiresSuggestionEscaping: true);
             }
         }
 
@@ -342,7 +347,7 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
         /// <returns>
         /// Sequence of suggestions for first name node context.
         /// </returns>
-        internal virtual IEnumerable<string> SuggestableFirstNames => _powerFxConfig.GetSymbols().Select( symbol => symbol.DisplayName.Value);
+        internal virtual IEnumerable<string> SuggestableFirstNames => _powerFxConfig.GetSuggestableSymbolName();
 
         /// <summary>
         /// Invokes <see cref="AddSuggestionsForConstantKeywords"/> to supply suggestions for constant

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameOptionSetTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameOptionSetTests.cs
@@ -106,13 +106,13 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                         
             config.AddEntity(otherOptionSet, new DName("NonColliding"));
 
-            Assert.True(config.TryGetSymbol(new DName("OptionSet"), out _, out var displayName));
+            Assert.True(config.TryGetVariable(new DName("OptionSet"), out var displayName));
             Assert.Equal("SomeDisplayName", displayName.Value);
-            Assert.True(config.TryGetSymbol(new DName("OtherOptionSet"), out _, out displayName));
+            Assert.True(config.TryGetVariable(new DName("OtherOptionSet"), out displayName));
             Assert.Equal("NonColliding", displayName.Value);
-            Assert.True(config.TryGetSymbol(new DName("NonColliding"), out _, out displayName));
+            Assert.True(config.TryGetVariable(new DName("NonColliding"), out displayName));
             Assert.Equal("NonColliding", displayName.Value);
-            Assert.True(config.TryGetSymbol(new DName("SomeDisplayName"), out _, out displayName));
+            Assert.True(config.TryGetVariable(new DName("SomeDisplayName"), out displayName));
             Assert.Equal("SomeDisplayName", displayName.Value);
         }
     }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
@@ -110,6 +110,48 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             Assert.Throws<NameCollisionException>(() => r1.Add(new NamedFormulaType("DisplayNum", FormulaType.Date, "NoCollision")));
             Assert.Throws<NameCollisionException>(() => r1.Add(new NamedFormulaType("NoCollision", FormulaType.Date, "DisplayNum")));
             Assert.Throws<NameCollisionException>(() => r1.Add(new NamedFormulaType("NoCollision", FormulaType.Date, "Num")));
+
+            // Collision on symbol table
+            var symbol = new SymbolTable();
+
+            // Adds display name for a variable.
+            symbol.AddVariable("logicalVariable", FormulaType.Number, displayName: "displayVariable");
+
+            // should throw if try to add same name constant
+            Assert.Throws<NameCollisionException>(() => symbol.AddConstant("logicalVariable", FormulaValue.New(1)));
+            Assert.Throws<NameCollisionException>(() => symbol.AddConstant("displayVariable", FormulaValue.New(1)));
+
+            var config = new PowerFxConfig() { SymbolTable = symbol };
+
+            // should throw if try to add same name entity
+            // displayVariable is display name for variable logicalVariable
+            var optionSet = new OptionSet("displayVariable", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
+            {
+                    { "foo", "Option1" },
+                    { "baz", "foo" }
+            }));
+            Assert.Throws<NameCollisionException>(() => config.AddEntity(optionSet, new DName("newName")));
+
+            // logicalVariable is logical name for variable logicalVariable.
+            var optionSet2 = new OptionSet("logicalVariable", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
+            {
+                    { "foo", "Option1" },
+                    { "baz", "foo" }
+            }));
+            Assert.Throws<NameCollisionException>(() => config.AddEntity(optionSet2, new DName("newName")));
+
+            // option set with new name.
+            var optionSet3 = new OptionSet("newName", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
+            {
+                    { "foo", "Option1" },
+                    { "baz", "foo" }
+            }));
+
+            // displayVariable is display name for variable logicalVariable
+            Assert.Throws<NameCollisionException>(() => config.AddEntity(optionSet3, new DName("displayVariable")));
+
+            // logicalVariable is logical name for variable logicalVariable
+            Assert.Throws<NameCollisionException>(() => config.AddEntity(optionSet3, new DName("logicalVariable")));
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
@@ -116,10 +116,18 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             // Adds display name for a variable.
             symbol.AddVariable("logicalVariable", FormulaType.Number, displayName: "displayVariable");
+            symbol.AddVariable("logicalVariable2", FormulaType.Number, displayName: "displayVariable2");
 
             // should throw if try to add same name constant
             Assert.Throws<NameCollisionException>(() => symbol.AddConstant("logicalVariable", FormulaValue.New(1)));
             Assert.Throws<NameCollisionException>(() => symbol.AddConstant("displayVariable", FormulaValue.New(1)));
+
+            // should be able to remove variable using display name
+            Assert.Throws<NameCollisionException>(() => symbol.AddConstant("logicalVariable2", FormulaValue.New(1)));
+            Assert.Throws<NameCollisionException>(() => symbol.AddConstant("displayVariable2", FormulaValue.New(1)));
+            symbol.RemoveVariable("displayVariable2");
+            symbol.AddConstant("logicalVariable2", FormulaValue.New(1));
+            symbol.AddConstant("displayVariable2", FormulaValue.New(1));
 
             var config = new PowerFxConfig() { SymbolTable = symbol };
 
@@ -152,6 +160,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             // logicalVariable is logical name for variable logicalVariable
             Assert.Throws<NameCollisionException>(() => config.AddEntity(optionSet3, new DName("logicalVariable")));
+
+            // Remove variable and remove from display name as well.
+            symbol.RemoveVariable("logicalVariable");
+
+            // Now below should not throw an exception.
+            config.AddEntity(optionSet3, new DName("displayVariable"));
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
@@ -77,10 +77,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Theory]
-        [InlineData("displayVariable + 1", "logicalVariable + 1", 2)]
-        [InlineData("logicalVariable + 1", "logicalVariable + 1", 2)]
-        [InlineData("If(true, logicalVariable)", "If(true, logicalVariable)", 1)]
-        public async void TopLevelVariableDisplayName(string expression, string expectedInvariantExpression, double expected)
+        [InlineData("displayVariable + 1", "logicalVariable + 1", "displayVariable + 1", 2)]
+        [InlineData("logicalVariable + 1", "logicalVariable + 1", "displayVariable + 1", 2)]
+        [InlineData("If(true, logicalVariable)", "If(true, logicalVariable)", "If(true, displayVariable)", 1)]
+        public async void TopLevelVariableDisplayName(string expression, string expectedInvariantExpression,string expectedDisplayExpression, double expected)
         {
             var symbol = new SymbolTable();
 
@@ -101,6 +101,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             var actualInvariantExpression = engine.GetInvariantExpression(expression, null);
             Assert.Equal(expectedInvariantExpression, actualInvariantExpression);
+
+            var actualDisplayExpression = engine.GetDisplayExpression(expression, RecordType.Empty());
+            Assert.Equal(expectedDisplayExpression, actualDisplayExpression);
+
         }
 
         // Bind a function, eval it separately.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
@@ -76,6 +76,33 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             Assert.True(check.IsSuccess);
         }
 
+        [Theory]
+        [InlineData("displayVariable + 1", "logicalVariable + 1", 2)]
+        [InlineData("logicalVariable + 1", "logicalVariable + 1", 2)]
+        [InlineData("If(true, logicalVariable)", "If(true, logicalVariable)", 1)]
+        public async void TopLevelVariableDisplayName(string expression, string expectedInvariantExpression, double expected)
+        {
+            var symbol = new SymbolTable();
+
+            // Adds display name for a variable.
+            var logicalVariableSlot = symbol.AddVariable("logicalVariable", FormulaType.Number, displayName: "displayVariable");
+            var r1 = new SymbolValues(symbol);
+            r1.Set(logicalVariableSlot, FormulaValue.New(1));
+
+            var config = new PowerFxConfig() { SymbolTable = symbol };
+
+            var engine = new RecalcEngine(config);
+
+            var check = engine.Check(expression);
+            Assert.True(check.IsSuccess);
+
+            var eval = await engine.EvalAsync(expression,CancellationToken.None, runtimeConfig: r1);
+            Assert.Equal(expected, eval.ToObject());
+
+            var actualInvariantExpression = engine.GetInvariantExpression(expression, null);
+            Assert.Equal(expectedInvariantExpression, actualInvariantExpression);
+        }
+
         // Bind a function, eval it separately.
         // But still share symbol values.
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -678,7 +678,7 @@ namespace Microsoft.PowerFx.Tests
             config.SymbolTable.AddFunction(func);
             config.SymbolTable.AddEntity(optionSet);
 
-            Assert.True(config.TryGetSymbol(new DName("foo"), out _, out _));
+            Assert.True(config.TryGetVariable(new DName("foo"), out _));
             Assert.Contains(func, recalcEngine.Functions); // function was added to the config.
 
             Assert.DoesNotContain(BuiltinFunctionsCore.Abs, recalcEngine.Functions);


### PR DESCRIPTION
- Adds support for display name for top level variable via Symbol Table.
- Added tests in src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs/TopLevelVariableDisplayName and src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs/CollisionsThrow
- I have ran a buddy build with PA Client and have verified there's no impact of removing/changing the internal methods.

User's can now supply display name via Symbol Table as below:
var symbol = new Symbol Table();
symbol.AddVariable("logicalName", FormulaType, "DisplayName");

Fix #779 