### PR TITLE
Allow Boolean, Number, and Text values in respective UO constructors

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var isValid = true;
             var argType = argTypes[0];
-            if (!DType.Number.Accepts(argType) && !DType.String.Accepts(argType))
+            if (!DType.Number.Accepts(argType) && !DType.String.Accepts(argType) && !DType.Boolean.Accepts(argType))
             {
                 if (argType.CoercesTo(DType.DateTime) && !argType.IsControl)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool SupportsParamCoercion => false;
 
         public ValueFunction_UO()
-            : base(ValueFunction.ValueInvariantFunctionName, TexlStrings.AboutValue, FunctionCategories.Text, DType.Number, 0, 1, 1, DType.UntypedObject)
+            : base(ValueFunction.ValueInvariantFunctionName, TexlStrings.AboutValue, FunctionCategories.Text, DType.Number, 0, 1, 2, DType.UntypedObject, DType.String)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1384,11 +1384,14 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Value_UO,
-                StandardErrorHandling<UntypedObjectValue>(
+                StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Value_UO.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeTypes: ExactSequence(
+                        ExactValueTypeOrBlank<UntypedObjectValue>,
+                        ExactValueTypeOrBlank<StringValue>
+                        ),
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Value_UO)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -102,6 +102,11 @@ namespace Microsoft.PowerFx.Functions
                 return n;
             }
 
+            if (arg0 is BooleanValue b)
+            {
+                return BooleanToNumber(irContext, new BooleanValue[] { b });
+            }
+
             if (arg0 is DateValue dv)
             {
                 return DateToNumber(irContext, new DateValue[] { dv });

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -52,11 +52,16 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue Value_UO(IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Value_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
 
-            if (impl.Type == FormulaType.Number)
+            if (impl.Type == FormulaType.String)
+            {
+                var str = new StringValue(IRContext.NotInSource(FormulaType.String), impl.GetString());
+                return Value(runner, context, irContext, new FormulaValue[] { str });
+            }
+            else if (impl.Type == FormulaType.Number)
             {
                 var number = impl.GetDouble();
                 if (IsInvalidDouble(number))
@@ -66,11 +71,16 @@ namespace Microsoft.PowerFx.Functions
 
                 return new NumberValue(irContext, number);
             }
+            else if (impl.Type == FormulaType.Boolean)
+            {
+                var b = new BooleanValue(IRContext.NotInSource(FormulaType.Boolean), impl.GetBoolean());
+                return BooleanToNumber(irContext, new BooleanValue[] { b });
+            }
 
             return GetTypeMismatchError(irContext, BuiltinFunctionsCore.Value_UO.Name, DType.Number.GetKindString(), impl);
         }
 
-        public static FormulaValue Text_UO(IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Text_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, UntypedObjectValue[] args)
         {
             var impl = args[0].Impl;
 
@@ -78,6 +88,16 @@ namespace Microsoft.PowerFx.Functions
             {
                 var str = impl.GetString();
                 return new StringValue(irContext, str);
+            }
+            else if (impl.Type == FormulaType.Number)
+            {
+                var n = new NumberValue(IRContext.NotInSource(FormulaType.Number), impl.GetDouble());
+                return Text(runner, context, irContext, new FormulaValue[] { n });
+            }
+            else if (impl.Type == FormulaType.Boolean)
+            {
+                var b = impl.GetBoolean();
+                return new StringValue(irContext, PowerFxBooleanToString(b));
             }
 
             return GetTypeMismatchError(irContext, BuiltinFunctionsCore.Text_UO.Name, DType.String.GetKindString(), impl);
@@ -132,7 +152,17 @@ namespace Microsoft.PowerFx.Functions
         {
             var impl = args[0].Impl;
 
-            if (impl.Type == FormulaType.Boolean)
+            if (impl.Type == FormulaType.String)
+            {
+                var str = new StringValue(IRContext.NotInSource(FormulaType.String), impl.GetString());
+                return TextToBoolean(irContext, new StringValue[] { str });
+            }
+            else if (impl.Type == FormulaType.Number)
+            {
+                var n = new NumberValue(IRContext.NotInSource(FormulaType.Number), impl.GetDouble());
+                return NumberToBoolean(irContext, new NumberValue[] { n });
+            }
+            else if (impl.Type == FormulaType.Boolean)
             {
                 var b = impl.GetBoolean();
                 return new BooleanValue(irContext, b);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -52,13 +52,18 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
-        public static FormulaValue Value_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Value_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
-            var impl = args[0].Impl;
+            var uo = args[0] as UntypedObjectValue;
+            var impl = uo.Impl;
 
             if (impl.Type == FormulaType.String)
             {
                 var str = new StringValue(IRContext.NotInSource(FormulaType.String), impl.GetString());
+                if (args.Length > 1)
+                {
+                    return Value(runner, context, irContext, new FormulaValue[] { str, args[1] });
+                }
                 return Value(runner, context, irContext, new FormulaValue[] { str });
             }
             else if (impl.Type == FormulaType.Number)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ErrorKinds.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ErrorKinds.txt
@@ -68,10 +68,10 @@ Error({Kind:ErrorKind.Numeric})
 >> ForAll(Boolean([3, 1/0, 0, Sqrt(-1)]), IfError(Text(Value), $"ErrorKind={FirstError.Kind}"))
 Table({Value:"true"},{Value:"ErrorKind=13"},{Value:"false"},{Value:"ErrorKind=24"})
 
->> Boolean(ParseJSON("1"))
+>> Boolean(ParseJSON("[1]"))
 Error({Kind:ErrorKind.InvalidArgument})
 
->> Boolean(ParseJSON("{""a"":""true""}").a)
+>> Boolean(ParseJSON("{""a"":[""true""]}").a)
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> Concat([3, 2, 1, 0, -1, -2], Text(Sqrt(1/Value)))
@@ -589,7 +589,7 @@ Error({Kind:ErrorKind.BadLanguageCode})
 >> Text(Char(0), If(1/0<2,"format"), If(Sqrt(-1)<0,"language"))
 Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.Div0},{Kind:ErrorKind.Numeric}))
 
->> Text(ParseJSON("1"))
+>> Text(ParseJSON("[1]"))
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> Text(If(1/0<2,ParseJSON("1")))
@@ -634,7 +634,7 @@ Error({Kind:ErrorKind.Numeric})
 >> Value("1234", "not a culture")
 Error({Kind:ErrorKind.BadLanguageCode})
 
->> Value(ParseJSON("false"))
+>> Value(ParseJSON("[false]"))
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> Value(If(1/0<2,ParseJSON("1")))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -20,6 +20,9 @@
 >> Value(ParseJSON("""123,456"""))
 123456
 
+>> Value(ParseJSON("""123,456"""), "fr-FR")
+123.456
+
 >> Value(ParseJSON("""a"""))
 Error({Kind:ErrorKind.InvalidArgument})
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -23,6 +23,12 @@
 >> Value(ParseJSON("""123,456"""), "fr-FR")
 123.456
 
+>> Value(ParseJSON("""123.456"""), "es-ES")
+123456
+
+>> Value(ParseJSON("123.456"), "es-ES")
+123.456
+
 >> Value(ParseJSON("""a"""))
 Error({Kind:ErrorKind.InvalidArgument})
 
@@ -92,6 +98,9 @@ true
 
 >> Boolean(ParseJSON("0"))
 false
+
+>> Boolean(ParseJSON("5"))
+true
 
 >> Boolean(ParseJSON("null"))
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -75,6 +75,15 @@ true
 >> Boolean(ParseJSON("""false"""))
 false
 
+>> Boolean(ParseJSON("""tRuE"""))
+true
+
+>> Boolean(ParseJSON("""fAlSe"""))
+false
+
+>> Boolean(ParseJSON("""F"""))
+Error({Kind:ErrorKind.InvalidArgument})
+
 >> Boolean(ParseJSON("1"))
 true
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -9,13 +9,13 @@
 5
 
 >> Value(ParseJSON("true"))
-Error({Kind:ErrorKind.InvalidArgument})
+1
 
 >> Value(ParseJSON("false"))
-Error({Kind:ErrorKind.InvalidArgument})
+0
 
 >> Value(ParseJSON("""5"""))
-Error({Kind:ErrorKind.InvalidArgument})
+5
 
 >> Value(ParseJSON("""a"""))
 Error({Kind:ErrorKind.InvalidArgument})
@@ -52,18 +52,30 @@ Error({Kind:ErrorKind.InvalidArgument})
 Blank()
 
 >> Text(ParseJSON("true"))
-Error({Kind:ErrorKind.InvalidArgument})
+"true"
 
 >> Text(ParseJSON("false"))
-Error({Kind:ErrorKind.InvalidArgument})
+"false"
 
 >> Text(ParseJSON("5"))
-Error({Kind:ErrorKind.InvalidArgument})
+"5"
 
 >> Boolean(ParseJSON("true"))
 true
 
 >> Boolean(ParseJSON("false"))
+false
+
+>> Boolean(ParseJSON("""true"""))
+true
+
+>> Boolean(ParseJSON("""false"""))
+false
+
+>> Boolean(ParseJSON("1"))
+true
+
+>> Boolean(ParseJSON("0"))
 false
 
 >> Boolean(ParseJSON("null"))
@@ -139,7 +151,7 @@ Error({Kind:ErrorKind.Div0})
 Table({Value:"1"},{Value:"false"},{Value:"hello"})
 
 >> ForAll(ParseJSON("[1,true,3,false]"), Value(ThisRecord))
-Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))
+Table({Value:1},{Value:1},{Value:3},{Value:0})
 
 >> ForAll(ParseJSON("[1,2,3]"), If(Value(ThisRecord) < 2, Value(ThisRecord), ThisRecord))
 Errors: Error 74-84: Invalid argument type (UntypedObject). Expecting a Number value instead.|Error 29-85: The function 'If' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -17,6 +17,9 @@
 >> Value(ParseJSON("""5"""))
 5
 
+>> Value(ParseJSON("""123,456"""))
+123456
+
 >> Value(ParseJSON("""a"""))
 Error({Kind:ErrorKind.InvalidArgument})
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Value.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Value.txt
@@ -468,11 +468,11 @@ true
 
 // ******** BOOLEAN PARAMETERS ********
 
->> Value("true")
-Error({Kind:ErrorKind.InvalidArgument})
+>> Value(true)
+1
 
->> Value("false")
-Error({Kind:ErrorKind.InvalidArgument})
+>> Value(false)
+0
 
 // ******** DATE/TIME PARAMETERS ********
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioDotNetObjectWrapper.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioDotNetObjectWrapper.cs
@@ -37,6 +37,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         [Theory]
         [InlineData("Value(obj.Next.Value)", 20.0)]
+        [InlineData("Text(obj.Value)", "10")]
         [InlineData("obj.missing", null)] // missing fields are blank
         [InlineData("IsBlank(obj.Next.Next)", true)]
         [InlineData("IsBlank(obj.Next)", false)]
@@ -48,7 +49,6 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Index(array, 0)", "#error")] // Out of bounds, low
         [InlineData("Index(array, -1)", "#error")] // Out of bounds, low
         [InlineData("Index(array, 100)", "#error")] // Out of bounds, high
-        [InlineData("Text(obj.Value)", "10")] // cast error. 
         public void Test(string expr, object expected)
         {
             var engine = new RecalcEngine();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioDotNetObjectWrapper.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioDotNetObjectWrapper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Index(array, 0)", "#error")] // Out of bounds, low
         [InlineData("Index(array, -1)", "#error")] // Out of bounds, low
         [InlineData("Index(array, 100)", "#error")] // Out of bounds, high
-        [InlineData("Text(obj.Value)", "#error")] // cast error. 
+        [InlineData("Text(obj.Value)", "10")] // cast error. 
         public void Test(string expr, object expected)
         {
             var engine = new RecalcEngine();


### PR DESCRIPTION
As part design changes to ParseJSON, Boolean, Text, and Number values are supported in all 3 constructors. This change  also fixes tests which were expecting an error, which is a breaking change in PAClient.