### PR TITLE
Add Benchmarck.Net profiling project

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <!-- <PropertyGroup>
@@ -59,10 +59,14 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>$(SolutionDir)\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+  <PropertyGroup Condition="'$(Project)'!='Microsoft.PowerFx.Performance.Tests'">
+    <AssemblyOriginatorKeyFile Condition="EXISTS('..\..\..\src\build\35MSSharedLib1024.snk')">..\..\..\src\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'!='DEBUG'">
+    <Optimize>True</Optimize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' != '' ">

--- a/src/Microsoft.PowerFx.sln
+++ b/src/Microsoft.PowerFx.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerFx.Connector
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerFx.Connectors.Tests", "tests\Microsoft.PowerFx.Connectors.Tests\Microsoft.PowerFx.Connectors.Tests.csproj", "{81586372-FE63-4F6D-923D-B47E94487676}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerFx.Performance.Tests", "tests\Microsoft.PowerFx.Performance.Tests\Microsoft.PowerFx.Performance.Tests.csproj", "{5A2EEF08-7A8A-43E6-B498-EFB32B98CC5A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +79,9 @@ Global
 		{81586372-FE63-4F6D-923D-B47E94487676}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{81586372-FE63-4F6D-923D-B47E94487676}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81586372-FE63-4F6D-923D-B47E94487676}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A2EEF08-7A8A-43E6-B498-EFB32B98CC5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A2EEF08-7A8A-43E6-B498-EFB32B98CC5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A2EEF08-7A8A-43E6-B498-EFB32B98CC5A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +95,7 @@ Global
 		{ED98A690-863A-443C-9DBB-8F0F5BCACE2B} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
 		{CEE27893-EE7D-4832-858F-70AF6BA325E3} = {4269F3C3-6B42-419B-B64A-3E6DC0F1574A}
 		{81586372-FE63-4F6D-923D-B47E94487676} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{5A2EEF08-7A8A-43E6-B498-EFB32B98CC5A} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {30372F91-B206-4351-A621-F0E2773C337B}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -28,5 +28,10 @@ namespace Microsoft.PowerFx
         /// Filter(A, A[@Value] = 2)
         /// </summary>
         DisableRowScopeDisambiguationSyntax = 0x4,
+
+        /// <summary>
+        /// All features enabled
+        /// </summary>
+        All = ~0
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -435,7 +435,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var result3 = engine.EvalAsync("a + b", CancellationToken.None, runtimeConfig: r2).Result;
             Assert.Equal(11.0, result3.ToObject());
         }
-             
+
         [Fact]
         public void Test1()
         {
@@ -624,7 +624,6 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             Assert.Throws<InvalidOperationException>(() => symValues.Set(slot, FormulaValue.New("abc")));
         }
 
-
         [Fact]
         public void CreateSingle()
         {
@@ -653,12 +652,86 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             {
                 symTable1.CreateValues(values1, values2); // error
             }
-            catch(InvalidOperationException e)
+            catch (InvalidOperationException e)
             {
                 // Message should be useful. 
                 Assert.Contains(symTable1.DebugName, e.Message);
                 Assert.Contains(values1.DebugName, e.Message);
                 Assert.Contains(values2.DebugName, e.Message);
+            }
+        }
+
+        // Demonstrate how to use ThisItem in a loop.
+        // All Loop iterations can access common global state,
+        // but also have their own loop-specific identifer. 
+        [Fact]
+        public async Task ThisItemTest()
+        {
+            var symTableGlobals = new SymbolTable { DebugName = "Globals" };
+            var slotGlobal = symTableGlobals.AddVariable("globalVar", FormulaType.Number);
+
+            // Note from PowerFx perspective, there is nothing special about the identifier 'ThisItem'.
+            // It's all determined by SymbolTable topology. 
+            var symTableThisItem = new SymbolTable { DebugName = "ThisItem" };
+            var slotThisItem = symTableThisItem.AddVariable("ThisItem", FormulaType.Number);
+
+            // Combine together
+            var symTable = ReadOnlySymbolTable.Compose(symTableThisItem, symTableGlobals);
+
+            var expr = "globalVar + ThisItem";
+            
+            // Compile once outside the loop, then run many times. 
+            var engine = new RecalcEngine();
+            var check = engine.Check(expr, symbolTable: symTable);
+            check.ThrowOnErrors();
+
+            // Now move to runtime...
+            var run = check.GetEvaluator();
+
+            // all loop bodies can read-only access common global state. 
+            var symValuesGlobals = symTableGlobals.CreateValues();
+            symValuesGlobals.Set(slotGlobal, FormulaValue.New(1000));
+
+            // Loop body can be run in parallel since each eval is independent. 
+            // An there are no mutations on shared state.
+            Parallel.For(0, 10, (i) =>
+            {
+                // Each loop body gets its own iteration-specific values.
+                var symValuesThisItem = symTableThisItem.CreateValues();
+                symValuesThisItem.Set(slotThisItem, FormulaValue.New(i));
+
+                var symValues = symTable.CreateValues(symValuesGlobals, symValuesThisItem);
+
+                // In the loop, just eval.
+                var result = run.Eval(symValues);
+
+                var expected = (double)1000 + i; // matches 'expr'
+                Assert.Equal(expected, result.ToObject());
+            });
+
+            // ThisItem is also immutable.
+            // But we could do other mutations from within - but if it's shared state, be careful to not run in parallel.
+            {
+                var symValuesThisItem = symTableThisItem.CreateValues();
+                symValuesThisItem.Set(slotThisItem, FormulaValue.New(5));
+
+                // Add another table with a mutable var, 'Counter', and demonstrate 
+                // we can call Set. 
+                var symTable2 = new SymbolTable();
+                symTable2.EnableMutationFunctions();
+                var slot = symTable2.AddVariable("counter", FormulaType.Number, mutable: true);
+
+                var symTableAll = ReadOnlySymbolTable.Compose(symTable2, symTableThisItem);
+                var symValuesAll = symTableAll.CreateValues(symValuesThisItem);
+
+                var opts = new ParserOptions { AllowsSideEffects = true };
+                var result = engine.EvalAsync("Set(counter, ThisItem);counter", CancellationToken.None, options: opts, runtimeConfig: symValuesAll).Result;
+
+                Assert.Equal(5.0, result.ToObject());
+
+                // but we can't call Set on ThisItem 
+                var check2 = engine.Check("Set(ThisItem, 5)", options: opts, symbolTable: symValuesAll.SymbolTable);
+                Assert.False(check2.IsSuccess);
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/Microsoft.PowerFx.Performance.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/Microsoft.PowerFx.Performance.Tests.csproj
@@ -1,0 +1,53 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>        
+    <IsPackable Condition="'$(InternalBuild)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(InternalBuild)' != 'true'">false</IsPackable>
+    <GeneratePackageOnBuild Condition="'$(InternalBuild)' == 'true'">$(GeneratePackages)</GeneratePackageOnBuild>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp3.1</TargetFrameworks>
+    <Version Condition=" '$(ReleasePackageVersion)' == '' ">$(LocalPackageVersion)</Version>
+    <Version Condition=" '$(ReleasePackageVersion)' != '' ">$(ReleasePackageVersion)</Version>
+    <PackageVersion Condition=" '$(ReleasePackageVersion)' == '' ">$(LocalPackageVersion)</PackageVersion>
+    <PackageVersion Condition=" '$(ReleasePackageVersion)' != '' ">$(ReleasePackageVersion)</PackageVersion>
+    <Configurations>Debug;Release</Configurations>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <StartupObject>Microsoft.PowerFx.Performance.Tests.Program</StartupObject>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'!='Debug' or '$(TURN_OFF_WARNING_AS_ERROR)'!='True' ">
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
+    <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\libraries\Microsoft.PowerFx.Core\Microsoft.PowerFx.Core.csproj" />
+    <ProjectReference Include="..\..\libraries\Microsoft.PowerFx.Interpreter\Microsoft.PowerFx.Interpreter.csproj" />
+    <ProjectReference Include="..\Microsoft.PowerFx.Core.Tests\Microsoft.PowerFx.Core.Tests.csproj" />
+  </ItemGroup>  
+
+</Project>

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/Microsoft.PowerFx.Performance.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/Microsoft.PowerFx.Performance.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/PerformanceTest1.cs
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/PerformanceTest1.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Globalization;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnostics.Windows;
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
+using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Performance.Tests
+{
+    [EtwProfiler] // https://benchmarkdotnet.org/articles/features/etwprofiler.html
+    [CsvExporter] // https://benchmarkdotnet.org/articles/configs/exporters.html
+    [MinColumn, Q1Column, MeanColumn, Q3Column, MaxColumn]
+    public class PerformanceTest1 : PowerFxTest
+    {
+        private PowerFxConfig powerFxConfig;
+        private Engine engine;
+        private RecalcEngine recalcEngine;
+        private ParserOptions parserOptions;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            powerFxConfig = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            engine = new Engine(powerFxConfig);
+            parserOptions = new ParserOptions() { AllowsSideEffects = true, Culture = new CultureInfo("en-US") };
+            recalcEngine = new RecalcEngine(powerFxConfig);
+        }
+
+        [Params(1, 2, 5, 10, 20, 50, 100)]
+        public int N { get; set; }
+
+        [Benchmark]
+        public ParseResult Parse()
+        {
+            var expr = string.Join(" + ", Enumerable.Repeat("Sum(1)", N));
+
+            var parse = engine.Parse(expr, parserOptions);
+            return parse;
+        }
+
+        [Benchmark]
+        public CheckResult Check()
+        {
+            var expr = string.Join(" + ", Enumerable.Repeat("Sum(1)", N));
+
+            var check = engine.Check(expr);
+            return check;
+        }
+
+        [Benchmark]
+        public FormulaValue Eval()
+        {
+            var expr = string.Join(" + ", Enumerable.Repeat("Sum(1)", N));
+
+            var result = recalcEngine.Eval(expr);
+            return result;
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/PerformanceTest1.cs
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/PerformanceTest1.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnostics.Windows;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Performance.Tests
@@ -30,8 +32,17 @@ namespace Microsoft.PowerFx.Performance.Tests
             recalcEngine = new RecalcEngine(powerFxConfig);
         }
 
-        [Params(1, 2, 5, 10, 20, 50, 100)]
+        [Params(1, 5, 10)]
         public int N { get; set; }
+
+        [Benchmark]
+        public IReadOnlyList<Token> Tokenize()
+        {
+            var expr = string.Join(" + ", Enumerable.Repeat("Sum(1)", N));
+
+            var tokens = engine.Tokenize(expr);
+            return tokens;
+        }
 
         [Benchmark]
         public ParseResult Parse()

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/Program.cs
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/Program.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.PowerFx.Performance.Tests
+{
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            /*
+             * 
+             *       --> This program needs to be run ELEVATED
+             *       
+             *       --> Also set the following env. variable before starting VS
+             *           SET MSBuildSDKsPath=C:\Program Files\dotnet\sdk\7.0.100\Sdks
+             *              
+             */
+
+            var summary = BenchmarkRunner.Run<PerformanceTest1>();
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/UnitTests/PerformanceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/UnitTests/PerformanceTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.PowerFx.Performance.Tests.UnitTests
+{
+    public class PerformanceTests
+    {
+        [Fact]
+        public void PerformanceTest()
+        {
+            var pt = new PerformanceTest1();
+            pt.GlobalSetup();
+            pt.N = 20;
+
+            for (var i = 0; i < 10000; i++)
+            {
+                var cr = pt.Check();
+                Assert.True(cr.IsSuccess);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Benchmarck.Net profiling project to measure performance of key PowerFx APIs.
This console app needs to be compiled in release mode and will produce results like the example below.
Notice that these results will depend on the machine used.

| Method |   N |         Mean |      Error |     StdDev |          Min |           Q1 |           Q3 |          Max |
|------- |---- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|-------------:|
|  Parse |   1 |     5.634 us |  0.0343 us |  0.0304 us |     5.579 us |     5.625 us |     5.652 us |     5.677 us |
|  Check |   1 |    56.129 us |  1.0138 us |  0.8465 us |    55.568 us |    55.673 us |    56.153 us |    58.825 us |
|   Eval |   1 |    57.456 us |  0.3150 us |  0.2947 us |    56.932 us |    57.324 us |    57.697 us |    57.764 us |
|  Parse |   2 |    12.029 us |  0.0651 us |  0.0577 us |    11.950 us |    11.996 us |    12.065 us |    12.159 us |
|  Check |   2 |   114.498 us |  1.0578 us |  0.9377 us |   112.682 us |   113.873 us |   115.152 us |   116.451 us |
|   Eval |   2 |   112.719 us |  0.9399 us |  0.8792 us |   111.661 us |   111.926 us |   113.149 us |   114.603 us |
|  Parse |   5 |    30.931 us |  0.5996 us |  0.8208 us |    29.922 us |    30.253 us |    31.317 us |    32.828 us |
|  Check |   5 |   283.300 us |  2.9594 us |  2.7682 us |   279.459 us |   281.388 us |   284.453 us |   288.856 us |
|   Eval |   5 |   270.327 us |  2.9469 us |  2.6123 us |   265.346 us |   268.750 us |   271.924 us |   275.122 us |
|  Parse |  10 |    59.969 us |  0.2200 us |  0.1951 us |    59.685 us |    59.838 us |    60.144 us |    60.262 us |
|  Check |  10 |   553.311 us |  3.4061 us |  3.0194 us |   546.914 us |   551.101 us |   554.823 us |   558.592 us |
|   Eval |  10 |   527.913 us |  2.8641 us |  2.5390 us |   523.217 us |   526.081 us |   529.657 us |   532.359 us |
|  Parse |  20 |   126.709 us |  2.5166 us |  5.5239 us |   119.027 us |   120.950 us |   131.278 us |   136.713 us |
|  Check |  20 | 1,182.082 us | 23.3672 us | 37.0628 us | 1,121.656 us | 1,151.371 us | 1,213.736 us | 1,245.586 us |
|   Eval |  20 | 1,023.810 us |  7.3008 us |  6.8292 us | 1,016.347 us | 1,017.929 us | 1,028.714 us | 1,037.119 us |
|  Parse |  50 |   304.723 us |  2.3317 us |  2.0670 us |   301.125 us |   303.259 us |   306.117 us |   307.844 us |
|  Check |  50 | 2,776.818 us |  6.5057 us |  6.0854 us | 2,767.250 us | 2,772.776 us | 2,781.323 us | 2,786.738 us |
|   Eval |  50 | 2,688.011 us | 52.6876 us | 86.5673 us | 2,578.290 us | 2,609.024 us | 2,761.661 us | 2,836.030 us |
|  Parse | 100 |   628.569 us |  3.7187 us |  3.2965 us |   623.051 us |   626.312 us |   630.026 us |   635.731 us |
|  Check | 100 | 5,537.963 us | 19.3509 us | 17.1540 us | 5,514.151 us | 5,525.402 us | 5,549.316 us | 5,577.848 us |
|   Eval | 100 | 5,135.896 us | 60.8737 us | 56.9413 us | 5,056.144 us | 5,097.930 us | 5,167.779 us | 5,263.991 us |
