### PR TITLE
Text function doesn't handle date format specifiers like Excel

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -530,6 +530,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrOperatorExpected = new ErrorResourceKey("ErrOperatorExpected");
         public static ErrorResourceKey ErrNumberExpected = new ErrorResourceKey("ErrNumberExpected");
         public static ErrorResourceKey ErrNumberTooLarge = new ErrorResourceKey("ErrNumberTooLarge");
+        public static ErrorResourceKey ErrTextFormatTooLarge = new ErrorResourceKey("ErrTextFormatTooLarge");
         public static ErrorResourceKey ErrBooleanExpected = new ErrorResourceKey("ErrBooleanExpected");
         public static ErrorResourceKey ErrOnlyOneViewExpected = new ErrorResourceKey("ErrOnlyOneViewExpected");
         public static ErrorResourceKey ErrViewFromCurrentTableExpected = new ErrorResourceKey("ErrViewFromCurrentTableExpected");

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -110,31 +110,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 // Verify statically that the format string doesn't contain BOTH numeric and date/time
                 // format specifiers. If it does, that's an error according to Excel and our spec.
-
-                // But firstly skip any locale-prefix
-                if (formatArg.StartsWith("[$-"))
+                if (!TextFormatUtils.IsValidFormatArg(formatArg, out _, out _))
                 {
-                    var end = formatArg.IndexOf(']', 3);
-                    if (end > 0)
-                    {
-                        formatArg = formatArg.Substring(end + 1);
-                    }
-                }
-
-                var hasDateTimeFmt = formatArg.IndexOfAny(new char[] { 'm', 'd', 'y', 'h', 'H', 's', 'a', 'A', 'p', 'P' }) >= 0;
-                var hasNumericFmt = formatArg.IndexOfAny(new char[] { '0', '#' }) >= 0;
-                if (hasDateTimeFmt && hasNumericFmt)
-                {
-                    // Check if the date time format contains '0's after the seconds specifier, which
-                    // is used for fractional seconds - in which case it is valid
-                    var formatWithoutZeroSubseconds = Regex.Replace(formatArg, @"[sS]\.?(0+)",
-                        m => m.Groups[1].Success ? "" : m.Groups[1].Value);
-                    hasNumericFmt = formatWithoutZeroSubseconds.IndexOfAny(new char[] { '0', '#' }) >= 0;
-                }
-
-                if (hasDateTimeFmt && hasNumericFmt)
-                {
-                    errors.EnsureError(DocumentErrorSeverity.Moderate, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
+                    errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
                     isValid = false;
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // format specifiers. If it does, that's an error according to Excel and our spec.
                 if (!TextFormatUtils.IsValidFormatArg(formatArg, out _, out _))
                 {
-                    errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
+                    errors.EnsureError(DocumentErrorSeverity.Moderate, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
                     isValid = false;
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
@@ -46,25 +46,5 @@ namespace Microsoft.PowerFx.Core.Utils
 
             return true;
         }
-
-        public static bool IsNumericFormat(string formatArg)
-        {
-            if (formatArg == null)
-            {
-                return false;
-            }
-
-            return IsValidFormatArg(formatArg, out _, out var hasNumericFmt) && hasNumericFmt;
-        }
-
-        public static bool IsDateTimeFormat(string formatArg)
-        {
-            if (formatArg == null)
-            {
-                return false;
-            }
-
-            return IsValidFormatArg(formatArg, out var hasDateTimeFmt, out _) && hasDateTimeFmt;
-        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerFx.Core.Utils
 {
     internal sealed class TextFormatUtils
     {
-        static public DateTime BaseDateTime => new DateTime(1899, 12, 30, 0, 0, 0, 0);
+        static public DateTime BaseDateTime => new DateTime(1899, 12, 30, 0, 0, 0, 0, DateTimeKind.Local);
 
         public static bool IsValidFormatArg(string formatArg, out bool hasDateTimeFmt, out bool hasNumericFmt)
         {
@@ -65,15 +65,6 @@ namespace Microsoft.PowerFx.Core.Utils
             }
 
             return IsValidFormatArg(formatArg, out var hasDateTimeFmt, out _) && hasDateTimeFmt;
-        }
-
-        public static DateTime NumberValueToDateTime(NumberValue numberValue)
-        {
-            var millisecondsPerDay = 86400000; // hours * minutes * seconds * 1000
-            var intPart = (int)Math.Floor(numberValue.Value);
-            var fracPart = numberValue.Value - intPart;
-
-            return BaseDateTime.AddDays(intPart).AddMilliseconds((int)(fracPart * millisecondsPerDay));
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerFx.Core.Utils
 {
     internal sealed class TextFormatUtils
     {
-        static public DateTime BaseDateTime => new DateTime(1899, 12, 30, 0, 0, 0, 0, DateTimeKind.Local);
+        static readonly private Regex _formatWithoutZeroSubsecondsRegex = new Regex(@"[sS]\.?(0+)", RegexOptions.Compiled);
 
         public static bool IsValidFormatArg(string formatArg, out bool hasDateTimeFmt, out bool hasNumericFmt)
         {
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Core.Utils
             {
                 // Check if the date time format contains '0's after the seconds specifier, which
                 // is used for fractional seconds - in which case it is valid
-                var formatWithoutZeroSubseconds = Regex.Replace(formatArg, @"[sS]\.?(0+)",
+                var formatWithoutZeroSubseconds = _formatWithoutZeroSubsecondsRegex.Replace(formatArg,
                     m => m.Groups[1].Success ? "" : m.Groups[1].Value);
                 hasNumericFmt = formatWithoutZeroSubseconds.IndexOfAny(new char[] { '0', '#' }) >= 0;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Utils/TextFormatUtils.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Localization;
+using System.Xml.Linq;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Core.Utils
+{
+    internal sealed class TextFormatUtils
+    {
+        static public DateTime BaseDateTime => new DateTime(1899, 12, 30, 0, 0, 0, 0);
+
+        public static bool IsValidFormatArg(string formatArg, out bool hasDateTimeFmt, out bool hasNumericFmt)
+        {
+            // Verify statically that the format string doesn't contain BOTH numeric and date/time
+            // format specifiers. If it does, that's an error according to Excel and our spec.
+
+            // But firstly skip any locale-prefix
+            if (formatArg.StartsWith("[$-"))
+            {
+                var end = formatArg.IndexOf(']', 3);
+                if (end > 0)
+                {
+                    formatArg = formatArg.Substring(end + 1);
+                }
+            }
+
+            hasDateTimeFmt = formatArg.IndexOfAny(new char[] { 'm', 'M', 'd', 'D', 'y', 'Y', 'h', 'H', 's', 'S', 'a', 'A', 'p', 'P' }) >= 0;
+            hasNumericFmt = formatArg.IndexOfAny(new char[] { '0', '#' }) >= 0;
+            if (hasDateTimeFmt && hasNumericFmt)
+            {
+                // Check if the date time format contains '0's after the seconds specifier, which
+                // is used for fractional seconds - in which case it is valid
+                var formatWithoutZeroSubseconds = Regex.Replace(formatArg, @"[sS]\.?(0+)",
+                    m => m.Groups[1].Success ? "" : m.Groups[1].Value);
+                hasNumericFmt = formatWithoutZeroSubseconds.IndexOfAny(new char[] { '0', '#' }) >= 0;
+            }
+
+            if (hasDateTimeFmt && hasNumericFmt)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool IsNumericFormat(string formatArg)
+        {
+            if (formatArg == null)
+            {
+                return false;
+            }
+
+            return IsValidFormatArg(formatArg, out _, out var hasNumericFmt) && hasNumericFmt;
+        }
+
+        public static bool IsDateTimeFormat(string formatArg)
+        {
+            if (formatArg == null)
+            {
+                return false;
+            }
+
+            return IsValidFormatArg(formatArg, out var hasDateTimeFmt, out _) && hasDateTimeFmt;
+        }
+
+        public static DateTime NumberValueToDateTime(NumberValue numberValue)
+        {
+            var millisecondsPerDay = 86400000; // hours * minutes * seconds * 1000
+            var intPart = (int)Math.Floor(numberValue.Value);
+            var fracPart = numberValue.Value - intPart;
+
+            return BaseDateTime.AddDays(intPart).AddMilliseconds((int)(fracPart * millisecondsPerDay));
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -33,6 +33,8 @@ namespace Microsoft.PowerFx
 
         private readonly CancellationToken _cancellationToken;
 
+        internal CancellationToken CancelationToken => _cancellationToken;
+
         public EvalVisitor(CultureInfo cultureInfo, CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig = null)
         {
             _defaultCultureInfo = cultureInfo;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx
 
         private readonly CancellationToken _cancellationToken;
 
-        internal CancellationToken CancelationToken => _cancellationToken;
+        internal CancellationToken CancellationToken => _cancellationToken;
 
         public EvalVisitor(CultureInfo cultureInfo, CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig = null)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
@@ -108,6 +108,16 @@ namespace Microsoft.PowerFx.Functions
             });
         }
 
+        public static ErrorValue GenericInvalidArgument(IRContext irContext, string message)
+        {
+            return new ErrorValue(irContext, new ExpressionError()
+            {
+                Message = message,
+                Span = irContext.SourceContext,
+                Kind = ErrorKind.InvalidArgument
+            });
+        }
+
         public static ErrorValue InvalidBooleanFormatError(IRContext irContext)
         {
             return new ErrorValue(irContext, new ExpressionError()

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
@@ -98,11 +98,11 @@ namespace Microsoft.PowerFx.Functions
             });
         }
 
-        public static ErrorValue GenericInvalidArgument(IRContext irContext, string message = null)
+        public static ErrorValue GenericInvalidArgument(IRContext irContext, string message = "Invalid Argument")
         {
             return new ErrorValue(irContext, new ExpressionError()
             {
-                Message = message ?? "Invalid Argument",
+                Message = message,
                 Span = irContext.SourceContext,
                 Kind = ErrorKind.InvalidArgument
             });

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/CommonErrors.cs
@@ -98,21 +98,11 @@ namespace Microsoft.PowerFx.Functions
             });
         }
 
-        public static ErrorValue GenericInvalidArgument(IRContext irContext)
+        public static ErrorValue GenericInvalidArgument(IRContext irContext, string message = null)
         {
             return new ErrorValue(irContext, new ExpressionError()
             {
-                Message = "Invalid Argument",
-                Span = irContext.SourceContext,
-                Kind = ErrorKind.InvalidArgument
-            });
-        }
-
-        public static ErrorValue GenericInvalidArgument(IRContext irContext, string message)
-        {
-            return new ErrorValue(irContext, new ExpressionError()
-            {
-                Message = message,
+                Message = message ?? "Invalid Argument",
                 Span = irContext.SourceContext,
                 Kind = ErrorKind.InvalidArgument
             });

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -209,7 +209,7 @@ namespace Microsoft.PowerFx.Functions
                     {
                         // It's a number, formatted as date/time. Let's convert it to a date/time value first
                         var newDateTime = Library.NumberToDateTime(runner, context, IRContext.NotInSource(FormulaType.DateTime), new NumberValue[] { num });
-                        resultString = ExpandDateTimeExcelFormatSpecifiers(formatString, "g", newDateTime.Value, culture, runner.CancelationToken);
+                        resultString = ExpandDateTimeExcelFormatSpecifiers(formatString, "g", newDateTime.Value, culture, runner.CancellationToken);
                     }
                     else
                     {
@@ -242,7 +242,7 @@ namespace Microsoft.PowerFx.Functions
                     }
                     else
                     {
-                        resultString = ExpandDateTimeExcelFormatSpecifiers(formatString, "g", dateTimeValue.Value, culture, runner.CancelationToken);
+                        resultString = ExpandDateTimeExcelFormatSpecifiers(formatString, "g", dateTimeValue.Value, culture, runner.CancellationToken);
                     }
                     break;
             }
@@ -326,12 +326,14 @@ namespace Microsoft.PowerFx.Functions
 
         private static string ResolveDateTimeFormatAmbiguities(string format, DateTime dateTime, CultureInfo culture, CancellationToken cancellationToken)
         {
-            format = ReplaceDoubleQuotedStrings(format, out var replaceList, cancellationToken);        
-            format = TokenizeDatetimeFormat(format, cancellationToken);
-            format = DetokenizeDatetimeFormat(format, dateTime, culture);
-            format = RestoreDoubleQuotedStrings(format, replaceList, cancellationToken);
+            var resultString = format;
 
-            return format;
+            resultString = ReplaceDoubleQuotedStrings(resultString, out var replaceList, cancellationToken);
+            resultString = TokenizeDatetimeFormat(resultString, cancellationToken);
+            resultString = DetokenizeDatetimeFormat(resultString, dateTime, culture);
+            resultString = RestoreDoubleQuotedStrings(resultString, replaceList, cancellationToken);
+
+            return resultString;
         }
 
         private static string RestoreDoubleQuotedStrings(string format, List<string> replaceList, CancellationToken cancellationToken)
@@ -375,19 +377,19 @@ namespace Microsoft.PowerFx.Functions
 
             // Day component            
             format = _daysDetokenizeRegex.Replace(format, dateTime.ToString("dddd", culture))
-                          .Replace("\u0004\u0004\u0004", dateTime.ToString("dddd", culture).Substring(0, 3))
+                          .Replace("\u0004\u0004\u0004", dateTime.ToString("ddd", culture))
                           .Replace("\u0004\u0004", dateTime.ToString("dd", culture))
                           .Replace("\u0004", dateTime.ToString("%d", culture));
 
             // Month component
             format = _monthsDetokenizeRegex.Replace(format, dateTime.ToString("MMMM", culture))
-                          .Replace("\u0003\u0003\u0003", dateTime.ToString("MMMM", culture).Substring(0, 3))
+                          .Replace("\u0003\u0003\u0003", dateTime.ToString("MMM", culture))
                           .Replace("\u0003\u0003", dateTime.ToString("MM", culture))
                           .Replace("\u0003", dateTime.ToString("%M", culture));
 
             // Year component
             format = _yearsDetokenizeRegex.Replace(format, dateTime.ToString("yyyy", culture));
-            format = _years2DetokenizeRegex.Replace(format, dateTime.ToString("yyyy", culture).Substring(2, 2));
+            format = _years2DetokenizeRegex.Replace(format, dateTime.ToString("yy", culture));
 
             // Hour component
             format = _hoursDetokenizeRegex.Replace(format, hasAmPm ? dateTime.ToString("hh", culture) : dateTime.ToString("HH", culture))

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -22,20 +22,20 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
-        static readonly Regex _ampmReplaceRegex = new Regex("[aA][mM]\\/[pP][mM]", RegexOptions.Compiled);
-        static readonly Regex _apReplaceRegex = new Regex("[aA]\\/[pP]", RegexOptions.Compiled);
-        static readonly Regex _minutesBeforeSecondsRegex = new Regex("[mM][^dDyYhH]+[sS]", RegexOptions.Compiled);
-        static readonly Regex _minutesAfterHoursRegex = new Regex("[hH][^dDyYmM]+[mM]", RegexOptions.Compiled);
-        static readonly Regex _minutesRegex = new Regex("[mM]", RegexOptions.Compiled);
-        static readonly Regex _internalStringRegex = new Regex("([\"][^\"]*[\"])", RegexOptions.Compiled);
-        static readonly Regex _daysDetokenizeRegex = new Regex("[\u0004][\u0004][\u0004][\u0004]+", RegexOptions.Compiled);
-        static readonly Regex _monthsDetokenizeRegex = new Regex("[\u0003][\u0003][\u0003][\u0003]+", RegexOptions.Compiled);
-        static readonly Regex _yearsDetokenizeRegex = new Regex("[\u0005][\u0005][\u0005]+", RegexOptions.Compiled);
-        static readonly Regex _years2DetokenizeRegex = new Regex("[\u0005]+", RegexOptions.Compiled);
-        static readonly Regex _hoursDetokenizeRegex = new Regex("[\u0006][\u0006]+", RegexOptions.Compiled);
-        static readonly Regex _minutesDetokenizeRegex = new Regex("[\u000A][\u000A]+", RegexOptions.Compiled);
-        static readonly Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegexOptions.Compiled);
-        static readonly Regex _milisecondsDetokenizeRegex = new Regex("[\u000e][\u000e][\u000e]+", RegexOptions.Compiled);
+        static readonly private Regex _ampmReplaceRegex = new Regex("[aA][mM]\\/[pP][mM]", RegexOptions.Compiled);
+        static readonly private Regex _apReplaceRegex = new Regex("[aA]\\/[pP]", RegexOptions.Compiled);
+        static readonly private Regex _minutesBeforeSecondsRegex = new Regex("[mM][^dDyYhH]+[sS]", RegexOptions.Compiled);
+        static readonly private Regex _minutesAfterHoursRegex = new Regex("[hH][^dDyYmM]+[mM]", RegexOptions.Compiled);
+        static readonly private Regex _minutesRegex = new Regex("[mM]", RegexOptions.Compiled);
+        static readonly private Regex _internalStringRegex = new Regex("([\"][^\"]*[\"])", RegexOptions.Compiled);
+        static readonly private Regex _daysDetokenizeRegex = new Regex("[\u0004][\u0004][\u0004][\u0004]+", RegexOptions.Compiled);
+        static readonly private Regex _monthsDetokenizeRegex = new Regex("[\u0003][\u0003][\u0003][\u0003]+", RegexOptions.Compiled);
+        static readonly private Regex _yearsDetokenizeRegex = new Regex("[\u0005][\u0005][\u0005]+", RegexOptions.Compiled);
+        static readonly private Regex _years2DetokenizeRegex = new Regex("[\u0005]+", RegexOptions.Compiled);
+        static readonly private Regex _hoursDetokenizeRegex = new Regex("[\u0006][\u0006]+", RegexOptions.Compiled);
+        static readonly private Regex _minutesDetokenizeRegex = new Regex("[\u000A][\u000A]+", RegexOptions.Compiled);
+        static readonly private Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegexOptions.Compiled);
+        static readonly private Regex _milisecondsDetokenizeRegex = new Regex("[\u000e][\u000e][\u000e]+", RegexOptions.Compiled);
 
         // Char is used for PA string escaping 
         public static FormulaValue Char(IRContext irContext, NumberValue[] args)
@@ -201,7 +201,8 @@ namespace Microsoft.PowerFx.Functions
             // We limit the format string size
             if (formatString != null && formatString.Length > formatSize)
             {
-                return CommonErrors.CustomError(irContext, StringResources.Get(TexlStrings.ErrTextFormatTooLarge, culture.Name));
+                var customErrorMessage = StringResources.Get(TexlStrings.ErrTextFormatTooLarge, culture.Name);
+                return CommonErrors.CustomError(irContext, string.Format(customErrorMessage, formatSize));
             }
 
             switch (args[0])

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -208,7 +208,7 @@ namespace Microsoft.PowerFx.Functions
                     if (TextFormatUtils.IsDateTimeFormat(formatString))
                     {
                         // It's a number, formatted as date/time. Let's convert it to a date/time value first
-                        var newDateTime = Library.NumberToDateTime(runner, context, irContext, new NumberValue[] { num });
+                        var newDateTime = Library.NumberToDateTime(runner, context, IRContext.NotInSource(FormulaType.DateTime), new NumberValue[] { num });
                         resultString = ExpandDateTimeExcelFormatSpecifiers(formatString, "g", newDateTime.Value, culture, runner.CancelationToken);
                     }
                     else
@@ -223,7 +223,7 @@ namespace Microsoft.PowerFx.Functions
 
                     if (args[0] is TimeValue t)
                     {
-                        dateTimeValue = Library.TimeToDateTime(runner, context, irContext, new TimeValue[] { t });
+                        dateTimeValue = Library.TimeToDateTime(runner, context, IRContext.NotInSource(FormulaType.DateTime), new TimeValue[] { t });
                     }
                     else if (args[0] is DateValue d)
                     {
@@ -237,7 +237,7 @@ namespace Microsoft.PowerFx.Functions
                     if (TextFormatUtils.IsNumericFormat(formatString))
                     {
                         // It's a datetime, formatted as number. Let's convert it to a number value first
-                        var newNumber = Library.DateTimeToNumber(irContext, new DateTimeValue[] { dateTimeValue });
+                        var newNumber = Library.DateTimeToNumber(IRContext.NotInSource(FormulaType.Number), new DateTimeValue[] { dateTimeValue });
                         resultString = newNumber.Value.ToString(formatString ?? "g", culture);
                     }
                     else

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1798,6 +1798,10 @@
     <value>Numeric value is too large.</value>
     <comment>Error Message.</comment>
   </data>
+  <data name="ErrTextFormatTooLarge" xml:space="preserve">
+    <value>Format string size is too large.</value>
+    <comment>Error Message.</comment>
+  </data>
   <data name="ErrInvalidDataSource" xml:space="preserve">
     <value>This Data source is invalid. Please fix the error in "Data sources" pane by clicking "Content -&gt; Data sources" or "View -&gt; Options"</value>
     <comment>Error Message.</comment>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1799,7 +1799,7 @@
     <comment>Error Message.</comment>
   </data>
   <data name="ErrTextFormatTooLarge" xml:space="preserve">
-    <value>Format string size is too large.</value>
+    <value>Format string size can't be more than {0} characters.</value>
     <comment>Error Message.</comment>
   </data>
   <data name="ErrInvalidDataSource" xml:space="preserve">

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/NotYetReady/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/NotYetReady/Text_Format.txt
@@ -1,489 +1,368 @@
 ﻿>> Text(30470, "DDDD, MMM ""D"" DD, YYY") // excelDate22
-#skip
-//"Friday, Jun D 03, 1983"
+"Friday, Jun D 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") // date22c
-#skip
-//"Friday, Jun D 03, 1983"
+"Friday, Jun D 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") // date23
-#skip
-//"Friday, Jun 03, 1983 d"
+"Friday, Jun 03, 1983 d"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") // date23b
-#skip
-//"Friday, Jun 03, 1983 D"
+"Friday, Jun 03, 1983 D"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") // date24
-#skip
-//"Friday, Jun d. 03, 1983"
+"Friday, Jun d. 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") // date25
-#skip
-//"Friday, Jun yyy 03, 1983"
+"Friday, Jun yyy 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") // date25b
-#skip
-//"Friday, Jun YYY 03, 1983"
+"Friday, Jun YYY 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date26
-#skip
-//"Friday, Jun yyy 03, mmm 1983"
+"Friday, Jun yyy 03, mmm 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date27
-#skip
-//"ddd Friday, Jun yyy 03, mmm 1983"
+"ddd Friday, Jun yyy 03, mmm 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") // date27b
-#skip
-//"ddd Friday, Jun yyy 03, mmm 1983"
+"ddd Friday, Jun yyy 03, mmm 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") // date28
-#skip
-//"Friday, Jun carrymeforward 03, 1983"
+"Friday, Jun carrymeforward 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") // date28b
-#skip
-//"Friday, Jun carrymeforward 03, 1983"
+"Friday, Jun carrymeforward 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") // date29
-#skip
-//"Friday, Juncarrymeforward03, mmm 1983"
+"Friday, Juncarrymeforward03, mmm 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") // date29
-#skip
-//"Friday, Juncarrymeforward03, MMM 1983"
+"Friday, Juncarrymeforward03, MMM 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") // time26
-#skip
-//"02:53:09.123"
+"02:53:09.123"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") // time26b
-#skip
-//"02:53:09.123"
+"02:53:09.123"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") // time27
-#skip
-//"02:53:09.ff"
+"02:53:09.ff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") // time27b
-#skip
-//"02:53:09.12"
+"02:53:09.12"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") // time28
-#skip
-//"02:53:09.f"
+"02:53:09.f"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") // time28b
-#skip
-//"02:53:09.1"
+"02:53:09.1"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") // time29
-#skip
-//"02:53:09.fff"
+"02:53:09.fff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") // time29b
-#skip
-//"02:53:09.013"
+"02:53:09.013"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") // time30
-#skip
-//"02:53:09.ff"
+"02:53:09.ff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") // time30b
-#skip
-//"02:53:09.01"
+"02:53:09.01"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") // time31
-#skip
-//"02:53:09.f"
+"02:53:09.f"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") // time31b
-#skip
-//"02:53:09.0"
+"02:53:09.0"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") // time32
-#skip
-//"02:53:09.fff"
+"02:53:09.fff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") // time32b
-#skip
-//"02:53:09.003"
+"02:53:09.003"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") // time33
-#skip
-//"02:53:09.ff"
+"02:53:09.ff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") // time33b
-#skip
-//"02:53:09.00"
+"02:53:09.00"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") // time34
-#skip
-//"02:53:09.f"
+"02:53:09.f"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") // time34b
-#skip
-//"02:53:09.0"
+"02:53:09.0"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") // time35
-#skip
-//"53:09.fff"
+"53:09.fff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") // time35b
-#skip
-//"53:09.123"
+"53:09.123"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") // time36
-#skip
-//"53:09.ff"
+"53:09.ff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") // time36b
-#skip
-//"53:09.12"
+"53:09.12"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") // time37
-#skip
-//"53:09.f"
+"53:09.f"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") // time37b
-#skip
-//"53:09.1"
+"53:09.1"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") // time38
-#skip
-//"53:09.fff"
+"53:09.fff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") // time38b
-#skip
-//"53:09.013"
+"53:09.013"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") // time39
-#skip
-//"53:09.ff"
+"53:09.ff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") // time39b
-#skip
-//"53:09.01"
+"53:09.01"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") // time40
-#skip
-//"53:09.f"
+"53:09.f"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") // time40b
-#skip
-//"53:09.0"
+"53:09.0"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") // time41
-#skip
-//"53:09.fff"
+"53:09.fff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") // time41b
-#skip
-//"53:09.003"
+"53:09.003"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") // time42
-#skip
-//"53:09.ff"
+"53:09.ff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") // time42b
-#skip
-//"53:09.00"
+"53:09.00"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") // time43
-#skip
-//"53:09.f"
+"53:09.f"
 
 >> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0") // time44b
-#skip
-//"30471"
+"30471"
 
 >> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0.00") // time44c
-#skip
-//"30470.75"
+"30470.75"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") // time49
-#skip
-//"Thursday, January 1, 1970 14:32:25"
+"Thursday, January 1, 1970 14:32:25"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") // time50
-#skip
-//"1/1/1970 14:32"
+"1/1/1970 14:32"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") // time51
-#skip
-//"14:32:25"
+"14:32:25"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") // time52
-#skip
-//"14:32"
+"14:32"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") // time55
-#skip
-//"long1ateti1e"
+"long1ateti1e"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") // time56
-#skip
-//"2514ort1ateti1e"
+"2514ort1ateti1e"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") // time57
-#skip
-//"long1ateti1e24"
+"long1ateti1e24"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") // time58
-#skip
-//"2514ort1ateti1e24"
+"2514ort1ateti1e24"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") // time59
-#skip
-//"longti1e24"
+"longti1e24"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") // time60
-#skip
-//"2514ortti32e24"
+"2514ortti32e24"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") // time61
-#skip
-//"longti1e"
+"longti1e"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") // time62
-#skip
-//"2514ortti32e"
+"2514ortti32e"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") // time63
-#skip
-//"h Friday, Jun 03, 1983"
+"h Friday, Jun 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") // time64
-#skip
-//"Friday, Jun h 03, 1983"
+"Friday, Jun h 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") // time65
-#skip
-//"Friday, Jun 03, 1983 h"
+"Friday, Jun 03, 1983 h"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") // time66
-#skip
-//"Friday, Jun h. 03, 1983"
+"Friday, Jun h. 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") // time67
-#skip
-//"Friday, Jun hh:mm 03, 1983"
+"Friday, Jun hh:mm 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // time68
-#skip
-//"Friday, Jun hh.m 03, mm.f 1983"
+"Friday, Jun hh.m 03, mm.f 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // time69
-#skip
-//"hh Friday, Jun mm 03, fff 1983"
+"hh Friday, Jun mm 03, fff 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") // time70
-#skip
-//"Friday, Jun carrymefforward 03, 1983"
+"Friday, Jun carrymefforward 03, 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // time71
-#skip
-//"Friday, Juncarrymefforward03, fff 1983"
+"Friday, Juncarrymefforward03, fff 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") // time72
-#skip
-//"Jun [some*] 03 (de)+ 1983"
+"Jun [some*] 03 (de)+ 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") // time73
-#skip
-//"Jun ([][^]*[""]) 03 1983"
+"Jun ([][^]*[""]) 03 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") // time74
-#skip
-//"Jun ([][^]*[]) 03 1983"
+"Jun ([][^]*[]) 03 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") // time75
-#skip
-//"Jun ([][^]*[])"" 03 1983"
+"Jun ([][^]*[])"" 03 1983"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") // datetime1
-#skip
-//"1983-06-03 02:53:09.fff"
+"1983-06-03 02:53:09.fff"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") // datetime1b
-#skip
-//"1983-06-03 02:53:09.123"
+"1983-06-03 02:53:09.123"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") // datetime2
-#skip
-//"1983-06-03 02:53:09.123"
+"1983-06-03 02:53:09.123"
 
 >> Text(0, "mm/dd/yy") // excelDate1
-#skip
-//"12/30/99"
+"12/30/99"
 
 >> Text(0, "mmm mm/dd/yy") // excelDate2
-#skip
-//"Dec 12/30/99"
+"Dec 12/30/99"
 
 >> Text(0, "mmmm mm/dd/yy") // excelDate3
-#skip
-//"December 12/30/99"
+"December 12/30/99"
 
 >> Text(0, "ddd mm/dd/yy") // excelDate4
-#skip
-//"Sat 12/30/99"
+"Sat 12/30/99"
 
 >> Text(0, "dddd mm/dd/yy") // excelDate5
-#skip
-//"Saturday 12/30/99"
+"Saturday 12/30/99"
 
 >> Text(0, "dddd, mmm dd, yy") // excelDate6
-#skip
-//"Saturday, Dec 30, 99"
+"Saturday, Dec 30, 99"
 
 >> Text(0, "dddd, mmm dd, yyy") // excelDate7
-#skip
-//"Saturday, Dec 30, 1899"
+"Saturday, Dec 30, 1899"
 
 >> Text(0, "dddd, mmm dd, yyyy") // excelDate8
-#skip
-//"Saturday, Dec 30, 1899"
+"Saturday, Dec 30, 1899"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy") // date9b
 "Friday, Jun 03, 1983"
 
 >> Text(30470, "dddd, mmm dd, yyy") // excelDate9
-#skip
-//"Friday, Jun 03, 1983"
+"Friday, Jun 03, 1983"
 
 >> Text(0, "'longdate'") // excelDate12
-#skip
-//"Saturday, December 30, 1899"
+"Saturday, December 30, 1899"
 
 >> Text(0, "'shortdate'") // excelDate13
-#skip
-//"12/30/1899"
+"12/30/1899"
 
 >> Text(0, "longdate") // excelDate14
-#skip
-//"long30ate"
+"long30ate"
 
 >> Text(0, "shortdate") // excelDate15
-#skip
-//"00ort30ate"
+"00ort30ate"
 
 >> Text(0, "short day") // excelDate16
-#skip
-//"00ort 30a99"
+"00ort 30a99"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") // date17
-#skip
-//"Friday, Jun "" 03, 1983"
+"Friday, Jun "" 03, 1983"
 
 >> Text(30470, "DDDD, MMM "" DD, YYY") // excelDate17
-#skip
-//"Friday, Jun "" 03, 1983"
+"Friday, Jun "" 03, 1983"
 
 >> Text(30470, "DDDD, MMM"""" DD, YYY") // excelDate19
-#skip
-//"Friday, Jun 03, 1983"
+"Friday, Jun 03, 1983"
 
 >> Text(30470, "DDDD, MMM""""DD, YYY") // excelDate20
-#skip
-//"Friday, Jun03, 1983"
+"Friday, Jun03, 1983"
 
 >> Text(30470, """D"" DDDD, MMM DD, YYY") // excelDate21
-#skip
-//"D Friday, Jun 03, 1983"
+"D Friday, Jun 03, 1983"
 
 >> Text(33333.75, "'longdatetime'") // excelTime47
-#skip
-//"Friday, April 5, 1991 6:00:00 PM"
+"Friday, April 5, 1991 6:00:00 PM"
 
 >> Text(33333.75, "'shortdatetime'") // excelTime48
-#skip
-//"4/5/1991 6:00 PM"
+"4/5/1991 6:00 PM"
 
 >> Text(33333.75, "'longdatetime24'") // excelTime49
-#skip
-//"Friday, April 5, 1991 18:00:00"
+"Friday, April 5, 1991 18:00:00"
 
 >> Text(0.6875, "'longtime24'") // excelTime51
-#skip
-//"16:30:00"
+"16:30:00"
 
 >> Text(0.6875, "'shorttime24'") // excelTime52
-#skip
-//"16:30"
+"16:30"
 
 >> Text(12345.6875, "'longtime'") // excelTime53
-#skip
-//"4:30:00 PM"
+"4:30:00 PM"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") // time54
 "2:32 PM"
 
 >> Text(33333.6875, "'shorttime'") // excelTime54
-#skip
-//"4:30 PM"
+"4:30 PM"
 
 >> Text(30470, """h"" dddd, mmm dd, yyy") // excelTime63
-#skip
-//"h Friday, Jun 03, 1983"
+"h Friday, Jun 03, 1983"
 
 >> Text(30470, "dddd, mmm ""h"" dd, yyy") // excelTime64
-#skip
-//"Friday, Jun h 03, 1983"
+"Friday, Jun h 03, 1983"
 
 >> Text(30470, "dddd, mmm dd, yyy ""h""") // excelTime65
-#skip
-//"Friday, Jun 03, 1983 h"
+"Friday, Jun 03, 1983 h"
 
 >> Text(30470, "dddd, mmm ""h."" dd, yyy") // excelTime66
-#skip
-//"Friday, Jun h. 03, 1983"
+"Friday, Jun h. 03, 1983"
 
 >> Text(30470, "dddd, mmm ""hh:mm"" dd, yyy") // excelTime67
-#skip
-//"Friday, Jun hh:mm 03, 1983"
+"Friday, Jun hh:mm 03, 1983"
 
 >> Text(30470, "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // excelTime68
-#skip
-//"Friday, Jun hh.m 03, mm.f 1983"
+"Friday, Jun hh.m 03, mm.f 1983"
 
 >> Text(30470, """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // excelTime69
-#skip
-//"hh Friday, Jun mm 03, fff 1983"
+"hh Friday, Jun mm 03, fff 1983"
 
 >> Text(30470, "dddd, mmm ""carrymefforward"" dd, yyy") // excelTime70
-#skip
-//"Friday, Jun carrymefforward 03, 1983"
+"Friday, Jun carrymefforward 03, 1983"
 
 >> Text(30470, "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // excelTime71
-#skip
-//"Friday, Juncarrymefforward03, fff 1983"
+"Friday, Juncarrymefforward03, fff 1983"
 
 >> Text(30470, "mmm ""[some*]"" dd ""(de)+"" yyyy") // excelTime72
-#skip
-//"Jun [some*] 03 (de)+ 1983"
+"Jun [some*] 03 (de)+ 1983"
 
 >> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") // excelTime73
-#skip
-//"Jun ([][^]*[""]) 03 1983"
+"Jun ([][^]*[""]) 03 1983"
 
 >> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") // excelTime74
-#skip
-//"Jun ([][^]*[]) 03 1983"
+"Jun ([][^]*[]) 03 1983"
 
 >> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") // excelTime75
-#skip
-//"Jun ([][^]*[])"" 03 1983"
+"Jun ([][^]*[])"" 03 1983"
 
 >> Text(30470, "mmm ""[de]+de"" dd yyyy") // excelTime76
-#skip
-//"Jun [de]+de 03 1983"
+"Jun [de]+de 03 1983"
 
 >> Text(30470.01953125, "yyyy-mm-dd HH:mm:ss.000") // excelDatetime1b
-#skip
-//"1983-06-03 00:28:07.500"
+"1983-06-03 00:28:07.500"
 
 >> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000") // excelDatetime2
-#skip
-//"1983-06-03 00:28:07.500"
+"1983-06-03 00:28:07.500"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/NotYetReady/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/NotYetReady/Text_Format.txt
@@ -1,0 +1,489 @@
+﻿>> Text(30470, "DDDD, MMM ""D"" DD, YYY") // excelDate22
+#skip
+//"Friday, Jun D 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") // date22c
+#skip
+//"Friday, Jun D 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") // date23
+#skip
+//"Friday, Jun 03, 1983 d"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") // date23b
+#skip
+//"Friday, Jun 03, 1983 D"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") // date24
+#skip
+//"Friday, Jun d. 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") // date25
+#skip
+//"Friday, Jun yyy 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") // date25b
+#skip
+//"Friday, Jun YYY 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date26
+#skip
+//"Friday, Jun yyy 03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date27
+#skip
+//"ddd Friday, Jun yyy 03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") // date27b
+#skip
+//"ddd Friday, Jun yyy 03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") // date28
+#skip
+//"Friday, Jun carrymeforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") // date28b
+#skip
+//"Friday, Jun carrymeforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") // date29
+#skip
+//"Friday, Juncarrymeforward03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") // date29
+#skip
+//"Friday, Juncarrymeforward03, MMM 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") // time26
+#skip
+//"02:53:09.123"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") // time26b
+#skip
+//"02:53:09.123"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") // time27
+#skip
+//"02:53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") // time27b
+#skip
+//"02:53:09.12"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") // time28
+#skip
+//"02:53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") // time28b
+#skip
+//"02:53:09.1"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") // time29
+#skip
+//"02:53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") // time29b
+#skip
+//"02:53:09.013"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") // time30
+#skip
+//"02:53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") // time30b
+#skip
+//"02:53:09.01"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") // time31
+#skip
+//"02:53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") // time31b
+#skip
+//"02:53:09.0"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") // time32
+#skip
+//"02:53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") // time32b
+#skip
+//"02:53:09.003"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") // time33
+#skip
+//"02:53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") // time33b
+#skip
+//"02:53:09.00"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") // time34
+#skip
+//"02:53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") // time34b
+#skip
+//"02:53:09.0"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") // time35
+#skip
+//"53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") // time35b
+#skip
+//"53:09.123"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") // time36
+#skip
+//"53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") // time36b
+#skip
+//"53:09.12"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") // time37
+#skip
+//"53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") // time37b
+#skip
+//"53:09.1"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") // time38
+#skip
+//"53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") // time38b
+#skip
+//"53:09.013"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") // time39
+#skip
+//"53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") // time39b
+#skip
+//"53:09.01"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") // time40
+#skip
+//"53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") // time40b
+#skip
+//"53:09.0"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") // time41
+#skip
+//"53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") // time41b
+#skip
+//"53:09.003"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") // time42
+#skip
+//"53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") // time42b
+#skip
+//"53:09.00"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") // time43
+#skip
+//"53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0") // time44b
+#skip
+//"30471"
+
+>> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0.00") // time44c
+#skip
+//"30470.75"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") // time49
+#skip
+//"Thursday, January 1, 1970 14:32:25"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") // time50
+#skip
+//"1/1/1970 14:32"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") // time51
+#skip
+//"14:32:25"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") // time52
+#skip
+//"14:32"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") // time55
+#skip
+//"long1ateti1e"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") // time56
+#skip
+//"2514ort1ateti1e"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") // time57
+#skip
+//"long1ateti1e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") // time58
+#skip
+//"2514ort1ateti1e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") // time59
+#skip
+//"longti1e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") // time60
+#skip
+//"2514ortti32e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") // time61
+#skip
+//"longti1e"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") // time62
+#skip
+//"2514ortti32e"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") // time63
+#skip
+//"h Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") // time64
+#skip
+//"Friday, Jun h 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") // time65
+#skip
+//"Friday, Jun 03, 1983 h"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") // time66
+#skip
+//"Friday, Jun h. 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") // time67
+#skip
+//"Friday, Jun hh:mm 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // time68
+#skip
+//"Friday, Jun hh.m 03, mm.f 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // time69
+#skip
+//"hh Friday, Jun mm 03, fff 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") // time70
+#skip
+//"Friday, Jun carrymefforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // time71
+#skip
+//"Friday, Juncarrymefforward03, fff 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") // time72
+#skip
+//"Jun [some*] 03 (de)+ 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") // time73
+#skip
+//"Jun ([][^]*[""]) 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") // time74
+#skip
+//"Jun ([][^]*[]) 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") // time75
+#skip
+//"Jun ([][^]*[])"" 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") // datetime1
+#skip
+//"1983-06-03 02:53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") // datetime1b
+#skip
+//"1983-06-03 02:53:09.123"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") // datetime2
+#skip
+//"1983-06-03 02:53:09.123"
+
+>> Text(0, "mm/dd/yy") // excelDate1
+#skip
+//"12/30/99"
+
+>> Text(0, "mmm mm/dd/yy") // excelDate2
+#skip
+//"Dec 12/30/99"
+
+>> Text(0, "mmmm mm/dd/yy") // excelDate3
+#skip
+//"December 12/30/99"
+
+>> Text(0, "ddd mm/dd/yy") // excelDate4
+#skip
+//"Sat 12/30/99"
+
+>> Text(0, "dddd mm/dd/yy") // excelDate5
+#skip
+//"Saturday 12/30/99"
+
+>> Text(0, "dddd, mmm dd, yy") // excelDate6
+#skip
+//"Saturday, Dec 30, 99"
+
+>> Text(0, "dddd, mmm dd, yyy") // excelDate7
+#skip
+//"Saturday, Dec 30, 1899"
+
+>> Text(0, "dddd, mmm dd, yyyy") // excelDate8
+#skip
+//"Saturday, Dec 30, 1899"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy") // date9b
+"Friday, Jun 03, 1983"
+
+>> Text(30470, "dddd, mmm dd, yyy") // excelDate9
+#skip
+//"Friday, Jun 03, 1983"
+
+>> Text(0, "'longdate'") // excelDate12
+#skip
+//"Saturday, December 30, 1899"
+
+>> Text(0, "'shortdate'") // excelDate13
+#skip
+//"12/30/1899"
+
+>> Text(0, "longdate") // excelDate14
+#skip
+//"long30ate"
+
+>> Text(0, "shortdate") // excelDate15
+#skip
+//"00ort30ate"
+
+>> Text(0, "short day") // excelDate16
+#skip
+//"00ort 30a99"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") // date17
+#skip
+//"Friday, Jun "" 03, 1983"
+
+>> Text(30470, "DDDD, MMM "" DD, YYY") // excelDate17
+#skip
+//"Friday, Jun "" 03, 1983"
+
+>> Text(30470, "DDDD, MMM"""" DD, YYY") // excelDate19
+#skip
+//"Friday, Jun 03, 1983"
+
+>> Text(30470, "DDDD, MMM""""DD, YYY") // excelDate20
+#skip
+//"Friday, Jun03, 1983"
+
+>> Text(30470, """D"" DDDD, MMM DD, YYY") // excelDate21
+#skip
+//"D Friday, Jun 03, 1983"
+
+>> Text(33333.75, "'longdatetime'") // excelTime47
+#skip
+//"Friday, April 5, 1991 6:00:00 PM"
+
+>> Text(33333.75, "'shortdatetime'") // excelTime48
+#skip
+//"4/5/1991 6:00 PM"
+
+>> Text(33333.75, "'longdatetime24'") // excelTime49
+#skip
+//"Friday, April 5, 1991 18:00:00"
+
+>> Text(0.6875, "'longtime24'") // excelTime51
+#skip
+//"16:30:00"
+
+>> Text(0.6875, "'shorttime24'") // excelTime52
+#skip
+//"16:30"
+
+>> Text(12345.6875, "'longtime'") // excelTime53
+#skip
+//"4:30:00 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") // time54
+"2:32 PM"
+
+>> Text(33333.6875, "'shorttime'") // excelTime54
+#skip
+//"4:30 PM"
+
+>> Text(30470, """h"" dddd, mmm dd, yyy") // excelTime63
+#skip
+//"h Friday, Jun 03, 1983"
+
+>> Text(30470, "dddd, mmm ""h"" dd, yyy") // excelTime64
+#skip
+//"Friday, Jun h 03, 1983"
+
+>> Text(30470, "dddd, mmm dd, yyy ""h""") // excelTime65
+#skip
+//"Friday, Jun 03, 1983 h"
+
+>> Text(30470, "dddd, mmm ""h."" dd, yyy") // excelTime66
+#skip
+//"Friday, Jun h. 03, 1983"
+
+>> Text(30470, "dddd, mmm ""hh:mm"" dd, yyy") // excelTime67
+#skip
+//"Friday, Jun hh:mm 03, 1983"
+
+>> Text(30470, "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // excelTime68
+#skip
+//"Friday, Jun hh.m 03, mm.f 1983"
+
+>> Text(30470, """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // excelTime69
+#skip
+//"hh Friday, Jun mm 03, fff 1983"
+
+>> Text(30470, "dddd, mmm ""carrymefforward"" dd, yyy") // excelTime70
+#skip
+//"Friday, Jun carrymefforward 03, 1983"
+
+>> Text(30470, "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // excelTime71
+#skip
+//"Friday, Juncarrymefforward03, fff 1983"
+
+>> Text(30470, "mmm ""[some*]"" dd ""(de)+"" yyyy") // excelTime72
+#skip
+//"Jun [some*] 03 (de)+ 1983"
+
+>> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") // excelTime73
+#skip
+//"Jun ([][^]*[""]) 03 1983"
+
+>> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") // excelTime74
+#skip
+//"Jun ([][^]*[]) 03 1983"
+
+>> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") // excelTime75
+#skip
+//"Jun ([][^]*[])"" 03 1983"
+
+>> Text(30470, "mmm ""[de]+de"" dd yyyy") // excelTime76
+#skip
+//"Jun [de]+de 03 1983"
+
+>> Text(30470.01953125, "yyyy-mm-dd HH:mm:ss.000") // excelDatetime1b
+#skip
+//"1983-06-03 00:28:07.500"
+
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000") // excelDatetime2
+#skip
+//"1983-06-03 00:28:07.500"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/NotYetReady/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/NotYetReady/Text_Format.txt
@@ -1,368 +1,98 @@
-﻿>> Text(30470, "DDDD, MMM ""D"" DD, YYY") // excelDate22
-"Friday, Jun D 03, 1983"
+﻿>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "utc") // utc1
+"1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") // date22c
-"Friday, Jun D 03, 1983"
+>> Text(30470.519531251, "utc") // excelUtc1
+"1983-06-03T12:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") // date23
-"Friday, Jun 03, 1983 d"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Utc") // utc2
+"1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") // date23b
-"Friday, Jun 03, 1983 D"
+>> Text(30470.519531251, "Utc") // excelUtc2
+"1983-06-03T12:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") // date24
-"Friday, Jun d. 03, 1983"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "utC") // utc3
+"1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") // date25
-"Friday, Jun yyy 03, 1983"
+>> Text(30470.769531251, "utC") // excelUtc3
+"1983-06-03T18:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") // date25b
-"Friday, Jun YYY 03, 1983"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "uTc") // utc4
+"1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date26
-"Friday, Jun yyy 03, mmm 1983"
+>> Text(30470.519531251, "uTc") // excelUtc4
+"1983-06-03T12:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date27
-"ddd Friday, Jun yyy 03, mmm 1983"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "UTC") // utc5
+"1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") // date27b
-"ddd Friday, Jun yyy 03, mmm 1983"
+>> Text(30470.269531251, "UTC") // excelUtc5
+"1983-06-03T06:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") // date28
-"Friday, Jun carrymeforward 03, 1983"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), " utc ") // utc6
+" 1983-06-03T02:53:09.000Z "
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") // date28b
-"Friday, Jun carrymeforward 03, 1983"
+>> Text(30470.519531251, " utc ") // excelUtc6
+" 1983-06-03T12:28:07.500Z "
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") // date29
-"Friday, Juncarrymeforward03, mmm 1983"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "utc utc") // utc6bis
+"1983-06-03T02:53:09.000Z 1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") // date29
-"Friday, Juncarrymeforward03, MMM 1983"
+>> Text(30470.019531251, "utc utc") // excelUtc6bis
+"1983-06-03T00:28:07.500Z 1983-06-03T00:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") // time26
-"02:53:09.123"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss.fffutc") // utc7
+"hh:mm:ss.fff1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") // time26b
-"02:53:09.123"
+>> Text(30470.519531251, "hh:mm:ss.fffutc") // excelUtc7
+"hh:mm:ss.fff1983-06-03T12:28:07.500Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") // time27
-"02:53:09.ff"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s.futc") // utc8
+"hh:mm:s.f1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") // time27b
-"02:53:09.12"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mmutc") // utc9
+"hh:mm1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") // time28
-"02:53:09.f"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ssutc") // utc10
+"mm:ss1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") // time28b
-"02:53:09.1"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hhutc") // utc11
+"mm:hh1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") // time29
-"02:53:09.fff"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mmutc") // utc12
+"hh:yyyy:mm1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") // time29b
-"02:53:09.013"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/putc") // utc13
+"ha/p1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") // time30
-"02:53:09.ff"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/putc") // utc14
+"hha/p1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") // time30b
-"02:53:09.01"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PMutc") // utc15
+"hAM/PM1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") // time31
-"02:53:09.f"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PMutc") // utc16
+"hhAM/PM1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") // time31b
-"02:53:09.0"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/putc") // utc17
+"h:mm a/p1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") // time32
-"02:53:09.fff"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/putc") // utc18
+"hh:mm a/p1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") // time32b
-"02:53:09.003"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PMutc") // utc19
+"h:mm AM/PM1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") // time33
-"02:53:09.ff"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PMutc") // utc20
+"hh:mm AM/PM1983-06-03T02:53:09.000Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") // time33b
-"02:53:09.00"
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PMutc") // utc21
+"hh:mm:ss AM/PM2013-06-19T10:48:38.100Z"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") // time34
-"02:53:09.f"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "utchh:mm:ss") // utc22
+"1983-06-03T02:53:09.000Zhh:mm:ss"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") // time34b
-"02:53:09.0"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ssutchh:mm:ss") // utc23
+"hh:mm:ss1983-06-03T02:53:09.000Zhh:mm:ss"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") // time35
-"53:09.fff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") // time35b
-"53:09.123"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") // time36
-"53:09.ff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") // time36b
-"53:09.12"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") // time37
-"53:09.f"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") // time37b
-"53:09.1"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") // time38
-"53:09.fff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") // time38b
-"53:09.013"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") // time39
-"53:09.ff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") // time39b
-"53:09.01"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") // time40
-"53:09.f"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") // time40b
-"53:09.0"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") // time41
-"53:09.fff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") // time41b
-"53:09.003"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") // time42
-"53:09.ff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") // time42b
-"53:09.00"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") // time43
-"53:09.f"
-
->> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0") // time44b
-"30471"
-
->> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0.00") // time44c
-"30470.75"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") // time49
-"Thursday, January 1, 1970 14:32:25"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") // time50
-"1/1/1970 14:32"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") // time51
-"14:32:25"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") // time52
-"14:32"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") // time55
-"long1ateti1e"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") // time56
-"2514ort1ateti1e"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") // time57
-"long1ateti1e24"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") // time58
-"2514ort1ateti1e24"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") // time59
-"longti1e24"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") // time60
-"2514ortti32e24"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") // time61
-"longti1e"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") // time62
-"2514ortti32e"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") // time63
-"h Friday, Jun 03, 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") // time64
-"Friday, Jun h 03, 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") // time65
-"Friday, Jun 03, 1983 h"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") // time66
-"Friday, Jun h. 03, 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") // time67
-"Friday, Jun hh:mm 03, 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // time68
-"Friday, Jun hh.m 03, mm.f 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // time69
-"hh Friday, Jun mm 03, fff 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") // time70
-"Friday, Jun carrymefforward 03, 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // time71
-"Friday, Juncarrymefforward03, fff 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") // time72
-"Jun [some*] 03 (de)+ 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") // time73
-"Jun ([][^]*[""]) 03 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") // time74
-"Jun ([][^]*[]) 03 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") // time75
-"Jun ([][^]*[])"" 03 1983"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") // datetime1
-"1983-06-03 02:53:09.fff"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") // datetime1b
-"1983-06-03 02:53:09.123"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") // datetime2
-"1983-06-03 02:53:09.123"
-
->> Text(0, "mm/dd/yy") // excelDate1
-"12/30/99"
-
->> Text(0, "mmm mm/dd/yy") // excelDate2
-"Dec 12/30/99"
-
->> Text(0, "mmmm mm/dd/yy") // excelDate3
-"December 12/30/99"
-
->> Text(0, "ddd mm/dd/yy") // excelDate4
-"Sat 12/30/99"
-
->> Text(0, "dddd mm/dd/yy") // excelDate5
-"Saturday 12/30/99"
-
->> Text(0, "dddd, mmm dd, yy") // excelDate6
-"Saturday, Dec 30, 99"
-
->> Text(0, "dddd, mmm dd, yyy") // excelDate7
-"Saturday, Dec 30, 1899"
-
->> Text(0, "dddd, mmm dd, yyyy") // excelDate8
-"Saturday, Dec 30, 1899"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy") // date9b
-"Friday, Jun 03, 1983"
-
->> Text(30470, "dddd, mmm dd, yyy") // excelDate9
-"Friday, Jun 03, 1983"
-
->> Text(0, "'longdate'") // excelDate12
-"Saturday, December 30, 1899"
-
->> Text(0, "'shortdate'") // excelDate13
-"12/30/1899"
-
->> Text(0, "longdate") // excelDate14
-"long30ate"
-
->> Text(0, "shortdate") // excelDate15
-"00ort30ate"
-
->> Text(0, "short day") // excelDate16
-"00ort 30a99"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") // date17
-"Friday, Jun "" 03, 1983"
-
->> Text(30470, "DDDD, MMM "" DD, YYY") // excelDate17
-"Friday, Jun "" 03, 1983"
-
->> Text(30470, "DDDD, MMM"""" DD, YYY") // excelDate19
-"Friday, Jun 03, 1983"
-
->> Text(30470, "DDDD, MMM""""DD, YYY") // excelDate20
-"Friday, Jun03, 1983"
-
->> Text(30470, """D"" DDDD, MMM DD, YYY") // excelDate21
-"D Friday, Jun 03, 1983"
-
->> Text(33333.75, "'longdatetime'") // excelTime47
-"Friday, April 5, 1991 6:00:00 PM"
-
->> Text(33333.75, "'shortdatetime'") // excelTime48
-"4/5/1991 6:00 PM"
-
->> Text(33333.75, "'longdatetime24'") // excelTime49
-"Friday, April 5, 1991 18:00:00"
-
->> Text(0.6875, "'longtime24'") // excelTime51
-"16:30:00"
-
->> Text(0.6875, "'shorttime24'") // excelTime52
-"16:30"
-
->> Text(12345.6875, "'longtime'") // excelTime53
-"4:30:00 PM"
-
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") // time54
-"2:32 PM"
-
->> Text(33333.6875, "'shorttime'") // excelTime54
-"4:30 PM"
-
->> Text(30470, """h"" dddd, mmm dd, yyy") // excelTime63
-"h Friday, Jun 03, 1983"
-
->> Text(30470, "dddd, mmm ""h"" dd, yyy") // excelTime64
-"Friday, Jun h 03, 1983"
-
->> Text(30470, "dddd, mmm dd, yyy ""h""") // excelTime65
-"Friday, Jun 03, 1983 h"
-
->> Text(30470, "dddd, mmm ""h."" dd, yyy") // excelTime66
-"Friday, Jun h. 03, 1983"
-
->> Text(30470, "dddd, mmm ""hh:mm"" dd, yyy") // excelTime67
-"Friday, Jun hh:mm 03, 1983"
-
->> Text(30470, "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // excelTime68
-"Friday, Jun hh.m 03, mm.f 1983"
-
->> Text(30470, """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // excelTime69
-"hh Friday, Jun mm 03, fff 1983"
-
->> Text(30470, "dddd, mmm ""carrymefforward"" dd, yyy") // excelTime70
-"Friday, Jun carrymefforward 03, 1983"
-
->> Text(30470, "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // excelTime71
-"Friday, Juncarrymefforward03, fff 1983"
-
->> Text(30470, "mmm ""[some*]"" dd ""(de)+"" yyyy") // excelTime72
-"Jun [some*] 03 (de)+ 1983"
-
->> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") // excelTime73
-"Jun ([][^]*[""]) 03 1983"
-
->> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") // excelTime74
-"Jun ([][^]*[]) 03 1983"
-
->> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") // excelTime75
-"Jun ([][^]*[])"" 03 1983"
-
->> Text(30470, "mmm ""[de]+de"" dd yyyy") // excelTime76
-"Jun [de]+de 03 1983"
-
->> Text(30470.01953125, "yyyy-mm-dd HH:mm:ss.000") // excelDatetime1b
-"1983-06-03 00:28:07.500"
-
->> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000") // excelDatetime2
-"1983-06-03 00:28:07.500"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Time: utc is in ISO format") // utc24
+"Time: 1983-06-03T02:53:09.000Z is in ISO format"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -527,6 +527,5 @@
   "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
 Error({Kind:ErrorKind.Custom})
 
-// !JYL! Need a more precise error message?
 >> Text(1, "00.00 dd-mm-yyyy")
 Errors: Error 0-27: The function 'Text' has some invalid arguments.|Error 8-26: Incorrect format specifier for 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -1,0 +1,200 @@
+﻿>> Text(DateTime(2022,12,1,23,45,59), "YYYY-MM-DD HH:MM:SS AM/PM")
+"2022-12-01 11:45:59 PM"
+
+>> Text(DateTime(2022,12,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM")
+"2022-12-01 11:45:59 PM"
+
+>> Text(DateTime(2022,12,1,23,45,59), "YYYY-MM-DD HH:MM:SS A/P")
+"2022-12-01 11:45:59 P"
+
+>> Text(DateTime(2022,12,1,23,45,59), "YYYY-MM-DD HH:MM:SS a/pa/p")
+"2022-12-01 11:45:59 PM"
+
+>> Text(DateTime(2022,12,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss")
+"2022-12-01 23:45:59"
+
+>> Text(DateTime(2022,12,1,23,45,59), "yY-m-d h:M:Ss")
+"22-12-1 23:45:59"
+
+>> Text(DateTime(2022,12,1,23,5,9), "yY-m-d h:M:S")
+"22-12-1 23:5:9"
+
+>> Text(DateTime(2022,1,1,23,45,59), "MM MM MM:SS M")
+"01 01 45:59 1"
+
+>> Text(DateTime(2022,1,1,23,45,59), "mm mm H:m m")
+"01 01 23:45 1"
+
+>> Text(DateTime(2022,12,1,23,45,59), "mmmm H:m m")
+"December 23:45 12"
+
+>> Text(DateTime(2022,12,1,23,45,59), "mmmm")
+"December"
+
+>> Text(DateTime(2022,12,1,23,45,59), "mmm")
+"Dec"
+
+>> Text(DateTime(2022,12,1,23,45,59), "mm")
+"12"
+
+>> Text(DateTime(2022,12,1,23,45,59), "m")
+"12"
+
+>> Text(DateTime(2022,1,1,23,45,59), "m")
+"1"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") // date18
+"Friday, Jun  03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") // date19
+"Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") // date20
+"Friday, Jun03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") // date21
+"d Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") // date22
+"Friday, Jun d 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") // time1
+"02:53:09"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") // time1b
+"02:53:09"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") // time1c
+"02:53:09"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") // time1d
+"02:53:09"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") // time2
+"02:53:9"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") // time2b
+"02:53:9"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") // time3
+"02:53"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") // time3b
+"02:53"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") // time4
+"53:09"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") // time4b
+"53:09"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") // time5
+"06:02"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") // time5b
+"06:02"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") // time6
+"02:1983:06"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") // time6b
+"02:1983:06"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") // time7
+"2A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") // time7b
+"2A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") // time8
+"02A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") // time8b
+"02A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") // time9
+"2AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") // time9b
+"2AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") // time10
+"02AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") // time10b
+"02AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") // time11
+"2:53 A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") // time11b
+"2:53 A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") // time12
+"02:53 A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") // time12b
+"02:53 A"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") // time13
+"2:53 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") // time13b
+"2:53 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") // time14
+"02:53 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") // time14b
+"02:53 AM"
+
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") // time15
+"10:48:38 AM"
+
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") // time15b
+"10:48:38 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") // time18
+"2:53:09 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") // time19
+"02:53:09 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") // time20
+"02:53:09 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") // time21
+"02:53:09 AM"
+
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") // time22
+"10:48:38 AM"
+
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") // time23
+"10:48:38 AM"
+
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") // time24
+"10:48:38 AM"
+
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") // time25
+"10:48:38 AM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") // time43b
+"53:09.0"
+
+>> Text(423456789013, "0") // not-time45c
+"423456789013"
+
+>> Text(423456789003, "0") // not-time46c
+"423456789003"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") // time47
+"Thursday, January 1, 1970 2:32:25 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") // time48
+"1/1/1970 2:32 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") // time53
+"2:32:25 PM"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") // time76
+"Jun [de]+de 03 1983"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -1,531 +1,537 @@
-﻿>> Text(0, "mm/dd/yy") // excelDate1
+﻿>> Text(0, "mm/dd/yy") 
 "12/30/99"
 
->> Text(0, "mmm mm/dd/yy") // excelDate2
+>> Text(0, "mmm mm/dd/yy") 
 "Dec 12/30/99"
 
->> Text(0, "mmmm mm/dd/yy") // excelDate3
+>> Text(0, "mmmm mm/dd/yy") 
 "December 12/30/99"
 
->> Text(0, "ddd mm/dd/yy") // excelDate4
+>> Text(0, "ddd mm/dd/yy") 
 "Sat 12/30/99"
 
->> Text(0, "dddd mm/dd/yy") // excelDate5
+>> Text(0, "dddd mm/dd/yy") 
 "Saturday 12/30/99"
 
->> Text(0, "dddd, mmm dd, yy") // excelDate6
+>> Text(0, "dddd, mmm dd, yy") 
 "Saturday, Dec 30, 99"
 
->> Text(0, "dddd, mmm dd, yyy") // excelDate7
+>> Text(0, "dddd, mmm dd, yyy") 
 "Saturday, Dec 30, 1899"
 
->> Text(0, "dddd, mmm dd, yyyy") // excelDate8
+>> Text(0, "dddd, mmm dd, yyyy") 
 "Saturday, Dec 30, 1899"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy") // date9b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy") 
 "Friday, Jun 03, 1983"
 
->> Text(30470, "dddd, mmm dd, yyy") // excelDate9
+>> Text(30470, "dddd, mmm dd, yyy") 
 "Friday, Jun 03, 1983"
 
->> Text(0, "'longdate'") // excelDate12
+>> Text(0, "'longdate'") 
 "Saturday, December 30, 1899"
 
->> Text(0, "'shortdate'") // excelDate13
+>> Text(0, "'shortdate'") 
 "12/30/1899"
 
->> Text(0, "longdate") // excelDate14
+>> Text(0, "longdate") 
 "long30ate"
 
->> Text(0, "shortdate") // excelDate15
+>> Text(0, "shortdate") 
 "00ort30ate"
 
->> Text(0, "short day") // excelDate16
+>> Text(0, "short day") 
 "00ort 30a99"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") // date17
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") 
 "Friday, Jun "" 03, 1983"
 
->> Text(30470, "DDDD, MMM "" DD, YYY") // excelDate17
+>> Text(30470, "DDDD, MMM "" DD, YYY") 
 "Friday, Jun "" 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") // date18
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") 
 "Friday, Jun  03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") // date19
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") 
 "Friday, Jun 03, 1983"
 
->> Text(30470, "DDDD, MMM"""" DD, YYY") // excelDate19
+>> Text(30470, "DDDD, MMM"""" DD, YYY") 
 "Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") // date20
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") 
 "Friday, Jun03, 1983"
 
->> Text(30470, "DDDD, MMM""""DD, YYY") // excelDate20
+>> Text(30470, "DDDD, MMM""""DD, YYY") 
 "Friday, Jun03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") // date21
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") 
 "d Friday, Jun 03, 1983"
 
->> Text(30470, """D"" DDDD, MMM DD, YYY") // excelDate21
+>> Text(30470, """D"" DDDD, MMM DD, YYY") 
 "D Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") // date22
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") 
 "Friday, Jun d 03, 1983"
 
->> Text(30470, "DDDD, MMM ""D"" DD, YYY") // excelDate22
+>> Text(30470, "DDDD, MMM ""D"" DD, YYY") 
 "Friday, Jun D 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") // date22c
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") 
 "Friday, Jun D 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") // date23
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") 
 "Friday, Jun 03, 1983 d"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") // date23b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") 
 "Friday, Jun 03, 1983 D"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") // date24
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") 
 "Friday, Jun d. 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") // date25
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") 
 "Friday, Jun yyy 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") // date25b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") 
 "Friday, Jun YYY 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date26
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") 
 "Friday, Jun yyy 03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date27
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") 
 "ddd Friday, Jun yyy 03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") // date27b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") 
 "ddd Friday, Jun yyy 03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") // date28
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") 
 "Friday, Jun carrymeforward 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") // date28b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") 
 "Friday, Jun carrymeforward 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") // date29
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") 
 "Friday, Juncarrymeforward03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") // date29
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") 
 "Friday, Juncarrymeforward03, MMM 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") // time1
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") // time1b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") // time1c
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") // time1d
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") // time2
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") 
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") // time2b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") 
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") // time3
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") 
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") // time3b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") 
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") // time4
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") 
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") // time4b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") 
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") // time5
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") 
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") // time5b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") 
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") // time6
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") 
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") // time6b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") 
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") // time7
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") 
 "2a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") // time7b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") 
 "2a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") // time8
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") 
 "02a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") // time8b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") 
 "02a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") // time9
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") 
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") // time9b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") 
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") // time10
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") 
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") // time10b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") 
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") // time11
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") 
 "2:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") // time11b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") 
 "2:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") // time12
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") 
 "02:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") // time12b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") 
 "02:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") // time13
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") 
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") // time13b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") 
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") // time14
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") 
 "02:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") // time14b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") 
 "02:53 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") // time15
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") // time15b
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") // time18
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") 
 "2:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") // time19
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") 
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") // time20
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") 
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") // time21
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") 
 "02:53:09 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") // time22
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") // time23
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") // time24
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") // time25
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") // time26
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") 
 "02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") // time26b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") 
 "02:53:09.123"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") // time27
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") 
 "02:53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") // time27b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") 
 "02:53:09.12"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") // time28
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") 
 "02:53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") // time28b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") 
 "02:53:09.1"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") // time29
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") 
 "02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") // time29b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") 
 "02:53:09.013"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") // time30
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") 
 "02:53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") // time30b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") 
 "02:53:09.01"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") // time31
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") 
 "02:53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") // time31b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") 
 "02:53:09.0"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") // time32
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") 
 "02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") // time32b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") 
 "02:53:09.003"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") // time33
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") 
 "02:53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") // time33b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") 
 "02:53:09.00"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") // time34
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") 
 "02:53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") // time34b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") 
 "02:53:09.0"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") // time35
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") 
 "53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") // time35b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") 
 "53:09.123"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") // time36
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") 
 "53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") // time36b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") 
 "53:09.12"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") // time37
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") 
 "53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") // time37b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") 
 "53:09.1"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") // time38
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") 
 "53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") // time38b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") 
 "53:09.013"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") // time39
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") 
 "53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") // time39b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") 
 "53:09.01"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") // time40
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") 
 "53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") // time40b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") 
 "53:09.0"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") // time41
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") 
 "53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") // time41b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") 
 "53:09.003"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") // time42
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") 
 "53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") // time42b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") 
 "53:09.00"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") // time43
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") 
 "53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") // time43b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") 
 "53:09.0"
 
->> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0") // time44b
+>> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0") 
 "30471"
 
->> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0.00") // time44c
+>> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0.00") 
 "30470.75"
 
->> Text(423456789013, "0") // not-time45c
+>> Text(423456789013, "0")
 "423456789013"
 
->> Text(423456789003, "0") // not-time46c
+>> Text(423456789003, "0")
 "423456789003"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") // time47
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") 
 "Thursday, January 1, 1970 2:32:25 PM"
 
->> Text(33333.75, "'longdatetime'") // excelTime47
+>> Text(33333.75, "'longdatetime'") 
 "Friday, April 5, 1991 6:00:00 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") // time48
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") 
 "1/1/1970 2:32 PM"
 
->> Text(33333.75, "'shortdatetime'") // excelTime48
+>> Text(33333.75, "'shortdatetime'") 
 "4/5/1991 6:00 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") // time49
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") 
 "Thursday, January 1, 1970 14:32:25"
 
->> Text(33333.75, "'longdatetime24'") // excelTime49
+>> Text(33333.75, "'longdatetime24'") 
 "Friday, April 5, 1991 18:00:00"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") // time50
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") 
 "1/1/1970 14:32"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") // time51
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") 
 "14:32:25"
 
->> Text(0.6875, "'longtime24'") // excelTime51
+>> Text(0.6875, "'longtime24'") 
 "16:30:00"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") // time52
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") 
 "14:32"
 
->> Text(0.6875, "'shorttime24'") // excelTime52
+>> Text(0.6875, "'shorttime24'") 
 "16:30"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") // time53
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") 
 "2:32:25 PM"
 
->> Text(12345.6875, "'longtime'") // excelTime53
+>> Text(12345.6875, "'longtime'") 
 "4:30:00 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") // time54
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") 
 "2:32 PM"
 
->> Text(33333.6875, "'shorttime'") // excelTime54
+>> Text(33333.6875, "'shorttime'") 
 "4:30 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") // time55
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") 
 "long1ateti1e"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") // time56
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") 
 "2514ort1ateti1e"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") // time57
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") 
 "long1ateti1e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") // time58
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") 
 "2514ort1ateti1e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") // time59
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") 
 "longti1e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") // time60
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") 
 "2514ortti32e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") // time61
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") 
 "longti1e"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") // time62
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") 
 "2514ortti32e"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") // time63
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") 
 "h Friday, Jun 03, 1983"
 
->> Text(30470, """h"" dddd, mmm dd, yyy") // excelTime63
+>> Text(30470, """h"" dddd, mmm dd, yyy") 
 "h Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") // time64
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") 
 "Friday, Jun h 03, 1983"
 
->> Text(30470, "dddd, mmm ""h"" dd, yyy") // excelTime64
+>> Text(30470, "dddd, mmm ""h"" dd, yyy") 
 "Friday, Jun h 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") // time65
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") 
 "Friday, Jun 03, 1983 h"
 
->> Text(30470, "dddd, mmm dd, yyy ""h""") // excelTime65
+>> Text(30470, "dddd, mmm dd, yyy ""h""") 
 "Friday, Jun 03, 1983 h"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") // time66
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") 
 "Friday, Jun h. 03, 1983"
 
->> Text(30470, "dddd, mmm ""h."" dd, yyy") // excelTime66
+>> Text(30470, "dddd, mmm ""h."" dd, yyy") 
 "Friday, Jun h. 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") // time67
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") 
 "Friday, Jun hh:mm 03, 1983"
 
->> Text(30470, "dddd, mmm ""hh:mm"" dd, yyy") // excelTime67
+>> Text(30470, "dddd, mmm ""hh:mm"" dd, yyy") 
 "Friday, Jun hh:mm 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // time68
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") 
 "Friday, Jun hh.m 03, mm.f 1983"
 
->> Text(30470, "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // excelTime68
+>> Text(30470, "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") 
 "Friday, Jun hh.m 03, mm.f 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // time69
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") 
 "hh Friday, Jun mm 03, fff 1983"
 
->> Text(30470, """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // excelTime69
+>> Text(30470, """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") 
 "hh Friday, Jun mm 03, fff 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") // time70
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") 
 "Friday, Jun carrymefforward 03, 1983"
 
->> Text(30470, "dddd, mmm ""carrymefforward"" dd, yyy") // excelTime70
+>> Text(30470, "dddd, mmm ""carrymefforward"" dd, yyy") 
 "Friday, Jun carrymefforward 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // time71
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") 
 "Friday, Juncarrymefforward03, fff 1983"
 
->> Text(30470, "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // excelTime71
+>> Text(30470, "dddd, mmm""carrymefforward""dd, ""fff"" yyy") 
 "Friday, Juncarrymefforward03, fff 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") // time72
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") 
 "Jun [some*] 03 (de)+ 1983"
 
->> Text(30470, "mmm ""[some*]"" dd ""(de)+"" yyyy") // excelTime72
+>> Text(30470, "mmm ""[some*]"" dd ""(de)+"" yyyy") 
 "Jun [some*] 03 (de)+ 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") // time73
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") 
 "Jun ([][^]*[""]) 03 1983"
 
->> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") // excelTime73
+>> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") 
 "Jun ([][^]*[""]) 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") // time74
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") 
 "Jun ([][^]*[]) 03 1983"
 
->> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") // excelTime74
+>> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") 
 "Jun ([][^]*[]) 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") // time75
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") 
 "Jun ([][^]*[])"" 03 1983"
 
->> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") // excelTime75
+>> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") 
 "Jun ([][^]*[])"" 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") // time76
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") 
 "Jun [de]+de 03 1983"
 
->> Text(30470, "mmm ""[de]+de"" dd yyyy") // excelTime76
+>> Text(30470, "mmm ""[de]+de"" dd yyyy") 
 "Jun [de]+de 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") // datetime1
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") 
 "1983-06-03 02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") // datetime1b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") 
 "1983-06-03 02:53:09.123"
 
->> Text(30470.01953125, "yyyy-mm-dd HH:mm:ss.000") // excelDatetime1b
+>> Text(30470.01953125, "yyyy-mm-dd HH:mm:ss.000") 
 "1983-06-03 00:28:07.500"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") // datetime2
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") 
 "1983-06-03 02:53:09.123"
 
->> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000") // excelDatetime2
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000") 
 "1983-06-03 00:28:07.500"
 
 >> Text(1, 
   "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
-Error({Kind:ErrorKind.Custom})
+Error({Kind:ErrorKind.InvalidArgument})
 
 >> Text(1, "00.00 dd-mm-yyyy")
 Errors: Error 0-27: The function 'Text' has some invalid arguments.|Error 8-26: Incorrect format specifier for 'Text'.
+
+>> Text(1, "M#")
+Errors: Error 0-13: The function 'Text' has some invalid arguments.|Error 8-12: Incorrect format specifier for 'Text'.
+
+>> Text(1, "M""#""")
+false

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -1,383 +1,532 @@
-﻿>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") 
-"Friday, Jun "" 03, 1983"
+﻿>> Text(0, "mm/dd/yy") // excelDate1
+"12/30/99"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") 
-"Friday, Jun  03, 1983"
+>> Text(0, "mmm mm/dd/yy") // excelDate2
+"Dec 12/30/99"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") 
+>> Text(0, "mmmm mm/dd/yy") // excelDate3
+"December 12/30/99"
+
+>> Text(0, "ddd mm/dd/yy") // excelDate4
+"Sat 12/30/99"
+
+>> Text(0, "dddd mm/dd/yy") // excelDate5
+"Saturday 12/30/99"
+
+>> Text(0, "dddd, mmm dd, yy") // excelDate6
+"Saturday, Dec 30, 99"
+
+>> Text(0, "dddd, mmm dd, yyy") // excelDate7
+"Saturday, Dec 30, 1899"
+
+>> Text(0, "dddd, mmm dd, yyyy") // excelDate8
+"Saturday, Dec 30, 1899"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy") // date9b
 "Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") 
+>> Text(30470, "dddd, mmm dd, yyy") // excelDate9
+"Friday, Jun 03, 1983"
+
+>> Text(0, "'longdate'") // excelDate12
+"Saturday, December 30, 1899"
+
+>> Text(0, "'shortdate'") // excelDate13
+"12/30/1899"
+
+>> Text(0, "longdate") // excelDate14
+"long30ate"
+
+>> Text(0, "shortdate") // excelDate15
+"00ort30ate"
+
+>> Text(0, "short day") // excelDate16
+"00ort 30a99"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") // date17
+"Friday, Jun "" 03, 1983"
+
+>> Text(30470, "DDDD, MMM "" DD, YYY") // excelDate17
+"Friday, Jun "" 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") // date18
+"Friday, Jun  03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") // date19
+"Friday, Jun 03, 1983"
+
+>> Text(30470, "DDDD, MMM"""" DD, YYY") // excelDate19
+"Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") // date20
 "Friday, Jun03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") 
+>> Text(30470, "DDDD, MMM""""DD, YYY") // excelDate20
+"Friday, Jun03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") // date21
 "d Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") 
+>> Text(30470, """D"" DDDD, MMM DD, YYY") // excelDate21
+"D Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") // date22
 "Friday, Jun d 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") 
+>> Text(30470, "DDDD, MMM ""D"" DD, YYY") // excelDate22
 "Friday, Jun D 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") // date22c
+"Friday, Jun D 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") // date23
 "Friday, Jun 03, 1983 d"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") // date23b
 "Friday, Jun 03, 1983 D"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") // date24
 "Friday, Jun d. 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") // date25
 "Friday, Jun yyy 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") // date25b
 "Friday, Jun YYY 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date26
 "Friday, Jun yyy 03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") // date27
 "ddd Friday, Jun yyy 03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") // date27b
 "ddd Friday, Jun yyy 03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") // date28
 "Friday, Jun carrymeforward 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") // date28b
 "Friday, Jun carrymeforward 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") // date29
 "Friday, Juncarrymeforward03, mmm 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") // date29
 "Friday, Juncarrymeforward03, MMM 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") // time1
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") // time1b
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") // time1c
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") // time1d
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") // time2
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") // time2b
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") // time3
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") // time3b
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") // time4
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") // time4b
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") // time5
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") // time5b
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") // time6
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") // time6b
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") // time7
 "2a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") // time7b
 "2a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") // time8
 "02a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") // time8b
 "02a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") // time9
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") // time9b
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") // time10
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") // time10b
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") // time11
 "2:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") // time11b
 "2:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") // time12
 "02:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") // time12b
 "02:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") // time13
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") // time13b
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") // time14
 "02:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") // time14b
 "02:53 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") 
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") // time15
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") 
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") // time15b
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") // time18
 "2:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") // time19
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") // time20
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") // time21
 "02:53:09 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") 
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") // time22
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") 
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") // time23
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") 
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") // time24
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") 
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") // time25
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") // time26
 "02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") // time26b
 "02:53:09.123"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") // time27
 "02:53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") // time27b
 "02:53:09.12"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") // time28
 "02:53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") // time28b
 "02:53:09.1"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") // time29
 "02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") // time29b
 "02:53:09.013"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") // time30
 "02:53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") // time30b
 "02:53:09.01"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") // time31
 "02:53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") // time31b
 "02:53:09.0"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") // time32
 "02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") // time32b
 "02:53:09.003"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") // time33
 "02:53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") // time33b
 "02:53:09.00"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") // time34
 "02:53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") // time34b
 "02:53:09.0"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") // time35
 "53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") // time35b
 "53:09.123"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") // time36
 "53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") // time36b
 "53:09.12"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") // time37
 "53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") // time37b
 "53:09.1"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") // time38
 "53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") // time38b
 "53:09.013"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") // time39
 "53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") // time39b
 "53:09.01"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") // time40
 "53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") // time40b
 "53:09.0"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") // time41
 "53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") // time41b
 "53:09.003"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") // time42
 "53:09.ff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") // time42b
 "53:09.00"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") // time43
 "53:09.f"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") // time43b
 "53:09.0"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") 
+>> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0") // time44b
+"30471"
+
+>> Text(DateTime(1983, 6, 3, 18, 0, 0, 0), "0.00") // time44c
+"30470.75"
+
+>> Text(423456789013, "0") // not-time45c
+"423456789013"
+
+>> Text(423456789003, "0") // not-time46c
+"423456789003"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") // time47
 "Thursday, January 1, 1970 2:32:25 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") 
+>> Text(33333.75, "'longdatetime'") // excelTime47
+"Friday, April 5, 1991 6:00:00 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") // time48
 "1/1/1970 2:32 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") 
+>> Text(33333.75, "'shortdatetime'") // excelTime48
+"4/5/1991 6:00 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") // time49
 "Thursday, January 1, 1970 14:32:25"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") 
+>> Text(33333.75, "'longdatetime24'") // excelTime49
+"Friday, April 5, 1991 18:00:00"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") // time50
 "1/1/1970 14:32"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") // time51
 "14:32:25"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") 
+>> Text(0.6875, "'longtime24'") // excelTime51
+"16:30:00"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") // time52
 "14:32"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") 
+>> Text(0.6875, "'shorttime24'") // excelTime52
+"16:30"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") // time53
 "2:32:25 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") 
+>> Text(12345.6875, "'longtime'") // excelTime53
+"4:30:00 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") // time54
 "2:32 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") 
+>> Text(33333.6875, "'shorttime'") // excelTime54
+"4:30 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") // time55
 "long1ateti1e"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") // time56
 "2514ort1ateti1e"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") // time57
 "long1ateti1e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") // time58
 "2514ort1ateti1e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") // time59
 "longti1e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") // time60
 "2514ortti32e24"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") // time61
 "longti1e"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") 
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") // time62
 "2514ortti32e"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") // time63
 "h Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") 
+>> Text(30470, """h"" dddd, mmm dd, yyy") // excelTime63
+"h Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") // time64
 "Friday, Jun h 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") 
+>> Text(30470, "dddd, mmm ""h"" dd, yyy") // excelTime64
+"Friday, Jun h 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") // time65
 "Friday, Jun 03, 1983 h"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") 
+>> Text(30470, "dddd, mmm dd, yyy ""h""") // excelTime65
+"Friday, Jun 03, 1983 h"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") // time66
 "Friday, Jun h. 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") 
+>> Text(30470, "dddd, mmm ""h."" dd, yyy") // excelTime66
+"Friday, Jun h. 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") // time67
 "Friday, Jun hh:mm 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") 
+>> Text(30470, "dddd, mmm ""hh:mm"" dd, yyy") // excelTime67
+"Friday, Jun hh:mm 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // time68
 "Friday, Jun hh.m 03, mm.f 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") 
+>> Text(30470, "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") // excelTime68
+"Friday, Jun hh.m 03, mm.f 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // time69
 "hh Friday, Jun mm 03, fff 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") 
+>> Text(30470, """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") // excelTime69
+"hh Friday, Jun mm 03, fff 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") // time70
 "Friday, Jun carrymefforward 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") 
+>> Text(30470, "dddd, mmm ""carrymefforward"" dd, yyy") // excelTime70
+"Friday, Jun carrymefforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // time71
 "Friday, Juncarrymefforward03, fff 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") 
+>> Text(30470, "dddd, mmm""carrymefforward""dd, ""fff"" yyy") // excelTime71
+"Friday, Juncarrymefforward03, fff 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") // time72
 "Jun [some*] 03 (de)+ 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") 
+>> Text(30470, "mmm ""[some*]"" dd ""(de)+"" yyyy") // excelTime72
+"Jun [some*] 03 (de)+ 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") // time73
 "Jun ([][^]*[""]) 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") 
+>> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") // excelTime73
+"Jun ([][^]*[""]) 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") // time74
 "Jun ([][^]*[]) 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") 
+>> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") // excelTime74
+"Jun ([][^]*[]) 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") // time75
 "Jun ([][^]*[])"" 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") 
+>> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") // excelTime75
+"Jun ([][^]*[])"" 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") // time76
 "Jun [de]+de 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") 
+>> Text(30470, "mmm ""[de]+de"" dd yyyy") // excelTime76
+"Jun [de]+de 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") // datetime1
 "1983-06-03 02:53:09.fff"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") 
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") // datetime1b
 "1983-06-03 02:53:09.123"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") 
+>> Text(30470.01953125, "yyyy-mm-dd HH:mm:ss.000") // excelDatetime1b
+"1983-06-03 00:28:07.500"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") // datetime2
 "1983-06-03 02:53:09.123"
+
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000") // excelDatetime2
+"1983-06-03 00:28:07.500"
+
+>> Text(1, 
+  "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
+Error({Kind:ErrorKind.Custom})
+
+// !JYL! Need a more precise error message?
+>> Text(1, "00.00 dd-mm-yyyy")
+Errors: Error 0-27: The function 'Text' has some invalid arguments.|Error 8-26: Incorrect format specifier for 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -532,3 +532,69 @@ Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 8-26
 
 >> Text(1, "M#")
 Errors: Error 0-13: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.
+
+>> Text(Time(2, 53, 9, 3), "mm:ss.00") 
+"53:09.00"
+
+>> Text(Time(2, 53, 9, 123), "hh:mm:ss.00") 
+"02:53:09.12"
+
+>> Text(Time(18, 0, 0), "0.00")
+"0.75"
+
+>> Text(Time(14, 32, 25, 678), "'shorttime24'") 
+"14:32"
+
+>> Text(Time(14, 32, 25, 678), DateTimeFormat.ShortTime24)
+"14:32"
+
+>> Text(Time(14, 32, 25, 678), "'shorttime'") 
+"2:32 PM"
+
+>> Text(Time(14, 32, 25, 678), DateTimeFormat.ShortTime) 
+"2:32 PM"
+
+>> Text(Date(1983, 6, 3), "dddd, mmm dd, yyy") 
+"Friday, Jun 03, 1983"
+
+>> Text(Date(1983, 6, 3), "dddd, mmm "" dd, yyy") 
+"Friday, Jun "" 03, 1983"
+
+>> Text(Date(1970, 1, 1), "'shortdate'") 
+"1/1/1970"
+
+>> Text(Date(1970, 1, 1), DateTimeFormat.ShortDate) 
+"1/1/1970"
+
+>> Text(Date(1970, 1, 1), "'shortdatetime'") 
+"1/1/1970 12:00 AM"
+
+>> Text(Date(1970, 1, 1), DateTimeFormat.ShortDateTime) 
+"1/1/1970 12:00 AM"
+
+>> Text(Date(1970, 1, 1), "'shortdatetime24'") 
+"1/1/1970 0:00"
+
+>> Text(Date(1970, 1, 1), DateTimeFormat.ShortDateTime24) 
+"1/1/1970 0:00"
+
+>> Text(Date(1970, 1, 1), "'longdate'") 
+"Thursday, January 1, 1970"
+
+>> Text(Date(1970, 1, 1), DateTimeFormat.LongDate) 
+"Thursday, January 1, 1970"
+
+>> Text(Date(1970, 1, 1), "'longdatetime'") 
+"Thursday, January 1, 1970 12:00:00 AM"
+
+>> Text(Date(1970, 1, 1), DateTimeFormat.LongDateTime) 
+"Thursday, January 1, 1970 12:00:00 AM"
+
+>> Text(Date(1970, 1, 1), "'longdatetime24'") 
+"Thursday, January 1, 1970 0:00:00"
+
+>> Text(Date(1970, 1, 1), DateTimeFormat.LongDateTime24)
+"Thursday, January 1, 1970 0:00:00"
+
+>> With({format:"0.00 dd/mm/yyyy"},Text(123, format))
+Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -43,158 +43,173 @@
 >> Text(DateTime(2022,1,1,23,45,59), "m")
 "1"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") // date18
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy")
 "Friday, Jun  03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") // date19
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy")
 "Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") // date20
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy")
 "Friday, Jun03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") // date21
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy")
 "d Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") // date22
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy")
 "Friday, Jun d 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") // time1
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss")
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") // time1b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS")
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") // time1c
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss")
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") // time1d
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS")
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") // time2
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s")
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") // time2b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S")
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") // time3
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm")
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") // time3b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM")
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") // time4
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss")
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") // time4b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS")
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") // time5
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh")
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") // time5b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH")
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") // time6
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm")
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") // time6b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM")
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") // time7
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p")
 "2A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") // time7b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P")
 "2A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") // time8
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p")
 "02A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") // time8b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P")
 "02A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") // time9
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM")
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") // time9b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM")
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") // time10
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM")
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") // time10b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM")
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") // time11
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p")
 "2:53 A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") // time11b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p")
 "2:53 A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") // time12
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p")
 "02:53 A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") // time12b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p")
 "02:53 A"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") // time13
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM")
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") // time13b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM")
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") // time14
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM")
 "02:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") // time14b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM")
 "02:53 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") // time15
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM")
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") // time15b
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM")
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") // time18
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM")
 "2:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") // time19
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM")
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") // time20
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM")
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") // time21
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM")
 "02:53:09 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") // time22
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM")
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") // time23
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM")
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") // time24
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM")
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") // time25
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM")
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") // time43b
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0")
 "53:09.0"
 
->> Text(423456789013, "0") // not-time45c
+>> Text(423456789013, "0")
 "423456789013"
 
->> Text(423456789003, "0") // not-time46c
+>> Text(423456789003, "0")
 "423456789003"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") // time47
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'")
 "Thursday, January 1, 1970 2:32:25 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") // time48
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'")
 "1/1/1970 2:32 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") // time53
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") 
 "2:32:25 PM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") // time76
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy")
 "Jun [de]+de 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS HH:MM:SS")
+"02:53:09 02:53:09"
+
+>> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Mm:Ss M")
+"2022-02-01 11:45:59 PM 45:59 2"
+
+>> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Hh:Mm M")
+"2022-02-01 11:45:59 PM 11:45 2"
+
+>> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Mm:Ss mM")
+"2022-02-01 11:45:59 PM 45:59 02"
+
+>> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Hh:Mm mm")
+"2022-02-01 11:45:59 PM 11:45 02"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -528,10 +528,7 @@
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> Text(1, "00.00 dd-mm-yyyy")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Error 8-26: Incorrect format specifier for 'Text'.
+Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 8-26: Incorrect format specifier for 'Text'.
 
 >> Text(1, "M#")
-Errors: Error 0-13: The function 'Text' has some invalid arguments.|Error 8-12: Incorrect format specifier for 'Text'.
-
->> Text(1, "M""#""")
-false
+Errors: Error 0-13: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -1,215 +1,383 @@
-﻿>> Text(DateTime(2022,12,1,23,45,59), "YYYY-MM-DD HH:MM:SS AM/PM")
-"2022-12-01 11:45:59 PM"
+﻿>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") 
+"Friday, Jun "" 03, 1983"
 
->> Text(DateTime(2022,12,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM")
-"2022-12-01 11:45:59 PM"
-
->> Text(DateTime(2022,12,1,23,45,59), "YYYY-MM-DD HH:MM:SS A/P")
-"2022-12-01 11:45:59 P"
-
->> Text(DateTime(2022,12,1,23,45,59), "YYYY-MM-DD HH:MM:SS a/pa/p")
-"2022-12-01 11:45:59 PM"
-
->> Text(DateTime(2022,12,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss")
-"2022-12-01 23:45:59"
-
->> Text(DateTime(2022,12,1,23,45,59), "yY-m-d h:M:Ss")
-"22-12-1 23:45:59"
-
->> Text(DateTime(2022,12,1,23,5,9), "yY-m-d h:M:S")
-"22-12-1 23:5:9"
-
->> Text(DateTime(2022,1,1,23,45,59), "MM MM MM:SS M")
-"01 01 45:59 1"
-
->> Text(DateTime(2022,1,1,23,45,59), "mm mm H:m m")
-"01 01 23:45 1"
-
->> Text(DateTime(2022,12,1,23,45,59), "mmmm H:m m")
-"December 23:45 12"
-
->> Text(DateTime(2022,12,1,23,45,59), "mmmm")
-"December"
-
->> Text(DateTime(2022,12,1,23,45,59), "mmm")
-"Dec"
-
->> Text(DateTime(2022,12,1,23,45,59), "mm")
-"12"
-
->> Text(DateTime(2022,12,1,23,45,59), "m")
-"12"
-
->> Text(DateTime(2022,1,1,23,45,59), "m")
-"1"
-
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm """" dd, yyy") 
 "Friday, Jun  03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm"""" dd, yyy") 
 "Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""""dd, yyy") 
 "Friday, Jun03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """d"" dddd, mmm dd, yyy") 
 "d Friday, Jun 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d"" dd, yyy") 
 "Friday, Jun d 03, 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DdDd, MmM ""D"" dD, yYy") 
+"Friday, Jun D 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm dd, yyy ""d""") 
+"Friday, Jun 03, 1983 d"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM DD, YYY ""D""") 
+"Friday, Jun 03, 1983 D"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""d."" dd, yyy") 
+"Friday, Jun d. 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, yyy") 
+"Friday, Jun yyy 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""YYY"" DD, YYY") 
+"Friday, Jun YYY 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""yyy"" dd, ""mmm"" yyy") 
+"Friday, Jun yyy 03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" dddd, mmm ""yyy"" dd, ""mmm"" yyy") 
+"ddd Friday, Jun yyy 03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), """ddd"" DDdd, mMM ""yyy"" Dd, ""mmm"" yYY") 
+"ddd Friday, Jun yyy 03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm ""carrymeforward"" dd, yyy") 
+"Friday, Jun carrymeforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM ""carrymeforward"" DD, YYY") 
+"Friday, Jun carrymeforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm""carrymeforward""dd, ""mmm"" yyy") 
+"Friday, Juncarrymeforward03, mmm 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "DDDD, MMM""carrymeforward""DD, ""MMM"" YYY") 
+"Friday, Juncarrymeforward03, MMM 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:ss") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "Hh:Mm:Ss") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hH:mM:sS") 
 "02:53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm:s") 
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:S") 
 "02:53:9"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm") 
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM") 
 "02:53"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:ss") 
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:SS") 
 "53:09"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "mm:hh") 
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "MM:HH") 
 "06:02"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:yyyy:mm") 
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:YYYY:MM") 
 "02:1983:06"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p")
-"2A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p") 
+"2a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P")
-"2A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HA/P") 
+"2a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p")
-"02A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p") 
+"02a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P")
-"02A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHA/P") 
+"02a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hAM/PM") 
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HAM/PM") 
 "2AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hhAM/PM") 
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHAM/PM") 
 "02AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p")
-"2:53 A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p") 
+"2:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p")
-"2:53 A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p") 
+"2:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p")
-"02:53 A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p") 
+"02:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p")
-"02:53 A"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p") 
+"02:53 a"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm AM/PM") 
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM AM/PM") 
 "2:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm AM/PM") 
 "02:53 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM AM/PM") 
 "02:53 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM")
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "hh:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM")
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:MM:SS AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:mm:ss AM/PM") 
 "2:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:mm:ss AM/PM") 
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHH:mm:ss AM/PM") 
 "02:53:09 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HHHHHH:mm:ss AM/PM") 
 "02:53:09 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM")
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "H:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM")
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HH:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM")
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHH:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM")
+>> Text(DateTime(2013, 6, 19, 10, 48, 38, 100), "HHHHHH:mm:ss AM/PM") 
 "10:48:38 AM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.fff") 
+"02:53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.000") 
+"02:53:09.123"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.ff") 
+"02:53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.00") 
+"02:53:09.12"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.f") 
+"02:53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "hh:mm:ss.0") 
+"02:53:09.1"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.fff") 
+"02:53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.000") 
+"02:53:09.013"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.ff") 
+"02:53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.00") 
+"02:53:09.01"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.f") 
+"02:53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "hh:mm:ss.0") 
+"02:53:09.0"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.fff") 
+"02:53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.000") 
+"02:53:09.003"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.ff") 
+"02:53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.00") 
+"02:53:09.00"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.f") 
+"02:53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "hh:mm:ss.0") 
+"02:53:09.0"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.fff") 
+"53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.000") 
+"53:09.123"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.ff") 
+"53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.00") 
+"53:09.12"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.f") 
+"53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mm:ss.0") 
+"53:09.1"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.fff") 
+"53:09.fff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.000") 
+"53:09.013"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.ff") 
+"53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.00") 
+"53:09.01"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.f") 
+"53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 13), "mm:ss.0") 
 "53:09.0"
 
->> Text(423456789013, "0")
-"423456789013"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.fff") 
+"53:09.fff"
 
->> Text(423456789003, "0")
-"423456789003"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.000") 
+"53:09.003"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'")
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.ff") 
+"53:09.ff"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.00") 
+"53:09.00"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.f") 
+"53:09.f"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 3), "mm:ss.0") 
+"53:09.0"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime'") 
 "Thursday, January 1, 1970 2:32:25 PM"
 
->> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'")
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime'") 
 "1/1/1970 2:32 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longdatetime24'") 
+"Thursday, January 1, 1970 14:32:25"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shortdatetime24'") 
+"1/1/1970 14:32"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime24'") 
+"14:32:25"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime24'") 
+"14:32"
 
 >> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'longtime'") 
 "2:32:25 PM"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy")
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "'shorttime'") 
+"2:32 PM"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime") 
+"long1ateti1e"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime") 
+"2514ort1ateti1e"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longdatetime24") 
+"long1ateti1e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shortdatetime24") 
+"2514ort1ateti1e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime24") 
+"longti1e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime24") 
+"2514ortti32e24"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "longtime") 
+"longti1e"
+
+>> Text(DateTime(1970, 1, 1, 14, 32, 25, 678), "shorttime") 
+"2514ortti32e"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """h"" dddd, mmm dd, yyy") 
+"h Friday, Jun 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h"" dd, yyy") 
+"Friday, Jun h 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm dd, yyy ""h""") 
+"Friday, Jun 03, 1983 h"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""h."" dd, yyy") 
+"Friday, Jun h. 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh:mm"" dd, yyy") 
+"Friday, Jun hh:mm 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""hh.m"" dd, ""mm.f"" yyy") 
+"Friday, Jun hh.m 03, mm.f 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), """hh"" dddd, mmm ""mm"" dd, ""fff"" yyy") 
+"hh Friday, Jun mm 03, fff 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm ""carrymefforward"" dd, yyy") 
+"Friday, Jun carrymefforward 03, 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "dddd, mmm""carrymefforward""dd, ""fff"" yyy") 
+"Friday, Juncarrymefforward03, fff 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[some*]"" dd ""(de)+"" yyyy") 
+"Jun [some*] 03 (de)+ 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") 
+"Jun ([][^]*[""]) 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy") 
+"Jun ([][^]*[]) 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") 
+"Jun ([][^]*[])"" 03 1983"
+
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""[de]+de"" dd yyyy") 
 "Jun [de]+de 03 1983"
 
->> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM:SS HH:MM:SS")
-"02:53:09 02:53:09"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.fff") 
+"1983-06-03 02:53:09.fff"
 
->> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Mm:Ss M")
-"2022-02-01 11:45:59 PM 45:59 2"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "yyyy-mm-dd HH:mm:ss.000") 
+"1983-06-03 02:53:09.123"
 
->> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Hh:Mm M")
-"2022-02-01 11:45:59 PM 11:45 2"
-
->> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Mm:Ss mM")
-"2022-02-01 11:45:59 PM 45:59 02"
-
->> Text(DateTime(2022,2,1,23,45,59), "yYyY-Mm-dd Hh:Mm:Ss Am/pM Hh:Mm mm")
-"2022-02-01 11:45:59 PM 11:45 02"
+>> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "YYYY-MM-DD HH:MM:SS.000") 
+"1983-06-03 02:53:09.123"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Time.txt
@@ -105,7 +105,7 @@ Error({Kind:ErrorKind.Div0})
 "09:24:00"
 
 >> Text(Time(23, 59, 59, 999), "HH:mm:ss.fff")
-"23:59:59.999"
+"23:59:59.fff"
 
 >> Date(2011, 2, 3) + Time(1, 2, 3)
 DateTime(2011,2,3,1,2,3,0)


### PR DESCRIPTION
Issue #869. 

This PR expanded from its original scope and now is handling 4 bugs:

> Text function: millisecond format specifier should be '0' not 'f'

> Text function can't handle numbers formatted as dates or dates formatted as numbers

> Text function doesn't handle date format specifiers like Excel

> Text function should return an error if both numeric and date format specifiers are passed to it