### PR TITLE
Boolean(true) and Boolean([true]) should be valid.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -174,11 +174,11 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Boolean,
-                StandardErrorHandling<StringValue>(
+                StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Boolean.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
+                    checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: TextToBoolean)
@@ -1511,7 +1511,7 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Boolean_T,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Boolean_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Boolean])
+                StandardErrorHandlingTabularOverload<FormulaValue>(BuiltinFunctionsCore.Boolean_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Boolean])
             },
             {
                 BuiltinFunctionsCore.BooleanN_T,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -313,9 +313,21 @@ namespace Microsoft.PowerFx.Functions
             return new NumberValue(irContext, b ? 1.0 : 0.0);
         }
 
-        public static FormulaValue TextToBoolean(IRContext irContext, StringValue[] args)
+        public static FormulaValue TextToBoolean(IRContext irContext, FormulaValue[] args)
         {
-            var val = args[0].Value;
+            string val = default;
+            if (args[0] is BooleanValue bv)
+            {
+                return bv;
+            }
+            else if (args[0] is StringValue s)
+            {
+                val = s.Value;
+            }
+            else
+            {
+                CommonErrors.RuntimeTypeMismatch(irContext);
+            }
 
             if (string.IsNullOrEmpty(val))
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -316,6 +316,8 @@ namespace Microsoft.PowerFx.Functions
         public static FormulaValue TextToBoolean(IRContext irContext, FormulaValue[] args)
         {
             string val = default;
+
+            // args can only be BooleanValue or StringValue, else ChekType would have raised an error.
             if (args[0] is BooleanValue bv)
             {
                 return bv;
@@ -323,10 +325,6 @@ namespace Microsoft.PowerFx.Functions
             else if (args[0] is StringValue s)
             {
                 val = s.Value;
-            }
-            else
-            {
-                CommonErrors.RuntimeTypeMismatch(irContext);
             }
 
             if (string.IsNullOrEmpty(val))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -53,7 +53,13 @@ Table({Value:false},{Value:true},{Value:true})
 Errors: Error 0-11: The function 'Boolean' has some invalid arguments.|Error 8-10: Invalid schema, expected a one-column table.
 
 >> Boolean(true)
-Errors: Error 0-13: The function 'Boolean' has some invalid arguments.|Error 8-12: Invalid argument type (Boolean). Expecting a Text value instead.
+true
 
 >> Boolean(false)
-Errors: Error 0-14: The function 'Boolean' has some invalid arguments.|Error 8-13: Invalid argument type (Boolean). Expecting a Text value instead.
+false
+
+>> Boolean([true, false])
+Table({Value:true},{Value:false})
+
+>> Boolean([Today()])
+Errors: Error 0-18: The function 'Boolean' has some invalid arguments.|Error 8-17: Invalid schema, expected a column of text values for 'Value'.


### PR DESCRIPTION
- Fixes #489 
- Now `Boolean()` can take `Boolean` and `Table of Boolean` as a valid input.
- Changed and added new tests in src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt