### PR TITLE
For ColorFade() Blank() should be map to default value.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -266,7 +266,7 @@ namespace Microsoft.PowerFx.Functions
                         ExactValueTypeOrBlank<ColorValue>,
                         ExactValueTypeOrBlank<NumberValue>),
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: ColorFade)
             },
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
@@ -88,8 +88,19 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue ColorFade(IRContext irContext, FormulaValue[] args)
         {
+
+            if (args[0] is BlankValue)
+            {
+                args[0] = FormulaValue.New(Color.FromArgb(255, 0, 0, 0));
+            }
+            if (args[1] is BlankValue)
+            {
+                args[1] = FormulaValue.New(0);
+            }
+
             var color = (ColorValue)args[0];
             var fadeDelta = ((NumberValue)args[1]).Value;
+
 
             // Ensure fade amount is between -1 and 1
             if (fadeDelta < -1.0d || fadeDelta > 1.0d)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFade.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFade.txt
@@ -50,13 +50,13 @@ RGBA(127,0,0,1)
 RGBA(255,127,127,1)
 
 >> ColorFade(RGBA(255,0,0,1), Blank())
-Blank()
+RGBA(255,0,0,1)
 
 >> ColorFade(Blank(), -1)
-Blank()
+RGBA(0,0,0,1)
 
 >> ColorFade(If(1<0, RGBA(255,0,0,1)), If(1<0, 0))
-Blank()
+RGBA(0,0,0,1)
 
 >> ColorFade(RGBA(255,0,0,1), 1/0)
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFadeT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFadeT.txt
@@ -26,7 +26,7 @@ Table({Value:Error({Kind:ErrorKind.InvalidArgument})},{Value:Error({Kind:ErrorKi
 Table({Value:RGBA(255,127,127,1)},{Value:RGBA(255,127,127,0)})
 
 >> ColorFade([RGBA(255,0,0,1), Blank()], 0.5)
-Table({Value:RGBA(255,127,127,1)},{Value:Blank()})
+Table({Value:RGBA(255,127,127,1)},{Value:RGBA(127,127,127,1)})
 
 >> ColorFade([RGBA(255,0,0,1), Blank()], If(1<0, 1))
-Table({Value:Blank()},{Value:Blank()})
+Table({Value:RGBA(255,0,0,1)},{Value:RGBA(0,0,0,1)})


### PR DESCRIPTION
- JS backend maps Blank() color to Color(0, 0, 0, 1) and Blank() fadeDelta to 0.