### PR TITLE
Add safety check for SymbolValues

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SlotMap.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SlotMap.cs
@@ -4,35 +4,68 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx
-{
+{   
     /// <summary>
     /// Storage for slots. Dense assignment. 
     /// </summary>
     /// <typeparam name="T"></typeparam>
     internal class SlotMap<T>
     {
+        // Lowest value of a null slot in _items. 
+        // Saves a linear scan from idnex 0. 
         private int _lowest;
 
+        // null items mean vacant slot. 
         private readonly List<T> _items = new List<T>();
 
-        public int Add(T item)
+        // Total non-null items. 
+        int _count = 0;
+
+        public bool IsEmpty => _count == 0;
+
+        public SlotMap()
+        {
+            // Either a class or nullable struct.
+            Contracts.Assert(default(T) == null);
+        }
+
+        // Must be followed by a call to SetInitial. 
+        public int Alloc()
         {
             for (var i = _lowest; i < _items.Count; i++)
             {
                 if (_items[i] == null)
                 {
+                    // Found gap.
                     _lowest = i + 1;
-                    _items[i] = item;
+                    Contracts.Assert(_items[i] == null);
+                    _count++;
                     return i;
                 }
             }
 
-            _items.Add(item);
+            // Fully packed, add to end. 
+            _lowest = _items.Count+1;
+
+            _count++;
+            _items.Add(default(T));
             return _items.Count - 1;
         }
 
+        // Update a previously added slot 
+        // Caller ensures this is a valid slot. 
+        public void SetInitial(int index, T item)
+        {
+            Contracts.Assert(item != null);
+            Contracts.Assert(_items[index] == null);
+
+            _items[index] = item;
+        }
+
+        // Caller ensures this is a valid slot. 
         public bool TryGet(int index, out T value)
         {
             if (index < _items.Count)
@@ -41,15 +74,8 @@ namespace Microsoft.PowerFx
                 return value != null;
             }
 
-            var t = default(T);
-            value = t;
+            value = default(T);
             return false;
-        }
-
-        // Update a previously added slot 
-        public void Set(int index, T item)
-        {
-            _items[index] = item;
         }
 
         // Frees up a slot for reassignment. 
@@ -61,8 +87,12 @@ namespace Microsoft.PowerFx
                 _lowest = index;
             }
 
-            var t = default(T);
-            _items[index] = t;
+            // There should be some non-null value from SetInitial. 
+            Contracts.Assert(_items[index] != null);
+
+            _count--;
+            Contracts.Assert(_count >= 0);
+            _items[index] = default(T);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -25,6 +25,12 @@ namespace Microsoft.PowerFx
     {
         private readonly SlotMap<NameLookupInfo?> _slots = new SlotMap<NameLookupInfo?>();
 
+        /// <summary>
+        /// Does this SymbolTable require a corresponding SymbolValue?
+        /// True if we have AddVariables, but not needed if we just have constants or functions.
+        /// </summary>
+        public bool NeedsValues => !_slots.IsEmpty;
+
         // Expose public setters
         // https://github.com/microsoft/Power-Fx/issues/828
         [Obsolete("Use Composition instead of Parent Pointer")]
@@ -101,7 +107,7 @@ namespace Microsoft.PowerFx
             DName displayDName = default;
             DName varDName = ValidateName(name);
 
-            if(displayName != null)
+            if (displayName != null)
             {
                 displayDName = ValidateName(displayName);
             }
@@ -111,7 +117,7 @@ namespace Microsoft.PowerFx
                 throw new InvalidOperationException($"{name} is already defined");
             }
 
-            var slotIndex = _slots.Add(null);
+            var slotIndex = _slots.Alloc();
             var data = new NameSymbol(name, mutable)
             {
                 Owner = this,
@@ -126,7 +132,7 @@ namespace Microsoft.PowerFx
                 data: data,
                 displayName:displayDName);
 
-            _slots.Set(slotIndex, info);
+            _slots.SetInitial(slotIndex, info);
 
             // Attempt to update display name provider before symbol table,
             // since it can throw on collision and we want to leave the config in a good state.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerFx
         /// <returns></returns>
         public static ReadOnlySymbolValues CreateValues(this ReadOnlySymbolTable symbolTable, params ReadOnlySymbolValues[] existing)
         {
-            return ComposedReadOnlySymbolValues.New(symbolTable, existing);
+            return ComposedReadOnlySymbolValues.New(true, symbolTable, existing);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -134,6 +134,7 @@ namespace Microsoft.PowerFx
         public async Task<FormulaValue> EvalAsync(CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig = null)
         {
             ReadOnlySymbolValues runtimeConfig2 = ComposedReadOnlySymbolValues.New(
+                false,
                 _allSymbols,
                 runtimeConfig,
                 _globals);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/SlotMapTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/SlotMapTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Types;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    public class SlotMapTests
+    {
+        [Fact]
+        public void StaysCompact()
+        {
+            var map = new SlotMap<string>();
+
+            Assert.True(map.IsEmpty);
+
+            Add(map, "0");            
+            Assert.False(map.IsEmpty);
+
+            Add(map, "1");
+                        
+            map.Remove(0);
+            Assert.False(map.IsEmpty);
+
+            // Get a removed slot will fail
+            var f1 = map.TryGet(0, out var value);
+            Assert.False(f1);
+            Assert.Null(value);
+
+            Add(map, "0");
+            
+            // Empty 
+            map.Remove(0);
+            map.Remove(1);
+            Assert.True(map.IsEmpty);
+        }
+
+        [Fact]
+        public void StaysCompact2()
+        {
+            var map = new SlotMap<string>();
+
+            Add(map, "0");
+            Add(map, "1");
+            Add(map, "2");
+
+            map.Remove(1);
+            map.Remove(0);
+
+            Add(map, "0");
+            Add(map, "1");
+            Add(map, "3");
+        }
+
+        [Fact]
+        public void GetFail()
+        {
+            var map = new SlotMap<string>();
+
+            var f = map.TryGet(0, out var value);
+            Assert.False(f);
+            Assert.Null(value);
+        }
+
+        // Value should be string form of expected slot. 
+        static int Add(SlotMap<string> map, string value)
+        {
+            var i = map.Alloc();
+            map.SetInitial(i, value);
+
+            var expectedSlot = int.Parse(value);
+            Assert.Equal(expectedSlot, i);
+
+            var f = map.TryGet(i, out var value2);
+            Assert.True(f);
+            Assert.Equal(value2, value);
+
+            return i;
+        }
+    }
+}


### PR DESCRIPTION
Add check that eval has SymbolValues that match the SymbolTable it was bound against.
Add tests for SlotMap.