### PR TITLE
Fix [Add/Drop]Columns tests

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns.txt
@@ -43,8 +43,8 @@ Table({Value:1,cu:1,sq:1},{Value:2,cu:8,sq:4},{Value:3,cu:27,sq:9})
 >> AddColumns([1,2,3], "sq", Value * Value, "cu", sq * Value)
 Errors: Error 47-49: Name isn't valid. 'sq' isn't recognized.
 
->> AddColumns([1, 2, 3], 5, Value * Value);
-Errors: Error 39-40: Expected operator. We expect an operator such as +, *, or & at this point in the formula.|Error 40-40: Expected an operand. The formula or expression expects a valid operand. For example, you can add the operand '2' to the expression ' 1 +_' so that the result is '3'. Or, you can add the operand "there" to the expression '"Hi "& _ ' so that the result is 'Hi there'.|Error 22-23: Argument '5' is invalid, expected a text literal.|Error 0-39: The function 'AddColumns' has some invalid arguments.|Error 39-40: Expected operator. We expect an operator such as +, *, or & at this point in the formula.
+>> AddColumns([1, 2, 3], 5, Value * Value)
+Errors: Error 22-23: Argument '5' is invalid, expected a text literal.|Error 0-39: The function 'AddColumns' has some invalid arguments.
 
->> AddColumns([1, 2, 3], "", Value * Value);
-Errors: Error 40-41: Expected operator. We expect an operator such as +, *, or & at this point in the formula.|Error 41-41: Expected an operand. The formula or expression expects a valid operand. For example, you can add the operand '2' to the expression ' 1 +_' so that the result is '3'. Or, you can add the operand "there" to the expression '"Hi "& _ ' so that the result is 'Hi there'.|Error 22-24: Argument '' is not a valid identifier.|Error 0-40: The function 'AddColumns' has some invalid arguments.|Error 40-41: Expected operator. We expect an operator such as +, *, or & at this point in the formula.
+>> AddColumns([1, 2, 3], "", Value * Value)
+Errors: Error 22-24: Argument '' is not a valid identifier.|Error 0-40: The function 'AddColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DropColumns.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DropColumns.txt
@@ -20,8 +20,8 @@ Errors: Error 45-48: The specified column 'a' does not exist. The column with th
 >> DropColumns([1, 2, 3], "Value")
 Table({},{},{})
 
->> DropColumns([1, 2, 3], 5);
-Errors: Error 25-26: Expected operator. We expect an operator such as +, *, or & at this point in the formula.|Error 26-26: Expected an operand. The formula or expression expects a valid operand. For example, you can add the operand '2' to the expression ' 1 +_' so that the result is '3'. Or, you can add the operand "there" to the expression '"Hi "& _ ' so that the result is 'Hi there'.|Error 23-24: Argument '5' is invalid, expected a text literal.|Error 0-25: The function 'DropColumns' has some invalid arguments.|Error 25-26: Expected operator. We expect an operator such as +, *, or & at this point in the formula.
+>> DropColumns([1, 2, 3], 5)
+Errors: Error 23-24: Argument '5' is invalid, expected a text literal.|Error 0-25: The function 'DropColumns' has some invalid arguments.
 
->> DropColumns([1, 2, 3], "");
-Errors: Error 26-27: Expected operator. We expect an operator such as +, *, or & at this point in the formula.|Error 27-27: Expected an operand. The formula or expression expects a valid operand. For example, you can add the operand '2' to the expression ' 1 +_' so that the result is '3'. Or, you can add the operand "there" to the expression '"Hi "& _ ' so that the result is 'Hi there'.|Error 23-25: Argument '' is not a valid identifier.|Error 0-26: The function 'DropColumns' has some invalid arguments.|Error 26-27: Expected operator. We expect an operator such as +, *, or & at this point in the formula.
+>> DropColumns([1, 2, 3], "")
+Errors: Error 23-25: Argument '' is not a valid identifier.|Error 0-26: The function 'DropColumns' has some invalid arguments.


### PR DESCRIPTION
Some of the recently added tests for those functions have an extra ';' which is making the error that the test was intended to cover.