### PR TITLE
Update blank handling for ColorFade function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
@@ -88,11 +88,11 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue ColorFade(IRContext irContext, FormulaValue[] args)
         {
-
             if (args[0] is BlankValue)
             {
-                args[0] = FormulaValue.New(Color.FromArgb(255, 0, 0, 0));
+                args[0] = FormulaValue.New(Color.FromArgb(0, 0, 0, 0));
             }
+
             if (args[1] is BlankValue)
             {
                 args[1] = FormulaValue.New(0);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFade.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFade.txt
@@ -52,11 +52,11 @@ RGBA(255,127,127,1)
 >> ColorFade(RGBA(255,0,0,1), Blank())
 RGBA(255,0,0,1)
 
->> ColorFade(Blank(), -1)
-RGBA(0,0,0,1)
+>> ColorFade(Blank(), 0.5)
+RGBA(127,127,127,0)
 
 >> ColorFade(If(1<0, RGBA(255,0,0,1)), If(1<0, 0))
-RGBA(0,0,0,1)
+RGBA(0,0,0,0)
 
 >> ColorFade(RGBA(255,0,0,1), 1/0)
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFadeT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ColorFadeT.txt
@@ -26,7 +26,7 @@ Table({Value:Error({Kind:ErrorKind.InvalidArgument})},{Value:Error({Kind:ErrorKi
 Table({Value:RGBA(255,127,127,1)},{Value:RGBA(255,127,127,0)})
 
 >> ColorFade([RGBA(255,0,0,1), Blank()], 0.5)
-Table({Value:RGBA(255,127,127,1)},{Value:RGBA(127,127,127,1)})
+Table({Value:RGBA(255,127,127,1)},{Value:RGBA(127,127,127,0)})
 
 >> ColorFade([RGBA(255,0,0,1), Blank()], If(1<0, 1))
-Table({Value:RGBA(255,0,0,1)},{Value:RGBA(0,0,0,1)})
+Table({Value:RGBA(255,0,0,1)},{Value:RGBA(0,0,0,0)})


### PR DESCRIPTION
Blank values in a color context should be interpreted as RGBA(0,0,0,0)