### PR TITLE
Boolean(true) shouldn't be invalid

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1075,6 +1075,13 @@ namespace Microsoft.PowerFx.Core.Functions
             return CheckColumnType(type, arg, DType.DateTime, errors, TexlStrings.ErrInvalidSchemaNeedDateCol_Col, ref nodeToCoercedTypeMap);
         }
 
+        // Check that the type of a specified node is a boolean column type, and possibly emit errors
+        // accordingly. Returns true if the types align, false otherwise.
+        protected bool CheckBooleanColumnType(DType type, TexlNode arg, IErrorContainer errors, ref Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            return CheckColumnType(type, arg, DType.Boolean, errors, TexlStrings.ErrInvalidSchemaNeedColorCol_Col, ref nodeToCoercedTypeMap);
+        }
+
         // Enumerate some of the function signatures for a specified arity and known parameter descriptions.
         // The last parameter may be repeated as many times as necessary in order to satisfy the arity constraint.
         protected IEnumerable<TexlStrings.StringGetter[]> GetGenericSignatures(int arity, params TexlStrings.StringGetter[] args)

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -330,11 +330,6 @@ namespace Microsoft.PowerFx.Core.IR
                 // e.g. For Boolean(true), Instead of IR as Call(Boolean, true) it can be rewritten directly to emit true.
                 var irNode = func.CreateIRCallNode(node, context, args, scope);
 
-                if (scope != null)
-                {
-                    return MaybeInjectCoercion(node, irNode, context);
-                }
-
                 return MaybeInjectCoercion(node, irNode, context);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.IR
             return (binding.Top.Accept(new IRTranslatorVisitor(binding.Features), new IRTranslatorContext(binding, ruleScopeSymbol)), ruleScopeSymbol);
         }
 
-        internal class IRTranslatorVisitor : TexlFunctionalVisitor<IntermediateNode, IRTranslatorContext>
+        private class IRTranslatorVisitor : TexlFunctionalVisitor<IntermediateNode, IRTranslatorContext>
         {
             private readonly Features _features;
 
@@ -310,6 +310,7 @@ namespace Microsoft.PowerFx.Core.IR
                     {
                         var identifierNode = arg.AsFirstName();
                         Contracts.Assert(identifierNode != null);
+
                         // Transform the identifier node as a string literal
                         var nodeName = context.Binding.TryGetReplacedIdentName(identifierNode.Ident, out var newIdent) ? new DName(newIdent) : identifierNode.Ident.Name;
                         args.Add(new TextLiteralNode(context.GetIRContext(arg, DType.String), nodeName.Value));

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -99,6 +99,11 @@ namespace Microsoft.PowerFx.Core.Localization
         public static StringGetter AboutBooleanNT = (b) => StringResources.Get("AboutBooleanNT", b);
         public static StringGetter BooleanNTArg1 = (b) => StringResources.Get("BooleanNTArg1", b);
 
+        public static StringGetter AboutBooleanB = (b) => StringResources.Get("AboutBooleanB", b);
+        public static StringGetter BooleanBArg1 = (b) => StringResources.Get("BooleanBArg1", b);
+        public static StringGetter AboutBooleanBT = (b) => StringResources.Get("AboutBooleanBT", b);
+        public static StringGetter BooleanBTArg1 = (b) => StringResources.Get("BooleanBTArg1", b);
+
         public static StringGetter AboutConcatenate = (b) => StringResources.Get("AboutConcatenate", b);
         public static StringGetter ConcatenateArg1 = (b) => StringResources.Get("ConcatenateArg1", b);
         public static StringGetter AboutConcatenateT = (b) => StringResources.Get("AboutConcatenateT", b);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -45,6 +45,8 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Boolean_T = _library.Append(new BooleanFunction_T());
         public static readonly TexlFunction BooleanN = _library.Append(new BooleanNFunction());
         public static readonly TexlFunction BooleanN_T = _library.Append(new BooleanNFunction_T());
+        public static readonly TexlFunction BooleanB = _library.Append(new BooleanBFunction());
+        public static readonly TexlFunction BooleanB_T = _library.Append(new BooleanBFunction_T());
         public static readonly TexlFunction Boolean_UO = _library.Append(new BooleanFunction_UO());
         public static readonly TexlFunction Clock24 = _library.Append(new IsClock24Function());
         public static readonly TexlFunction Char = _library.Append(new CharFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
 
         /// <summary>
-        /// If arg is BoolLit node, no need to make a function call to boolean function. It can just emit arg directly.
+        /// If arg's result type is Boolean, no need to make a function call to Boolean() function. It can just emit arg directly.
         /// </summary>
         internal override IR.Nodes.IntermediateNode CreateIRCallNode(PowerFx.Syntax.CallNode node, IRTranslator.IRTranslatorContext context, List<IntermediateNode> args, ScopeSymbol scope)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -181,11 +181,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.BooleanArg1 };
         }
 
-        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
-        {
-            return GetUniqueTexlRuntimeName(suffix: "B");
-        }
-
         /// <summary>
         /// If arg's result type is Boolean, no need to make a function call to Boolean() function. It can just emit arg directly.
         /// </summary>
@@ -218,11 +213,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.BooleanNTArg1 };
-        }
-
-        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
-        {
-            return GetUniqueTexlRuntimeName(suffix: "B_T");
         }
 
         public override bool CheckTypes(TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Boolean.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
@@ -66,16 +67,15 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         /// <summary>
         /// If arg is BoolLit node, no need to make a function call to boolean function. It can just emit arg directly.
         /// </summary>
-        internal override IR.Nodes.IntermediateNode CreateIRCallNode(PowerFx.Syntax.CallNode node, IRTranslator.IRTranslatorContext context, IRTranslator.IRTranslatorVisitor visitor, ScopeSymbol scope, Features features)
+        internal override IR.Nodes.IntermediateNode CreateIRCallNode(PowerFx.Syntax.CallNode node, IRTranslator.IRTranslatorContext context, List<IntermediateNode> args, ScopeSymbol scope)
         {
-            var arg = node.Args.Children[0];
-            if(arg is BoolLitNode)
+            if(args[0].IRContext.ResultType._type == DType.Boolean)
             {
-                return arg.Accept(visitor, context); 
+                return args[0]; 
             }
             else
             {
-                return base.CreateIRCallNode(node, context, visitor, scope, features);
+                return base.CreateIRCallNode(node, context, args, scope);
             }
         }
     }
@@ -148,18 +148,18 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         /// If arg is Table of boolean, no need to make a function call to boolean function. It can just emit the table 
         /// arg directly.
         /// </summary>
-        internal override IR.Nodes.IntermediateNode CreateIRCallNode(PowerFx.Syntax.CallNode node, IRTranslator.IRTranslatorContext context, IRTranslator.IRTranslatorVisitor visitor, ScopeSymbol scope, Features features)
+        internal override IR.Nodes.IntermediateNode CreateIRCallNode(PowerFx.Syntax.CallNode node, IRTranslator.IRTranslatorContext context, List<IntermediateNode> args, ScopeSymbol scope)
         {
-            var children = node.Args.Children[0].Accept(visitor, context);
+            var child = args[0];
             var rowType = DType.EmptyRecord.Add(new TypedName(DType.Boolean, ColumnName_Value));
-            var returnType = rowType.ToTable();
-            if (node.Args.Children[0] is TableNode table && children.IRContext.ResultType._type == returnType)
+            var booleanTReturnType = rowType.ToTable();
+            if (child.IRContext.ResultType._type == booleanTReturnType)
             {
-                return node.Args.Children[0].Accept(visitor, context);
+                return child;
             }
             else
             {
-                return base.CreateIRCallNode(node, context, visitor, scope, features);
+                return base.CreateIRCallNode(node, context, args, scope);
             }
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -194,6 +194,9 @@ namespace Microsoft.PowerFx.Functions
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: NumberToBoolean)
             },
+
+            // This implementation is not actually used for this as this is handled at IR level. 
+            // This is a placeholder, so that RecalcEngine._interpreterSupportedFunctions can add it for txt tests.
             {
                 BuiltinFunctionsCore.BooleanB,
                 StandardErrorHandling<StringValue>(
@@ -1528,9 +1531,12 @@ namespace Microsoft.PowerFx.Functions
                 BuiltinFunctionsCore.BooleanN_T,
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.BooleanN_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanN])
             },
+
+            // This implementation is not actually used for this as this is handled at IR level. 
+            // This is a placeholder, so that RecalcEngine._interpreterSupportedFunctions can add it for txt tests.
             {
                 BuiltinFunctionsCore.BooleanB_T,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.BooleanB_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanB])
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.BooleanB_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanB])
             },
             {
                 BuiltinFunctionsCore.CharT,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -195,6 +195,17 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: NumberToBoolean)
             },
             {
+                BuiltinFunctionsCore.BooleanB,
+                StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.BooleanN.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: NumberToBoolean)
+            },
+            {
                 BuiltinFunctionsCore.Boolean_UO,
                 StandardErrorHandling<UntypedObjectValue>(
                     BuiltinFunctionsCore.Boolean_UO.Name,
@@ -1516,6 +1527,10 @@ namespace Microsoft.PowerFx.Functions
             {
                 BuiltinFunctionsCore.BooleanN_T,
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.BooleanN_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanN])
+            },
+            {
+                BuiltinFunctionsCore.BooleanB_T,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.BooleanB_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanB])
             },
             {
                 BuiltinFunctionsCore.CharT,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -196,14 +196,14 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.BooleanB,
-                StandardErrorHandling<NumberValue>(
+                StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.BooleanN.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: NumberToBoolean)
+                    targetFunction: TextToBoolean)
             },
             {
                 BuiltinFunctionsCore.Boolean_UO,

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -530,6 +530,28 @@
   <data name="AboutBooleanNT_input" xml:space="preserve">
     <value>A column of number values to process.</value>
   </data>
+  <data name="AboutBooleanB" xml:space="preserve">
+    <value>Converts a 'boolean' to a boolean value.</value>
+    <comment>Description of 'Boolean' function.</comment>
+  </data>
+  <data name="BooleanBArg1" xml:space="preserve">
+    <value>boolean</value>
+    <comment>function_parameter - First argument to the Boolean function - the boolean that will be converted to a boolean.</comment>
+  </data>
+  <data name="AboutBooleanB_boolean" xml:space="preserve">
+    <value>The boolean value to convert to a boolean value.</value>
+  </data>
+  <data name="AboutBooleanBT" xml:space="preserve">
+    <value>Converts a column of boolean values to a column of boolean values.</value>
+    <comment>Description of 'Boolean' function.</comment>
+  </data>
+  <data name="BooleanBTArg1" xml:space="preserve">
+    <value>input</value>
+    <comment>function_parameter - First argument to the Boolean function - a column of boolean values.</comment>
+  </data>
+  <data name="AboutBooleanBT_input" xml:space="preserve">
+    <value>A column of boolean values to process.</value>
+  </data>
   <data name="AboutCoalesce" xml:space="preserve">
     <value>Returns the first non blank argument</value>
     <comment>Description of 'Coalesce' function.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -53,7 +53,22 @@ Table({Value:false},{Value:true},{Value:true})
 Errors: Error 0-11: The function 'Boolean' has some invalid arguments.|Error 8-10: Invalid schema, expected a one-column table.
 
 >> Boolean(true)
-Errors: Error 0-13: The function 'Boolean' has some invalid arguments.|Error 8-12: Invalid argument type (Boolean). Expecting a Text value instead.
+true
 
 >> Boolean(false)
-Errors: Error 0-14: The function 'Boolean' has some invalid arguments.|Error 8-13: Invalid argument type (Boolean). Expecting a Text value instead.
+false
+
+>> Boolean([false])
+Table({Value:false})
+
+>> Boolean([true, 0, "true"])
+Table({Value:true},{Value:false},{Value:true})
+
+>> Boolean([0, true])
+Table({Value:false},{Value:true})
+
+>> Boolean([0, true, "false"])
+Table({Value:false},{Value:true},{Value:Error({Kind:ErrorKind.InvalidArgument})})
+
+>> Boolean(["true", false])
+Table({Value:true},{Value:false})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -57,3 +57,6 @@ Blank()
 
 >> Boolean(If(0<1, true))
 true
+
+>> Boolean(IfError(true, false))
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -72,3 +72,12 @@ Table({Value:false},{Value:true},{Value:Error({Kind:ErrorKind.InvalidArgument})}
 
 >> Boolean(["true", false])
 Table({Value:true},{Value:false})
+
+>> Boolean(true Or true)
+true
+
+>> Boolean(If(1<0, true))
+Blank()
+
+>> Boolean(If(0<1, true))
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Boolean.txt
@@ -34,9 +34,6 @@ Error({Kind:ErrorKind.Div0})
 >> Boolean("0")
 Error({Kind:ErrorKind.InvalidArgument})
 
->> Boolean(["true", "True", "TRUE", "false", "False", "FALSE"])
-Table({Value:true},{Value:true},{Value:true},{Value:false},{Value:false},{Value:false})
-
 >> Boolean(0)
 false
 
@@ -46,32 +43,11 @@ true
 >> Boolean(2)
 true
 
->> Boolean([0, 1, 2])
-Table({Value:false},{Value:true},{Value:true})
-
->> Boolean([])
-Errors: Error 0-11: The function 'Boolean' has some invalid arguments.|Error 8-10: Invalid schema, expected a one-column table.
-
 >> Boolean(true)
 true
 
 >> Boolean(false)
 false
-
->> Boolean([false])
-Table({Value:false})
-
->> Boolean([true, 0, "true"])
-Table({Value:true},{Value:false},{Value:true})
-
->> Boolean([0, true])
-Table({Value:false},{Value:true})
-
->> Boolean([0, true, "false"])
-Table({Value:false},{Value:true},{Value:Error({Kind:ErrorKind.InvalidArgument})})
-
->> Boolean(["true", false])
-Table({Value:true},{Value:false})
 
 >> Boolean(true Or true)
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
@@ -1,0 +1,33 @@
+﻿
+>> Boolean(["true", "True", "TRUE", "false", "False", "FALSE"])
+Table({Value:true},{Value:true},{Value:true},{Value:false},{Value:false},{Value:false})
+
+>> Boolean(["true", 1])
+Table({Value:true},{Value:Error({Kind:ErrorKind.InvalidArgument})})
+
+>> Boolean(["true", false])
+Table({Value:true},{Value:false})
+
+>> Boolean([0, 1, 2])
+Table({Value:false},{Value:true},{Value:true})
+
+>> Boolean([0, "true"])
+Table({Value:false},{Value:Error({Kind:ErrorKind.InvalidArgument})})
+
+>> Boolean([0, true])
+Table({Value:false},{Value:true})
+
+>> Boolean([])
+Errors: Error 0-11: The function 'Boolean' has some invalid arguments.|Error 8-10: Invalid schema, expected a one-column table.
+
+>> Boolean([false])
+Table({Value:false})
+
+>> Boolean([true, 0, "true"])
+Table({Value:true},{Value:false},{Value:true})
+
+>> Boolean([0, true, "false"])
+Table({Value:false},{Value:true},{Value:Error({Kind:ErrorKind.InvalidArgument})})
+
+>> Boolean([Blank(), true])
+Table({Value:Blank()},{Value:true})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
@@ -1,5 +1,4 @@
-﻿
->> Boolean(["true", "True", "TRUE", "false", "False", "FALSE"])
+﻿>> Boolean(["true", "True", "TRUE", "false", "False", "FALSE"])
 Table({Value:true},{Value:true},{Value:true},{Value:false},{Value:false},{Value:false})
 
 >> Boolean(["true", 1])

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
@@ -30,3 +30,6 @@ Table({Value:false},{Value:true},{Value:Error({Kind:ErrorKind.InvalidArgument})}
 
 >> Boolean([Blank(), true])
 Table({Value:Blank()},{Value:true})
+
+>> Boolean(If(1<0,[false]))
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
@@ -33,3 +33,6 @@ Table({Value:Blank()},{Value:true})
 
 >> Boolean(If(1<0,[false]))
 Blank()
+
+>> Boolean(Filter([false], Value))
+Table()


### PR DESCRIPTION
- Fixes #489 
- Now TexlFunction provides an override that can be used via creating IR call node to rewrite the node.
- e.g. this is purely a fix in the IR for Boolean() - for Boolean(x) when x is a bool, it just emits x