### PR TITLE
Initial work on UntypedObject implicit coercions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4045,6 +4045,15 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
             }
 
+            private void UntypedObjectScopeError(CallNode node, TexlFunction maybeFunc, TexlNode firstArg)
+            {
+                _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, firstArg, TexlStrings.ErrUntypedObjectScope);
+                _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
+
+                _txb.SetInfo(node, new CallInfo(maybeFunc, node, null, default, false, _currentScope.Nest));
+                _txb.SetType(node, maybeFunc.ReturnType);
+            }
+
             public override bool PreVisit(CallNode node)
             {
                 AssertValid();
@@ -4251,11 +4260,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                     else
                     {
-                        _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, nodeInput, TexlStrings.ErrUntypedObjectScope);
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
-
-                        _txb.SetInfo(node, new CallInfo(maybeFunc, node, null, default, false, _currentScope.Nest));
-                        _txb.SetType(node, maybeFunc.ReturnType);
+                        UntypedObjectScopeError(node, maybeFunc, nodeInput);
 
                         PreVisitBottomUp(node, 1);
                         FinalizeCall(node);
@@ -4837,11 +4842,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // already an error for this node, add the ErrUntypedObjectScope
                         var functionWithLambdas = functionsWithLambdas.Single();
 
-                        _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, node, TexlStrings.ErrUntypedObjectScope);
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, functionWithLambdas.Name);
-
-                        _txb.SetInfo(node, new CallInfo(functionWithLambdas, node, null, default, false, _currentScope.Nest));
-                        _txb.SetType(node, functionWithLambdas.ReturnType);
+                        UntypedObjectScopeError(node, functionWithLambdas, args[0]);
                         return;
                     }
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
@@ -59,5 +59,12 @@ namespace Microsoft.PowerFx.Core.IR
 
         BooleanToOptionSet,
         AggregateToDataEntity,
+
+        UntypedToText,
+        UntypedToBoolean,
+        UntypedToNumber,
+        UntypedToDate,
+        UntypedToTime,
+        UntypedToDateTime,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
@@ -66,5 +66,7 @@ namespace Microsoft.PowerFx.Core.IR
         UntypedToDate,
         UntypedToTime,
         UntypedToDateTime,
+        UntypedToColor,
+        UntypedToGUID
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
@@ -35,6 +35,11 @@ namespace Microsoft.PowerFx.Core.IR
                 }
             }
 
+            if (fromType.IsUntypedObject)
+            {
+                return GetUntypedObjectCoercion(toType);
+            }
+
             return FlattenCoercionMatrix(fromType, toType);
         }
 
@@ -349,6 +354,27 @@ namespace Microsoft.PowerFx.Core.IR
             else
             {
                 return CoercionKind.None; // Implicit coercion?
+            }
+        }
+
+        private static CoercionKind GetUntypedObjectCoercion(DType toType)
+        {
+            switch (toType.Kind)
+            {
+                case DKind.String:
+                    return CoercionKind.UntypedToText;
+                case DKind.Boolean:
+                    return CoercionKind.UntypedToBoolean;
+                case DKind.Number:
+                    return CoercionKind.UntypedToNumber;
+                case DKind.Date:
+                    return CoercionKind.UntypedToDate;
+                case DKind.Time:
+                    return CoercionKind.UntypedToTime;
+                case DKind.DateTime:
+                    return CoercionKind.UntypedToDateTime;
+                default:
+                    return CoercionKind.None;
             }
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
@@ -373,6 +373,10 @@ namespace Microsoft.PowerFx.Core.IR
                     return CoercionKind.UntypedToTime;
                 case DKind.DateTime:
                     return CoercionKind.UntypedToDateTime;
+                case DKind.Color:
+                    return CoercionKind.UntypedToColor;
+                case DKind.Guid:
+                    return CoercionKind.UntypedToGUID;
                 default:
                     return CoercionKind.None;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -805,6 +805,10 @@ namespace Microsoft.PowerFx.Core.IR
                         return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.TimeValue_UO, child);
                     case CoercionKind.UntypedToDateTime:
                         return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.DateTimeValue_UO, child);
+                    case CoercionKind.UntypedToColor:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.ColorValue_UO, child);
+                    case CoercionKind.UntypedToGUID:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.GUID_UO, child);
                     case CoercionKind.None:
                         // No coercion needed, return the child node
                         return child;

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -793,6 +793,18 @@ namespace Microsoft.PowerFx.Core.IR
                     case CoercionKind.AggregateToDataEntity:
                         unaryOpKind = UnaryOpKind.AggregateToDataEntity;
                         break;
+                    case CoercionKind.UntypedToText:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.Text_UO, child);
+                    case CoercionKind.UntypedToNumber:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.Value_UO, child);
+                    case CoercionKind.UntypedToBoolean:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.Boolean_UO, child);
+                    case CoercionKind.UntypedToDate:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.DateValue_UO, child);
+                    case CoercionKind.UntypedToTime:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.TimeValue_UO, child);
+                    case CoercionKind.UntypedToDateTime:
+                        return new CallNode(IRContext.NotInSource(FormulaType.Build(toType)), BuiltinFunctionsCore.DateTimeValue_UO, child);
                     case CoercionKind.None:
                         // No coercion needed, return the child node
                         return child;

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -600,6 +600,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrEmptyIsland = new ErrorResourceKey("ErrEmptyIsland");
         public static ErrorResourceKey ErrDeprecated = new ErrorResourceKey("ErrDeprecated");
         public static ErrorResourceKey ErrInvalidFunction = new ErrorResourceKey("ErrInvalidFunction");
+        public static ErrorResourceKey ErrUntypedObjectScope = new ErrorResourceKey("ErrUntypedObjectScope");
 
         public static ErrorResourceKey ErrErrorIrrelevantField = new ErrorResourceKey("ErrErrorIrrelevantField");
         public static ErrorResourceKey ErrAsNotInContext = new ErrorResourceKey("ErrAsNotInContext");

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -3079,6 +3079,26 @@ namespace Microsoft.PowerFx.Core.Types
                 return true;
             }
 
+            if (Kind == DKind.UntypedObject)
+            {
+                isSafe = false;
+                if (typeDest.Kind == DKind.String ||
+                    typeDest.Kind == DKind.Number ||
+                    typeDest.Kind == DKind.Boolean ||
+                    typeDest.Kind == DKind.Date ||
+                    typeDest.Kind == DKind.Time ||
+                    typeDest.Kind == DKind.DateTime)
+                {
+                    coercionType = typeDest;
+                    return true;
+                }
+                else
+                {
+                    coercionType = this;
+                    return false;
+                }
+            }
+
             if (Kind == DKind.Error)
             {
                 isSafe = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -3087,7 +3087,9 @@ namespace Microsoft.PowerFx.Core.Types
                     typeDest.Kind == DKind.Boolean ||
                     typeDest.Kind == DKind.Date ||
                     typeDest.Kind == DKind.Time ||
-                    typeDest.Kind == DKind.DateTime)
+                    typeDest.Kind == DKind.DateTime ||
+                    typeDest.Kind == DKind.Color ||
+                    typeDest.Kind == DKind.Guid)
                 {
                     coercionType = typeDest;
                     return true;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -201,7 +201,7 @@ namespace Microsoft.PowerFx.Functions
                 {
                     datetime = MakeValidDateTime(runner, datetime, runner.GetService<TimeZoneInfo>() ?? TimeZoneInfo.Local);
 
-                    return new DateValue(irContext, datetime);
+                    return new DateValue(irContext, datetime.Date);
                 }
 
                 return CommonErrors.InvalidDateTimeParsingError(irContext);

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -6617,6 +6617,10 @@
     <value>As is not permitted in this context</value>
     <comment>{Locked=As} This is an error message that shows up when the As keyword is used but is not valid</comment>
   </data>
+  <data name="ErrorResource_ErrUntypedObjectScope_ShortMessage" xml:space="preserve">
+    <value>Untyped objects cannot be used as the first argument to functions which support record scopes.</value>
+    <comment>This error message shows up when using untyped objects as the first arugment to functions with lambda overloads</comment>
+  </data>
   <data name="ErrNamedFormula_MissingSemicolon" xml:space="preserve">
     <value>Named formula must end with a semicolon.</value>
     <comment>A semicolon must terminate named formulas. For example, a=10;</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -178,7 +178,7 @@ Table({Value:"1"},{Value:"false"},{Value:"hello"})
 Table({Value:1},{Value:1},{Value:3},{Value:0})
 
 >> ForAll(ParseJSON("[1,2,3]"), If(Value(ThisRecord) < 2, Value(ThisRecord), ThisRecord))
-Errors: Error 74-84: Invalid argument type (UntypedObject). Expecting a Number value instead.|Error 29-85: The function 'If' has some invalid arguments.
+Table({Value:1},{Value:2},{Value:3})
 
 >> ForAll(ParseJSON("[1,2,3]"), ThisItem)
 Errors: Error 29-37: Name isn't valid. 'ThisItem' isn't recognized.|Error 0-38: The function 'ForAll' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -8,6 +8,9 @@
 >> Value(ParseJSON("5"))
 5
 
+>> Value(ParseJSON("5")) = Value("5")
+true
+
 >> Value(ParseJSON("true"))
 1
 
@@ -60,6 +63,9 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> Text(ParseJSON("""s"""))
 "s"
 
+>> Text(ParseJSON("""s""")) = Text("s")
+true
+
 >> Text(ParseJSON("null"))
 Blank()
 
@@ -77,6 +83,12 @@ true
 
 >> Boolean(ParseJSON("false"))
 false
+
+>> Boolean(ParseJSON("true")) = Boolean("true")
+true
+
+>> Boolean(ParseJSON("false")) = Boolean("false")
+true
 
 >> Boolean(ParseJSON("""true"""))
 true
@@ -269,6 +281,9 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> DateTimeValue(ParseJSON("""2011T08:00:00.000Z"""))
 Error({Kind:ErrorKind.InvalidArgument})
 
+>> DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z""")) = DateTimeValue("2011-01-15T08:00:00.000Z")
+true
+
 >> DateTimeValue(ParseJSON("null"))
 Blank()
 
@@ -290,8 +305,14 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> DateDiff(DateValue(ParseJSON("""2011-01-15T08:00:00.000""")), DateValue(ParseJSON("""2011-01-30T08:00:00.000""")))
 15
 
+>> DateValue(ParseJSON("""2011-01-15T08:00:00.000""")) = DateValue("2011-01-15T08:00:00.000")
+true
+
 >> Text(TimeValue(ParseJSON("""08:03:05.000""")), "HH:mm:ss")
 "08:03:05"
+
+>> TimeValue(ParseJSON("""08:03:05.000""")) = TimeValue("08:03:05.000")
+true
 
 >> TimeValue(ParseJSON("""08:93:05.000"""))
 Error({Kind:ErrorKind.InvalidArgument})
@@ -304,6 +325,9 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> GUID(ParseJSON("""5cc45615-f759-4a53-b225-d3a2497f60ad"""))
 GUID("5cc45615-f759-4a53-b225-d3a2497f60ad")
+
+>> GUID(ParseJSON("""5cc45615-f759-4a53-b225-d3a2497f60ad""")) = GUID("5cc45615-f759-4a53-b225-d3a2497f60ad")
+true
 
 >> GUID(ParseJSON("null"))
 Blank()
@@ -326,6 +350,9 @@ RGBA(1,2,3,0.016)
 
 >> ColorValue(ParseJSON("""#010203"""))
 RGBA(1,2,3,1)
+
+>> ColorValue(ParseJSON("""#010203""")) = ColorValue("#010203")
+true
 
 >> ColorValue(ParseJSON("""Red"""))
 Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -29,315 +29,247 @@ Errors: Error 4-24: Untyped objects cannot be used as the first argument to func
 Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.
 
 // Comparison tests
->> Abs(5)
-5
-
->> Abs(ParseJSON("5"))
-5
-
->> Acot(5)
-0.19739555984988066
-
->> Acot(ParseJSON("5"))
-0.19739555984988066
-
->> And(true)
+>> Abs(5) = Abs(ParseJSON("5"))
 true
 
->> And(ParseJSON("true"))
+>> Acot(5) = Acot(ParseJSON("5"))
 true
 
->> Atan(5)
-1.373400766945016
-
->> Atan(ParseJSON("5"))
-1.373400766945016
-
->> Atan2(5, 5)
-0.7853981633974483
-
->> Atan2(ParseJSON("5"), 5)
-0.7853981633974483
-
->> Atan2(5, ParseJSON("5"))
-0.7853981633974483
-
->> Average(5)
-5
-
->> Char(36)
-"$"
-
->> Char(ParseJSON("36"))
-"$"
-
->> Cos(5)
-0.28366218546322625
-
->> Cos(ParseJSON("5"))
-0.28366218546322625
-
->> Cot(5)
--0.2958129155327455
-
->> Cot(ParseJSON("5"))
--0.2958129155327455
-
->> Day(DateTimeValue("2022-12-19T12:08:45.000Z"))
-19
-
->> Day(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-19
-
->> Degrees(5)
-286.4788975654116
-
->> Degrees(ParseJSON("5"))
-286.4788975654116
-
->> EndsWith("Hello World", "Hello World")
+>> And(true) = And(ParseJSON("true"))
 true
 
->> EndsWith(ParseJSON("""Hello World"""), "Hello World")
+>> Atan(5) = Atan(ParseJSON("5"))
 true
 
->> EndsWith("Hello World", ParseJSON("""Hello World"""))
+>> Atan2(5, 5) = Atan2(ParseJSON("5"), 5)
 true
 
->> Exp(5)
-148.41315910257657
-
->> Exp(ParseJSON("5"))
-148.41315910257657
-
->> Find("Hello World", "Hello World")
-1
-
->> Find(ParseJSON("""Hello World"""), "Hello World")
-1
-
->> Find("Hello World", ParseJSON("""Hello World"""))
-1
-
->> Find("Hello World", "Hello World", 5)
-Blank()
-
->> Find(ParseJSON("""Hello World"""), "Hello World", 5)
-Blank()
-
->> Find("Hello World", ParseJSON("""Hello World"""), 5)
-Blank()
-
->> Find("Hello World", "Hello World", ParseJSON("5"))
-Blank()
-
->> Hour(DateTimeValue("2022-12-19T12:08:45.000Z"))
-4
-
->> Hour(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-4
-
->> Int(5)
-5
-
->> Int(ParseJSON("5"))
-5
-
->> IsToday(DateTimeValue("2022-12-19T12:08:45.000Z"))
+>> Atan2(5, 5) = Atan2(5, ParseJSON("5"))
 true
 
->> IsToday(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+>> Char(5) = Char(ParseJSON("5"))
 true
 
->> Left("Hello World", 5)
-"Hello"
-
->> Left(ParseJSON("""Hello World"""), 5)
-"Hello"
-
->> Left("Hello World", ParseJSON("5"))
-"Hello"
-
->> Len("Hello World")
-11
-
->> Len(ParseJSON("""Hello World"""))
-11
-
->> Ln(5)
-1.6094379124341003
-
->> Ln(ParseJSON("5"))
-1.6094379124341003
-
->> Log(5)
-0.6989700043360187
-
->> Log(ParseJSON("5"))
-0.6989700043360187
-
->> Log(5, 5)
-1
-
->> Log(ParseJSON("5"), 5)
-1
-
->> Log(5, ParseJSON("5"))
-1
-
->> Lower("Hello World")
-"hello world"
-
->> Lower(ParseJSON("""Hello World"""))
-"hello world"
-
->> Max(5)
-5
-
->> Mid("Hello World", 5)
-"o World"
-
->> Mid(ParseJSON("""Hello World"""), 5)
-"o World"
-
->> Mid("Hello World", ParseJSON("5"))
-"o World"
-
->> Mid("Hello World", 5, 5)
-"o Wor"
-
->> Mid(ParseJSON("""Hello World"""), 5, 5)
-"o Wor"
-
->> Mid("Hello World", ParseJSON("5"), 5)
-"o Wor"
-
->> Mid("Hello World", 5, ParseJSON("5"))
-"o Wor"
-
->> Min(5)
-5
-
->> Minute(DateTimeValue("2022-12-19T12:08:45.000Z"))
-8
-
->> Minute(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-8
-
->> Mod(5, 5)
-0
-
->> Mod(ParseJSON("5"), 5)
-0
-
->> Mod(5, ParseJSON("5"))
-0
-
->> Month(DateTimeValue("2022-12-19T12:08:45.000Z"))
-12
-
->> Month(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-12
-
->> Not(true)
-false
-
->> Not(ParseJSON("true"))
-false
-
->> Or(true)
+>> Cos(5) = Cos(ParseJSON("5"))
 true
 
->> Or(ParseJSON("true"))
+>> Cot(5) = Cot(ParseJSON("5"))
 true
 
->> Power(5, 5)
-3125
+>> Day(DateTimeValue("2022-12-19T12:08:45.000Z")) = Day(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
 
->> Power(ParseJSON("5"), 5)
-3125
+>> Degrees(5) = Degrees(ParseJSON("5"))
+true
 
->> Power(5, ParseJSON("5"))
-3125
+>> EndsWith("Hello World", "Hello World") = EndsWith(ParseJSON("""Hello World"""), "Hello World")
+true
 
->> Proper("Hello World")
-"Hello World"
+>> EndsWith("Hello World", "Hello World") = EndsWith("Hello World", ParseJSON("""Hello World"""))
+true
 
->> Proper(ParseJSON("""Hello World"""))
-"Hello World"
+>> Exp(5) = Exp(ParseJSON("5"))
+true
 
->> Radians(5)
-0.08726646259971647
+>> Find("Hello World", "Hello World") = Find(ParseJSON("""Hello World"""), "Hello World")
+true
 
->> Radians(ParseJSON("5"))
-0.08726646259971647
+>> Find("Hello World", "Hello World") = Find("Hello World", ParseJSON("""Hello World"""))
+true
 
->> RandBetween(5, 5)
-5
+>> Find("Hello World", "Hello World", 5) = Find(ParseJSON("""Hello World"""), "Hello World", 5)
+true
 
->> RandBetween(ParseJSON("5"), 5)
-5
+>> Find("Hello World", "Hello World", 5) = Find("Hello World", ParseJSON("""Hello World"""), 5)
+true
 
->> RandBetween(5, ParseJSON("5"))
-5
+>> Find("Hello World", "Hello World", 5) = Find("Hello World", "Hello World", ParseJSON("5"))
+true
 
->> Replace("Hello World", 5, 5, "Hello World")
-"HellHello Worldld"
+>> Hour(DateTimeValue("2022-12-19T12:08:45.000Z")) = Hour(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
 
->> Replace(ParseJSON("""Hello World"""), 5, 5, "Hello World")
-"HellHello Worldld"
+>> Int(5) = Int(ParseJSON("5"))
+true
 
->> Replace("Hello World", ParseJSON("5"), 5, "Hello World")
-"HellHello Worldld"
+>> IsToday(DateTimeValue("2022-12-19T12:08:45.000Z")) = IsToday(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
 
->> Replace("Hello World", 5, ParseJSON("5"), "Hello World")
-"HellHello Worldld"
+>> Left("Hello World", 5) = Left(ParseJSON("""Hello World"""), 5)
+true
 
->> Replace("Hello World", 5, 5, ParseJSON("""Hello World"""))
-"HellHello Worldld"
+>> Left("Hello World", 5) = Left("Hello World", ParseJSON("5"))
+true
 
->> Right("Hello World", 5)
-"World"
+>> Len("Hello World") = Len(ParseJSON("""Hello World"""))
+true
 
->> Right(ParseJSON("""Hello World"""), 5)
-"World"
+>> Ln(5) = Ln(ParseJSON("5"))
+true
 
->> Right("Hello World", ParseJSON("5"))
-"World"
+>> Log(5) = Log(ParseJSON("5"))
+true
 
->> Round(5, 5)
-5
+>> Log(5, 5) = Log(ParseJSON("5"), 5)
+true
 
->> Round(ParseJSON("5"), 5)
-5
+>> Log(5, 5) = Log(5, ParseJSON("5"))
+true
 
->> Round(5, ParseJSON("5"))
-5
+>> Lower("Hello World") = Lower(ParseJSON("""Hello World"""))
+true
 
->> RoundDown(5, 5)
-5
+>> Mid("Hello World", 5) = Mid(ParseJSON("""Hello World"""), 5)
+true
 
->> RoundDown(ParseJSON("5"), 5)
-5
+>> Mid("Hello World", 5) = Mid("Hello World", ParseJSON("5"))
+true
 
->> RoundDown(5, ParseJSON("5"))
-5
+>> Mid("Hello World", 5, 5) = Mid(ParseJSON("""Hello World"""), 5, 5)
+true
 
->> RoundUp(5, 5)
-5
+>> Mid("Hello World", 5, 5) = Mid("Hello World", ParseJSON("5"), 5)
+true
 
->> RoundUp(ParseJSON("5"), 5)
-5
+>> Mid("Hello World", 5, 5) = Mid("Hello World", 5, ParseJSON("5"))
+true
 
->> RoundUp(5, ParseJSON("5"))
-5
+>> Minute(DateTimeValue("2022-12-19T12:08:45.000Z")) = Minute(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
 
->> Second(DateTimeValue("2022-12-19T12:08:45.000Z"))
-45
+>> Mod(5, 5) = Mod(ParseJSON("5"), 5)
+true
 
->> Second(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-45
+>> Mod(5, 5) = Mod(5, ParseJSON("5"))
+true
 
+>> Month(DateTimeValue("2022-12-19T12:08:45.000Z")) = Month(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
+
+>> Not(true) = Not(ParseJSON("true"))
+true
+
+>> Or(true) = Or(ParseJSON("true"))
+true
+
+>> Power(5, 5) = Power(ParseJSON("5"), 5)
+true
+
+>> Power(5, 5) = Power(5, ParseJSON("5"))
+true
+
+>> Proper("Hello World") = Proper(ParseJSON("""Hello World"""))
+true
+
+>> Radians(5) = Radians(ParseJSON("5"))
+true
+
+>> RandBetween(5, 5) = RandBetween(ParseJSON("5"), 5)
+true
+
+>> RandBetween(5, 5) = RandBetween(5, ParseJSON("5"))
+true
+
+>> Replace("Hello World", 5, 5, "Hello World") = Replace(ParseJSON("""Hello World"""), 5, 5, "Hello World")
+true
+
+>> Replace("Hello World", 5, 5, "Hello World") = Replace("Hello World", ParseJSON("5"), 5, "Hello World")
+true
+
+>> Replace("Hello World", 5, 5, "Hello World") = Replace("Hello World", 5, ParseJSON("5"), "Hello World")
+true
+
+>> Replace("Hello World", 5, 5, "Hello World") = Replace("Hello World", 5, 5, ParseJSON("""Hello World"""))
+true
+
+>> Right("Hello World", 5) = Right(ParseJSON("""Hello World"""), 5)
+true
+
+>> Right("Hello World", 5) = Right("Hello World", ParseJSON("5"))
+true
+
+>> Round(5, 5) = Round(ParseJSON("5"), 5)
+true
+
+>> Round(5, 5) = Round(5, ParseJSON("5"))
+true
+
+>> RoundDown(5, 5) = RoundDown(ParseJSON("5"), 5)
+true
+
+>> RoundDown(5, 5) = RoundDown(5, ParseJSON("5"))
+true
+
+>> RoundUp(5, 5) = RoundUp(ParseJSON("5"), 5)
+true
+
+>> RoundUp(5, 5) = RoundUp(5, ParseJSON("5"))
+true
+
+>> Second(DateTimeValue("2022-12-19T12:08:45.000Z")) = Second(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
+
+>> Sin(5) = Sin(ParseJSON("5"))
+true
+
+>> Sqrt(5) = Sqrt(ParseJSON("5"))
+true
+
+>> StartsWith("Hello World", "Hello World") = StartsWith(ParseJSON("""Hello World"""), "Hello World")
+true
+
+>> StartsWith("Hello World", "Hello World") = StartsWith("Hello World", ParseJSON("""Hello World"""))
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World") = Substitute(ParseJSON("""Hello World"""), "Hello World", "Hello World")
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World") = Substitute("Hello World", ParseJSON("""Hello World"""), "Hello World")
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World") = Substitute("Hello World", "Hello World", ParseJSON("""Hello World"""))
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World", 5) = Substitute(ParseJSON("""Hello World"""), "Hello World", "Hello World", 5)
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World", 5) = Substitute("Hello World", ParseJSON("""Hello World"""), "Hello World", 5)
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World", 5) = Substitute("Hello World", "Hello World", ParseJSON("""Hello World"""), 5)
+true
+
+>> Substitute("Hello World", "Hello World", "Hello World", 5) = Substitute("Hello World", "Hello World", "Hello World", ParseJSON("5"))
+true
+
+>> Tan(5) = Tan(ParseJSON("5"))
+true
+
+>> TimeZoneOffset(DateTimeValue("2022-12-19T12:08:45.000Z")) = TimeZoneOffset(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
+
+>> Trim("Hello World") = Trim(ParseJSON("""Hello World"""))
+true
+
+>> TrimEnds("Hello World") = TrimEnds(ParseJSON("""Hello World"""))
+true
+
+>> Trunc(5) = Trunc(ParseJSON("5"))
+true
+
+>> Trunc(5, 5) = Trunc(ParseJSON("5"), 5)
+true
+
+>> Trunc(5, 5) = Trunc(5, ParseJSON("5"))
+true
+
+>> Upper("Hello World") = Upper(ParseJSON("""Hello World"""))
+true
+
+>> Year(DateTimeValue("2022-12-19T12:08:45.000Z")) = Year(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
+
+// Table comparison tests
 >> Sequence(5)
 Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
 
@@ -365,12 +297,6 @@ Table({Value:5},{Value:10},{Value:15},{Value:20},{Value:25})
 >> Sequence(5, 5, ParseJSON("5"))
 Table({Value:5},{Value:10},{Value:15},{Value:20},{Value:25})
 
->> Sin(5)
--0.9589242746631385
-
->> Sin(ParseJSON("5"))
--0.9589242746631385
-
 >> Split("Hello World", "Hello World")
 Table({Result:""},{Result:""})
 
@@ -379,105 +305,3 @@ Table({Result:""},{Result:""})
 
 >> Split("Hello World", ParseJSON("""Hello World"""))
 Table({Result:""},{Result:""})
-
->> Sqrt(5)
-2.23606797749979
-
->> Sqrt(ParseJSON("5"))
-2.23606797749979
-
->> StartsWith("Hello World", "Hello World")
-true
-
->> StartsWith(ParseJSON("""Hello World"""), "Hello World")
-true
-
->> StartsWith("Hello World", ParseJSON("""Hello World"""))
-true
-
->> StdevP(5)
-0
-
->> Substitute("Hello World", "Hello World", "Hello World")
-"Hello World"
-
->> Substitute(ParseJSON("""Hello World"""), "Hello World", "Hello World")
-"Hello World"
-
->> Substitute("Hello World", ParseJSON("""Hello World"""), "Hello World")
-"Hello World"
-
->> Substitute("Hello World", "Hello World", ParseJSON("""Hello World"""))
-"Hello World"
-
->> Substitute("Hello World", "Hello World", "Hello World", 5)
-"Hello World"
-
->> Substitute(ParseJSON("""Hello World"""), "Hello World", "Hello World", 5)
-"Hello World"
-
->> Substitute("Hello World", ParseJSON("""Hello World"""), "Hello World", 5)
-"Hello World"
-
->> Substitute("Hello World", "Hello World", ParseJSON("""Hello World"""), 5)
-"Hello World"
-
->> Substitute("Hello World", "Hello World", "Hello World", ParseJSON("5"))
-"Hello World"
-
->> Sum(5)
-5
-
->> Tan(5)
--3.380515006246586
-
->> Tan(ParseJSON("5"))
--3.380515006246586
-
->> TimeZoneOffset(DateTimeValue("2022-12-19T12:08:45.000Z"))
-480
-
->> TimeZoneOffset(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-480
-
->> Trim("Hello World")
-"Hello World"
-
->> Trim(ParseJSON("""Hello World"""))
-"Hello World"
-
->> TrimEnds("Hello World")
-"Hello World"
-
->> TrimEnds(ParseJSON("""Hello World"""))
-"Hello World"
-
->> Trunc(5)
-5
-
->> Trunc(ParseJSON("5"))
-5
-
->> Trunc(5, 5)
-5
-
->> Trunc(ParseJSON("5"), 5)
-5
-
->> Trunc(5, ParseJSON("5"))
-5
-
->> Upper("Hello World")
-"HELLO WORLD"
-
->> Upper(ParseJSON("""Hello World"""))
-"HELLO WORLD"
-
->> VarP(5)
-0
-
->> Year(DateTimeValue("2022-12-19T12:08:45.000Z"))
-2022
-
->> Year(ParseJSON("""2022-12-19T12:08:45.000Z"""))
-2022

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -25,6 +25,10 @@ Errors: Error 4-24: Untyped objects cannot be used as the first argument to func
 >> Sum(ParseJSON("[1,2,3]"))
 Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-25: The function 'Sum' has some invalid arguments.
 
+// Scalar version of Sum
+>> Sum([ParseJSON("1"), ParseJSON("2"), ParseJSON("3")], Value)
+6
+
 >> Filter(ParseJSON("[1,2,3]"), true)
 Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -27,3 +27,457 @@ Errors: Error 4-24: Untyped objects cannot be used as the first argument to func
 
 >> Filter(ParseJSON("[1,2,3]"), true)
 Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.
+
+// Comparison tests
+>> Abs(5)
+5
+
+>> Abs(ParseJSON("5"))
+5
+
+>> Acot(5)
+0.19739555984988066
+
+>> Acot(ParseJSON("5"))
+0.19739555984988066
+
+>> And(true)
+true
+
+>> And(ParseJSON("true"))
+true
+
+>> Atan(5)
+1.373400766945016
+
+>> Atan(ParseJSON("5"))
+1.373400766945016
+
+>> Atan2(5, 5)
+0.7853981633974483
+
+>> Atan2(ParseJSON("5"), 5)
+0.7853981633974483
+
+>> Atan2(5, ParseJSON("5"))
+0.7853981633974483
+
+>> Average(5)
+5
+
+>> Char(36)
+"$"
+
+>> Char(ParseJSON("36"))
+"$"
+
+>> Cos(5)
+0.28366218546322625
+
+>> Cos(ParseJSON("5"))
+0.28366218546322625
+
+>> Cot(5)
+-0.2958129155327455
+
+>> Cot(ParseJSON("5"))
+-0.2958129155327455
+
+>> Day(DateTimeValue("2022-12-19T12:08:45.000Z"))
+19
+
+>> Day(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+19
+
+>> Degrees(5)
+286.4788975654116
+
+>> Degrees(ParseJSON("5"))
+286.4788975654116
+
+>> EndsWith("Hello World", "Hello World")
+true
+
+>> EndsWith(ParseJSON("""Hello World"""), "Hello World")
+true
+
+>> EndsWith("Hello World", ParseJSON("""Hello World"""))
+true
+
+>> Exp(5)
+148.41315910257657
+
+>> Exp(ParseJSON("5"))
+148.41315910257657
+
+>> Find("Hello World", "Hello World")
+1
+
+>> Find(ParseJSON("""Hello World"""), "Hello World")
+1
+
+>> Find("Hello World", ParseJSON("""Hello World"""))
+1
+
+>> Find("Hello World", "Hello World", 5)
+Blank()
+
+>> Find(ParseJSON("""Hello World"""), "Hello World", 5)
+Blank()
+
+>> Find("Hello World", ParseJSON("""Hello World"""), 5)
+Blank()
+
+>> Find("Hello World", "Hello World", ParseJSON("5"))
+Blank()
+
+>> Hour(DateTimeValue("2022-12-19T12:08:45.000Z"))
+4
+
+>> Hour(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+4
+
+>> Int(5)
+5
+
+>> Int(ParseJSON("5"))
+5
+
+>> IsToday(DateTimeValue("2022-12-19T12:08:45.000Z"))
+true
+
+>> IsToday(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+true
+
+>> Left("Hello World", 5)
+"Hello"
+
+>> Left(ParseJSON("""Hello World"""), 5)
+"Hello"
+
+>> Left("Hello World", ParseJSON("5"))
+"Hello"
+
+>> Len("Hello World")
+11
+
+>> Len(ParseJSON("""Hello World"""))
+11
+
+>> Ln(5)
+1.6094379124341003
+
+>> Ln(ParseJSON("5"))
+1.6094379124341003
+
+>> Log(5)
+0.6989700043360187
+
+>> Log(ParseJSON("5"))
+0.6989700043360187
+
+>> Log(5, 5)
+1
+
+>> Log(ParseJSON("5"), 5)
+1
+
+>> Log(5, ParseJSON("5"))
+1
+
+>> Lower("Hello World")
+"hello world"
+
+>> Lower(ParseJSON("""Hello World"""))
+"hello world"
+
+>> Max(5)
+5
+
+>> Mid("Hello World", 5)
+"o World"
+
+>> Mid(ParseJSON("""Hello World"""), 5)
+"o World"
+
+>> Mid("Hello World", ParseJSON("5"))
+"o World"
+
+>> Mid("Hello World", 5, 5)
+"o Wor"
+
+>> Mid(ParseJSON("""Hello World"""), 5, 5)
+"o Wor"
+
+>> Mid("Hello World", ParseJSON("5"), 5)
+"o Wor"
+
+>> Mid("Hello World", 5, ParseJSON("5"))
+"o Wor"
+
+>> Min(5)
+5
+
+>> Minute(DateTimeValue("2022-12-19T12:08:45.000Z"))
+8
+
+>> Minute(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+8
+
+>> Mod(5, 5)
+0
+
+>> Mod(ParseJSON("5"), 5)
+0
+
+>> Mod(5, ParseJSON("5"))
+0
+
+>> Month(DateTimeValue("2022-12-19T12:08:45.000Z"))
+12
+
+>> Month(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+12
+
+>> Not(true)
+false
+
+>> Not(ParseJSON("true"))
+false
+
+>> Or(true)
+true
+
+>> Or(ParseJSON("true"))
+true
+
+>> Power(5, 5)
+3125
+
+>> Power(ParseJSON("5"), 5)
+3125
+
+>> Power(5, ParseJSON("5"))
+3125
+
+>> Proper("Hello World")
+"Hello World"
+
+>> Proper(ParseJSON("""Hello World"""))
+"Hello World"
+
+>> Radians(5)
+0.08726646259971647
+
+>> Radians(ParseJSON("5"))
+0.08726646259971647
+
+>> RandBetween(5, 5)
+5
+
+>> RandBetween(ParseJSON("5"), 5)
+5
+
+>> RandBetween(5, ParseJSON("5"))
+5
+
+>> Replace("Hello World", 5, 5, "Hello World")
+"HellHello Worldld"
+
+>> Replace(ParseJSON("""Hello World"""), 5, 5, "Hello World")
+"HellHello Worldld"
+
+>> Replace("Hello World", ParseJSON("5"), 5, "Hello World")
+"HellHello Worldld"
+
+>> Replace("Hello World", 5, ParseJSON("5"), "Hello World")
+"HellHello Worldld"
+
+>> Replace("Hello World", 5, 5, ParseJSON("""Hello World"""))
+"HellHello Worldld"
+
+>> Right("Hello World", 5)
+"World"
+
+>> Right(ParseJSON("""Hello World"""), 5)
+"World"
+
+>> Right("Hello World", ParseJSON("5"))
+"World"
+
+>> Round(5, 5)
+5
+
+>> Round(ParseJSON("5"), 5)
+5
+
+>> Round(5, ParseJSON("5"))
+5
+
+>> RoundDown(5, 5)
+5
+
+>> RoundDown(ParseJSON("5"), 5)
+5
+
+>> RoundDown(5, ParseJSON("5"))
+5
+
+>> RoundUp(5, 5)
+5
+
+>> RoundUp(ParseJSON("5"), 5)
+5
+
+>> RoundUp(5, ParseJSON("5"))
+5
+
+>> Second(DateTimeValue("2022-12-19T12:08:45.000Z"))
+45
+
+>> Second(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+45
+
+>> Sequence(5)
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> Sequence(ParseJSON("5"))
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> Sequence(5, 5)
+Table({Value:5},{Value:6},{Value:7},{Value:8},{Value:9})
+
+>> Sequence(ParseJSON("5"), 5)
+Table({Value:5},{Value:6},{Value:7},{Value:8},{Value:9})
+
+>> Sequence(5, ParseJSON("5"))
+Table({Value:5},{Value:6},{Value:7},{Value:8},{Value:9})
+
+>> Sequence(5, 5, 5)
+Table({Value:5},{Value:10},{Value:15},{Value:20},{Value:25})
+
+>> Sequence(ParseJSON("5"), 5, 5)
+Table({Value:5},{Value:10},{Value:15},{Value:20},{Value:25})
+
+>> Sequence(5, ParseJSON("5"), 5)
+Table({Value:5},{Value:10},{Value:15},{Value:20},{Value:25})
+
+>> Sequence(5, 5, ParseJSON("5"))
+Table({Value:5},{Value:10},{Value:15},{Value:20},{Value:25})
+
+>> Sin(5)
+-0.9589242746631385
+
+>> Sin(ParseJSON("5"))
+-0.9589242746631385
+
+>> Split("Hello World", "Hello World")
+Table({Result:""},{Result:""})
+
+>> Split(ParseJSON("""Hello World"""), "Hello World")
+Table({Result:""},{Result:""})
+
+>> Split("Hello World", ParseJSON("""Hello World"""))
+Table({Result:""},{Result:""})
+
+>> Sqrt(5)
+2.23606797749979
+
+>> Sqrt(ParseJSON("5"))
+2.23606797749979
+
+>> StartsWith("Hello World", "Hello World")
+true
+
+>> StartsWith(ParseJSON("""Hello World"""), "Hello World")
+true
+
+>> StartsWith("Hello World", ParseJSON("""Hello World"""))
+true
+
+>> StdevP(5)
+0
+
+>> Substitute("Hello World", "Hello World", "Hello World")
+"Hello World"
+
+>> Substitute(ParseJSON("""Hello World"""), "Hello World", "Hello World")
+"Hello World"
+
+>> Substitute("Hello World", ParseJSON("""Hello World"""), "Hello World")
+"Hello World"
+
+>> Substitute("Hello World", "Hello World", ParseJSON("""Hello World"""))
+"Hello World"
+
+>> Substitute("Hello World", "Hello World", "Hello World", 5)
+"Hello World"
+
+>> Substitute(ParseJSON("""Hello World"""), "Hello World", "Hello World", 5)
+"Hello World"
+
+>> Substitute("Hello World", ParseJSON("""Hello World"""), "Hello World", 5)
+"Hello World"
+
+>> Substitute("Hello World", "Hello World", ParseJSON("""Hello World"""), 5)
+"Hello World"
+
+>> Substitute("Hello World", "Hello World", "Hello World", ParseJSON("5"))
+"Hello World"
+
+>> Sum(5)
+5
+
+>> Tan(5)
+-3.380515006246586
+
+>> Tan(ParseJSON("5"))
+-3.380515006246586
+
+>> TimeZoneOffset(DateTimeValue("2022-12-19T12:08:45.000Z"))
+480
+
+>> TimeZoneOffset(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+480
+
+>> Trim("Hello World")
+"Hello World"
+
+>> Trim(ParseJSON("""Hello World"""))
+"Hello World"
+
+>> TrimEnds("Hello World")
+"Hello World"
+
+>> TrimEnds(ParseJSON("""Hello World"""))
+"Hello World"
+
+>> Trunc(5)
+5
+
+>> Trunc(ParseJSON("5"))
+5
+
+>> Trunc(5, 5)
+5
+
+>> Trunc(ParseJSON("5"), 5)
+5
+
+>> Trunc(5, ParseJSON("5"))
+5
+
+>> Upper("Hello World")
+"HELLO WORLD"
+
+>> Upper(ParseJSON("""Hello World"""))
+"HELLO WORLD"
+
+>> VarP(5)
+0
+
+>> Year(DateTimeValue("2022-12-19T12:08:45.000Z"))
+2022
+
+>> Year(ParseJSON("""2022-12-19T12:08:45.000Z"""))
+2022

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -1,4 +1,6 @@
-﻿>> If(false, 4, ParseJSON("5"))
+﻿// The If function will attempt to coerce the else clause to the same type as the then clause
+// this allows us to control the exact expected coercion type
+>> If(false, 4, ParseJSON("5"))
 5
 
 >> If(false, "s", ParseJSON("""t"""))
@@ -16,12 +18,12 @@
 >> Text(If(false, Time(0,0,0), TimeValue(ParseJSON("""08:03:05.000"""))), "HH:mm:ss")
 "08:03:05"
 
->> Filter(ParseJSON("[1,2,3]"), true)
-Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.
-
 >> Sum(ParseJSON("[1,2,3]"), Blank())
 Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Sum' has some invalid arguments.
 
 // Arity error code path for Sum
 >> Sum(ParseJSON("[1,2,3]"))
-Errors: Error 0-25: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-25: The function 'Sum' has some invalid arguments.
+Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-25: The function 'Sum' has some invalid arguments.
+
+>> Filter(ParseJSON("[1,2,3]"), true)
+Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -17,4 +17,11 @@
 "08:03:05"
 
 >> Filter(ParseJSON("[1,2,3]"), true)
-Errors: Error 7-27: Invalid argument type.|Error 0-34: The function 'Filter' has some invalid arguments.
+Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.
+
+>> Sum(ParseJSON("[1,2,3]"), Blank())
+Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Sum' has some invalid arguments.
+
+// Arity error code path for Sum
+>> Sum(ParseJSON("[1,2,3]"))
+Errors: Error 0-25: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-25: The function 'Sum' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -1,0 +1,20 @@
+﻿>> If(false, 4, ParseJSON("5"))
+5
+
+>> If(false, "s", ParseJSON("""t"""))
+"t"
+
+>> If(ParseJSON("true"), 1, 0)
+1
+
+>> DateDiff(If(false, DateTime(0,0,0,0,0,0), DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z"""))), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
+15
+
+>> DateDiff(If(false, Date(0,0,0), DateValue(ParseJSON("""2011-01-15T00:00:00"""))), DateValue(ParseJSON("""2011-01-30""")))
+15
+
+>> Text(If(false, Time(0,0,0), TimeValue(ParseJSON("""08:03:05.000"""))), "HH:mm:ss")
+"08:03:05"
+
+>> Filter(ParseJSON("[1,2,3]"), true)
+Errors: Error 7-27: Invalid argument type.|Error 0-34: The function 'Filter' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -3,6 +3,9 @@
 >> If(false, 4, ParseJSON("5"))
 5
 
+>> If(true, 4, ParseJSON("5"))
+4
+
 >> If(false, "s", ParseJSON("""t"""))
 "t"
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -12,6 +12,12 @@
 >> If(ParseJSON("true"), 1, 0)
 1
 
+>> If(false, ColorValue("#aabbcc"), ParseJSON("""#aabbcc"""))
+RGBA(170,187,204,1)
+
+>> If(false, GUID("5cc45615-f759-4a53-b225-d3a2497f60ad"), ParseJSON("""5cc45615-f759-4a53-b225-d3a2497f60ad"""))
+GUID("5cc45615-f759-4a53-b225-d3a2497f60ad")
+
 >> DateDiff(If(false, DateTime(0,0,0,0,0,0), DateTimeValue(ParseJSON("""2011-01-15T08:00:00.000Z"""))), DateTimeValue(ParseJSON("""2011-01-30T08:00:00.000Z""")))
 15
 


### PR DESCRIPTION
Adds initial support for UO to Text, Number, Boolean, Date, Time, and DateTime coercions in functions which do not accept lambdas. Does not add support for UO to Table coercions. Functions which accept lambdas can never accept UO as the first argument without an explicit override. These explicit overrides will be added in future PRs.