### PR TITLE
Enable DelegationValidationStrategy to determine if a function can be delegated without reporting warnings

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DefaultOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DefaultOpDelegationStrategy.cs
@@ -7,8 +7,8 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
 {
     internal sealed class DefaultBinaryOpDelegationStrategy : BinaryOpDelegationStrategy
     {
-        public DefaultBinaryOpDelegationStrategy(BinaryOp op, TexlFunction function)
-            : base(op, function)
+        public DefaultBinaryOpDelegationStrategy(BinaryOp op, TexlFunction function, bool generateHints = true)
+            : base(op, function, generateHints)
         {
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DefaultUnaryOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DefaultUnaryOpDelegationStrategy.cs
@@ -7,8 +7,8 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
 {
     internal sealed class DefaultUnaryOpDelegationStrategy : UnaryOpDelegationStrategy
     {
-        public DefaultUnaryOpDelegationStrategy(UnaryOp op, TexlFunction function)
-            : base(op, function)
+        public DefaultUnaryOpDelegationStrategy(UnaryOp op, TexlFunction function, bool generateHints = true)
+            : base(op, function, generateHints)
         {
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
@@ -16,8 +16,8 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
     {
         private readonly BinaryOpNode _binaryOpNode;
 
-        public InOpDelegationStrategy(BinaryOpNode node, TexlFunction function)
-            : base(BinaryOp.In, function)
+        public InOpDelegationStrategy(BinaryOpNode node, TexlFunction function, bool generateHints = true)
+            : base(BinaryOp.In, function, generateHints)
         {
             Contracts.AssertValue(node);
             Contracts.Assert(node.Op == BinaryOp.In);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
     {
         private readonly TexlFunction _function;
 
-        public BinaryOpDelegationStrategy(BinaryOp op, TexlFunction function)
-            : base(function)
+        public BinaryOpDelegationStrategy(BinaryOp op, TexlFunction function, bool generateHints = true)
+            : base(function, generateHints)
         {
             Contracts.AssertValue(function);
 
@@ -113,7 +113,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                             return false;
                         }
 
-                        var dottedNodeValStrategy = _function.GetDottedNameNodeDelegationStrategy();
+                        var dottedNodeValStrategy = _function.GetDottedNameNodeDelegationStrategy(GenerateHints);
                         return dottedNodeValStrategy.IsValidDottedNameNode(node.AsDottedName(), binding, metadata, opDelStrategy);
                     }
 
@@ -124,13 +124,13 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                             return false;
                         }
 
-                        var cNodeValStrategy = _function.GetCallNodeDelegationStrategy();
+                        var cNodeValStrategy = _function.GetCallNodeDelegationStrategy(GenerateHints);
                         return cNodeValStrategy.IsValidCallNode(node.AsCall(), binding, metadata);
                     }
 
                 case NodeKind.FirstName:
                     {
-                        var firstNameNodeValStrategy = _function.GetFirstNameNodeDelegationStrategy();
+                        var firstNameNodeValStrategy = _function.GetFirstNameNodeDelegationStrategy(GenerateHints);
                         return firstNameNodeValStrategy.IsValidFirstNameNode(node.AsFirstName(), binding, opDelStrategy);
                     }
 
@@ -142,7 +142,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                         }
 
                         var unaryopNode = node.AsUnaryOpLit();
-                        var unaryOpNodeDelegationStrategy = _function.GetOpDelegationStrategy(unaryopNode.Op);
+                        var unaryOpNodeDelegationStrategy = _function.GetOpDelegationStrategy(unaryopNode.Op, GenerateHints);
                         return unaryOpNodeDelegationStrategy.IsSupportedOpNode(unaryopNode, metadata, binding);
                     }
 
@@ -154,7 +154,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                         }
 
                         var binaryOpNode = node.AsBinaryOp().VerifyValue();
-                        opDelStrategy = _function.GetOpDelegationStrategy(binaryOpNode.Op, binaryOpNode);
+                        opDelStrategy = _function.GetOpDelegationStrategy(binaryOpNode.Op, binaryOpNode, GenerateHints);
 
                         var binaryOpDelStrategy = (opDelStrategy as BinaryOpDelegationStrategy).VerifyValue();
                         Contracts.Assert(binaryOpNode.Op == binaryOpDelStrategy.Op);
@@ -262,7 +262,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return false;
             }
 
-            var opDelStrategy = _function.GetOpDelegationStrategy(binaryOpNode.Op, binaryOpNode);
+            var opDelStrategy = _function.GetOpDelegationStrategy(binaryOpNode.Op, binaryOpNode, GenerateHints);
             var binaryOpDelStrategy = (opDelStrategy as BinaryOpDelegationStrategy).VerifyValue();
             Contracts.Assert(binaryOpNode.Op == binaryOpDelStrategy.Op);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/UnaryOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/UnaryOpDelegationStrategy.cs
@@ -14,8 +14,8 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
     {
         private readonly TexlFunction _function;
 
-        public UnaryOpDelegationStrategy(UnaryOp op, TexlFunction function)
-            : base(function)
+        public UnaryOpDelegationStrategy(UnaryOp op, TexlFunction function, bool generateHints = true)
+            : base(function, generateHints)
         {
             Contracts.AssertValue(function);
 
@@ -89,7 +89,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                             return false;
                         }
 
-                        var dottedNodeValStrategy = _function.GetDottedNameNodeDelegationStrategy();
+                        var dottedNodeValStrategy = _function.GetDottedNameNodeDelegationStrategy(GenerateHints);
                         return dottedNodeValStrategy.IsValidDottedNameNode(node.AsDottedName(), binding, metadata, opDelStrategy);
                     }
 
@@ -100,13 +100,13 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                             return false;
                         }
 
-                        var cNodeValStrategy = _function.GetCallNodeDelegationStrategy();
+                        var cNodeValStrategy = _function.GetCallNodeDelegationStrategy(GenerateHints);
                         return cNodeValStrategy.IsValidCallNode(node.AsCall(), binding, metadata);
                     }
 
                 case NodeKind.FirstName:
                     {
-                        var firstNameNodeValStrategy = _function.GetFirstNameNodeDelegationStrategy();
+                        var firstNameNodeValStrategy = _function.GetFirstNameNodeDelegationStrategy(GenerateHints);
                         return firstNameNodeValStrategy.IsValidFirstNameNode(node.AsFirstName(), binding, opDelStrategy);
                     }
 
@@ -118,7 +118,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                         }
 
                         var unaryOpNode = node.AsUnaryOpLit().VerifyValue();
-                        opDelStrategy = _function.GetOpDelegationStrategy(unaryOpNode.Op).VerifyValue();
+                        opDelStrategy = _function.GetOpDelegationStrategy(unaryOpNode.Op, GenerateHints).VerifyValue();
 
                         var unaryOpDelStrategy = (opDelStrategy as UnaryOpDelegationStrategy).VerifyValue();
                         Contracts.Assert(unaryOpDelStrategy.Op == unaryOpNode.Op);
@@ -140,7 +140,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                         }
 
                         var binaryOpNode = node.AsBinaryOp().VerifyValue();
-                        var binaryOpNodeDelValidationStrategy = _function.GetOpDelegationStrategy(binaryOpNode.Op, binaryOpNode);
+                        var binaryOpNodeDelValidationStrategy = _function.GetOpDelegationStrategy(binaryOpNode.Op, binaryOpNode, GenerateHints);
                         return binaryOpNodeDelValidationStrategy.IsSupportedOpNode(node.AsBinaryOp(), metadata, binding);
                     }
             }
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return false;
             }
 
-            var opDelStrategy = _function.GetOpDelegationStrategy(unaryOpNode.Op);
+            var opDelStrategy = _function.GetOpDelegationStrategy(unaryOpNode.Op, GenerateHints);
             var unaryOpDelStrategy = (opDelStrategy as UnaryOpDelegationStrategy).VerifyValue();
             Contracts.Assert(unaryOpDelStrategy.Op == unaryOpNode.Op);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -702,7 +702,7 @@ namespace Microsoft.PowerFx.Core.Functions
 
         // Returns true if function is row scoped and supports delegation.
         // Needs to be overriden by functions (For example, IsBlank) which are not server delegatable themselves but can become one when scoped inside a delegatable function.
-        public virtual bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public virtual bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
@@ -1209,7 +1209,7 @@ namespace Microsoft.PowerFx.Core.Functions
             return false;
         }
 
-        public virtual IOpDelegationStrategy GetOpDelegationStrategy(BinaryOp op, BinaryOpNode opNode)
+        public virtual IOpDelegationStrategy GetOpDelegationStrategy(BinaryOp op, BinaryOpNode opNode, bool generateHints = true)
         {
             Contracts.AssertValueOrNull(opNode);
 
@@ -1218,10 +1218,10 @@ namespace Microsoft.PowerFx.Core.Functions
                 Contracts.AssertValue(opNode);
                 Contracts.Assert(opNode.Op == op);
 
-                return new InOpDelegationStrategy(opNode, this);
+                return new InOpDelegationStrategy(opNode, this, generateHints);
             }
 
-            return new DefaultBinaryOpDelegationStrategy(op, this);
+            return new DefaultBinaryOpDelegationStrategy(op, this, generateHints);
         }
 
         // This updates the field projection info for datasources. For most of the functions, binder takes care of it.
@@ -1232,24 +1232,24 @@ namespace Microsoft.PowerFx.Core.Functions
             return false;
         }
 
-        public IOpDelegationStrategy GetOpDelegationStrategy(UnaryOp op)
+        public IOpDelegationStrategy GetOpDelegationStrategy(UnaryOp op, bool generateHints = true)
         {
-            return new DefaultUnaryOpDelegationStrategy(op, this);
+            return new DefaultUnaryOpDelegationStrategy(op, this, generateHints);
         }
 
-        public ICallNodeDelegatableNodeValidationStrategy GetCallNodeDelegationStrategy()
+        public ICallNodeDelegatableNodeValidationStrategy GetCallNodeDelegationStrategy(bool generateHints = true)
         {
-            return new DelegationValidationStrategy(this);
+            return new DelegationValidationStrategy(this, generateHints);
         }
 
-        public IDottedNameNodeDelegatableNodeValidationStrategy GetDottedNameNodeDelegationStrategy()
+        public IDottedNameNodeDelegatableNodeValidationStrategy GetDottedNameNodeDelegationStrategy(bool generateHints = true)
         {
-            return new DelegationValidationStrategy(this);
+            return new DelegationValidationStrategy(this, generateHints);
         }
 
-        public IFirstNameNodeDelegatableNodeValidationStrategy GetFirstNameNodeDelegationStrategy()
+        public IFirstNameNodeDelegatableNodeValidationStrategy GetFirstNameNodeDelegationStrategy(bool generateHints = true)
         {
-            return new DelegationValidationStrategy(this);
+            return new DelegationValidationStrategy(this, generateHints);
         }
 
         // Check the type of a specified node against an expected type (either desiredType or DType.Table with a desiredType column)

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
@@ -181,5 +181,20 @@ namespace Microsoft.PowerFx
             lookupInfo = default;
             return false;
         }
+
+        internal override IExternalEntityScope InternalEntityScope
+        {
+            get
+            {
+                foreach (INameResolver table in _symbolTables)
+                {
+                    if (table.EntityScope != null)
+                    {
+                        return table.EntityScope;
+                    }
+                }
+                return default;
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -349,7 +349,8 @@ namespace Microsoft.PowerFx
         // Methods from INameResolver that we default / don't implement
         IExternalDocument INameResolver.Document => default;
 
-        IExternalEntityScope INameResolver.EntityScope => default;
+        internal virtual IExternalEntityScope InternalEntityScope => default;
+        IExternalEntityScope INameResolver.EntityScope => InternalEntityScope;
 
         IExternalEntity INameResolver.CurrentEntity => default;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             return binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled && metadata.IsDelegationSupportedByTable(DelegationCapability.AsType);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -55,13 +55,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(paramTypes[0] == DType.DateTime);
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
             Contracts.AssertValue(metadata);
 
-            return base.IsRowScopedServerDelegatable(callNode, binding, metadata);
+            return base.IsRowScopedServerDelegatable(callNode, binding, metadata, generateHints);
         }
     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/EndsWith.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/EndsWith.cs
@@ -24,13 +24,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
             Contracts.AssertValue(metadata);
 
-            return IsRowScopedServerDelegatableHelper(callNode, binding, metadata);
+            return IsRowScopedServerDelegatableHelper(callNode, binding, metadata, generateHints);
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.IsBlankArg1 };
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
@@ -33,9 +33,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Length;
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
-            return base.IsRowScopedServerDelegatable(callNode, binding, metadata);
+            return base.IsRowScopedServerDelegatable(callNode, binding, metadata, generateHints);
         }
     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return fArgsValid;
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
@@ -116,7 +116,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 {
                     case NodeKind.FirstName:
                         {
-                            var firstNameStrategy = GetFirstNameNodeDelegationStrategy();
+                            var firstNameStrategy = GetFirstNameNodeDelegationStrategy(generateHints);
                             if (!firstNameStrategy.IsValidFirstNameNode(arg.AsFirstName(), binding, null))
                             {
                                 return false;
@@ -127,10 +127,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                     case NodeKind.Call:
                         {
-                            var cNodeStrategy = GetCallNodeDelegationStrategy();
+                            var cNodeStrategy = GetCallNodeDelegationStrategy(generateHints);
                             if (!cNodeStrategy.IsValidCallNode(arg.AsCall(), binding, metadata))
                             {
-                                SuggestDelegationHint(arg, binding);
+                                if (generateHints)
+                                {
+                                    SuggestDelegationHint(arg, binding);
+                                }
                                 return false;
                             }
 
@@ -139,10 +142,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                     case NodeKind.DottedName:
                         {
-                            var dottedStrategy = GetDottedNameNodeDelegationStrategy();
+                            var dottedStrategy = GetDottedNameNodeDelegationStrategy(generateHints);
                             if (!dottedStrategy.IsValidDottedNameNode(arg.AsDottedName(), binding, metadata, null))
                             {
-                                SuggestDelegationHint(arg, binding);
+                                if (generateHints)
+                                {
+                                    SuggestDelegationHint(arg, binding);
+                                }
                                 return false;
                             }
 
@@ -152,10 +158,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     case NodeKind.BinaryOp:
                         {
                             var opNode = arg.AsBinaryOp();
-                            var binaryOpNodeValidationStrategy = GetOpDelegationStrategy(opNode.Op, opNode);
+                            var binaryOpNodeValidationStrategy = GetOpDelegationStrategy(opNode.Op, opNode, generateHints);
                             if (!binaryOpNodeValidationStrategy.IsSupportedOpNode(opNode, metadata, binding))
                             {
-                                SuggestDelegationHint(arg, binding);
+                                if (generateHints)
+                                {
+                                    SuggestDelegationHint(arg, binding);
+                                }
                                 return false;
                             }
 
@@ -165,10 +174,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     case NodeKind.UnaryOp:
                         {
                             var opNode = arg.AsUnaryOpLit();
-                            var unaryOpNodeValidationStrategy = GetOpDelegationStrategy(opNode.Op);
+                            var unaryOpNodeValidationStrategy = GetOpDelegationStrategy(opNode.Op, generateHints);
                             if (!unaryOpNodeValidationStrategy.IsSupportedOpNode(opNode, metadata, binding))
                             {
-                                SuggestDelegationHint(arg, binding);
+                                if (generateHints)
+                                {
+                                    SuggestDelegationHint(arg, binding);
+                                }
                                 return false;
                             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LowerUpper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LowerUpper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override DelegationCapability FunctionDelegationCapability => _isLower ? DelegationCapability.Lower : DelegationCapability.Upper;
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/NotFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/NotFunction.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Not | DelegationCapability.Filter;
 
         // For binary op node args, we need to use filter delegation strategy. Hence we override this method here.
-        public override IOpDelegationStrategy GetOpDelegationStrategy(BinaryOp op, BinaryOpNode opNode)
+        public override IOpDelegationStrategy GetOpDelegationStrategy(BinaryOp op, BinaryOpNode opNode, bool generateHints = true)
         {
             Contracts.AssertValueOrNull(opNode);
 
@@ -44,13 +44,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 Contracts.AssertValue(opNode);
                 Contracts.Assert(opNode.Op == op);
 
-                return new InOpDelegationStrategy(opNode, BuiltinFunctionsCore.Filter);
+                return new InOpDelegationStrategy(opNode, BuiltinFunctionsCore.Filter, generateHints);
             }
 
-            return new DefaultBinaryOpDelegationStrategy(op, BuiltinFunctionsCore.Filter);
+            return new DefaultBinaryOpDelegationStrategy(op, BuiltinFunctionsCore.Filter, generateHints);
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Proper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Proper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             return false;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StartsWith.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StartsWith.cs
@@ -21,13 +21,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
             Contracts.AssertValue(metadata);
 
-            return IsRowScopedServerDelegatableHelper(callNode, binding, metadata);
+            return IsRowScopedServerDelegatableHelper(callNode, binding, metadata, generateHints);
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.StringFuncArg1 };
         }
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 case NodeKind.FirstName:
                     {
-                        var firstNameStrategy = GetFirstNameNodeDelegationStrategy();
+                        var firstNameStrategy = GetFirstNameNodeDelegationStrategy(generateHints);
                         return firstNameStrategy.IsValidFirstNameNode(args[0].AsFirstName(), binding, null);
                     }
 
@@ -67,13 +67,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                             return false;
                         }
 
-                        var cNodeStrategy = GetCallNodeDelegationStrategy();
+                        var cNodeStrategy = GetCallNodeDelegationStrategy(generateHints);
                         return cNodeStrategy.IsValidCallNode(args[0].AsCall(), binding, metadata);
                     }
 
                 case NodeKind.DottedName:
                     {
-                        var dottedStrategy = GetDottedNameNodeDelegationStrategy();
+                        var dottedStrategy = GetDottedNameNodeDelegationStrategy(generateHints);
                         return dottedStrategy.IsValidDottedNameNode(args[0].AsDottedName(), binding, metadata, null);
                     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringTwoArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringTwoArgFunction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
         }
 
-        protected bool IsRowScopedServerDelegatableHelper(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        protected bool IsRowScopedServerDelegatableHelper(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
@@ -58,7 +58,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 switch (argKind)
                 {
                     case NodeKind.FirstName:
-                        var firstNameStrategy = GetFirstNameNodeDelegationStrategy();
+                        var firstNameStrategy = GetFirstNameNodeDelegationStrategy(generateHints);
                         if (!firstNameStrategy.IsValidFirstNameNode(arg.AsFirstName(), binding, null))
                         {
                             return false;
@@ -71,7 +71,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                             return false;
                         }
 
-                        var cNodeStrategy = GetCallNodeDelegationStrategy();
+                        var cNodeStrategy = GetCallNodeDelegationStrategy(generateHints);
                         if (!cNodeStrategy.IsValidCallNode(arg.AsCall(), binding, metadata))
                         {
                             return false;
@@ -82,7 +82,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                         break;
                     case NodeKind.DottedName:
                         {
-                            var dottedStrategy = GetDottedNameNodeDelegationStrategy();
+                            var dottedStrategy = GetDottedNameNodeDelegationStrategy(generateHints);
                             return dottedStrategy.IsValidDottedNameNode(arg.AsDottedName(), binding, metadata, null);
                         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trim.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trim.cs
@@ -38,13 +38,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Trim;
 
-        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
+        public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata, bool generateHints = true)
         {
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
             Contracts.AssertValue(metadata);
 
-            return base.IsRowScopedServerDelegatable(callNode, binding, metadata);
+            return base.IsRowScopedServerDelegatable(callNode, binding, metadata, generateHints);
         }
     }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
@@ -289,6 +291,49 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
             public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
             {
                 return base.GetUniqueTexlRuntimeName() + _runtimeFunctionNameSuffix;
+            }
+        }
+
+        public sealed class MockSilentDelegableFilterFunction : FilterFunctionBase
+        {
+            private readonly string _runtimeFunctionNameSuffix;
+
+            public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+            {
+                yield break;
+            }
+
+            public MockSilentDelegableFilterFunction(string name, string runtimeFunctionNameSuffix)
+                : base(name, (l) => "MockFunction", FunctionCategories.Table, DType.EmptyTable, -2, 2, int.MaxValue, DType.EmptyTable)
+            {
+                _runtimeFunctionNameSuffix = runtimeFunctionNameSuffix;
+                ScopeInfo = new FunctionScopeInfo(this, acceptsLiteralPredicates: false);
+            }
+
+            public override bool IsServerDelegatable(CallNode callNode, TexlBinding binding)
+            {
+                IExternalDataSource dataSource = null;
+
+                if ((binding.Document != null && !binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled) || !TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource))
+                {
+                    if (dataSource != null && !dataSource.IsDelegatable)
+                    {
+                        return false;
+                    }
+                }
+
+                var args = callNode.Args.Children.VerifyValue();
+
+                if (dataSource != null && dataSource.DelegationMetadata != null)
+                {
+                    var metadata = dataSource.DelegationMetadata.FilterDelegationMetadata;
+                    if (!IsValidDelegatableFilterPredicateNode(args[1], binding, metadata, false))
+                    {
+                         return false;
+                    }
+                }
+
+                return false;
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -10,6 +10,8 @@ using Microsoft.PowerFx.Core.App.Controls;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Functions.Delegation;
+using Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata;
 using Microsoft.PowerFx.Core.Glue;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Parser;
@@ -3042,6 +3044,64 @@ namespace Microsoft.PowerFx.Core.Tests
             symbol.AddEntity(new TestDataSource("DS", schema));
 
             TestSimpleBindingSuccess("If(true, DS, DS)", schema, symbol);
+        }
+
+        [Theory]
+        [InlineData("Filter(DS, StartsWith(Value, \"d\"))", false)]
+        [InlineData("Filter(DS, Left(Value, 1) = \"d\")", true)]
+        [InlineData("Filter(DS, Substitute(Value, \"x\", \"y\"))", true)]
+        [InlineData("Filter(DS, Value(Value) <= 3 Or Value(Value) > 7)", true)]
+        public void TestValidDelegatableFilterPredicateNode(string script, bool warnings)
+        {
+            var schema = DType.CreateTable(new TypedName(TestUtils.DT("s"), new DName("Value")));
+
+            var symbol = new DelegatableSymbolTable();
+            symbol.AddEntity(new TestDelegableDataSource("DS", schema, 
+                new TestDelegationMetadata(DelegationCapability.Filter, schema,
+                    new FilterOpMetadata(
+                        schema,
+                        new Dictionary<DPath, DelegationCapability>(),
+                        new Dictionary<DPath, DelegationCapability>(),
+                        new DelegationCapability(DelegationCapability.Equal | DelegationCapability.StartsWith),
+                        null))));
+
+             var silentFilterFunction = new TestUtils.MockSilentDelegableFilterFunction("TestSilentFilter", script);
+
+            try
+            {
+                symbol.AddFunction(silentFilterFunction);
+
+                var config = new PowerFxConfig
+                {
+                    SymbolTable = symbol
+                };
+
+                var engine = new Engine(config);
+
+                // first run using the original Filter
+                var result = engine.Check(script);
+
+                Assert.True(result.IsSuccess);
+
+                if (warnings)
+                {
+                    Assert.True(result.Errors.Count() > 0, "Expected warnings in original function");
+                }
+                else
+                {
+                    Assert.False(result.Errors.Count() > 0, "No warnings expected in original function");
+                }
+
+                // then run with the mock filter function that does silent delgation checks
+                result = engine.Check("TestSilent" + script);
+
+                Assert.True(result.IsSuccess);
+                Assert.False(result.Errors.Count() > 0, "No warnings expected in silent function");
+            }
+            finally
+            {
+                symbol.RemoveFunction(silentFilterFunction);
+            }
         }
 
         private void TestBindingPurity(string script, bool isPure, SymbolTable symbolTable = null)


### PR DESCRIPTION
In order to better understand the challenges that users have in using functions and data sources that can't be delegated today, we need to collect failure telemetry without causing breaking UI changes.

This change adds the ability for a function to create delegation validation strategies that do not generate warnings.