### PR TITLE
Revert portion of #890

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -110,7 +110,29 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 // Verify statically that the format string doesn't contain BOTH numeric and date/time
                 // format specifiers. If it does, that's an error according to Excel and our spec.
-                if (!TextFormatUtils.IsValidFormatArg(formatArg, out _, out _))
+
+                // But firstly skip any locale-prefix
+                if (formatArg.StartsWith("[$-"))
+                {
+                    var end = formatArg.IndexOf(']', 3);
+                    if (end > 0)
+                    {
+                        formatArg = formatArg.Substring(end + 1);
+                    }
+                }
+
+                var hasDateTimeFmt = formatArg.IndexOfAny(new char[] { 'm', 'd', 'y', 'h', 'H', 's', 'a', 'A', 'p', 'P' }) >= 0;
+                var hasNumericFmt = formatArg.IndexOfAny(new char[] { '0', '#' }) >= 0;
+                if (hasDateTimeFmt && hasNumericFmt)
+                {
+                    // Check if the date time format contains '0's after the seconds specifier, which
+                    // is used for fractional seconds - in which case it is valid
+                    var formatWithoutZeroSubseconds = Regex.Replace(formatArg, @"[sS]\.?(0+)",
+                        m => m.Groups[1].Success ? "" : m.Groups[1].Value);
+                    hasNumericFmt = formatWithoutZeroSubseconds.IndexOfAny(new char[] { '0', '#' }) >= 0;
+                }
+
+                if (hasDateTimeFmt && hasNumericFmt)
                 {
                     errors.EnsureError(DocumentErrorSeverity.Moderate, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
                     isValid = false;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -531,7 +531,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 8-26: Incorrect format specifier for 'Text'.
 
 >> Text(1, "M#")
-Errors: Error 0-13: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.
+Error({Kind:ErrorKind.InvalidArgument})
 
 >> Text(Time(2, 53, 9, 3), "mm:ss.00") 
 "53:09.00"
@@ -598,3 +598,7 @@ Errors: Error 0-13: The function 'Text' has some invalid arguments.|Warning 8-12
 
 >> With({format:"0.00 dd/mm/yyyy"},Text(123, format))
 Error({Kind:ErrorKind.InvalidArgument})
+
+// Unrecognized '$' and 'M' char are copied to output. 
+>> Text(123.466, "[$-en-US]$#0.0M") 
+"$123.5M"

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/Text_Format_Override.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/Text_Format_Override.txt
@@ -1,0 +1,5 @@
+﻿#OVERRIDE: Text_Format.txt
+
+// https://github.com/microsoft/Power-Fx/issues/932
+>> Text(123.466, "[$-en-US]$#0.0M") 
+Error({Kind:ErrorKind.InvalidArgument})


### PR DESCRIPTION
#890 makes some Text() format arguments be compile-time errors (if they're literal).  This is handled in Text.cs and shared by all backends -so it impacts PowerApps.
Previously, they may have been runtime errors - which means each backend handles separately. 

Revert the change to Text.cs because that is shared with PowerApps - the change is making this a compile-time error (instead of runtime), which is causing PA to fail at compile time.  
Reverting this so that in effect 890 has no impact on PowerApps (the rest of 890 is interpreter-only changes). 

Here is a specific expression causing a problem: 
`Text(123.466, "[$-en-US]$#0.0M")`

Interpreter doesn't implement it yet (#932), so adding override to call it out.