### PR TITLE
Override GetUniqueTexlRuntimeName;

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -58,6 +58,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.Dec2HexTArg1, TexlStrings.Dec2HexTArg2 };
         }
 
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_T");
+        }
+
         public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Hex2Dec.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Hex2Dec.cs
@@ -45,5 +45,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.Hex2DecTArg1 };
         }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_T");
+        }
     }
 }


### PR DESCRIPTION
Overide GetUniqueTexlRuntimeName to include "_T" at the end of tabular Dec2Hex/Hex2Dec