### PR TITLE
Allow more than 3 subsecond digits in the Text function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -551,6 +551,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrNumberExpected = new ErrorResourceKey("ErrNumberExpected");
         public static ErrorResourceKey ErrNumberTooLarge = new ErrorResourceKey("ErrNumberTooLarge");
         public static ErrorResourceKey ErrTextFormatTooLarge = new ErrorResourceKey("ErrTextFormatTooLarge");
+        public static ErrorResourceKey ErrTextInvalidFormat = new ErrorResourceKey("ErrTextInvalidFormat");
         public static ErrorResourceKey ErrBooleanExpected = new ErrorResourceKey("ErrBooleanExpected");
         public static ErrorResourceKey ErrOnlyOneViewExpected = new ErrorResourceKey("ErrOnlyOneViewExpected");
         public static ErrorResourceKey ErrViewFromCurrentTableExpected = new ErrorResourceKey("ErrViewFromCurrentTableExpected");

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -433,12 +433,6 @@ namespace Microsoft.PowerFx.Functions
             format = _milisecondsDetokenizeRegex.Replace(format, match =>
             {
                 var len = match.Groups[0].Value.Length;
-                if (len > 7)
-                {
-                    // Exception will be replaced by an error in the caller
-                    throw new FormatException("Only 7 digits are supported");
-                }
-
                 var subSecondFormat = len == 1 ? "%f" : new string('f', len);
                 return dateTime.ToString(subSecondFormat, culture);
             });

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1841,6 +1841,10 @@
     <value>Format string size can't be more than {0} characters.</value>
     <comment>Error Message.</comment>
   </data>
+  <data name="ErrTextInvalidFormat" xml:space="preserve">
+    <value>Invalid format.</value>
+    <comment>Error Message returned by the Text function when the format passed to it is invalid.</comment>
+  </data>
   <data name="ErrInvalidDataSource" xml:space="preserve">
     <value>This Data source is invalid. Please fix the error in "Data sources" pane by clicking "Content -&gt; Data sources" or "View -&gt; Options"</value>
     <comment>Error Message.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -602,3 +602,25 @@ Error({Kind:ErrorKind.InvalidArgument})
 // Unrecognized '$' and 'M' char are copied to output. 
 >> Text(123.466, "[$-en-US]$#0.0M") 
 "$123.5M"
+
+>> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.000")
+"2023-01-03 09:23:45.678"
+
+>> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.0000")
+"2023-01-03 09:23:45.6780"
+
+>> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.00000")
+"2023-01-03 09:23:45.67800"
+
+>> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.000000")
+"2023-01-03 09:23:45.678000"
+
+>> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.0000000")
+"2023-01-03 09:23:45.6780000"
+
+>> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.00000000")
+Error({Kind:ErrorKind.InvalidArgument})
+
+// C# interpreter can handle up to 7 decimals after the second
+>> Text(DateTimeValue("2023-01-03 00:01:02.3456789"), "yyyy-mm-dd hh:mm:ss.0000000")
+"2023-01-03 00:01:02.3456789"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -621,6 +621,21 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> Text(DateTime(2023,1,3,9,23,45,678), "yyyy-mm-dd hh:mm:ss.00000000")
 Error({Kind:ErrorKind.InvalidArgument})
 
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.0000") 
+"1983-06-03 00:28:07.5000"
+
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.00000") 
+"1983-06-03 00:28:07.50000"
+
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.000000") 
+"1983-06-03 00:28:07.500000"
+
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.0000000") 
+"1983-06-03 00:28:07.5000000"
+
+>> Text(30470.01953125, "YYYY-MM-DD HH:MM:SS.00000000") 
+Error({Kind:ErrorKind.InvalidArgument})
+
 // C# interpreter can handle up to 7 decimals after the second
 >> Text(DateTimeValue("2023-01-03 00:01:02.3456789"), "yyyy-mm-dd hh:mm:ss.0000000")
 "2023-01-03 00:01:02.3456789"


### PR DESCRIPTION
.NET supports up to 7 sub-second digits, so we should support it in the Text function as well.