### PR TITLE
Split IServiceProvider out of SymbolValues

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/BasicServiceProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/BasicServiceProvider.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.PowerFx
+{    
+    /// <summary>
+    /// Trivial <see cref="IServiceProvider"/> implementation that allows chaining and composition. 
+    /// </summary>
+    public sealed class BasicServiceProvider : IServiceProvider
+    {
+        // Chain to list of inner service providers. 
+        private readonly IServiceProvider[] _inners;
+
+        // services we implement. 
+        private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+        public BasicServiceProvider()
+            : this(null)
+        {
+        }
+
+        // Chain to an inner service. 
+        // Must always create a new copy since the caller can now AddServices to this. 
+        public BasicServiceProvider(params IServiceProvider[] inners)
+        {
+            _inners = (inners?.Length == 0) ? null : inners;
+        }
+
+        public void AddService<T>(T service)
+        {
+            AddService(typeof(T), service);
+        }
+
+        public void AddService(Type serviceType, object service)
+        {
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            if (!serviceType.IsAssignableFrom(service.GetType()))
+            {
+                throw new InvalidOperationException($"Service instance {service.GetType()} must match service type {serviceType.GetType()}.");
+            }
+
+            _services[serviceType] = service;
+        }
+
+        // Null if service is missing 
+        public object GetService(Type serviceType)
+        {
+            if (!_services.TryGetValue(serviceType, out var service))
+            {
+                if (_inners != null)
+                {
+                    foreach (var inner in _inners)
+                    {
+                        service = inner?.GetService(serviceType);
+                        if (service != null)
+                        {
+                            return service;
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            return service;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
@@ -16,17 +16,12 @@ namespace Microsoft.PowerFx
         // Map to composed tables 
         private readonly IReadOnlyDictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> _map;
 
-        // Existing services providers. Chain to in order.
-        private readonly IServiceProvider[] _existing;
-
         private ComposedReadOnlySymbolValues(
             ReadOnlySymbolTable symbolTable,
-            IReadOnlyDictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map,
-            IServiceProvider[] existing)
+            IReadOnlyDictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map)
             : base(symbolTable)
         {
             _map = map;
-            _existing = existing;
             DebugName = symbolTable.DebugName;
         }
 
@@ -80,7 +75,7 @@ namespace Microsoft.PowerFx
                 return symValues;
             }
 
-            return new ComposedReadOnlySymbolValues(symbolTable, map, existing);
+            return new ComposedReadOnlySymbolValues(symbolTable, map);
         }
 
         private static void Add(Dictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map, ReadOnlySymbolValues symValues)
@@ -161,20 +156,6 @@ namespace Microsoft.PowerFx
             {
                 throw new NotImplementedException($"Unhandled symbol table kind: {symbolTable.DebugName} of type {symbolTable.GetType().FullName} ");
             }
-        }
-
-        public override object GetService(Type serviceType)
-        {
-            foreach (var table in _existing)
-            {
-                var service = table.GetService(serviceType);
-                if (service != null)
-                {
-                    return service;
-                }
-            }
-
-            return null;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerFx
     /// See <see cref="SymbolValues"/> for a mutable derived class. 
     /// </summary>
     [DebuggerDisplay("{this.GetType().Name}({DebugName})")]
-    public abstract class ReadOnlySymbolValues : IServiceProvider
+    public abstract class ReadOnlySymbolValues
     {
         private readonly ReadOnlySymbolTable _symbolTable;
 
@@ -25,22 +25,6 @@ namespace Microsoft.PowerFx
         /// Get the symbol table that these values correspond to.
         /// </summary>
         public ReadOnlySymbolTable SymbolTable => _symbolTable;
-
-        /// <summary>
-        /// Expose services to functions. For example, this can provide TimeZone information to the 
-        /// Now()/TimeZoneInfo()/etc. Or current culture to the various text parsing functions. 
-        /// </summary>
-        /// <param name="serviceType">type of service requested.</param>
-        /// <returns>Return null if service is not provided.</returns>
-        public virtual object GetService(Type serviceType)
-        {
-            return null;
-        }
-
-        public T GetService<T>()
-        {
-            return (T)GetService(typeof(T));
-        }
 
         protected ReadOnlySymbolValues(ReadOnlySymbolTable symbolTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+    /// <summary>
+    /// Runtime configuration for the execution of an expression.
+    /// </summary>
+    public class RuntimeConfig
+    {
+        /// <summary>
+        /// This should match the SymbolTable provided at bind time. 
+        /// </summary>
+        public ReadOnlySymbolValues Values { get; set; }
+
+        public IServiceProvider Services { get; set; }
+
+        // Other services:
+        // CultureInfo, Timezone, Clock, 
+        // Stack depth 
+        // Max memory 
+        // Logging
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Types;
 
@@ -10,20 +11,95 @@ namespace Microsoft.PowerFx
 {
     /// <summary>
     /// Runtime configuration for the execution of an expression.
+    /// This can be reused across multiple evals - so it shouldn't have any state that expires such as a cancellation token. 
     /// </summary>
-    public class RuntimeConfig
+    public sealed class RuntimeConfig
     {
         /// <summary>
         /// This should match the SymbolTable provided at bind time. 
         /// </summary>
         public ReadOnlySymbolValues Values { get; set; }
 
-        public IServiceProvider Services { get; set; }
+        public BasicServiceProvider Services { get; set; } = new BasicServiceProvider();
 
         // Other services:
         // CultureInfo, Timezone, Clock, 
         // Stack depth 
         // Max memory 
         // Logging
+        // 
+
+        // $$$ Implicit conversion operator?
+        public RuntimeConfig()
+        {
+        }
+
+        public RuntimeConfig(ReadOnlySymbolValues values)
+        {
+            this.Values = values;
+        }
+
+        public RuntimeConfig(ReadOnlySymbolValues values, CultureInfo runtimeCulture)
+        {
+            this.Values = values;
+            AddService(runtimeCulture); // $$$ Nom utates the services... which could be shared. 
+        }
+
+        public void AddService<T>(T service)
+        {
+            Services.AddService(typeof(T), service);
+        }
+
+        public T GetService<T>()
+        {
+            return (T) Services.GetService(typeof(T));
+        }
+    }
+
+    // $$$
+    // Use existing?
+    // https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.serviceprovider?view=dotnet-plat-ext-7.0 ? 
+    public sealed class BasicServiceProvider : IServiceProvider
+    {
+        private readonly IServiceProvider _inner;
+
+
+        private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+        public BasicServiceProvider() : this(null)
+        {
+        }
+
+        // Chain to an inner service. 
+        public BasicServiceProvider(IServiceProvider inner)
+        {
+            _inner = inner;
+        }
+
+        public void AddService(Type serviceType, object service)
+        {
+            if (service == null)
+            {
+                throw new ArgumentNullException(nameof(service));
+            }
+
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            _services[serviceType] = service;
+        }
+
+
+        // Null if service is missing 
+        public object GetService(Type serviceType)
+        {
+            if (!_services.TryGetValue(serviceType, out var service))
+            {
+                return _inner?.GetService(serviceType);
+            }
+            return service;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
@@ -35,7 +35,9 @@ namespace Microsoft.PowerFx
         /// </summary>
         public ReadOnlySymbolValues Values { get; set; }
 
-        // $$$ Can this just be a IServiceProvider? But then how do we add to it?
+        /// <summary>
+        /// Mutable set of serivces for runtime functions and evaluation. 
+        /// </summary>
         public BasicServiceProvider Services { get; set; } = new BasicServiceProvider();
 
         IServiceProvider IRuntimeConfig.Services => Services;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/RuntimeConfig.cs
@@ -19,9 +19,9 @@ namespace Microsoft.PowerFx
         public ReadOnlySymbolValues Values { get; }
 
         /// <summary>
-        /// Services. 
+        /// Mutable set of serivces for runtime functions and evaluation. 
         /// </summary>
-        public IServiceProvider Services { get; }
+        public IServiceProvider ServiceProvider { get; }
     }
 
     /// <summary>
@@ -38,9 +38,9 @@ namespace Microsoft.PowerFx
         /// <summary>
         /// Mutable set of serivces for runtime functions and evaluation. 
         /// </summary>
-        public BasicServiceProvider Services { get; set; } = new BasicServiceProvider();
+        public BasicServiceProvider ServiceProvider { get; set; } = new BasicServiceProvider();
 
-        IServiceProvider IRuntimeConfig.Services => Services;
+        IServiceProvider IRuntimeConfig.ServiceProvider => ServiceProvider;
 
         public RuntimeConfig()
         {
@@ -65,12 +65,12 @@ namespace Microsoft.PowerFx
         // - Logging
         public void AddService<T>(T service)
         {
-            Services.AddService(typeof(T), service);
+            ServiceProvider.AddService(typeof(T), service);
         }
 
         public T GetService<T>()
         {
-            return (T)Services.GetService(typeof(T));
+            return (T)ServiceProvider.GetService(typeof(T));
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerFx
         /// <param name="symbols">SymbolValues where to set the TimeZoneInfo.</param>
         /// <param name="timezone">TimeZoneInfo to set.</param>
         /// <exception cref="ArgumentNullException">When timezone is null.</exception>
-        public static void SetTimeZone(this SymbolValues symbols, TimeZoneInfo timezone)
+        public static void SetTimeZone(this RuntimeConfig symbols, TimeZoneInfo timezone)
         {
             symbols.AddService(timezone ?? throw new ArgumentNullException(nameof(timezone)));
         }
@@ -26,7 +26,7 @@ namespace Microsoft.PowerFx
         /// <param name="symbols">SymbolValues where to set the CultureInfo.</param>
         /// <param name="culture">CultureInfo to set.</param>
         /// <exception cref="ArgumentNullException">When culture is null.</exception>
-        public static void SetCulture(this SymbolValues symbols, CultureInfo culture)
+        public static void SetCulture(this RuntimeConfig symbols, CultureInfo culture)
         {
             symbols.AddService(culture ?? throw new ArgumentNullException(nameof(culture)));
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolValues.cs
@@ -19,9 +19,6 @@ namespace Microsoft.PowerFx
         // Index by Slot.SlotIndex. This could be optimized to be a dense array. 
         private readonly Dictionary<int, Tuple<ISymbolSlot, FormulaValue>> _symbolValues = new Dictionary<int, Tuple<ISymbolSlot, FormulaValue>>();
 
-        // Services for runtime functions. Lazy created.
-        private Dictionary<Type, object> _services;
-
         private readonly SymbolTable _symTable;
 
         /// <summary>
@@ -45,19 +42,6 @@ namespace Microsoft.PowerFx
             DebugName = table.DebugName;
         }
 
-        public SymbolValues AddService<T>(T data)
-        {
-            // this changes the symbols.            
-            if (_services == null)
-            {
-                _services = new Dictionary<Type, object>();
-            }
-
-            // Can't already exist. 
-            _services.Add(typeof(T), data);
-            return this;
-        }
-
         /// <summary>
         /// Convenience method to add a new unique symbol.
         /// </summary>
@@ -70,16 +54,6 @@ namespace Microsoft.PowerFx
             Set(slot, value);
 
             return this;
-        }
-
-        public override object GetService(Type serviceType)
-        {
-            if (_services != null && _services.TryGetValue(serviceType, out var data))
-            {
-                return data;
-            }
-
-            return null;
         }
 
         public override void Set(ISymbolSlot slot, FormulaValue value)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx
             _symbolValues = config.Values; // may be null 
             _cancellationToken = cancellationToken;
 
-            _services = config.Services ?? new BasicServiceProvider();
+            _services = config.ServiceProvider ?? new BasicServiceProvider();
 
             CultureInfo = GetService<CultureInfo>();
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -25,9 +25,7 @@ namespace Microsoft.PowerFx
     // Use Task for public methods, but ValueTask for internal methods that we expect to be mostly sync. 
     internal class EvalVisitor : IRNodeVisitor<ValueTask<FormulaValue>, EvalVisitorContext>
     {
-        private readonly CultureInfo _cultureInfo;
-
-        private readonly ReadOnlySymbolValues _runtimeConfig;
+        private readonly ReadOnlySymbolValues _symbolValues;
 
         private readonly CancellationToken _cancellationToken;
 
@@ -37,25 +35,16 @@ namespace Microsoft.PowerFx
 
         public IServiceProvider FunctionServices => _services;
 
-        public CultureInfo CultureInfo => _cultureInfo;
+        public CultureInfo CultureInfo { get; private set; }
 
-        /* $$$
-        public EvalVisitor(CultureInfo cultureInfo, CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig = null)
+        public EvalVisitor(IRuntimeConfig config, CancellationToken cancellationToken)
         {
-            _defaultCultureInfo = cultureInfo;
-            _cancellationToken = cancellationToken;
-            _runtimeConfig = runtimeConfig;
-        }*/
-
-        public EvalVisitor(RuntimeConfig config, CancellationToken cancellationToken)
-        {
-            _runtimeConfig = config.Values; // may be null 
+            _symbolValues = config.Values; // may be null 
             _cancellationToken = cancellationToken;
 
             _services = config.Services ?? new BasicServiceProvider();
-            
-            // $$$ Pass in culture?
-            _cultureInfo = GetService<CultureInfo>();
+
+            CultureInfo = GetService<CultureInfo>();
         }
 
         /// <summary>
@@ -160,9 +149,9 @@ namespace Microsoft.PowerFx
             {
                 if (obj.Value is ISymbolSlot sym)
                 {
-                    if (_runtimeConfig != null)
+                    if (_symbolValues != null)
                     {
-                        _runtimeConfig.Set(sym, newValue);
+                        _symbolValues.Set(sym, newValue);
                         return FormulaValue.New(true);
                     }
 
@@ -621,9 +610,9 @@ namespace Microsoft.PowerFx
 
         private FormulaValue GetVariableOrFail(ResolvedObjectNode node, ISymbolSlot slot)
         {
-            if (_runtimeConfig != null)                
+            if (_symbolValues != null)                
             {
-                var value = _runtimeConfig.Get(slot);
+                var value = _symbolValues.Get(slot);
                 if (value != null)
                 {
                     return value;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -31,13 +31,11 @@ namespace Microsoft.PowerFx
 
         private readonly CancellationToken _cancellationToken;
 
-<<<<<<< HEAD
         internal CancellationToken CancellationToken => _cancellationToken;
-=======
+
         private readonly IServiceProvider _services;
 
         public IServiceProvider FunctionServices => _services;
->>>>>>> Remove IServiceProvider from SymbolValues
 
         public CultureInfo CultureInfo => _cultureInfo;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PowerFx
             var runtimeConfig2 = new RuntimeConfig
             {
                 Values = symbolValues,
-                Services = new BasicServiceProvider(runtimeConfig?.Services, innerServices)
+                ServiceProvider = new BasicServiceProvider(runtimeConfig?.ServiceProvider, innerServices)
             };
 
             var evalVisitor = new EvalVisitor(runtimeConfig2, cancellationToken);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -50,7 +50,6 @@ namespace Microsoft.PowerFx
             return await expr.EvalAsync(cancellationToken, new RuntimeConfig(runtimeConfig));
         }
 
-
         public static async Task<FormulaValue> EvalAsync(this IExpressionEvaluator expr, CancellationToken cancellationToken, ReadOnlySymbolValues symbolValues)
         {
             var runtimeConfig = new RuntimeConfig(symbolValues);
@@ -155,9 +154,14 @@ namespace Microsoft.PowerFx
             // var culture = runtimeConfig.GetService<CultureInfo>() ?? _cultureInfo;
             var runtimeConfig2 = new RuntimeConfig
             {
-                 Values = symbolValues,
-                 Services = runtimeConfig.Services // $$$ 
+                Values = symbolValues
             };
+
+            // $$$ Anti-pattern.
+            if (runtimeConfig != null)
+            {
+                runtimeConfig2.Services = runtimeConfig.Services;
+            }
 
             // If RuntimeConfig doesn't have a culture, fallback to the culture used for parsing. 
             var culture = runtimeConfig2.GetService<CultureInfo>();

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx
     /// </summary>
     public interface IExpressionEvaluator
     {
-        public Task<FormulaValue> EvalAsync(CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig = null);
+        public Task<FormulaValue> EvalAsync(CancellationToken cancellationToken, RuntimeConfig runtimeConfig = null);
     }
 
     // Extensions for adding evaluation methods. 
@@ -27,7 +27,12 @@ namespace Microsoft.PowerFx
     // Creating an evaluator uses internal state. 
     public static class CheckResultExtensions
     {
-        public static FormulaValue Eval(this IExpressionEvaluator expr, ReadOnlySymbolValues runtimeConfig = null)
+        public static FormulaValue Eval(this IExpressionEvaluator expr, ReadOnlySymbolValues runtimeConfig)
+        {
+            return expr.EvalAsync(CancellationToken.None, new RuntimeConfig(runtimeConfig)).Result;
+        }
+
+        public static FormulaValue Eval(this IExpressionEvaluator expr, RuntimeConfig runtimeConfig = null)
         {
             return expr.EvalAsync(CancellationToken.None, runtimeConfig).Result;
         }
@@ -42,6 +47,13 @@ namespace Microsoft.PowerFx
             // If we eval with a RecordValue, we must have called Check with a RecordType. 
             var parameterType = ((ParsedExpression)expr)._parameterSymbolTable;
             var runtimeConfig = SymbolValues.NewFromRecord(parameterType, parameters);
+            return await expr.EvalAsync(cancellationToken, new RuntimeConfig(runtimeConfig));
+        }
+
+
+        public static async Task<FormulaValue> EvalAsync(this IExpressionEvaluator expr, CancellationToken cancellationToken, ReadOnlySymbolValues symbolValues)
+        {
+            var runtimeConfig = new RuntimeConfig(symbolValues);
             return await expr.EvalAsync(cancellationToken, runtimeConfig);
         }
 
@@ -109,17 +121,18 @@ namespace Microsoft.PowerFx
         async Task<FormulaValue> IExpression.EvalAsync(RecordValue parameters, CancellationToken cancellationToken)
         {
             var useRowScope = _topScopeSymbol.AccessedFields.Count > 0;
-            ReadOnlySymbolValues runtimeConfig = null;
+            ReadOnlySymbolValues symbolValues = null;
 
             // For backwards compat - if a caller with internals access created a IR that binds to 
             // rowscope directly, then apply parameters to row scope. 
             if (!useRowScope)
             {
-                runtimeConfig = SymbolValues.NewFromRecord(parameters);
+                symbolValues = SymbolValues.NewFromRecord(parameters);
                 parameters = RecordValue.Empty();
             }
 
-            var evalVisitor = new EvalVisitor(_cultureInfo, cancellationToken, runtimeConfig);
+            var runtimeConfig = new RuntimeConfig(symbolValues, _cultureInfo);
+            var evalVisitor = new EvalVisitor(runtimeConfig, cancellationToken);
             try
             {
                 var newValue = await _irnode.Accept(evalVisitor, new EvalVisitorContext(SymbolContext.NewTopScope(_topScopeSymbol, parameters), _stackMarker));
@@ -131,16 +144,29 @@ namespace Microsoft.PowerFx
             }
         }
 
-        public async Task<FormulaValue> EvalAsync(CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig = null)
+        public async Task<FormulaValue> EvalAsync(CancellationToken cancellationToken, RuntimeConfig runtimeConfig = null)
         {
-            ReadOnlySymbolValues runtimeConfig2 = ComposedReadOnlySymbolValues.New(
+            ReadOnlySymbolValues symbolValues = ComposedReadOnlySymbolValues.New(
                 false,
                 _allSymbols,
-                runtimeConfig,
+                runtimeConfig?.Values,
                 _globals);
 
-            var culture = runtimeConfig2.GetService<CultureInfo>() ?? _cultureInfo;
-            var evalVisitor = new EvalVisitor(culture, cancellationToken, runtimeConfig2);
+            // var culture = runtimeConfig.GetService<CultureInfo>() ?? _cultureInfo;
+            var runtimeConfig2 = new RuntimeConfig
+            {
+                 Values = symbolValues,
+                 Services = runtimeConfig.Services // $$$ 
+            };
+
+            // If RuntimeConfig doesn't have a culture, fallback to the culture used for parsing. 
+            var culture = runtimeConfig2.GetService<CultureInfo>();
+            if (culture == null && _cultureInfo != null)
+            {
+                runtimeConfig2.SetCulture(_cultureInfo);
+            }
+
+            var evalVisitor = new EvalVisitor(runtimeConfig2, cancellationToken);
 
             try
             {
@@ -155,12 +181,21 @@ namespace Microsoft.PowerFx
 
         internal async Task<FormulaValue> EvalAsyncInternal(RecordValue parameters, CancellationToken cancel, StackDepthCounter stackMarker)
         {
-            var runtimeConfig = SymbolValues.NewFromRecord(_parameterSymbolTable, parameters);
+            var symbolValues = SymbolValues.NewFromRecord(_parameterSymbolTable, parameters);
             parameters = RecordValue.Empty();
+
+            var runtimeConfig2 = new RuntimeConfig
+            {
+                Values = symbolValues                
+            };
+            if (_cultureInfo != null)
+            {
+                runtimeConfig2.SetCulture(_cultureInfo);
+            }
 
             // We don't catch the max call depth exception here becuase someone could swallow the error with an "IfError" check.
             // Instead we only catch at the top of parsed expression, which is the above function.
-            var ev2 = new EvalVisitor(_cultureInfo, cancel, runtimeConfig);
+            var ev2 = new EvalVisitor(runtimeConfig2, cancel);
             var newValue = await _irnode.Accept(ev2, new EvalVisitorContext(SymbolContext.NewTopScope(_topScopeSymbol, parameters), stackMarker));
             return newValue;
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -159,17 +159,24 @@ namespace Microsoft.PowerFx
             }
 
             var symbolValues = ReadOnlySymbolValues.NewFromRecord(parameters);
+            var runtimeConfig = new RuntimeConfig(symbolValues);
 
-            return await EvalAsync(expressionText, cancellationToken, options, null, symbolValues);
+            return await EvalAsync(expressionText, cancellationToken, options, null, runtimeConfig);
         }
 
-        public async Task<FormulaValue> EvalAsync(string expressionText, CancellationToken cancellationToken, ParserOptions options = null, ReadOnlySymbolTable symbolTable = null, ReadOnlySymbolValues runtimeConfig = null)
+        public async Task<FormulaValue> EvalAsync(string expressionText, CancellationToken cancellationToken, ReadOnlySymbolValues runtimeConfig)
+        {
+            var runtimeConfig2 = new RuntimeConfig(runtimeConfig);
+            return await EvalAsync(expressionText, cancellationToken, runtimeConfig: runtimeConfig2);
+        }
+
+        public async Task<FormulaValue> EvalAsync(string expressionText, CancellationToken cancellationToken, ParserOptions options = null, ReadOnlySymbolTable symbolTable = null, RuntimeConfig runtimeConfig = null)
         {
             // We could have any combination of symbols and runtime values. 
             // - RuntimeConfig may be null if we don't need it. 
             // - Some Symbols are metadata-only (like option sets, UDFs, constants, etc)
             // and hence don't require a corresponnding runtime Symbol Value. 
-            var parameterSymbols = runtimeConfig?.SymbolTable;
+            var parameterSymbols = runtimeConfig?.Values?.SymbolTable;
             var symbolsAll = ReadOnlySymbolTable.Compose(parameterSymbols, symbolTable);
 
             var check = Check(expressionText, options, symbolsAll);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineWorker.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineWorker.cs
@@ -71,7 +71,8 @@ namespace Microsoft.PowerFx
 
                 var symbols = _parent._symbolValues;
 
-                var v = new EvalVisitor(_cultureInfo, CancellationToken.None, symbols);
+                var runtimeConfig = new RuntimeConfig(symbols, _cultureInfo);
+                var v = new EvalVisitor(runtimeConfig, CancellationToken.None);
 
                 var newValue = irnode.Accept(v, new EvalVisitorContext(SymbolContext.New(), new StackDepthCounter(_parent.Config.MaxCallDepth))).Result;
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
@@ -266,17 +266,17 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void RecalcEngine_Symbol_CultureInfo()
         {
-            var us_Symbols = new SymbolValues();
+            var us_Symbols = new RuntimeConfig();
             var us_Culture = new CultureInfo("en-US");
             us_Symbols.AddService(us_Culture);
             var us_ParserOptions = new ParserOptions() { Culture = us_Culture };
 
-            var fr_Symbols = new SymbolValues();
+            var fr_Symbols = new RuntimeConfig();
             var fr_Culture = new CultureInfo("fr-FR");
             fr_Symbols.AddService(fr_Culture);
             var fr_ParserOptions = new ParserOptions() { Culture = fr_Culture };
 
-            var fa_Symbols = new SymbolValues();
+            var fa_Symbols = new RuntimeConfig();
             var fa_Culture = new CultureInfo("fa-IR");
             fa_Symbols.AddService(fa_Culture);
 
@@ -294,12 +294,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void RecalcEngine_Symbol_CultureInfo2()
         {
-            var us_Symbols = new SymbolValues();
+            var us_Symbols = new RuntimeConfig();
             var us_Culture = new CultureInfo("en-US");
             us_Symbols.AddService(us_Culture);
             var us_ParserOptions = new ParserOptions() { Culture = us_Culture };
 
-            var fr_Symbols = new SymbolValues();
+            var fr_Symbols = new RuntimeConfig();
             var fr_Culture = new CultureInfo("fr-FR");
             fr_Symbols.AddService(fr_Culture);
             var fr_ParserOptions = new ParserOptions() { Culture = fr_Culture };
@@ -323,7 +323,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var config = new PowerFxConfig(CultureInfo.InvariantCulture);
             var engine = new RecalcEngine(config);
 
-            var tr_symbols = new SymbolValues();
+            var tr_symbols = new RuntimeConfig();
 
             tr_symbols.AddService(new CultureInfo("tr-TR"));
 
@@ -348,7 +348,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var config = new PowerFxConfig(CultureInfo.InvariantCulture);
             var engine = new RecalcEngine(config);
 
-            var us_symbols = new SymbolValues();
+            var us_symbols = new RuntimeConfig();
 
             us_symbols.AddService(new CultureInfo("en-US"));
 
@@ -561,8 +561,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             foreach (var name in new string[] { "Bill", "Steve", "Satya" })
             {
-                var runtime = new SymbolValues()
-                    .AddService(new UserFunction.Runtime { _name = name });
+                var runtime = new RuntimeConfig();
+                runtime.AddService(new UserFunction.Runtime { _name = name });
                 var result = await expr.EvalAsync(CancellationToken.None, runtime);
 
                 var expected = name + "3";
@@ -602,8 +602,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var s1 = new SymbolTable();
             s1.AddFunction(new UserFunction());
 
-            var runtime = new SymbolValues()
-                .AddService(new UserFunction.Runtime { _name = "Bill" });
+            var runtime = new RuntimeConfig();
+            runtime.AddService(new UserFunction.Runtime { _name = "Bill" });
 
             var engine = new RecalcEngine();
 
@@ -624,16 +624,17 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var s1 = new SymbolTable();
             s1.AddFunction(new UserFunction());
 
-            var r1 = new SymbolValues
-            {
-                DebugName = "Runtime-AddUserService"
-            }.AddService(new UserFunction.Runtime { _name = "Bill" });
-
+            
             var r2 = new SymbolValues
             {
                 DebugName = "Runtime-X",
             }.Add("x", FormulaValue.New(3));
-            var r12 = ReadOnlySymbolValues.Compose(r2, r1);
+
+            var r12 = new RuntimeConfig
+            {
+                 Values = r2
+            };
+            r12.AddService(new UserFunction.Runtime { _name = "Bill" });
 
             var engine = new RecalcEngine();
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
@@ -623,7 +623,6 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         {
             var s1 = new SymbolTable();
             s1.AddFunction(new UserFunction());
-
             
             var r2 = new SymbolValues
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -397,8 +397,8 @@ namespace Microsoft.PowerFx.Tests
 
             foreach (var name in new string[] { "Bill", "Steve", "Satya" })
             {
-                var runtime = new SymbolValues()
-                    .AddService(new UserAsyncFunction.Runtime { _name = name });
+                var runtime = new RuntimeConfig();
+                runtime.AddService(new UserAsyncFunction.Runtime { _name = name });
                 var result = await expr.EvalAsync(CancellationToken.None, runtime);
 
                 var expected = name + "3";

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/AsyncVerify.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/AsyncVerify.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerFx.Tests
 
         public async Task<FormulaValue> EvalAsync(RecalcEngine engine, string expr, InternalSetup setup)
         {
-            var rtConfig = new SymbolValues();
+            var rtConfig = new RuntimeConfig();
 
             if (setup.TimeZoneInfo != null)
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -292,16 +292,15 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     return new RunResult(check);
                 }
 
-                var rtConfig = SymbolValues.NewFromRecord(symbolTable, parameters);
+                var symbolValues = SymbolValues.NewFromRecord(symbolTable, parameters);
+                var runtimeConfig = new RuntimeConfig(symbolValues);
                                 
                 if (iSetup.TimeZoneInfo != null)
-                {
-                    var commonSymbols = new SymbolValues();
-                    commonSymbols.AddService(iSetup.TimeZoneInfo);
-                    rtConfig = ReadOnlySymbolValues.Compose(rtConfig, commonSymbols);
+                {                    
+                    runtimeConfig.AddService(iSetup.TimeZoneInfo);
                 }
 
-                var newValue = await check.GetEvaluator().EvalAsync(CancellationToken.None, rtConfig);
+                var newValue = await check.GetEvaluator().EvalAsync(CancellationToken.None, runtimeConfig);
 
                 // UntypedObjectType type is currently not supported for serialization.
                 if (newValue.Type is UntypedObjectType)
@@ -310,7 +309,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 }
 
                 // Serialization test. Serialized expression must produce an identical result.
-                var newValueDeserialized = await engine.EvalAsync(newValue.ToExpression(), CancellationToken.None, runtimeConfig: rtConfig);
+                var newValueDeserialized = await engine.EvalAsync(newValue.ToExpression(), CancellationToken.None, runtimeConfig: runtimeConfig);
 
                 return new RunResult(newValueDeserialized);
             }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerFx.Tests
                 $"{ns}.{nameof(IDynamicTypeMarshaller)}",
                 $"{ns}.{nameof(ObjectMarshallerProvider)}",
                 $"{ns}.{nameof(ObjectMarshaller)}",
+                $"{ns}.{nameof(RuntimeConfig)}",
                 $"{ns}.{nameof(PrimitiveMarshallerProvider)}",
                 $"{ns}.{nameof(PrimitiveTypeMarshaller)}",
                 $"{ns}.{nameof(SymbolValues)}",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -832,7 +832,7 @@ namespace Microsoft.PowerFx.Tests
             // CultureInfo not set in PowerFxConfig as we use Symbols
             var pfxConfig = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(pfxConfig);
-            var symbols = new SymbolValues();
+            var symbols = new RuntimeConfig();
 
             // 10/30/22 is the date where DST applies in France (https://www.timeanddate.com/time/change/france/paris)
             // So adding 2 hours to 1:34am will result in 2:34am
@@ -870,7 +870,7 @@ namespace Microsoft.PowerFx.Tests
         public void FunctionServices()
         {
             var engine = new RecalcEngine();
-            var values = new SymbolValues();
+            var values = new RuntimeConfig();
             values.AddService<IRandomService>(new TestRandService());
 
             // Rand 
@@ -890,7 +890,7 @@ namespace Microsoft.PowerFx.Tests
             // Need to protect against bogus values from a poorly implemented service.
             // These are exceptions, not ErrorValues, since it's a host bug. 
             var engine = new RecalcEngine();
-            var values = new SymbolValues();
+            var values = new RuntimeConfig();
 
             // Host bug, service should be 0...1, this is out of range. 
             var buggyService = new TestRandService { _value = 9999 };

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -47,6 +47,8 @@ namespace Microsoft.PowerFx.Tests
                 $"{ns}.{nameof(IDynamicTypeMarshaller)}",
                 $"{ns}.{nameof(ObjectMarshallerProvider)}",
                 $"{ns}.{nameof(ObjectMarshaller)}",
+                $"{ns}.{nameof(BasicServiceProvider)}",
+                $"{ns}.{nameof(IRuntimeConfig)}",
                 $"{ns}.{nameof(RuntimeConfig)}",
                 $"{ns}.{nameof(PrimitiveMarshallerProvider)}",
                 $"{ns}.{nameof(PrimitiveTypeMarshaller)}",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ServiceProviderTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ServiceProviderTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Xunit;
+
+namespace Microsoft.PowerFx.Interpreter.Tests
+{
+    public class ServiceProviderTests
+    {
+        [Fact]
+        public void Test()
+        {
+            var r1 = new BasicServiceProvider();
+            Assert.Throws<ArgumentNullException>(() => r1.AddService<MyService>(null));
+
+            Assert.Throws<ArgumentNullException>(() => r1.AddService(null, new MyService()));
+
+            // Nulls are ignored, don't crash
+            var r2 = new BasicServiceProvider(null);
+            Assert.Null(r2.GetService(typeof(MyService)));
+
+            r2 = new BasicServiceProvider((IServiceProvider[])null);
+            Assert.Null(r2.GetService(typeof(MyService)));
+
+            r2 = new BasicServiceProvider(new IServiceProvider[0]);
+            Assert.Null(r2.GetService(typeof(MyService)));
+        }
+
+        [Fact]
+        public void ServiceChaining()
+        {
+            var service1 = new MyService();
+            var r1 = new BasicServiceProvider();
+            var otherService = new OtherService();
+
+            r1.AddService(service1);
+            r1.AddService(otherService);
+
+            // Lookup succeeds
+            var lookup = r1.GetService(typeof(MyService));
+            Assert.Same(lookup, service1);
+
+            var r2 = new BasicServiceProvider();
+            var r21 = new BasicServiceProvider(r2, null, r1);
+
+            // Finds in child
+            lookup = r21.GetService(typeof(MyService));
+            Assert.Same(lookup, service1);
+
+            // Shadowing 
+            var service2 = new MyService();
+            Assert.NotSame(service1, service2);
+
+            r2.AddService(service2);
+
+            var lookup1 = r1.GetService(typeof(MyService));
+            Assert.Same(lookup1, service1);
+
+            lookup = r2.GetService(typeof(MyService));
+            Assert.Same(lookup, service2);
+
+            lookup = r21.GetService(typeof(MyService));
+            Assert.Same(lookup, service2);
+
+            // Lookup other - found only in r1. 
+            var other1 = r21.GetService(typeof(OtherService));
+            Assert.Same(otherService, other1);
+
+            // Missing 
+            var notFound = r21.GetService(typeof(NotFoundService));
+            Assert.Null(notFound);
+        }
+
+        private class BaseService
+        {
+        }
+
+        private class MyService : BaseService
+        {
+        }
+
+        private class OtherService
+        {
+        }
+
+        private class NotFoundService
+        {
+        }
+
+        // Composing 
+        [Fact]
+        public void Sharing()
+        {
+            var r1 = new BasicServiceProvider();
+            var r2 = new BasicServiceProvider(r1);
+
+            // Ensure wrapper doesn't just take a snapshot; returns live results. 
+            var service1 = new MyService();
+
+            r1.AddService(typeof(MyService), service1);
+            var service2 = r2.GetService(typeof(MyService));
+
+            Assert.Same(service1, service2);
+        }
+
+        [Fact]
+        public void Mismatch()
+        {
+            var r1 = new BasicServiceProvider();
+            Assert.Throws<InvalidOperationException>(() => r1.AddService(typeof(MyService), new OtherService()));
+        }
+
+        [Fact]
+        public void Derived()
+        {
+            var derivedService = new MyService();
+            var r1 = new BasicServiceProvider();
+
+            r1.AddService(derivedService);
+
+            // Lookup must be exact type; doesn't lookup by base class.
+            var lookup = r1.GetService(typeof(BaseService));
+            Assert.Null(lookup);
+
+            // Base and derived can coexist 
+            BaseService baseService = new MyService();
+            r1.AddService(baseService);
+
+            lookup = r1.GetService(typeof(BaseService));
+            Assert.Same(baseService, lookup);
+
+            lookup = r1.GetService(typeof(MyService));
+            Assert.Same(derivedService, lookup);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
@@ -140,8 +140,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var engine = new RecalcEngine(config);
 
             var expr = "Set(x, x+1);x";
-            
-            var result = engine.EvalAsync(expr, CancellationToken.None, options: _opts, runtimeConfig: sym).Result;
+
+            var runtimeConfig = new RuntimeConfig(sym);
+            var result = engine.EvalAsync(expr, CancellationToken.None, options: _opts, runtimeConfig: runtimeConfig).Result;
             Assert.Equal(13.0, result.ToObject());
 
             result = sym.Get(slotX);
@@ -263,7 +264,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             foreach (var symValue in new[] { symValues1, symValues2 })
             {
-                var result = eval.EvalAsync(CancellationToken.None, runtimeConfig: symValue);
+                var runtimeConfig = new RuntimeConfig(symValue);
+                var result = eval.EvalAsync(CancellationToken.None, runtimeConfig: runtimeConfig);
             }
 
             AssertValue(symValues1, "num", 15.0);
@@ -290,7 +292,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             config.EnableSetFunction();
             var engine = new RecalcEngine(config);
 
-            var result = engine.EvalAsync(expr, CancellationToken.None, options: _opts, runtimeConfig: sym).Result;
+            var runtimeConfig = new RuntimeConfig(sym);
+            var result = engine.EvalAsync(expr, CancellationToken.None, options: _opts, runtimeConfig: runtimeConfig).Result;
 
             Assert.Equal(12.0, result.ToObject());
 
@@ -344,7 +347,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             Assert.True(check1.IsSuccess);
 
             // Verify evaluation. 
-            var result = engine.EvalAsync(expr, CancellationToken.None, options: _opts, runtimeConfig: sym).Result;
+            var runtimeConfig = new RuntimeConfig(sym);
+            var result = engine.EvalAsync(expr, CancellationToken.None, options: _opts, runtimeConfig: runtimeConfig).Result;
 
             Assert.Equal(25.0, result.ToObject());
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -142,69 +142,6 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Fact]
-        public void Services()
-        {
-            var service1 = new MyService();
-            var r1 = new BasicServiceProvider();
-
-            r1.AddService(service1);
-
-            // Lookup succeeds
-            var lookup = r1.GetService(typeof(MyService));
-            Assert.Same(lookup, service1);
-
-            var r2 = new BasicServiceProvider();
-            var r21 = new BasicServiceProvider(r2, r1);
-
-            // Finds in child
-            lookup = r21.GetService(typeof(MyService));
-            Assert.Same(lookup, service1);
-
-            // Shadowing 
-            var service2 = new MyService();
-            Assert.NotSame(service1, service2);
-
-            r2.AddService(service2);
-
-            lookup = r2.GetService(typeof(MyService));
-            Assert.Same(lookup, service2);
-
-            lookup = r21.GetService(typeof(MyService));
-            Assert.Same(lookup, service2);
-        }
-
-        private class BaseService
-        {
-        }
-
-        private class MyService : BaseService
-        {
-        }
-
-        [Fact]
-        public void Derived()
-        {
-            var derivedService = new MyService();
-            var r1 = new BasicServiceProvider();
-
-            r1.AddService(derivedService);
-
-            // Lookup must be exact type; doesn't lookup by base class.
-            var lookup = r1.GetService(typeof(BaseService));
-            Assert.Null(lookup);
-
-            // Base and derived can coexist 
-            BaseService baseService = new MyService();
-            r1.AddService(baseService);
-
-            lookup = r1.GetService(typeof(BaseService));
-            Assert.Same(baseService, lookup);
-
-            lookup = r1.GetService(typeof(MyService));
-            Assert.Same(derivedService, lookup);
-        }
-
-        [Fact]
         public void TestRowScope()
         {
             var r1 = new SymbolValues();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -283,18 +283,14 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             public override int GetHashCode() => throw new NotImplementedException();
         }
-
-        /* $$$ Split this into 2 tests. 
+                
         // Test Composing symbol tables. 
         [Fact]
-        public void Compose()
+        public void Compose1()
         {
-            var culture1 = new CultureInfo("en-us");
-
             var r1 = new SymbolValues { DebugName = "L1" };
             r1.Add("x", FormulaValue.New("x1"));
-            r1.AddService(culture1);
-
+            
             var r2 = new SymbolValues { DebugName = "L2" };
             r2.Add("y", FormulaValue.New("y2"));
             r2.Add("x", FormulaValue.New("x2"));
@@ -313,19 +309,13 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             found = r3.TryGetValue("missing", out result);
             Assert.False(found);
             Assert.Null(result);
-
-            var culture2 = r3.GetService<CultureInfo>();
-            Assert.Same(culture1, culture2);
-
+            
             // Flipping the order changes precedence
             r3 = ReadOnlySymbolValues.Compose(r2, r1);
             found = r3.TryGetValue("x", out result);
             Assert.True(found);
-            Assert.Equal("x2", result.ToObject());
-
-            culture2 = r3.GetService<CultureInfo>();
-            Assert.Same(culture1, culture2);
-        }*/
+            Assert.Equal("x2", result.ToObject());            
+        }
 
         [Fact]
         public void ComposeNest()

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         public void Services()
         {
             var service1 = new MyService();
-            var r1 = new SymbolValues { DebugName = "Services " };
+            var r1 = new BasicServiceProvider();
 
             r1.AddService(service1);
 
@@ -153,8 +153,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var lookup = r1.GetService(typeof(MyService));
             Assert.Same(lookup, service1);
 
-            var r2 = new SymbolValues();
-            var r21 = ReadOnlySymbolValues.Compose(r2, r1);
+            var r2 = new BasicServiceProvider();
+            var r21 = new BasicServiceProvider(r2, r1);
 
             // Finds in child
             lookup = r21.GetService(typeof(MyService));
@@ -185,7 +185,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         public void Derived()
         {
             var derivedService = new MyService();
-            var r1 = new SymbolValues();
+            var r1 = new BasicServiceProvider();
 
             r1.AddService(derivedService);
 
@@ -347,6 +347,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             public override int GetHashCode() => throw new NotImplementedException();
         }
 
+        /* $$$ Split this into 2 tests. 
         // Test Composing symbol tables. 
         [Fact]
         public void Compose()
@@ -387,7 +388,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             culture2 = r3.GetService<CultureInfo>();
             Assert.Same(culture1, culture2);
-        }
+        }*/
 
         [Fact]
         public void ComposeNest()
@@ -750,7 +751,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 var symValuesAll = symTableAll.CreateValues(symValuesThisItem);
 
                 var opts = new ParserOptions { AllowsSideEffects = true };
-                var result = await engine.EvalAsync("Set(counter, ThisItem);counter", CancellationToken.None, options: opts, runtimeConfig: symValuesAll);
+
+                var runtimeConfig = new RuntimeConfig(symValuesAll);
+                var result = await engine.EvalAsync("Set(counter, ThisItem);counter", CancellationToken.None, options: opts, runtimeConfig: runtimeConfig);
 
                 Assert.Equal(5.0, result.ToObject());
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -687,6 +687,29 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var symValues1 = symTable1.CreateValues();
             run.Eval(symValues1);
         }
+                
+        // Fail when trying to eval with an extra SymbolValue that doesn't below.
+        [Fact]
+        public async Task MismatchedSymbolValues()
+        {
+            var symValue = new SymbolValues { DebugName = "Extra" };
+            var engine = new RecalcEngine();
+
+            // Succeeds since eval will get the symbol table from values 
+            await engine.EvalAsync("1+2", CancellationToken.None, runtimeConfig: symValue);
+
+            // Check() without binding to a symbol table
+            var check = engine.Check("1+2");
+            Assert.True(check.IsSuccess);
+
+            var run = check.GetEvaluator();
+
+            // Succeeds, no extra SymbolValues
+            await run.EvalAsync(CancellationToken.None, new RuntimeConfig());
+
+            // Fails, extra symbol Values 
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await run.EvalAsync(CancellationToken.None, new RuntimeConfig(symValue)));
+        }
 
         // Demonstrate how to use ThisItem in a loop.
         // All Loop iterations can access common global state,

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TimeZoneExtensions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TimeZoneExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Tests
         /// <exception cref="TimeZoneNotFoundException">Will throw if timeZoneId is not found.</exception>
         /// <exception cref="ArgumentException">When timeZoneId is null or made of spaces.</exception>
         /// <exception cref="ArgumentNullException">When symbols is null.</exception>
-        public static void SetTimeZoneById(this SymbolValues symbols, string timeZoneId)
+        public static void SetTimeZoneById(this RuntimeConfig symbols, string timeZoneId)
         {
             if (symbols == null)
             {
@@ -39,7 +39,7 @@ namespace Microsoft.PowerFx.Tests
         /// <exception cref="ArgumentException">When timeZoneDisplayName is null or made of spaces.</exception>
         /// <exception cref="ArgumentNullException">When symbols is null.</exception>
         /// <remarks>If the TimeZone DisplayName is not valid, the TimeZoneInfo will not be set.</remarks>
-        public static void SetTimeZoneByDisplayName(this SymbolValues symbols, string timeZoneDisplayName)
+        public static void SetTimeZoneByDisplayName(this RuntimeConfig symbols, string timeZoneDisplayName)
         {
             if (symbols == null)
             {


### PR DESCRIPTION
Fix #901 .

Breaking change to interpreter. Not impact to Core or PowerApps. 

Separate IServiceProvider from  ReadOnlySymbolValues.
This decouples two unrelated concepts and simplifies the contract. 
It also lets us enforce some stronger invariants - that SymbolValue and SymbolTable are 1:1.

New RuntimeConfig class which captures both SymbolValues and the ServiceProvider. 

This also means service provider helpers like SetCulture() are now moved off SymbolValue. 
