### PR TITLE
Add debug logging helpers

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTableOverRecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTableOverRecordType.cs
@@ -24,7 +24,9 @@ namespace Microsoft.PowerFx
 
         // Mapping between slots and logical names on RecordType.
         // name --> Slot; used at design time to ensure same slot per field. 
-        private readonly Dictionary<string, NameSymbol> _map = new Dictionary<string, NameSymbol>(); 
+        private readonly Dictionary<string, NameSymbol> _map = new Dictionary<string, NameSymbol>();
+
+        internal RecordType Type => _type;
 
         public SymbolTableOverRecordType(RecordType type, ReadOnlySymbolTable parent = null, bool mutable = false, bool allowThisRecord = false)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/NamedFormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/NamedFormulaType.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Diagnostics;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 
@@ -8,6 +9,7 @@ namespace Microsoft.PowerFx.Types
 {
     // Useful for representing fields in an aggregate.  
     [ThreadSafeImmutable]
+    [DebuggerDisplay("{Name}: {Type}")]
     public sealed class NamedFormulaType
     {
         internal readonly TypedName _typedName;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -38,6 +38,16 @@ namespace Microsoft.PowerFx.Types
 
         public new TableType Type => (TableType)base.Type;
 
+        public TableValue(RecordType recordType)
+            : this(IRContext.NotInSource(recordType.ToTable()))
+        {
+        }
+
+        public TableValue(TableType type)
+            : this(IRContext.NotInSource(type))
+        {
+        }
+
         internal TableValue(IRContext irContext)
             : base(irContext)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.IR.Nodes;
+using Microsoft.PowerFx.Core.Public;
+using Microsoft.PowerFx.Intellisense;
+using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+    /// <summary>
+    /// Helpers for getting a debugging log for various Power Fx core objects. 
+    /// These should just be used for diagnostic purposes / logging and can change at any time. 
+    /// They can also be invoked under a debugger. 
+    /// </summary>
+    internal static class DebugDump
+    {
+        public static string Dump(ReadOnlySymbolTable symbolTable)
+        {
+            using var tw = new StringWriter();
+            Dump(symbolTable, tw);
+            return tw.ToString();
+        }
+
+        public static void Dump(ReadOnlySymbolTable symbolTable, TextWriter tw, string indent = "")
+        {
+            // These should also align with intellisense APIs. 
+            tw.WriteLine($"{indent}SymbolTable '{symbolTable.DebugName()}', hash={symbolTable.VersionHash.GetHashCode()}");
+
+            if (symbolTable is ComposedReadOnlySymbolTable composed)
+            {
+                tw.WriteLine(indent + " Composed {");
+                foreach (var table in symbolTable.SubTables)
+                {
+                    Dump(table, tw, indent + "  ");
+                }
+
+                tw.WriteLine(indent + "}");
+            }
+            else
+            {
+                var values = (IGlobalSymbolNameResolver)symbolTable;
+                foreach (var kv in values.GlobalSymbols)
+                {
+                    var name = kv.Key;
+                    var info = kv.Value;
+
+                    tw.WriteLine($"{indent} {name}:{info.Type}");
+                }
+
+                // Functions
+                if (symbolTable.Functions.Any())
+                {
+                    tw.WriteLine();
+                    tw.WriteLine($"{indent} Functions ({symbolTable.Functions.Count()}) total:"); 
+                    foreach (var func in symbolTable.Functions)
+                    {
+                        tw.WriteLine($"{indent} {func.Name}");
+                    }
+                }
+            }             
+
+            tw.WriteLine();
+        }
+
+        public static string Dump(ReadOnlySymbolValues symbolValues)
+        {
+            using var tw = new StringWriter();
+            Dump(symbolValues, tw);
+            return tw.ToString();
+        }
+
+        public static void Dump(ReadOnlySymbolValues symbolValues, TextWriter tw, string indent = "")
+        {
+            tw.WriteLine($"{indent}SymbolValues '{symbolValues.DebugName}_{symbolValues.GetHashCode()}'");
+            var symbolTable = symbolValues.SymbolTable;
+
+            var values = (IGlobalSymbolNameResolver)symbolTable;
+            foreach (var kv in values.GlobalSymbols)
+            {
+                var name = kv.Key;
+                var info = kv.Value;
+
+                if (info.Data is ISymbolSlot slot)
+                {
+                    var value = symbolValues.Get(slot);
+
+                    var str = Dump(value);
+
+                    tw.WriteLine($"{indent} {name}:{info.Type}= {str}   ({slot.Owner.DebugName()})");
+                }
+                else
+                {
+                    tw.WriteLine($"{indent} {name}:{info.Type}=????");
+                }
+            }
+        }
+
+        public static string Dump(FormulaType type)
+        {
+            return type?.ToString();
+        }
+
+        public static string Dump(FormulaValue value)
+        {
+            var settings = new FormulaValueSerializerSettings
+            {
+                 UseCompactRepresentation = true
+            };
+            var sb = new StringBuilder();
+            value.ToExpression(sb, settings);
+            return sb.ToString();
+        }        
+
+        public static string Dump(TexlNode parseNode)
+        {
+            return TexlPretty.PrettyPrint(parseNode);
+        }
+
+        internal static string Dump(IntermediateNode eval)
+        {
+            var str = eval?.ToString();
+            return str;
+        }
+
+        public static string Dump(CheckResult check)
+        {
+            using var tw = new StringWriter();
+            Dump(check, tw);
+            return tw.ToString();
+        }
+
+        public static void Dump(CheckResult check, TextWriter tw, string indent = "")
+        {
+            tw.WriteLine($"{indent}CheckResult");
+            tw.WriteLine();
+
+            if (check.Parse != null)
+            {
+                tw.WriteLine(Dump(check.Parse.Root));
+                tw.WriteLine();
+            }
+
+            if (check._binding != null)
+            {
+                tw.WriteLine($"{indent}Binding: {Dump(check.ReturnType)}");
+                tw.WriteLine();
+            }
+
+            if (check.Errors.Any())
+            {
+                tw.WriteLine($"{indent}Errors:");
+                foreach (var error in check.Errors)
+                {
+                    tw.WriteLine($"{indent}  {error}");
+                }
+
+                tw.WriteLine();
+            }
+            else
+            {
+                var run = check.GetEvaluator();
+                if (run is ParsedExpression run2)
+                {
+                    tw.WriteLine($"{indent}IR:");
+                    tw.WriteLine(Dump(run2._irnode));
+                    tw.WriteLine();
+                }
+            }
+
+            // Symbols last - they can be very large 
+            if (check.Symbols != null)
+            {
+                tw.WriteLine($"{indent}Symbols:");
+                Dump(check.Symbols, tw, indent + "   ");
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerFx
             if (symbolTable is ComposedReadOnlySymbolTable composed)
             {
                 tw.WriteLine(indent + " Composed {");
-                foreach (var table in symbolTable.SubTables)
+                foreach (var table in composed.SubTables)
                 {
                     Dump(table, tw, indent + "  ");
                 }


### PR DESCRIPTION

Add new DebugDump* methods which can log SymbolTable, SymbolValues. 

This can help with debugging to provide visibility for these.  (like a text-based visualizer ... eventually ... https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-visualizers-of-data?view=vs-2022 ) 

For example:
```
CheckResult

x + y

Binding: Number

IR:
BinaryOp(AddNumbers, ResolvedObject('x:FromRecord_55206300'), ResolvedObject('y:Globals_31639720'))

Symbols:
   SymbolTable '(FromRecord,Globals,BuiltinFunctions (149),DefaultConfig)_3776722', hash=1776687751
    Composed {
     SymbolTable 'FromRecord_55206300', hash=954974759
      x:n

     SymbolTable 'Globals_31639720', hash=954174782
      y:n

     SymbolTable 'BuiltinFunctions (149)_43315893', hash=954660935

```