### PR TITLE
Tweak 2 editor rules.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -194,10 +194,14 @@ csharp_style_prefer_switch_expression = true:suggestion
 csharp_style_prefer_not_pattern = true:suggestion
 csharp_style_prefer_extended_property_pattern = true:suggestion
 
+# IDE0003: Name can be simplified
+dotnet_diagnostic.IDE0003.severity = none
 # IDE0004: Cast is redundant
 dotnet_diagnostic.IDE0004.severity = warning
 # IDE0005: Using directive is unnecessary ## REQUIRED
 dotnet_diagnostic.IDE0005.severity = none
+# IDE0007: use 'var' instead of explicit type 
+dotnet_diagnostic.IDE0007.severity = none
 # IDE0032: Use auto property
 dotnet_diagnostic.IDE0032.severity = none
 # IDE0052: Private member can be removed as the value assigned to it is never read


### PR DESCRIPTION
I'd like to tweak our Style Cop rules and disable these restrictions:

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0003-ide0009
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008

IDE003:
Today, we require 'var' instead of more explicit types --> I'd like to turn that off because a) sometimes the types are more readable; b) sometimes it's a nice enforcement check. 

We require:

`var sym = ComputeTables()  // not sure the type `

I want to allow:

`ReadOnlySymbolTable sym = ComputeTables()`

[2] we disallow 'this' qualifiers. --> I'd like to allow them as it also helps readability and being explicit.  
Today:
`var sym = SpecialValue` // I have to think where SpecialValue came from ... is it instance/static/ from an outer class/ etc? 

I want to allow:
`var sym = this.SpecialValue  // it's an instance property. `

