### PR TITLE
Fixes #952 Crash in interpreter - Blank of record type with multiple fields

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1655,9 +1655,24 @@ namespace Microsoft.PowerFx.Functions
             var recordType = tableType.ToRecord();
             return args.Select(arg =>
             {
-                if (!forceSingleColumn && arg is RecordValue record)
+                if (!forceSingleColumn)
                 {
-                    return DValue<RecordValue>.Of(record);
+                    if (arg is RecordValue record)
+                    {
+                        return DValue<RecordValue>.Of(record);
+                    }
+                    else if (arg is BlankValue bv)
+                    {
+                        var len = tableType.FieldNames.Count();
+                        var fields = new List<NamedValue>();
+
+                        foreach (var field in tableType.FieldNames)
+                        {
+                            fields.Add(new NamedValue(field, bv));
+                        }
+
+                        return DValue<RecordValue>.Of(FormulaValue.NewRecordFromFields(fields.ToArray()));
+                    }
                 }
 
                 // Handle the single-column-table case. 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1655,24 +1655,13 @@ namespace Microsoft.PowerFx.Functions
             var recordType = tableType.ToRecord();
             return args.Select(arg =>
             {
-                if (!forceSingleColumn)
+                if (!forceSingleColumn && arg is RecordValue rv)
                 {
-                    if (arg is RecordValue record)
-                    {
-                        return DValue<RecordValue>.Of(record);
-                    }
-                    else if (arg is BlankValue bv)
-                    {
-                        var len = tableType.FieldNames.Count();
-                        var fields = new List<NamedValue>();
-
-                        foreach (var field in tableType.FieldNames)
-                        {
-                            fields.Add(new NamedValue(field, bv));
-                        }
-
-                        return DValue<RecordValue>.Of(FormulaValue.NewRecordFromFields(fields.ToArray()));
-                    }
+                    return DValue<RecordValue>.Of(rv);
+                }
+                else if (!forceSingleColumn && arg is BlankValue bv && tableType.FieldNames.Count() > 1)
+                {
+                    return DValue<RecordValue>.Of(bv);
                 }
 
                 // Handle the single-column-table case. 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
@@ -70,3 +70,6 @@ Table({b:1},{b:-11},{b:3},{b:-7},{b:5})
 // Blank rows
 >> ForAll(Table({a:1},If(1<0,{a:2}),{a:3},If(1<0,{a:4}),{a:5}), {b:Coalesce(a, 100)})
 Table({b:1},{b:100},{b:3},{b:100},{b:5})
+
+>> ForAll([true,false],  If(ThisRecord.Value, {x:1,y:2}, Blank()))
+Table({x:1,y:2},{x:Blank(),y:Blank()})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
@@ -72,4 +72,7 @@ Table({b:1},{b:-11},{b:3},{b:-7},{b:5})
 Table({b:1},{b:100},{b:3},{b:100},{b:5})
 
 >> ForAll([true,false],  If(ThisRecord.Value, {x:1,y:2}, Blank()))
-Table({x:1,y:2},{x:Blank(),y:Blank()})
+Table({x:1,y:2},Blank())
+
+>> Last(ForAll([true,false], If(ThisRecord.Value, {x:1,y:2}, Blank()))).x
+Blank()


### PR DESCRIPTION
Fixes #952 

NOTE: Pretty Printing seems to still fail for the eval of below expression.

`With({L26:Table({x:1, y:2})}, ForAll([99], LookUp(L26, ThisRecord.y = 3)))` Issue filed for it #1028 