### PR TITLE
Fix 730 - better protection for expressions that generate large memory usage.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/Governor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/Governor.cs
@@ -22,17 +22,25 @@ namespace Microsoft.PowerFx
 {
     /// <summary>
     /// Throttling object to allow a host to control limits of memory and hardware resources.
+    /// These virtuals are called by the evaluator, and exceptions thrown by them will abort the evaluation. 
+    /// This is a service passed to <see cref="RuntimeConfig"/>, and a derived class can override and throw their own host exceptions if hardware limits are exceeded.
     /// </summary>
     public class Governor
     {
-        // Called by evaluator when allocating large memory blocks 
-        // to ensure there's storage to proceed. 
+        /// <summary>
+        /// Called by evaluator before allocating large memory blocks 
+        /// to ensure there's storage to proceed. 
+        /// This allows failure before we start to eval a memory intensive operation. 
+        /// </summary>
+        /// <param name="allocateBytes">Predicted number of bytes this function may need in order to execute. </param>
         public virtual void PollMemory(long allocateBytes)
         {
         }
 
-        // Called throughout engine. This can monitor system resources (like memory)
-        // and throw an exception to abort execution. 
+        /// <summary>
+        /// Called throughout engine. This can monitor system resources (like memory) 
+        /// and throw an exception to abort execution. 
+        /// </summary>
         public virtual void Poll()
         {
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/Governor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/Governor.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.IR.Nodes;
+using Microsoft.PowerFx.Core.IR.Symbols;
+using Microsoft.PowerFx.Core.Texl.Builtins;
+using Microsoft.PowerFx.Functions;
+using Microsoft.PowerFx.Interpreter;
+using Microsoft.PowerFx.Types;
+using static Microsoft.PowerFx.Functions.Library;
+
+namespace Microsoft.PowerFx
+{
+    /// <summary>
+    /// Throttling object to allow a host to control limits of memory and hardware resources.
+    /// </summary>
+    public class Governor
+    {
+        // Called by evaluator when allocating large memory blocks 
+        // to ensure there's storage to proceed. 
+        public virtual void PollMemory(long allocateBytes)
+        {
+        }
+
+        // Called throughout engine. This can monitor system resources (like memory)
+        // and throw an exception to abort execution. 
+        public virtual void Poll()
+        {
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/Governor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/Governor.cs
@@ -33,8 +33,15 @@ namespace Microsoft.PowerFx
         /// This allows failure before we start to eval a memory intensive operation. 
         /// </summary>
         /// <param name="allocateBytes">Predicted number of bytes this function may need in order to execute. </param>
-        public virtual void PollMemory(long allocateBytes)
+        public virtual void CanAllocateBytes(long allocateBytes)
         {
+        }
+
+        public virtual void CanAllocateString(long stringLength)
+        {
+            // .Net strings are an array of characters.
+            var allocateBytes = stringLength * sizeof(char);
+            this.CanAllocateBytes(allocateBytes);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -727,12 +727,12 @@ namespace Microsoft.PowerFx.Functions
             var maxLenBytes = maxLenChars * 2;
             runner.Governor.PollMemory(maxLenBytes);
 
-            var result = SubstituteWorker(runner, source, match, replacement, instanceNum);
+            var result = SubstituteWorker(runner, irContext, source, match, replacement, instanceNum);
 
-            return result; 
+            return result;
         }
 
-        private static StringValue SubstituteWorker(EvalVisitor eval, StringValue source, StringValue match, StringValue replacement, int instanceNum)
+        private static StringValue SubstituteWorker(EvalVisitor eval, IRContext irContext, StringValue source, StringValue match, StringValue replacement, int instanceNum)
         {
             if (string.IsNullOrEmpty(match.Value))
             {
@@ -786,7 +786,7 @@ namespace Microsoft.PowerFx.Functions
                 }
             }
 
-            return FormulaValue.New(sourceValue);
+            return new StringValue(irContext, sourceValue);
         }
 
         public static FormulaValue StartsWith(IRContext irContext, StringValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
@@ -1,4 +1,6 @@
-﻿// Basic LookUp
+﻿#SETUP: DisableMemChecks
+
+// Basic LookUp
 >> LookUp(Table({ Id: 1, Name: "Element 1" }, { Id:2, Name: "Element 2"}), Id = 2)
 {Id:2,Name:"Element 2"}
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMax.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMax.txt
@@ -1,4 +1,6 @@
-﻿// ****** Numeric arguments, scalar arguments ******
+﻿#SETUP: DisableMemChecks
+
+// ****** Numeric arguments, scalar arguments ******
 
 >> Max(1)
 1

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/InternalSetup.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/InternalSetup.cs
@@ -18,6 +18,8 @@ namespace Microsoft.PowerFx.Core.Tests
 
         internal TimeZoneInfo TimeZoneInfo { get; set; }
 
+        internal bool DisableMemChecks { get; set; }
+
         internal static InternalSetup Parse(string setupHandlerName)
         {
             var iSetup = new InternalSetup();
@@ -31,7 +33,12 @@ namespace Microsoft.PowerFx.Core.Tests
 
             foreach (var part in parts.ToArray())
             {
-                if (Enum.TryParse<TexlParser.Flags>(part, out var flag))
+                if (string.Equals(part, "DisableMemChecks", StringComparison.OrdinalIgnoreCase))
+                {
+                    iSetup.DisableMemChecks = true;
+                    parts.Remove(part);
+                }
+                else if (Enum.TryParse<TexlParser.Flags>(part, out var flag))
                 {
                     iSetup.Flags |= flag;
                     parts.Remove(part);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/InternalSetup.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/InternalSetup.cs
@@ -18,7 +18,11 @@ namespace Microsoft.PowerFx.Core.Tests
 
         internal TimeZoneInfo TimeZoneInfo { get; set; }
 
-        internal bool DisableMemChecks { get; set; }
+        /// <summary>
+        /// By default, we run expressions with a memory governor to enforce a limited amount of memory. 
+        /// When true, disable memory checks and allow expression to use as much memory as it needs. 
+        /// </summary>
+        internal bool DisableMemoryChecks { get; set; }
 
         internal static InternalSetup Parse(string setupHandlerName)
         {
@@ -35,7 +39,7 @@ namespace Microsoft.PowerFx.Core.Tests
             {
                 if (string.Equals(part, "DisableMemChecks", StringComparison.OrdinalIgnoreCase))
                 {
-                    iSetup.DisableMemChecks = true;
+                    iSetup.DisableMemoryChecks = true;
                     parts.Remove(part);
                 }
                 else if (Enum.TryParse<TexlParser.Flags>(part, out var flag))

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/BasicGovernor.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/BasicGovernor.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Xunit;
+
+namespace Microsoft.PowerFx.Tests
+{
+    // Custom exception thrown by Governor object. 
+    // Host implements the Governor and can control what's thrown. 
+    // Host also calls eval and controls what's caught. 
+    internal class GovernorException : Exception
+    {
+        public GovernorException(string msg)
+            : base(msg)
+        {
+        }
+    }
+
+    internal class BasicGovernor : Governor
+    {
+        private readonly long _memStart;
+        private readonly long _maxAllowedBytes;
+
+        public BasicGovernor(long maxAllowedBytes)
+        {
+            // This API requires NetStandard 2.1.
+            // Interpreter is built against 2.0.
+            _memStart = GC.GetAllocatedBytesForCurrentThread();
+            _maxAllowedBytes = maxAllowedBytes;
+        }
+
+        // Beware - this is a thread-local. But evals are stuck on a single thread anyways. 
+        // So we can't evaluate this property in the debugger. 
+        // This API requires at least NetStandard 2.1. 
+        public long CurrentBytesUsed => GC.GetAllocatedBytesForCurrentThread() - _memStart;
+
+        public override void PollMemory(long allocateBytes)
+        {
+            var used = CurrentBytesUsed;
+            if (used + allocateBytes > _maxAllowedBytes)
+            {
+                throw new GovernorException($"memory overuse");
+            }
+        }
+
+        public override void Poll()
+        {
+            PollMemory(0);
+        }
+    }
+
+    // Illustrate invariants about governor
+    public class GovernorTests
+    {
+        [Fact]
+        public void BasicGovernorTest()
+        {
+            var governor = new BasicGovernor(10 * 1000);
+            governor.Poll(); // safe
+
+            Assert.Throws<GovernorException>(() => governor.PollMemory(20 * 1000));
+
+            var bytes = new byte[40 * 1000];
+
+            // We've now crossed the limit. 
+            Assert.Throws<GovernorException>(() => governor.Poll());
+            bytes = null; // GC will free it up, process can continue.
+
+            // New counter is fine. 
+            var governor2 = new BasicGovernor(10 * 1000);
+            governor2.Poll(); // safe
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/SingleThreadedGovernor.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/SingleThreadedGovernor.cs
@@ -17,12 +17,12 @@ namespace Microsoft.PowerFx.Tests
         }
     }
 
-    internal class BasicGovernor : Governor
+    internal class SingleThreadedGovernor : Governor
     {
         private readonly long _memStart;
         private readonly long _maxAllowedBytes;
 
-        public BasicGovernor(long maxAllowedBytes)
+        public SingleThreadedGovernor(long maxAllowedBytes)
         {
             // This API requires NetStandard 2.1.
             // Interpreter is built against 2.0.
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void BasicGovernorTest()
         {
-            var governor = new BasicGovernor(10 * 1000);
+            var governor = new SingleThreadedGovernor(10 * 1000);
             governor.Poll(); // safe
 
             Assert.Throws<GovernorException>(() => governor.PollMemory(20 * 1000));
@@ -68,7 +68,7 @@ namespace Microsoft.PowerFx.Tests
             bytes = null; // GC will free it up, process can continue.
 
             // New counter is fine. 
-            var governor2 = new BasicGovernor(10 * 1000);
+            var governor2 = new SingleThreadedGovernor(10 * 1000);
             governor2.Poll(); // safe
         }
     }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/SingleThreadedGovernor.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Helpers/SingleThreadedGovernor.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Tests
         // This API requires at least NetStandard 2.1. 
         public long CurrentBytesUsed => GC.GetAllocatedBytesForCurrentThread() - _memStart;
 
-        public override void PollMemory(long allocateBytes)
+        public override void CanAllocateBytes(long allocateBytes)
         {
             var used = CurrentBytesUsed;
             if (used + allocateBytes > _maxAllowedBytes)
@@ -46,7 +46,7 @@ namespace Microsoft.PowerFx.Tests
 
         public override void Poll()
         {
-            PollMemory(0);
+            CanAllocateBytes(0);
         }
     }
 
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Tests
             var governor = new SingleThreadedGovernor(10 * 1000);
             governor.Poll(); // safe
 
-            Assert.Throws<GovernorException>(() => governor.PollMemory(20 * 1000));
+            Assert.Throws<GovernorException>(() => governor.CanAllocateBytes(20 * 1000));
 
             var bytes = new byte[40 * 1000];
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 // Ensure tests can run with governor on. 
                 // Some tests that use large memory can disable via:
                 //    #SETUP: DisableMemChecks
-                if (!iSetup.DisableMemChecks)
+                if (!iSetup.DisableMemoryChecks)
                 {
                     var kbytes = 1000;
                     var mem = new SingleThreadedGovernor(10 * 1000 * kbytes);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -308,7 +308,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 if (!iSetup.DisableMemChecks)
                 {
                     var kbytes = 1000;
-                    var mem = new BasicGovernor(10 * 1000 * kbytes);
+                    var mem = new SingleThreadedGovernor(10 * 1000 * kbytes);
                     runtimeConfig.AddService<Governor>(mem);
                 }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -302,6 +302,16 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     runtimeConfig.AddService(iSetup.TimeZoneInfo);
                 }
 
+                // Ensure tests can run with governor on. 
+                // Some tests that use large memory can disable via:
+                //    #SETUP: DisableMemChecks
+                if (!iSetup.DisableMemChecks)
+                {
+                    var kbytes = 1000;
+                    var mem = new BasicGovernor(10 * 1000 * kbytes);
+                    runtimeConfig.AddService<Governor>(mem);
+                }
+
                 var newValue = await check.GetEvaluator().EvalAsync(CancellationToken.None, runtimeConfig);
 
                 // UntypedObjectType type is currently not supported for serialization.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
@@ -166,28 +167,6 @@ namespace Microsoft.PowerFx.Tests
             cts.Cancel();
 
             await Assert.ThrowsAsync<TaskCanceledException>(async () => { await task; });
-        }
-
-        // Verify cancellation 
-        [Fact]
-        public async Task InfiniteLoop()
-        {
-            // Create an expression that will take hang (take very long)
-            var n = 10 * 1000;
-            var expr = $"ForAll(Sequence({n}), ForAll(Sequence({n}), ForAll(Sequence({n}), 5)))";
-
-            var engine = new RecalcEngine();
-
-            // Can be invoked. 
-            using var cts = new CancellationTokenSource();
-
-            cts.CancelAfter(5);
-
-            // Eval may never return.             
-            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            {
-                await engine.EvalAsync(expr, cts.Token);
-            });
         }
 
         // Test interleaved concurrent runs. 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -37,6 +37,7 @@ namespace Microsoft.PowerFx.Tests
                 $"{ns}.{nameof(CheckResultExtensions)}",
                 $"{ns}.{nameof(ReadOnlySymbolValues)}",
                 $"{ns}.{nameof(RecalcEngine)}",
+                $"{ns}.{nameof(Governor)}",
                 $"{ns}.{nameof(ReflectionFunction)}",
 #pragma warning disable CS0618 // Type or member is obsolete
                 $"{ns}.{nameof(RecalcEngineScope)}",
@@ -764,24 +765,6 @@ namespace Microsoft.PowerFx.Tests
             var checkResult = recalcEngine.Check("SortOrder.Ascending");
             Assert.True(checkResult.IsSuccess);
             Assert.IsType<StringType>(checkResult.ReturnType);
-        }
-
-        [Fact]
-        public async void MaxRecursionDepthTest()
-        {
-            var config = new PowerFxConfig(null)
-            {
-                MaxCallDepth = 5
-            };
-            var recalcEngine = new RecalcEngine(config);
-            Assert.IsType<ErrorValue>(recalcEngine.Eval("Abs(Abs(Abs(Abs(Abs(Abs(1))))))"));
-            Assert.IsType<NumberValue>(recalcEngine.Eval("Abs(Abs(Abs(Abs(Abs(1)))))"));
-            Assert.IsType<NumberValue>(recalcEngine.Eval(
-                @"Sum(
-                Sum(Sum(1),1),
-                Sum(Sum(1),1),
-                Sum(Sum(1),1)
-                )"));
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
@@ -152,12 +152,11 @@ namespace Microsoft.PowerFx.Tests
         // Verify cancellation.
         // Expression that takes a long time to run.  Doesn't need much stack or memory.  
         [Theory]
-        [InlineData("ForAll(Sequence(K), ForAll(Sequence(K), ForAll(Sequence(K), 5)))")]
-        [InlineData("ForAll(Sequence(1000), Max(Sequence(K), Value))")]
+        [InlineData("CountRows(ForAll(Sequence(K), CountRows(ForAll(Sequence(K), CountRows(Sequence(K))))))")]
         public async Task InfiniteLoop(string expr)
         {
             var engine = new RecalcEngine();
-            engine.UpdateVariable("K", 5);
+            engine.UpdateVariable("K", 10 * 1000);
 
             // Can be invoked. 
             using var cts = new CancellationTokenSource();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Types;
+using Xunit;
+using static Microsoft.PowerFx.Core.Localization.TexlStrings;
+
+namespace Microsoft.PowerFx.Tests
+{
+    // These tests illustrate various sandboxing features, such as protection against:
+    // - long-running scripts,
+    // - CPU usage,
+    // - memory usage,
+    // - stack overflows, etc.
+    public class SandboxTests
+    {
+        // Protect against stack overflows. 
+        [Fact]
+        public async void MaxRecursionDepthTest()
+        {
+            var config = new PowerFxConfig(null)
+            {
+                MaxCallDepth = 5
+            };
+            var recalcEngine = new RecalcEngine(config);
+            Assert.IsType<ErrorValue>(recalcEngine.Eval("Abs(Abs(Abs(Abs(Abs(Abs(1))))))"));
+            Assert.IsType<NumberValue>(recalcEngine.Eval("Abs(Abs(Abs(Abs(Abs(1)))))"));
+            Assert.IsType<NumberValue>(recalcEngine.Eval(
+                @"Sum(
+                Sum(Sum(1),1),
+                Sum(Sum(1),1),
+                Sum(Sum(1),1)
+                )"));
+        }
+
+        // Create a small expression that runs quickly and rapidly consumes large amounts of memory. 
+        // Memory used here is **expontential** :  O[nWidth ^ nDepth] 
+        private static string CreateMemoryExpression(int nWidth, int nDepth)
+        {
+            // Substitute() function can quickly expand to consume a lot of memory 
+            // Substitute("aaa", "a", "12345678910") // result is Len(arg0)*Len(arg2) = 30 chars
+
+            var a = "\"a\"";
+            var aa = "\"" + new string('a', nWidth) + "\"";
+            var left = $"Substitute(";
+            var right = $", {a}, {aa})";
+            var sb = new StringBuilder();
+            for (var i = 0; i < nDepth; i++)
+            {
+                sb.Append(left);
+            }
+
+            sb.Append(a);
+            for (var i = 0; i < nDepth; i++)
+            {
+                sb.Append(right);
+            }
+
+            var expr = sb.ToString();
+            return expr;
+        }
+
+        // Pick a "small" memory size that's large enough to execute basic expressions but will
+        // fail on intentionally large expressions. 
+        private const int DefaultMemorySizeBytes = 50 * 1000;
+
+        // Verify memory limits. 
+        [Theory]
+        [InlineData(10, 15)]
+        [InlineData(100, 4)]
+        [InlineData(50, 20)]
+        public async Task MemoryLimit(int nWidth, int nDepth)
+        {
+            var engine = new RecalcEngine();
+
+            var mem = new BasicGovernor(DefaultMemorySizeBytes);
+
+            var runtimeConfig = new RuntimeConfig();
+            runtimeConfig.AddService<Governor>(mem);
+
+            var expr = CreateMemoryExpression(nWidth, nDepth);
+
+            // Ensure governor traps excessive memory usage. 
+            await Assert.ThrowsAsync<GovernorException>(async () =>
+                    await engine.EvalAsync(expr, CancellationToken.None, runtimeConfig: runtimeConfig));
+
+#if false // https://github.com/microsoft/Power-Fx/issues/971
+            // Still traps without the pre-poll. 
+            // The pre-poll may fail the expression before it even executes. 
+            // So skipping pre-poll tests the execution can be aborted. 
+            var gov2 = new TestIgnorePrePollGovernor(DefaultMemorySizeBytes);
+            runtimeConfig.AddService<Governor>(gov2);
+
+            await Assert.ThrowsAsync<MyException>(async () =>
+                    await engine.EvalAsync(expr, CancellationToken.None, runtimeConfig: runtimeConfig));
+#endif
+        }
+
+        // We can recover after a oom expression
+        [Fact]
+        public async Task MemoryLimitRecover()
+        {
+            var engine = new RecalcEngine();
+
+            var mem = new BasicGovernor(DefaultMemorySizeBytes);
+
+            var runtimeConfig = new RuntimeConfig();
+            runtimeConfig.AddService<Governor>(mem);
+
+            var expr = CreateMemoryExpression(10, 15); // will cause OOM
+            var smallExpr = CreateMemoryExpression(1, 1); // should b eok
+
+            // Governor allows basic expressions
+            var result = await engine.EvalAsync(smallExpr, CancellationToken.None, runtimeConfig: runtimeConfig);
+            mem.Poll();
+
+            // Ensure governor traps excessive memory usage. 
+            await Assert.ThrowsAsync<GovernorException>(async () =>
+                    await engine.EvalAsync(expr, CancellationToken.None, runtimeConfig: runtimeConfig));
+
+            // Since Governor is cumulative, even the small evaluations now fails
+            Assert.Throws<GovernorException>(() => mem.Poll());
+
+            // But creating a new one works. 
+            runtimeConfig.AddService<Governor>(new BasicGovernor(DefaultMemorySizeBytes));
+            result = await engine.EvalAsync(smallExpr, CancellationToken.None, runtimeConfig: runtimeConfig);
+        }
+
+        private class TestIgnorePrePollGovernor : BasicGovernor
+        {
+            public TestIgnorePrePollGovernor(long maxAllowedBytes)
+                : base(maxAllowedBytes)
+            {
+            }
+
+            public override void PollMemory(long allocateBytes)
+            {
+                // nop. Ignore these warnings. Just rely on Poll.
+            }
+        }
+
+        // Verify cancellation.
+        // Expression that takes a long time to run.  Doesn't need much stack or memory.  
+        [Theory]
+        [InlineData("ForAll(Sequence(K), ForAll(Sequence(K), ForAll(Sequence(K), 5)))")]
+        [InlineData("ForAll(Sequence(1000), Max(Sequence(K), Value))")]
+        public async Task InfiniteLoop(string expr)
+        {
+            var engine = new RecalcEngine();
+            engine.UpdateVariable("K", 5);
+
+            // Can be invoked. 
+            using var cts = new CancellationTokenSource();
+
+            cts.CancelAfter(5);
+
+            // Eval may never return.             
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await engine.EvalAsync(expr, cts.Token);
+            });
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var engine = new RecalcEngine();
 
-            var mem = new BasicGovernor(DefaultMemorySizeBytes);
+            var mem = new SingleThreadedGovernor(DefaultMemorySizeBytes);
 
             var runtimeConfig = new RuntimeConfig();
             runtimeConfig.AddService<Governor>(mem);
@@ -112,7 +112,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var engine = new RecalcEngine();
 
-            var mem = new BasicGovernor(DefaultMemorySizeBytes);
+            var mem = new SingleThreadedGovernor(DefaultMemorySizeBytes);
 
             var runtimeConfig = new RuntimeConfig();
             runtimeConfig.AddService<Governor>(mem);
@@ -132,11 +132,11 @@ namespace Microsoft.PowerFx.Tests
             Assert.Throws<GovernorException>(() => mem.Poll());
 
             // But creating a new one works. 
-            runtimeConfig.AddService<Governor>(new BasicGovernor(DefaultMemorySizeBytes));
+            runtimeConfig.AddService<Governor>(new SingleThreadedGovernor(DefaultMemorySizeBytes));
             result = await engine.EvalAsync(smallExpr, CancellationToken.None, runtimeConfig: runtimeConfig);
         }
 
-        private class TestIgnorePrePollGovernor : BasicGovernor
+        private class TestIgnorePrePollGovernor : SingleThreadedGovernor
         {
             public TestIgnorePrePollGovernor(long maxAllowedBytes)
                 : base(maxAllowedBytes)


### PR DESCRIPTION
Fix #730 - better protection for expressions that generate large memory usage. 

Add "governor" service that can abort on large memory usage. Host can implement this and use GC functions to check memory usage and abort if an expression consumes too much memory.    Substitute() function has an inefficient implementation which provides one way to quickly consume memory (see #971 )
This coexists with other robustness checks like cancellation token and stack overflow. 

Functions can also "pre-poll" to calculate their memory usage and fail before they start executing. 

Refactored similar tests into a single location, "SandboxTests"

Add #setup so that it can be disabled by tests which intentionally use large memory.

We'll still need to review the rest of the code and enforce the checks are all rpesent. 