### PR TITLE
Fix display name bug for Single Column Table references

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3507,7 +3507,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                     else
                     {
-                        _txb.SetType(node, DType.CreateDTypeWithConnectedDataSourceInfoMetadata(DType.CreateTable(new TypedName(typeRhs, nameRhs)), typeRhs.AssociatedDataSources, typeRhs.DisplayNameProvider));
+                        _txb.SetType(node, DType.CreateDTypeWithConnectedDataSourceInfoMetadata(DType.CreateTable(new TypedName(typeRhs, nameRhs)), leftType.AssociatedDataSources, leftType.DisplayNameProvider));
                     }
                 }
                 else

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -2386,13 +2386,8 @@ namespace Microsoft.PowerFx.Core.Types
             type.AssertValid();
             Contracts.AssertValueOrNull(connectedDataSourceInfoSet);
 
-            if (connectedDataSourceInfoSet == null || connectedDataSourceInfoSet.Count == 0)
-            {
-                return type;
-            }
-
             var returnType = type;
-            foreach (var cds in connectedDataSourceInfoSet)
+            foreach (var cds in connectedDataSourceInfoSet ?? Enumerable.Empty<IExternalTabularDataSource>())
             {
                 returnType = AttachDataSourceInfo(returnType, cds);
             }


### PR DESCRIPTION
Single Column Table expressions (dotted names, with the lhs that's a table), are not supported in the interpreter. In Canvas, they have a subtle bug where the display name set for the resulting type is set to the field type rather than the base table's. This is incorrect, and leads to bugs when the base table was not associated with any child record/tables. 