### PR TITLE
Enforce parenthesis on reference to function property

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
@@ -20,6 +20,8 @@ namespace Microsoft.PowerFx.Core.App
         bool IsUseDisplayNameMetadataEnabled { get; }
 
         bool IsDynamicSchemaEnabled { get; }
+
+        bool IsEnhancedComponentFunctionProperty { get; }
     }
 
     internal sealed class DefaultEnabledFeatures : IExternalEnabledFeatures
@@ -33,5 +35,7 @@ namespace Microsoft.PowerFx.Core.App
         public bool IsUseDisplayNameMetadataEnabled => true;
 
         public bool IsDynamicSchemaEnabled => true;
+
+        public bool IsEnhancedComponentFunctionProperty => false;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.App
 
         bool IsDynamicSchemaEnabled { get; }
 
-        bool IsEnhancedComponentFunctionProperty { get; }
+        bool IsEnhancedComponentFunctionPropertyEnabled { get; }
     }
 
     internal sealed class DefaultEnabledFeatures : IExternalEnabledFeatures
@@ -36,6 +36,6 @@ namespace Microsoft.PowerFx.Core.App
 
         public bool IsDynamicSchemaEnabled => true;
 
-        public bool IsEnhancedComponentFunctionProperty => false;
+        public bool IsEnhancedComponentFunctionPropertyEnabled => true;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3284,8 +3284,8 @@ namespace Microsoft.PowerFx.Core.Binding
                         return;
                     }
 
-                    // We block the property access usage for scoped component properties.
-                    if (template.IsComponent && property.IsScopeVariable)
+                    // We block the property access usage for scoped component properties or functional properties
+                    if (template.IsComponent && (property.IsScopeVariable || property.IsScopedProperty))
                     {
                         SetDottedNameError(node, TexlStrings.ErrInvalidPropertyReference);
                         return;

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3285,7 +3285,10 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
 
                     // We block the property access usage for scoped component properties or functional properties
-                    if (template.IsComponent && (property.IsScopeVariable || property.IsScopedProperty))
+                    // TODO remove feature gate when ECS flag is completely rolled out
+                    if (template.IsComponent &&
+                        (property.IsScopeVariable ||
+                        ((_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionProperty ?? false) && property.IsScopedProperty)))
                     {
                         SetDottedNameError(node, TexlStrings.ErrInvalidPropertyReference);
                         return;

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3288,7 +3288,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // TODO remove feature gate when ECS flag is completely rolled out
                     if (template.IsComponent &&
                         (property.IsScopeVariable ||
-                        ((_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionProperty ?? false) && property.IsScopedProperty)))
+                        ((_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) && property.IsScopedProperty)))
                     {
                         SetDottedNameError(node, TexlStrings.ErrInvalidPropertyReference);
                         return;

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -5989,10 +5989,10 @@
     <comment>Error Message.</comment>
   </data>
   <data name="ErrorResource_ErrInvalidPropertyReference_LongMessage" xml:space="preserve">
-    <value>This error appears when a formula refers to component behavior properties with invalid syntax. (For example, Component.OnCustomChange instead of Component.OnCustomChange())</value>
+    <value>This error appears when a formula refers to component function properties with invalid syntax. (For example, Component.CustomFunction instead of Component.CustomFunction())</value>
   </data>
   <data name="ErrorResource_ErrInvalidPropertyReference_HowToFix_1" xml:space="preserve">
-    <value>Use correct syntax to refer to component behavior property. For example, Component.OnCustomChange()</value>
+    <value>Use correct syntax to refer to component function property. For example, Component.CustomFunction()</value>
     <comment>1 How to fix the error. </comment>
   </data>
   <data name="ErrorResource_ErrInvalidPropertyReference_Link_1" xml:space="preserve">


### PR DESCRIPTION
Currently when a function property has an optional parameter and that parameter is omitted at reference, there is no error because we allow it. 
This change is to make sure that we throw an invalid reference error when this happens because we want function calls to end with parenthesis with or without parameter going forward.

Note: the added feature gate must be removed once ECS flag is completely rolled out.