### PR TITLE
Adds error handling via Exception for Custom Function.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunctionErrorException.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunctionErrorException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerFx.Interpreter
+{
+    public class CustomFunctionErrorException : Exception
+    {
+        public CustomFunctionErrorException(string message)
+            : base(message) 
+        { 
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -28,10 +28,12 @@ namespace Microsoft.PowerFx.Tests
             {
                 if (arg.Value < 0)
                 {
+                    // CustomFunctionErrorException is caught and converted to error value.
                     throw new CustomFunctionErrorException("arg should be greater than 0");
                 }
                 else if (arg.Value == 0)
                 {
+                    // All other exceptions are uncaught and will abort the eval.
                     throw new NotSupportedException();
                 }
 
@@ -50,10 +52,12 @@ namespace Microsoft.PowerFx.Tests
             {
                 if (arg.Value < 0)
                 {
+                    // CustomFunctionErrorException is caught and converted to error value.
                     throw new CustomFunctionErrorException("arg should be greater than 0");
                 }
                 else if (arg.Value == 0)
                 {
+                    // All other exceptions are uncaught and will abort the eval.
                     throw new NotSupportedException();
                 }
 
@@ -126,7 +130,7 @@ namespace Microsoft.PowerFx.Tests
             // Can be invoked. 
             var result = await engine.EvalAsync("NullFunction()", CancellationToken.None);
             Assert.IsType<BlankValue>(result);
-            Assert.IsType<NumberType>(result.IRContext.ResultType);
+            Assert.IsType<NumberType>(result.Type);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -63,6 +63,7 @@ namespace Microsoft.PowerFx.Tests
                 $"{nsType}.{nameof(QueryableTableValue)}",
                 $"{ns}.InterpreterConfigException",
                 $"{ns}.Interpreter.{nameof(NotDelegableException)}",
+                $"{ns}.Interpreter.{nameof(CustomFunctionErrorException)}",
                 $"{ns}.Interpreter.UDF.{nameof(DefineFunctionsResult)}",                               
 
                 // Services for functions. 


### PR DESCRIPTION
Relates #1001  #999 
Before users had to loosen the return type to FormulaValue from Custom Function just to return an error, and due to that they were losing compile time strict type checking and the implementations were prone to errors of returning incorrect types.

Now instead of creating their own error, users can just throw `CustomFunctionErrorException` so they can keep the return type of `Execute` method strict and we populate the error with the correct return type.

Before they would do:
```csharp
        public class CustomFunctionError : ReflectionFunction
        {
            public CustomFunctionError()
                : base("CustomFunctionError", FormulaType.Number, FormulaType.Number) 
            {
            }

            public static FormulaValue Execute(NumberValue arg) 
            {
                if (arg.Value < 0)
                {
                    return CommonErrors.CustomError("arg should be greater than 0", FormulaType.Number);
                }
                else if (arg.Value == 0)
                {
                    throw new NotSupportedException();
                }

                return arg;
            }
        }
```
Now insted they can keep return type stricter.

```csharp
        public class CustomFunctionError : ReflectionFunction
        {
            public CustomFunctionError()
                : base("CustomFunctionError", FormulaType.Number, FormulaType.Number) 
            {
            }

            public static NumberValue Execute(NumberValue arg) 
            {
                if (arg.Value < 0)
                {
                    throw new CustomFunctionErrorException("arg should be greater than 0");
                }
                else if (arg.Value == 0)
                {
                    throw new NotSupportedException();
                }

                return arg;
            }
        }
```