### PR TITLE
Fix 767 - invariant translation with symbols 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/ExpressionLocalizationHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/ExpressionLocalizationHelper.cs
@@ -23,12 +23,17 @@ namespace Microsoft.PowerFx.Core
 
         internal static string ConvertExpression(string expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, PowerFxConfig fxConfig, bool toDisplay)
         {
-            var targetLexer = toDisplay ? TexlLexer.GetLocalizedInstance(fxConfig.CultureInfo) : TexlLexer.InvariantLexer;
-            var sourceLexer = toDisplay ? TexlLexer.InvariantLexer : TexlLexer.GetLocalizedInstance(fxConfig.CultureInfo);
+            return ConvertExpression(expressionText, parameters, bindingConfig, resolver, binderGlue, fxConfig.CultureInfo, fxConfig.Features, toDisplay);
+        }
+
+        internal static string ConvertExpression(string expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, CultureInfo culture, Features flags, bool toDisplay)
+        {
+            var targetLexer = toDisplay ? TexlLexer.GetLocalizedInstance(culture) : TexlLexer.InvariantLexer;
+            var sourceLexer = toDisplay ? TexlLexer.InvariantLexer : TexlLexer.GetLocalizedInstance(culture);
 
             var worklist = GetLocaleSpecificTokenConversions(expressionText, sourceLexer, targetLexer);
 
-            var formula = new Formula(expressionText, toDisplay ? CultureInfo.InvariantCulture : fxConfig.CultureInfo);
+            var formula = new Formula(expressionText, toDisplay ? CultureInfo.InvariantCulture : culture);
             formula.EnsureParsed(TexlParser.Flags.None);
 
             var binding = TexlBinding.Run(
@@ -41,7 +46,7 @@ namespace Microsoft.PowerFx.Core
                 ruleScope: parameters?._type,
                 updateDisplayNames: toDisplay,
                 forceUpdateDisplayNames: toDisplay,
-                features: fxConfig.Features);
+                features: flags);
 
             foreach (var token in binding.NodesToReplace)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -406,7 +406,14 @@ namespace Microsoft.PowerFx
             var ruleScope = this.GetRuleScope();
             var symbolTable = (parameters == null) ? null : SymbolTable.NewFromRecord(parameters);
 
-            return ExpressionLocalizationHelper.ConvertExpression(expressionText, ruleScope, GetDefaultBindingConfig(), CreateResolverInternal(symbolTable), CreateBinderGlue(), Config, toDisplay: false);
+            return GetInvariantExpressionWorker(expressionText, symbolTable, Config.CultureInfo);
+        }
+
+        internal string GetInvariantExpressionWorker(string expressionText, ReadOnlySymbolTable symbolTable, CultureInfo parseCulture)
+        {
+            var ruleScope = this.GetRuleScope();
+
+            return ExpressionLocalizationHelper.ConvertExpression(expressionText, ruleScope, GetDefaultBindingConfig(), CreateResolverInternal(symbolTable), CreateBinderGlue(), parseCulture, Config.Features, toDisplay: false);
         }
 
         /// <summary>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
@@ -33,6 +33,12 @@ namespace Microsoft.PowerFx.Tests
                 flags: Flags.EnableExpressionChaining);
 
             Assert.Equal(expected, result.GetAnonymizedFormula());
+            
+            // Test same cases via CheckResult
+            var check = new CheckResult(new Engine());
+            check.SetText(script, new ParserOptions { AllowsSideEffects = true });
+            var result2 = check.ApplyGetLogging();
+            Assert.Equal(expected, result2);
         }
 
         private class TestSanitizer : ISanitizedNameProvider


### PR DESCRIPTION
Fix #767  - needed for dataverse. 

Add to CheckResult: 
ApplyGetInvariant
ApplyGetLogging