### PR TITLE
Fixes the issue with TZ having minutes in utc offset.

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateDiff_TimeZone_Lord_Howe_Island.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateDiff_TimeZone_Lord_Howe_Island.txt
@@ -18,3 +18,6 @@
 
 >> DateDiff(DateTime(2006,12,31,23,59,59,999), DateTime(2007,1,1,0,0,0), TimeUnit.Hours)
 1
+
+>> DateDiff(DateTime(2006,6,30,23,59,59,999), DateTime(2006,7,1,0,0,0), TimeUnit.Hours)
+1

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateDiff_TimeZone_Lord_Howe_Island.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateDiff_TimeZone_Lord_Howe_Island.txt
@@ -1,0 +1,20 @@
+﻿// https://www.timeanddate.com/time/change/australia/lord-howe-island
+// This is a special TZ where UTC offset has minutes and DST diff is not one hour, but 30 minutes.
+#SETUP: TimeZoneInfo("Lord Howe Standard Time")
+
+// 2023, Sun, 2 Apr, 02:00	LHDT → LHST	-0:30 hours (DST end)
+>> DateDiff(DateTime(2023,4,2,0,0,0), DateTime(2023,4,2,2,30,0), TimeUnit.Hours)
+3
+
+>> DateDiff(DateTime(2023,4,1,0,0,0), DateTime(2023,4,1,2,30,0), TimeUnit.Hours)
+2
+
+// 2023, Sun, 2 Apr, 02:00	LHDT → LHST	-0:30 hours (DST end)
+>> DateDiff(DateTime(2023,4,2,0,0,0), DateTime(2023,4,2,2,30,0), TimeUnit.Minutes)
+180
+
+>> DateDiff(DateTime(2023,4,1,0,0,0), DateTime(2023,4,1,2,30,0), TimeUnit.Minutes)
+150
+
+>> DateDiff(DateTime(2006,12,31,23,59,59,999), DateTime(2007,1,1,0,0,0), TimeUnit.Hours)
+1


### PR DESCRIPTION
Fixes #1015 
Now instead of converting to UTC TZ, we subtract 1 hour from the time to accommodate DST.

This helps in cases where TZ has UTC offset.
e.g.
`DateDiff(DateTime(2005,12,31,23,59,59,999), DateTime(2006,1,1,0,0,0), TimeUnit.Hours)`

When converted to UTC from GMT+5:30 (IST), the expression would become
`DateDiff(DateTime(2005,12,31,18,59,59,999), DateTime(2005,12,31,18,30,0), TimeUnit,Hours)`
This would render the Hour the same due to offset having minutes in it.

Instead, Now for example,
`start = DateTime(2023, 3, 12, 0, 0, 0) is in UTC-8`
`end = DateTime(2023, 3, 12, 3, 0, 0) is in UTC-7`
`startUTCOffset - endUTCOffset = -1`
so adding that UTC offset difference to the end(instead of converting both to UTC) will adjust the subtraction for DST
while preserving hours, since cases having minutes offset can potentially change the hour.