### PR TITLE
CultureInfo support for errors

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -115,6 +115,7 @@ namespace Microsoft.PowerFx
 
             _expression = expression;
             _parserOptions = parserOptions ?? Engine.GetDefaultParserOptionsCopy();
+            this.ParserCultureInfo = _parserOptions.Culture;
 
             return this;
         }
@@ -239,10 +240,25 @@ namespace Microsoft.PowerFx
         /// </summary>
         public IEnumerable<ExpressionError> Errors
         {
-            get => _errors;
+            get => GetErrorsInLocale(null);
 
             [Obsolete("use constructor to set errors")]
             set => _errors.AddRange(value);
+        }
+
+        /// <summary>
+        /// Get errors localized with the given culture. 
+        /// </summary>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        public IEnumerable<ExpressionError> GetErrorsInLocale(CultureInfo culture)
+        {
+            culture ??= this.ParserCultureInfo;
+
+            foreach (var error in this._errors)
+            {
+                yield return error.GetInLocale(culture);
+            }
         }
 
         /// <summary>
@@ -303,9 +319,10 @@ namespace Microsoft.PowerFx
         }
 
         /// <summary>
-        /// Culture info passed to this binding. May be null. 
+        /// Culture info used for parsing. 
+        /// By default, this is also used for error messages. 
         /// </summary>
-        internal CultureInfo CultureInfo => this.Engine.Config.CultureInfo;
+        internal CultureInfo ParserCultureInfo { get; private set; }
 
         internal void ThrowIfSymbolsChanged()
         {
@@ -378,7 +395,7 @@ namespace Microsoft.PowerFx
                 this._allSymbols = combinedSymbols;
 
                 // Add the errors
-                IEnumerable<ExpressionError> bindingErrors = ExpressionError.New(binding.ErrorContainer.GetErrors(), CultureInfo);
+                IEnumerable<ExpressionError> bindingErrors = ExpressionError.New(binding.ErrorContainer.GetErrors(), ParserCultureInfo);
                 _errors.AddRange(bindingErrors);
 
                 if (this.IsSuccess)

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DTypeSpecParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DTypeSpecParser.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Globalization;
 using System.Linq;
 using Microsoft.PowerFx.Core.Utils;
@@ -46,7 +47,7 @@ namespace Microsoft.PowerFx.Core.Types
                 return true;
             }
 
-            var typeIdx = _typeEncodings.IndexOf(token);
+            var typeIdx = _typeEncodings.IndexOf(token, StringComparison.Ordinal);
             if (typeIdx < 0)
             {
                 type = DType.Invalid;
@@ -114,7 +115,7 @@ namespace Microsoft.PowerFx.Core.Types
             while (lexer.TryNextToken(out token) && token != "]")
             {
                 var name = token;
-                if (name.Length >= 2 && name.StartsWith("'") && name.EndsWith("'"))
+                if (name.Length >= 2 && name.StartsWith("'", StringComparison.Ordinal) && name.EndsWith("'", StringComparison.Ordinal))
                 {
                     name = TexlLexer.UnescapeName(name);
                 }
@@ -168,7 +169,7 @@ namespace Microsoft.PowerFx.Core.Types
             while (lexer.TryNextToken(out token) && token != "]")
             {
                 var name = token;
-                if (name.Length >= 2 && name.StartsWith("'") && name.EndsWith("'"))
+                if (name.Length >= 2 && name.StartsWith("'", StringComparison.Ordinal) && name.EndsWith("'", StringComparison.Ordinal))
                 {
                     name = name.TrimStart('\'').TrimEnd('\'');
                 }
@@ -244,7 +245,7 @@ namespace Microsoft.PowerFx.Core.Types
             }
 
             // Number (double) support
-            if (double.TryParse(token, out var numValue))
+            if (double.TryParse(token, NumberStyles.Float, CultureInfo.InvariantCulture, out var numValue))
             {
                 value = new EquatableObject(numValue);
                 return true;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PowerFx
             {
                 // There were existing SymbolValues that don't match. 
                 var kv = existingMap.First();
-                var msg = $"SymbolValues '{kv.Value.DebugName}' matches to symbol table '{kv.Key.DebugName}', which is not part of symbol table '{symbolTable.DebugName}'.";
+                var msg = $"SymbolValues '{kv.Value.DebugName}' matches to symbol table '{kv.Key.DebugName}', which is not part of symbol table '{symbolTable?.DebugName}'.";
                 throw new InvalidOperationException(msg);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
@@ -17,10 +17,10 @@ namespace Microsoft.PowerFx.Functions
     internal static partial class Library
     {
         // ColorTable is ARGB
-        private static readonly Regex RegexColorTable = new (@"^#(?<a>[0-9a-fA-F]{2})(?<r>[0-9a-fA-F]{2})(?<g>[0-9a-fA-F]{2})(?<b>[0-9a-fA-F]{2})?$", RegexOptions.Compiled);
+        private static readonly Regex RegexColorTable = new Regex(@"^#(?<a>[0-9a-fA-F]{2})(?<r>[0-9a-fA-F]{2})(?<g>[0-9a-fA-F]{2})(?<b>[0-9a-fA-F]{2})?$", LibraryFlags.RegExFlags);
 
         // CSS format is RGBA
-        private static readonly Regex RegexCSS = new (@"^#(?<r>[0-9a-fA-F]{2})(?<g>[0-9a-fA-F]{2})(?<b>[0-9a-fA-F]{2})(?<a>[0-9a-fA-F]{2})?$", RegexOptions.Compiled);
+        private static readonly Regex RegexCSS = new Regex(@"^#(?<r>[0-9a-fA-F]{2})(?<g>[0-9a-fA-F]{2})(?<b>[0-9a-fA-F]{2})(?<a>[0-9a-fA-F]{2})?$", LibraryFlags.RegExFlags);
 
         public static FormulaValue ColorValue(IRContext irContext, StringValue[] args)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -21,22 +21,30 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Functions
 {
+    // Due to .Net static ctor initialization, must place in a separate class from Library. 
+    internal static class LibraryFlags
+    {
+        public static readonly RegexOptions RegExFlags = RegexOptions.Compiled | RegexOptions.CultureInvariant;
+    }
+
     internal static partial class Library
     {
-        private static readonly Regex _ampmReplaceRegex = new Regex("[aA][mM]\\/[pP][mM]", RegexOptions.Compiled);
-        private static readonly Regex _apReplaceRegex = new Regex("[aA]\\/[pP]", RegexOptions.Compiled);
-        private static readonly Regex _minutesBeforeSecondsRegex = new Regex("[mM][^dDyYhH]+[sS]", RegexOptions.Compiled);
-        private static readonly Regex _minutesAfterHoursRegex = new Regex("[hH][^dDyYmM]+[mM]", RegexOptions.Compiled);
-        private static readonly Regex _minutesRegex = new Regex("[mM]", RegexOptions.Compiled);
-        private static readonly Regex _internalStringRegex = new Regex("([\"][^\"]*[\"])", RegexOptions.Compiled);
-        private static readonly Regex _daysDetokenizeRegex = new Regex("[\u0004][\u0004][\u0004][\u0004]+", RegexOptions.Compiled);
-        private static readonly Regex _monthsDetokenizeRegex = new Regex("[\u0003][\u0003][\u0003][\u0003]+", RegexOptions.Compiled);
-        private static readonly Regex _yearsDetokenizeRegex = new Regex("[\u0005][\u0005][\u0005]+", RegexOptions.Compiled);
-        private static readonly Regex _years2DetokenizeRegex = new Regex("[\u0005]+", RegexOptions.Compiled);
-        private static readonly Regex _hoursDetokenizeRegex = new Regex("[\u0006][\u0006]+", RegexOptions.Compiled);
-        private static readonly Regex _minutesDetokenizeRegex = new Regex("[\u000A][\u000A]+", RegexOptions.Compiled);
-        private static readonly Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegexOptions.Compiled);
-        private static readonly Regex _milisecondsDetokenizeRegex = new Regex("[\u000e]+", RegexOptions.Compiled);
+        private static readonly RegexOptions RegExFlags = LibraryFlags.RegExFlags;
+
+        private static readonly Regex _ampmReplaceRegex = new Regex("[aA][mM]\\/[pP][mM]", RegExFlags);
+        private static readonly Regex _apReplaceRegex = new Regex("[aA]\\/[pP]", RegExFlags);
+        private static readonly Regex _minutesBeforeSecondsRegex = new Regex("[mM][^dDyYhH]+[sS]", RegExFlags);
+        private static readonly Regex _minutesAfterHoursRegex = new Regex("[hH][^dDyYmM]+[mM]", RegExFlags);
+        private static readonly Regex _minutesRegex = new Regex("[mM]", RegExFlags);
+        private static readonly Regex _internalStringRegex = new Regex("([\"][^\"]*[\"])", RegExFlags);
+        private static readonly Regex _daysDetokenizeRegex = new Regex("[\u0004][\u0004][\u0004][\u0004]+", RegExFlags);
+        private static readonly Regex _monthsDetokenizeRegex = new Regex("[\u0003][\u0003][\u0003][\u0003]+", RegExFlags);
+        private static readonly Regex _yearsDetokenizeRegex = new Regex("[\u0005][\u0005][\u0005]+", RegExFlags);
+        private static readonly Regex _years2DetokenizeRegex = new Regex("[\u0005]+", RegExFlags);
+        private static readonly Regex _hoursDetokenizeRegex = new Regex("[\u0006][\u0006]+", RegExFlags);
+        private static readonly Regex _minutesDetokenizeRegex = new Regex("[\u000A][\u000A]+", RegExFlags);
+        private static readonly Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegExFlags);
+        private static readonly Regex _milisecondsDetokenizeRegex = new Regex("[\u000e]+", RegExFlags);
 
         // Char is used for PA string escaping 
         public static FormulaValue Char(IRContext irContext, NumberValue[] args)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerFx
             var irResult = result.ApplyIR();
             result.ThrowOnErrors();
 
-            var expr = new ParsedExpression(irResult.TopNode, irResult.RuleScopeSymbol, stackMarker, result.CultureInfo)
+            var expr = new ParsedExpression(irResult.TopNode, irResult.RuleScopeSymbol, stackMarker, result.ParserCultureInfo)
             {
                 _globals = globals,
                 _allSymbols = result.Symbols,

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionErrorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionErrorTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Syntax;
@@ -46,6 +48,124 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void NullSpanToString()
+        {
+            var error = new ExpressionError()
+            {
+                Message = "ouch",
+                Severity = ErrorSeverity.Critical
+            };
+
+            Assert.Equal("Error: ouch", error.ToString());
+        }
+
+        [Fact]
+        public void Defaults()
+        {
+            var error = new ExpressionError();
+
+            Assert.Equal(ErrorSeverity.Severe, error.Severity);
+            Assert.Equal(ErrorKind.None, error.Kind);
+            Assert.Null(error.Message);
+            Assert.Null(error.MessageKey);
+            Assert.Null(error.MessageLocale);
+            Assert.Null(error.Span);
+        }
+
+        private static IDocumentError GetBaseError(ErrorResourceKey errKey, params object[] args)
+        {
+            var span = new Span(2, 5);
+            var e = new MyError(null, null, DocumentErrorKind.Persistence, DocumentErrorSeverity.Critical, errKey, span, null, args);
+
+            return e;
+        }
+
+        private static ExpressionError GetError(ErrorResourceKey errKey, params object[] args)
+        {
+            var e = GetBaseError(errKey, args);
+            var error = ExpressionError.New(e);
+
+            Assert.Equal(error.MessageKey, errKey.Key);
+
+            return error;
+        }
+
+        [Fact]
+        public void Localize()
+        {
+            var error = GetError(TexlStrings.ErrInvalidName, "name");
+
+            Assert.Equal("Name isn't valid. 'name' isn't recognized.", error.Message);
+
+            var cultureFr = new CultureInfo("fr-FR");
+            var errorFr = error.GetInLocale(cultureFr);
+            Assert.Same(cultureFr, errorFr.MessageLocale);
+            
+            Assert.NotSame(error, errorFr);
+            Assert.Equal("Name isn't valid. 'name' isn't recognized.", error.Message);
+            Assert.Equal("Le nom n’est pas valide. « name » n’est pas reconnu.", errorFr.Message);
+
+            var error3 = error.GetInLocale(null);            
+            Assert.Equal("Name isn't valid. 'name' isn't recognized.", error3.Message);
+            Assert.Null(error3.MessageLocale);
+
+            var cultureBg = new CultureInfo("bg-BG");
+            var errorBg = errorFr.GetInLocale(cultureBg);
+            Assert.Equal("Името не е валидно. „name“ не е разпознато.", errorBg.Message);
+        }
+
+        // Can create an error with a default culture. 
+        [Fact]
+        public void LocalizeDefault()
+        {
+            var cultureFr = new CultureInfo("fr-FR");
+
+            var baseError = GetBaseError(TexlStrings.ErrInvalidName, "name");
+            var errorFr = ExpressionError.New(baseError, cultureFr);
+
+            Assert.Equal("Le nom n’est pas valide. « name » n’est pas reconnu.", errorFr.Message);
+        }
+
+        // If we don't have a MessageKey, then current culture is ignored 
+        [Fact]
+        public void LocalizeIgnoreCulture()
+        {
+            var error = new ExpressionError()
+            {
+                Message = "ouch",
+                Severity = ErrorSeverity.Critical
+            };
+            Assert.Null(error.MessageKey);
+
+            var cultureFr = new CultureInfo("fr-FR");
+            var error2 = error.GetInLocale(cultureFr);
+
+            Assert.Same(error2, error);
+            Assert.Equal("ouch", error2.Message);
+        }
+
+        [Fact]
+        public void New()
+        {
+            var baseError = GetBaseError(TexlStrings.ErrInvalidName, "name");
+            var baseErrors = new IDocumentError[] { baseError };
+
+            var errors = ExpressionError.New(baseErrors);
+
+            Assert.Single(errors);
+            var error = errors.First();
+            Assert.Equal("Name isn't valid. 'name' isn't recognized.", error.Message);
+
+            // Overload with Culture
+            var cultureFr = new CultureInfo("fr-FR");
+            var errors2 = ExpressionError.New(baseErrors, cultureFr);
+            Assert.Single(errors);
+            var errorFr = errors2.First();
+            Assert.Equal("Le nom n’est pas valide. « name » n’est pas reconnu.", errorFr.Message);
+            Assert.Same(cultureFr, errorFr.MessageLocale);
+        }
+
+        [Fact]
         public void Empty()
         {            
             // We don't want null IEnumerables. 
@@ -53,6 +173,9 @@ namespace Microsoft.PowerFx.Core.Tests
             var internalErrors = (IEnumerable<IDocumentError>)null;
             var errors = ExpressionError.New(internalErrors);
 
+            Assert.Empty(errors);
+
+            var errors2 = ExpressionError.New(internalErrors, CultureInfo.InvariantCulture);
             Assert.Empty(errors);
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/DoNotUseCulture.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/DoNotUseCulture.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.PowerFx
+{
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+
+    // Used to verify that that we're not accessing this culture. 
+    // For example, if we want to verify we don't access Thread.CurrentCulture. 
+    // then just set it to DoNotUseCulture and any access will throw. 
+    [DebuggerDisplay("DoNotUse Culture")]
+    public class DoNotUseCulture : CultureInfo
+    {
+        public DoNotUseCulture()
+            : base("en-US")
+        {
+        }
+
+        public override Calendar Calendar => throw new NotImplementedException();
+
+        public override object Clone() => throw new NotImplementedException();
+
+        public override CompareInfo CompareInfo => throw new NotImplementedException();
+
+        public override DateTimeFormatInfo DateTimeFormat { get => throw new NotImplementedException(); set => base.DateTimeFormat = value; }
+
+        // This one is special - used by parser. 
+        public override NumberFormatInfo NumberFormat { get => throw new NotImplementedException(); set => base.NumberFormat = value; }
+
+        public override string DisplayName => throw new NotImplementedException();
+
+        public override string EnglishName => throw new NotImplementedException();
+
+        public override bool Equals(object value) => throw new NotImplementedException();
+
+        public override object GetFormat(Type formatType)
+        {
+            if (formatType == typeof(ICustomFormatter))
+            {
+                // Commonly used for formatting errors...
+                // $$$ Shouldn't call this either - it means we're processing error messages eagerly
+                return base.GetFormat(formatType);
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public override int GetHashCode() => throw new NotImplementedException();
+
+        public override bool IsNeutralCulture => throw new NotImplementedException();
+
+        public override int KeyboardLayoutId => throw new NotImplementedException();
+
+        public override int LCID => throw new NotImplementedException();
+
+        public override string Name => throw new NotImplementedException();
+
+        public override string NativeName => throw new NotImplementedException();
+
+        public override TextInfo TextInfo => throw new NotImplementedException();
+
+        public override Calendar[] OptionalCalendars => throw new NotImplementedException();
+
+        public override CultureInfo Parent => throw new NotImplementedException();
+
+        public override string ThreeLetterISOLanguageName => throw new NotImplementedException();
+
+        public override string ThreeLetterWindowsLanguageName => throw new NotImplementedException();
+
+        public override string TwoLetterISOLanguageName => throw new NotImplementedException();
+
+        public override string ToString() => throw new NotImplementedException();
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/TestRunnerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/TestRunnerTests.cs
@@ -352,7 +352,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
             var test = new TestCase
             {
-                Expected = "Errors: Error X"
+                Expected = "Errors: Error: X"
             };
             var (result, message) = runner.RunTestCase(test);
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -52,8 +52,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
 
             _sendToClientData = new List<string>();
             _scopeFactory = new TestPowerFxScopeFactory(
-                (string documentUri) => engine.CreateEditorScope(options, GetFromUri(documentUri)),
-                options);
+                (string documentUri) => engine.CreateEditorScope(options, GetFromUri(documentUri)));
             _testServer = new TestLanguageServer(_sendToClientData.Add, _scopeFactory);
         }
 
@@ -1279,8 +1278,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
 
             _sendToClientData = new List<string>();
             _scopeFactory = new TestPowerFxScopeFactory(
-                (string documentUri) => engine.CreateEditorScope(new ParserOptions() { Culture = locale }, GetFromUri(documentUri)),
-                GetParserOptions(false));
+                (string documentUri) => engine.CreateEditorScope(new ParserOptions() { Culture = locale }, GetFromUri(documentUri)));
             _testServer = new TestLanguageServer(_sendToClientData.Add, _scopeFactory);
 
             _testServer.OnDataReceived(

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/TestPowerFxScopeFactory.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/TestPowerFxScopeFactory.cs
@@ -12,12 +12,10 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         public delegate IPowerFxScope GetOrCreateInstanceDelegate(string documentUri);
 
         private readonly GetOrCreateInstanceDelegate _getOrCreateInstance;
-        private readonly ParserOptions _parserOptions;
 
-        public TestPowerFxScopeFactory(GetOrCreateInstanceDelegate getOrCreateInstance, ParserOptions options = null)
+        public TestPowerFxScopeFactory(GetOrCreateInstanceDelegate getOrCreateInstance)
         {
             _getOrCreateInstance = getOrCreateInstance;
-            _parserOptions = options;
         }
 
         public IPowerFxScope GetOrCreateInstance(string documentUri)


### PR DESCRIPTION
Allow Errors to be in separate culture info that parser. 
Fix #918, and also #1039. Sets up a fix for #990.  

Make ExpressionError.Message localize lazily.  
- Callers can get the localized message in any culture after the parse/bind
- just checking IsSuccess can then avoid localization since that doesn't read the message property 


Add test to ensure we're not using Thread.CurrentCulture when a culture is provided. 
- Update a bunch of usages.  StartsWith(), EndsWith() ,etc require StringComparison.Ordinal, else they will check current culture. 
- RegEx required CultureInvariant 


Add more tests
- add ExpressionErrorTests to get 100% code coverage on ExpressionError. 
- add MultiCulture* tests to demonstrate how we can set Parse/ErrorMessage/Runtime  cultures independently 
- remove parserOptions usage in LSP that wasn't being used. 

