### PR TITLE
Fix bug, add test case for check.GetEvaluator()

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -264,7 +264,7 @@ namespace Microsoft.PowerFx
 
         internal bool HasDeferredArgsWarning => _errors.Any(x => x.IsWarning && x.MessageKey.Equals(TexlStrings.WarnDeferredType.Key));
 
-        internal ReadOnlySymbolTable AllSymbols { get; private set; }
+        private ReadOnlySymbolTable _allSymbols;
 
         /// <summary>
         /// Full set of Symbols passed to this binding. 
@@ -281,7 +281,7 @@ namespace Microsoft.PowerFx
                     throw new InvalidOperationException($"Must call {nameof(ApplyBinding)} before accessing combined Sybmols.");
                 }
 
-                return this.AllSymbols;
+                return this._allSymbols;
             }
         }
 
@@ -375,7 +375,7 @@ namespace Microsoft.PowerFx
                 // Don't modify any fields until after we've verified the symbols haven't change.
 
                 this._binding = binding;
-                this.AllSymbols = combinedSymbols;
+                this._allSymbols = combinedSymbols;
 
                 // Add the errors
                 IEnumerable<ExpressionError> bindingErrors = ExpressionError.New(binding.ErrorContainer.GetErrors(), CultureInfo);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
@@ -147,10 +147,17 @@ namespace Microsoft.PowerFx
                 tw.WriteLine();
             }
 
-            if (check.Binding != null)
+            try
             {
-                tw.WriteLine($"{indent}Binding: {Dump(check.ReturnType)}");
-                tw.WriteLine();
+                if (check.Binding != null)
+                {
+                    tw.WriteLine($"{indent}Binding: {Dump(check.ReturnType)}");
+                    tw.WriteLine();
+                }
+            }
+            catch
+            {
+                tw.WriteLine($"{indent}No Binding");
             }
 
             if (check.Errors.Any())
@@ -165,20 +172,34 @@ namespace Microsoft.PowerFx
             }
             else
             {
-                var run = check.GetEvaluator();
-                if (run is ParsedExpression run2)
+                try
                 {
-                    tw.WriteLine($"{indent}IR:");
-                    tw.WriteLine(Dump(run2._irnode));
-                    tw.WriteLine();
+                    var run = check.GetEvaluator();
+                    if (run is ParsedExpression run2)
+                    {
+                        tw.WriteLine($"{indent}IR:");
+                        tw.WriteLine(Dump(run2._irnode));
+                        tw.WriteLine();
+                    }
+                }
+                catch
+                {
+                    tw.WriteLine($"{indent}No IR");
                 }
             }
 
             // Symbols last - they can be very large 
-            if (check.AllSymbols != null)
+            try
             {
-                tw.WriteLine($"{indent}Symbols:");
-                Dump(check.AllSymbols, tw, indent + "   ");
+                if (check.Symbols != null)
+                {
+                    tw.WriteLine($"{indent}Symbols:");
+                    Dump(check.Symbols, tw, indent + "   ");
+                }
+            }
+            catch
+            {
+                tw.WriteLine($"{indent}No Symbols");
             }
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -70,7 +70,6 @@ namespace Microsoft.PowerFx
         internal static IExpressionEvaluator GetEvaluator(this CheckResult result, StackDepthCounter stackMarker)
         {
             ReadOnlySymbolValues globals = null;
-            var allSymbols = result.AllSymbols;
                 
             if (result.Engine is RecalcEngine recalcEngine)
             {
@@ -84,7 +83,7 @@ namespace Microsoft.PowerFx
             var expr = new ParsedExpression(irResult.TopNode, irResult.RuleScopeSymbol, stackMarker, result.CultureInfo)
             {
                 _globals = globals,
-                _allSymbols = allSymbols,
+                _allSymbols = result.Symbols,
                 _parameterSymbolTable = result.Parameters
             };
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -108,6 +108,24 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(17.0, ((NumberValue)result).Value);
         }
 
+        [Fact]
+        public void EvalWithoutParse()
+        {
+            var engine = new RecalcEngine();
+            engine.UpdateVariable("x", 2);
+
+            var check = new CheckResult(engine)
+                .SetText("x*3")
+                .SetBindingInfo();
+
+            // Call Evaluator directly.
+            // Ensure it also pulls engine's symbols. 
+            var run = check.GetEvaluator();
+
+            var result = run.Eval();
+            Assert.Equal(2.0 * 3, result.ToObject());
+        }
+
         /// <summary>
         /// Test that helps to ensure that RecalcEngine performs evaluation in thread safe manner.
         /// </summary>


### PR DESCRIPTION
Fix bug, add test case for check.GetEvaluator()

Demote AllSymbols  from internal property to private field to protect against misuse. 