### PR TITLE
Handling recordtorecord coercion

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -508,6 +508,24 @@ namespace Microsoft.PowerFx
 
                 return new InMemoryTableValue(node.IRContext, resultRows);
             }
+            else if (node.Op == UnaryOpKind.RecordToRecord)
+            {
+                var fields = new List<NamedValue>();
+                var scopeContext = context.SymbolContext.WithScope(node.Scope);
+                var newScope = scopeContext.WithScopeValues((RecordValue)arg1);
+
+                foreach (var coercion in node.FieldCoercions)
+                {
+                    CheckCancel();
+
+                    var newValue = await coercion.Value.Accept(this, context.NewScope(newScope));
+                    var name = coercion.Key;
+
+                    fields.Add(new NamedValue(name.Value, newValue));
+                }
+
+                return FormulaValue.NewRecordFromFields(fields);
+            }
 
             return CommonErrors.UnreachableCodeError(node.IRContext);
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Threading;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Types;
@@ -34,6 +35,28 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             var ir = IRTranslator.Translate(checkResult.Binding).ToString();
             Assert.DoesNotContain("AggregateCoercionNode", ir);
+        }
+
+        [Theory]
+
+        [InlineData("With({t1:Table({a:stringVar})},Patch(t1,First(t1),{a:integerVar}))")]
+        [InlineData("With({t1:Table({a:5})},Patch(t1,First(t1),{a:datetimeVar}))")]
+        public void RecordToRecordAggregateCoercionTest(string expr)
+        {
+            var engine = new RecalcEngine(new PowerFxConfig());
+
+            var stringVar = FormulaValue.New("lichess.org");
+            var integerVar = FormulaValue.New(1);
+            var datetimeVar = FormulaValue.New(DateTime.Now);
+
+            engine.Config.SymbolTable.EnableMutationFunctions();
+            engine.Config.SymbolTable.AddConstant("stringVar", stringVar);
+            engine.Config.SymbolTable.AddConstant("integerVar", integerVar);
+            engine.Config.SymbolTable.AddConstant("datetimeVar", datetimeVar);
+
+            var result = engine.Eval(expr, options: new ParserOptions() { AllowsSideEffects = true });
+
+            Assert.IsNotType<ErrorValue>(result);
         }
     }
 }


### PR DESCRIPTION
Called when patching a record with different types of fields.

Example:
`With({t1:Table({a:stringVar})},Patch(t1,First(t1),{a:5}))`