### PR TITLE
We can remove Sytem.Memory reference

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Microsoft.PowerFx.Core.csproj
+++ b/src/libraries/Microsoft.PowerFx.Core/Microsoft.PowerFx.Core.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Microsoft.PowerFx.Interpreter.csproj
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Microsoft.PowerFx.Interpreter.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This was only used by System.Text.Json, which was removed in #957 .



