### PR TITLE
Lazy loading of types for symbol tables 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -55,8 +55,7 @@ namespace Microsoft.PowerFx
 
         private readonly SlotMap<NameLookupInfo?> _slots = new SlotMap<NameLookupInfo?>();
 
-        // Called by 
-        // $$$ OVerride full
+        // Override lookup.
         bool INameResolver.Lookup(DName name, out NameLookupInfo nameInfo, NameLookupPreferences preferences)
         {
             if (_displayNameLookup.TryGetLogicalOrDisplayName(name, out var logical, out var display))

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.PowerFx.Core;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Binding.BindInfo;
+using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Types.Enums;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+#if false
+    /// <summary>
+    /// Provides symbol table with deferred semantics. 
+    /// This is semantically readonly - there is a fixes set of known symbols, just the type information is populated lazily.
+    /// Good when we can quickly load the names (to populate the intellisense completion list), but then load remaining symbol details on-demand. 
+    /// </summary>
+    [DebuggerDisplay("{DebugName}")]
+    public class DeferredSymbolTable : ReadOnlySymbolTable 
+    {
+        // $$$ Must be thread safe!!!        
+        private readonly object _lock = new object();
+
+        // All possible tables we could add. 
+        private readonly DisplayNameProvider _displayNameLookup;
+
+        // Full universe of possible symbols
+        // All other symbols are missing. 
+        public DeferredSymbolTable(DisplayNameProvider map, Action<string, string> funcAdd)
+        {
+            _displayNameLookup = map ?? throw new ArgumentNullException(nameof(map));   
+        }
+
+        // SymbolTable is conceptually constant. 
+        private readonly VersionHash _constant = VersionHash.New();
+
+        internal override VersionHash VersionHash => _constant;
+
+        // Called by 
+        internal override bool TryLookup(DName name, out NameLookupInfo nameInfo)
+        {
+            if (_displayNameLookup.TryGetLogicalName(name, out var logicalName))
+            {
+                // This callback will add the symbol, so that when we return, our caller will naturally find it. 
+                // But that add will inc the VersionHash, so we override to disable it. 
+                _funcAdd(logicalName.Value, name.Value);
+            }
+            else if (_displayNameLookup.TryGetDisplayName(name, out var displayName))
+            {
+                _funcAdd(name.Value, displayName.Value);
+            }
+
+            /*
+             
+            var slot = _symbols.AddVariable(logicalName, tableValue.Type, displayName: displayName);
+            _tablesLogical2Value[logicalName] = tableValue;
+            _parent.SymbolValues.Set(slot, tableValue);
+             */
+        }        
+
+        // Intellisense completitions 
+
+        public override FormulaType GetTypeFromSlot(ISymbolSlot slot)
+        {
+            return base.GetTypeFromSlot(slot);
+        }        
+    }
+#endif
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerFx
     /// Good when we can quickly load the names (to populate the intellisense completion list), but then load remaining symbol details on-demand. 
     /// </summary>
     [DebuggerDisplay("{DebugName}")]
-    internal class DeferredSymbolTable : ReadOnlySymbolTable, IGlobalSymbolNameResolver
+    internal class DeferredSymbolTable : ReadOnlySymbolTable, IGlobalSymbolNameResolver, INameResolver
     {
         // All possible tables we could add. 
         private readonly DisplayNameProvider _displayNameLookup;
@@ -57,7 +57,7 @@ namespace Microsoft.PowerFx
 
         // Called by 
         // $$$ OVerride full
-        internal override bool TryLookup(DName name, out NameLookupInfo nameInfo)
+        bool INameResolver.Lookup(DName name, out NameLookupInfo nameInfo, NameLookupPreferences preferences)
         {
             if (_displayNameLookup.TryGetLogicalOrDisplayName(name, out var logical, out var display))
             {
@@ -146,11 +146,12 @@ namespace Microsoft.PowerFx
                     if (!_variables.TryGetValue(logical.Value, out var nameInfo))
                     {
                         // We don't have type yet, make a placeholder. 
+                        var placeholder = Core.Types.DType.ObjNull;
                         var display = kv.Value;
 
                         nameInfo = new NameLookupInfo(
                             BindKind.PowerFxResolvedObject,
-                            Core.Types.DType.ObjNull,
+                            placeholder,
                             DPath.Root,
                             0,
                             data: null,

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.PowerFx.Core;
@@ -15,26 +16,30 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx
 {
-#if false
     /// <summary>
     /// Provides symbol table with deferred semantics. 
     /// This is semantically readonly - there is a fixes set of known symbols, just the type information is populated lazily.
     /// Good when we can quickly load the names (to populate the intellisense completion list), but then load remaining symbol details on-demand. 
     /// </summary>
     [DebuggerDisplay("{DebugName}")]
-    public class DeferredSymbolTable : ReadOnlySymbolTable 
+    internal class DeferredSymbolTable : ReadOnlySymbolTable, IGlobalSymbolNameResolver
     {
-        // $$$ Must be thread safe!!!        
-        private readonly object _lock = new object();
-
         // All possible tables we could add. 
         private readonly DisplayNameProvider _displayNameLookup;
 
+        // (Logical,Display) --> return type. 
+        // Call back to host to a) lazily get the type, b) notify the host this has been loaded. 
+        // Assume it can be invoked multiple times; host must protect
+        private readonly Func<string, string, FormulaType> _fetchTypeInfo;
+
         // Full universe of possible symbols
         // All other symbols are missing. 
-        public DeferredSymbolTable(DisplayNameProvider map, Action<string, string> funcAdd)
+        public DeferredSymbolTable(
+            DisplayNameProvider map, 
+            Func<string, string, FormulaType> fetchTypeInfo)
         {
-            _displayNameLookup = map ?? throw new ArgumentNullException(nameof(map));   
+            _displayNameLookup = map ?? throw new ArgumentNullException(nameof(map));
+            _fetchTypeInfo = fetchTypeInfo ?? throw new ArgumentNullException(nameof(fetchTypeInfo));
         }
 
         // SymbolTable is conceptually constant. 
@@ -42,34 +47,119 @@ namespace Microsoft.PowerFx
 
         internal override VersionHash VersionHash => _constant;
 
+        // Must be thread safe!!!        
+        // We can have multiple threads reading; which means they may be populating the cache. 
+        private readonly object _lock = new object();
+
+        private readonly Dictionary<string, NameLookupInfo> _variables = new Dictionary<string, NameLookupInfo>();
+
+        private readonly SlotMap<NameLookupInfo?> _slots = new SlotMap<NameLookupInfo?>();
+
         // Called by 
+        // $$$ OVerride full
         internal override bool TryLookup(DName name, out NameLookupInfo nameInfo)
         {
-            if (_displayNameLookup.TryGetLogicalName(name, out var logicalName))
+            if (_displayNameLookup.TryGetLogicalOrDisplayName(name, out var logical, out var display))
             {
-                // This callback will add the symbol, so that when we return, our caller will naturally find it. 
-                // But that add will inc the VersionHash, so we override to disable it. 
-                _funcAdd(logicalName.Value, name.Value);
-            }
-            else if (_displayNameLookup.TryGetDisplayName(name, out var displayName))
-            {
-                _funcAdd(name.Value, displayName.Value);
+                lock (_lock)
+                {
+                    // Previously cached 
+                    if (_variables.TryGetValue(logical.Value, out nameInfo))
+                    {
+                        return true;
+                    }
+                }
+
+                // Callback to host - do not hold lock while invoking this. 
+                // Host may do arbitrary operations, including network calls to fetch metadata.
+                var type = _fetchTypeInfo(logical.Value, display.Value);
+
+                lock (_lock)
+                {
+                    nameInfo = AddUnderLock(logical, display, type);
+                }
+
+                return true;
             }
 
-            /*
-             
-            var slot = _symbols.AddVariable(logicalName, tableValue.Type, displayName: displayName);
-            _tablesLogical2Value[logicalName] = tableValue;
-            _parent.SymbolValues.Set(slot, tableValue);
-             */
-        }        
-
-        // Intellisense completitions 
+            nameInfo = default;
+            return false;
+        }
 
         public override FormulaType GetTypeFromSlot(ISymbolSlot slot)
         {
-            return base.GetTypeFromSlot(slot);
-        }        
+            if (_slots.TryGet(slot.SlotIndex, out var nameInfo))
+            {
+                return FormulaType.Build(nameInfo.Value.Type);
+            }
+
+            throw NewBadSlotException(slot);
+        }
+
+        private NameLookupInfo AddUnderLock(DName logical, DName display, FormulaType type)
+        {
+            var oldSize = _variables.Count;
+
+            // recheck if another thread added while acquired lock. 
+            if (_variables.TryGetValue(logical.Value, out var nameInfo))
+            {
+                return nameInfo;
+            }
+            
+            // This is crticial that we're under lock.
+            // We only want to add these once. 
+            var slotIndex = _slots.Alloc();
+
+            var data = new NameSymbol(logical, mutable: false)
+            {
+                Owner = this,
+                SlotIndex = slotIndex
+            };
+
+            nameInfo = new NameLookupInfo(
+                BindKind.PowerFxResolvedObject,
+                type._type,
+                DPath.Root,
+                0,
+                data: data,
+                displayName: display);
+
+            _slots.SetInitial(slotIndex, nameInfo);
+
+            // fails if already added. Shouldn't happen since we're under lock. 
+            _variables.Add(logical.Value, nameInfo);
+            Contracts.Assert(_variables.Count == oldSize + 1);
+
+            return nameInfo;
+        }
+
+        // Intellisense completitions - show types even that we don't have loaded yet. 
+        // Intellisense doesn't need the Dtype. 
+        IEnumerable<KeyValuePair<string, NameLookupInfo>> IGlobalSymbolNameResolver.GlobalSymbols
+        {
+            get
+            {
+                foreach (var kv in _displayNameLookup.LogicalToDisplayPairs)
+                {
+                    var logical = kv.Key;
+
+                    if (!_variables.TryGetValue(logical.Value, out var nameInfo))
+                    {
+                        // We don't have type yet, make a placeholder. 
+                        var display = kv.Value;
+
+                        nameInfo = new NameLookupInfo(
+                            BindKind.PowerFxResolvedObject,
+                            Core.Types.DType.ObjNull,
+                            DPath.Root,
+                            0,
+                            data: null,
+                            displayName: new DName(display));
+                    }
+
+                    yield return new KeyValuePair<string, NameLookupInfo>(logical, nameInfo);
+                }
+            }
+        }     
     }
-#endif
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -171,10 +171,6 @@ namespace Microsoft.PowerFx
             return s;
         }
 
-        internal readonly Dictionary<string, NameLookupInfo> _variables = new Dictionary<string, NameLookupInfo>();
-
-        internal DisplayNameProvider _environmentSymbolDisplayNameProvider = new SingleSourceDisplayNameProvider();
-
         private protected readonly List<TexlFunction> _functions = new List<TexlFunction>();
 
         // Which enums are available. 
@@ -209,7 +205,7 @@ namespace Microsoft.PowerFx
 
         IEnumerable<TexlFunction> INameResolver.Functions => _functions; 
         
-        IEnumerable<KeyValuePair<string, NameLookupInfo>> IGlobalSymbolNameResolver.GlobalSymbols => _variables;
+        IEnumerable<KeyValuePair<string, NameLookupInfo>> IGlobalSymbolNameResolver.GlobalSymbols => Enumerable.Empty<KeyValuePair<string, NameLookupInfo>>();
 
         /// <summary>
         /// Get symbol names in this current scope.
@@ -229,21 +225,12 @@ namespace Microsoft.PowerFx
             }
         }
 
-        internal bool TryGetVariable(DName name, out NameLookupInfo symbol, out DName displayName)
+        // $$$ Merge with TryLookup? 
+        internal virtual bool TryGetVariable(DName name, out NameLookupInfo symbol, out DName displayName)
         {
-            var lookupName = name;
-
-            if (_environmentSymbolDisplayNameProvider.TryGetDisplayName(name, out displayName))
-            {
-                // do nothing as provided name can be used for lookup with logical name
-            }
-            else if (_environmentSymbolDisplayNameProvider.TryGetLogicalName(name, out var logicalName))
-            {
-                lookupName = logicalName;
-                displayName = name;
-            }
-
-            return _variables.TryGetValue(lookupName, out symbol);
+            symbol = default;
+            displayName = default;
+            return false;
         }
 
         // Derived symbol tables can hook. 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -266,7 +266,7 @@ namespace Microsoft.PowerFx
             }
         }
 
-        // $$$ Merge with TryLookup? 
+        // Hook from Lookup - Get just variables. 
         internal virtual bool TryGetVariable(DName name, out NameLookupInfo symbol, out DName displayName)
         {
             symbol = default;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -25,9 +25,10 @@ namespace Microsoft.PowerFx
     {
         private readonly SlotMap<NameLookupInfo?> _slots = new SlotMap<NameLookupInfo?>();
 
+        // $$$ NEeded by config... make private?
         internal readonly Dictionary<string, NameLookupInfo> _variables = new Dictionary<string, NameLookupInfo>();
 
-        internal DisplayNameProvider _environmentSymbolDisplayNameProvider = new SingleSourceDisplayNameProvider();
+        private DisplayNameProvider _environmentSymbolDisplayNameProvider = new SingleSourceDisplayNameProvider();
 
         IEnumerable<KeyValuePair<string, NameLookupInfo>> IGlobalSymbolNameResolver.GlobalSymbols => _variables;
 
@@ -52,35 +53,6 @@ namespace Microsoft.PowerFx
             if (_slots.TryGet(slot.SlotIndex, out var nameInfo))
             {
                 return FormulaType.Build(nameInfo.Value.Type);
-            }
-
-            throw NewBadSlotException(slot);
-        }
-
-        // Ensure that newType can be assigned to the given slot. 
-        internal void ValidateAccepts(ISymbolSlot slot, FormulaType newType)
-        {
-            if (_slots.TryGet(slot.SlotIndex, out var nameInfo))
-            {
-                var srcType = nameInfo.Value.Type;
-
-                if (newType is RecordType)
-                {
-                    // Lazy RecordTypes don't validate. 
-                    // https://github.com/microsoft/Power-Fx/issues/833
-                    return;
-                }
-
-                var ok = srcType.Accepts(newType._type);
-
-                if (ok)
-                {
-                    return;
-                }
-
-                var name = (nameInfo.Value.Data as NameSymbol)?.Name;
-
-                throw new InvalidOperationException($"Can't change '{name}' from {srcType} to {newType._type}.");
             }
 
             throw NewBadSlotException(slot);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/DisplayNameProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DisplayNames/DisplayNameProvider.cs
@@ -35,5 +35,28 @@ namespace Microsoft.PowerFx.Core
         /// KeyValuePair&lt;Dname, Dname&gt;&gt; represents  KeyValuePair&lt;LogicalName, DisplayName&gt;&gt;.
         /// </summary>
         public abstract IEnumerable<KeyValuePair<DName, DName>> LogicalToDisplayPairs { get; }
+
+        /// <summary>
+        /// Lookup when it is either logical or display name. 
+        /// </summary>
+        /// <param name="logicalOrDisplay"></param>
+        /// <param name="logicalName"></param>
+        /// <param name="displayName"></param>
+        /// <returns></returns>
+        public bool TryGetLogicalOrDisplayName(DName logicalOrDisplay, out DName logicalName, out DName displayName)
+        {
+            if (this.TryGetDisplayName(logicalOrDisplay, out displayName))
+            {
+                logicalName = logicalOrDisplay;
+                return true;
+            }
+            else if (this.TryGetLogicalName(logicalOrDisplay, out logicalName))
+            {
+                displayName = logicalOrDisplay;
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
@@ -165,6 +165,16 @@ namespace Microsoft.PowerFx
                 map[symbolTable] = symValues;
                 return;
             }
+            else if (symbolTable is DeferredSymbolTable symbolTable3)
+            {
+                var symValues = new SymbolValues(symbolTable3)
+                {
+                    DebugName = symbolTable3.DebugName
+                };
+
+                map[symbolTable] = symValues;
+                return;
+            }
             else
             {
                 throw new NotImplementedException($"Unhandled symbol table kind: {symbolTable.DebugName} of type {symbolTable.GetType().FullName} ");

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
@@ -45,7 +45,14 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, RecordType parameterType)
         {
             (var expression2, var cursorPosition) = Decode(expression);
-            return Suggest(expression2, parameterType, cursorPosition, config);
+            var symTable = ReadOnlySymbolTable.NewFromRecord(parameterType);
+            return Suggest(expression2, symTable, cursorPosition, config);
+        }
+
+        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, ReadOnlySymbolTable symTable)
+        {
+            (var expression2, var cursorPosition) = Decode(expression);
+            return Suggest(expression2, symTable, cursorPosition, config);
         }
 
         // Tests use | to indicate cursor position within an expression string. 
@@ -63,15 +70,16 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             return (expression, cursorPosition);
         }
 
-        internal IIntellisenseResult Suggest(string expression, RecordType parameterType, int cursorPosition, PowerFxConfig config)
+        internal IIntellisenseResult Suggest(string expression, ReadOnlySymbolTable symTable, int cursorPosition, PowerFxConfig config)
         {
             var engine = new Engine(config)
             {
                 SupportedFunctions = new SymbolTable()
             };
 
-            var suggestions = engine.Suggest(expression, parameterType, cursorPosition);
-
+            var checkResult = engine.Check(expression, symbolTable: symTable);
+            var suggestions = engine.Suggest(checkResult, cursorPosition);
+            
             if (suggestions.Exception != null)
             {
                 throw suggestions.Exception;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -9,6 +9,7 @@ using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Core.Types.Enums;
+using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
 using Xunit;
 
@@ -45,7 +46,15 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             var intellisense = Suggest(expression, config, context);
             return intellisense.Suggestions.Select(suggestion => suggestion.DisplayText.Text).ToArray();
         }
-        
+
+        private string[] SuggestStrings(string expression, PowerFxConfig config, ReadOnlySymbolTable symTable)
+        {
+            Assert.NotNull(expression);
+
+            var intellisense = Suggest(expression, config, symTable);
+            return intellisense.Suggestions.Select(suggestion => suggestion.DisplayText.Text).ToArray();
+        }
+
         internal static PowerFxConfig Default => PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder().WithDefaultEnums());
 
         internal static PowerFxConfig Default_DisableRowScopeDisambiguationSyntax => PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder().WithDefaultEnums(), Features.DisableRowScopeDisambiguationSyntax);
@@ -345,6 +354,27 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             // With adjusted config 
             AdjustConfig(config);
             actualSuggestions = SuggestStrings(expression, config, lazyInstance);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
+        }
+
+        [Theory]
+        [InlineData("logica|")] // No suggestions for logical names
+        [InlineData("displa|", "display1", "display2")] // display names
+        public void TestSuggestDeferredSymbols(string expression, params string[] expectedSuggestions)
+        {
+            var map = new SingleSourceDisplayNameProvider(new Dictionary<DName, DName>
+            {
+                { new DName("logical1"), new DName("display1") },
+                { new DName("logical2"), new DName("display2") }
+            });
+
+            var symTable = new DeferredSymbolTable(map, (disp, logical) =>
+            {
+                return FormulaType.Number;
+            });
+
+            var config = new PowerFxConfig();
+            var actualSuggestions = SuggestStrings(expression, config, symTable);
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }
 


### PR DESCRIPTION
Fix #1017 
Useful when names are known, but getting the list types is expensive -  common for dataverse tables. We can quickly get all tables in the org, but getting the table types requires EntityMetadata which is expensive. 
