### PR TITLE
Moves the blank value handling of function args to the IR

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.PowerFx.Core.Types.Enums
+namespace Microsoft.PowerFx.Core.Functions
 {
     internal enum ArgPreprocessor
     {

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1413,7 +1413,8 @@ namespace Microsoft.PowerFx.Core.Functions
         }
 
         /// <summary>
-        /// Function can override this method to provide BlankHandling policy for argument.
+        /// Function can override this method to provide pre-processing policy for argument.
+        /// By default, function does not attach any pre-processing for arguments.
         /// </summary>
         /// <param name="index">0 based Index of argument.</param>
         /// <returns></returns>
@@ -1422,7 +1423,12 @@ namespace Microsoft.PowerFx.Core.Functions
             return ArgPreprocessor.None;
         }
 
-        internal ArgPreprocessor GetDefaultArgPreprocessor(int index)
+        /// <summary>
+        /// Generic arg preprocessor that uses <see cref="ParamTypes"/> to determine pre-processing policy.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        internal ArgPreprocessor GetGenericArgPreprocessor(int index)
         {
             var paramType = ParamTypes[index] ?? DType.Unknown;
             if (paramType == DType.Number)

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -25,6 +25,7 @@ using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Logging.Trackers;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
@@ -37,6 +38,27 @@ namespace Microsoft.PowerFx.Core.Functions
     [ThreadSafeImmutable]
     internal abstract class TexlFunction : IFunction
     {
+        /// <summary>
+        /// Function can override this method to provide BlankHandling policy for argument.
+        /// </summary>
+        /// <param name="index">0 based Index of argument.</param>
+        /// <returns></returns>
+        public virtual ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return ArgPreprocessor.None;
+        }
+
+        internal ArgPreprocessor GetDefaultArgBlankHandlerPolicy(int index)
+        {
+            var paramType = ParamTypes[index] ?? DType.Unknown;
+            if (paramType == DType.Number)
+            {
+                return ArgPreprocessor.ReplaceWithZero;
+            }
+
+            return ArgPreprocessor.None;
+        }
+
         // Column name when Features.ConsistentOneColumnTableResult is enabled.
         public const string ColumnName_ValueStr = "Value";
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -38,27 +38,6 @@ namespace Microsoft.PowerFx.Core.Functions
     [ThreadSafeImmutable]
     internal abstract class TexlFunction : IFunction
     {
-        /// <summary>
-        /// Function can override this method to provide BlankHandling policy for argument.
-        /// </summary>
-        /// <param name="index">0 based Index of argument.</param>
-        /// <returns></returns>
-        public virtual ArgPreprocessor GetArgBlankHandlerPolicy(int index)
-        {
-            return ArgPreprocessor.None;
-        }
-
-        internal ArgPreprocessor GetDefaultArgBlankHandlerPolicy(int index)
-        {
-            var paramType = ParamTypes[index] ?? DType.Unknown;
-            if (paramType == DType.Number)
-            {
-                return ArgPreprocessor.ReplaceWithZero;
-            }
-
-            return ArgPreprocessor.None;
-        }
-
         // Column name when Features.ConsistentOneColumnTableResult is enabled.
         public const string ColumnName_ValueStr = "Value";
 
@@ -1432,6 +1411,27 @@ namespace Microsoft.PowerFx.Core.Functions
             }
 
             return new IRCallNode(context.GetIRContext(node), this, args);
+        }
+
+        /// <summary>
+        /// Function can override this method to provide BlankHandling policy for argument.
+        /// </summary>
+        /// <param name="index">0 based Index of argument.</param>
+        /// <returns></returns>
+        public virtual ArgPreprocessor GetArgPreprocessor(int index)
+        {
+            return ArgPreprocessor.None;
+        }
+
+        internal ArgPreprocessor GetDefaultArgPreprocessor(int index)
+        {
+            var paramType = ParamTypes[index] ?? DType.Unknown;
+            if (paramType == DType.Number)
+            {
+                return ArgPreprocessor.ReplaceWithZero;
+            }
+
+            return ArgPreprocessor.None;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -25,7 +25,6 @@ using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Logging.Trackers;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1416,7 +1416,7 @@ namespace Microsoft.PowerFx.Core.Functions
         /// Function can override this method to provide pre-processing policy for argument.
         /// By default, function does not attach any pre-processing for arguments.
         /// </summary>
-        /// <param name="index">0 based Index of argument.</param>
+        /// <param name="index">0 based index of argument.</param>
         /// <returns></returns>
         public virtual ArgPreprocessor GetArgPreprocessor(int index)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerFx.Core.IR
                         binaryOpResult = new CallNode(context.GetIRContext(node), BuiltinFunctionsCore.Power, left, right);
                         break;
                     case BinaryOpKind.Concatenate:
-                        binaryOpResult = ConcatenateArgs(left, right);
+                        binaryOpResult = ConcatenateArgs(left, right, context.GetIRContext(node));
                         break;
                     case BinaryOpKind.Or:
                     case BinaryOpKind.And:
@@ -373,11 +373,11 @@ namespace Microsoft.PowerFx.Core.IR
             private static IntermediateNode ReplaceBlankWithZero(IntermediateNode arg)
             {
                 var zeroNumLitNode = new NumberLiteralNode(IRContext.NotInSource(FormulaType.Number), 0);
-                var convertedNode = new CallNode(IRContext.NotInSource(FormulaType.Number), BuiltinFunctionsCore.Coalesce, arg, zeroNumLitNode);
+                var convertedNode = new CallNode(arg.IRContext, BuiltinFunctionsCore.Coalesce, arg, zeroNumLitNode);
                 return convertedNode;
             }
 
-            private static IntermediateNode ConcatenateArgs(IntermediateNode arg1, IntermediateNode arg2)
+            private static IntermediateNode ConcatenateArgs(IntermediateNode arg1, IntermediateNode arg2, IRContext irContext)
             {
                 var concatenateArgs = new List<IntermediateNode>();
                 foreach (var arg in new[] { arg1, arg2 })
@@ -396,7 +396,7 @@ namespace Microsoft.PowerFx.Core.IR
                     }
                 }
 
-                var concatenatedNode = new CallNode(IRContext.NotInSource(FormulaType.String), BuiltinFunctionsCore.Concatenate, concatenateArgs);
+                var concatenatedNode = new CallNode(irContext, BuiltinFunctionsCore.Concatenate, concatenateArgs);
                 return concatenatedNode;
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -12,7 +12,6 @@ using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Core.Texl.Builtins;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -353,7 +353,7 @@ namespace Microsoft.PowerFx.Core.IR
                 for (var i = 0; i < len; i++)
                 {
                     IntermediateNode convertedNode = default;
-                    var blankHandlerPolicy = func.GetArgBlankHandlerPolicy(i);
+                    var blankHandlerPolicy = func.GetArgPreprocessor(i);
 
                     switch (blankHandlerPolicy)
                     {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -16,9 +16,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Atan2
     internal sealed class Atan2Function : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
@@ -15,6 +16,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Atan2
     internal sealed class Atan2Function : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public Atan2Function()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -20,9 +20,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding Excel function: Char
     internal sealed class CharFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -19,6 +20,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding Excel function: Char
     internal sealed class CharFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;
@@ -102,7 +102,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -21,6 +21,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Date
     internal sealed class DateFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -69,6 +74,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Time
     internal sealed class TimeFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -90,6 +100,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateTime(year, month, day, hour, minute, second[, millisecond])
     internal sealed class DateTimeFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -21,9 +21,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Date
     internal sealed class DateFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;
@@ -74,9 +74,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Time
     internal sealed class TimeFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;
@@ -100,9 +100,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateTime(year, month, day, hour, minute, second[, millisecond])
     internal sealed class DateTimeFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Dec2Hex(number:n, [places:n])
     internal sealed class Dec2HexFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -16,6 +17,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Dec2Hex(number:n, [places:n])
     internal sealed class Dec2HexFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool IsStateless => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Log
     internal sealed class LogFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -16,6 +17,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Log
     internal sealed class LogFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Abstract base class for all 1-arg math functions that return numeric values.
     internal abstract class MathOneArgFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -16,6 +17,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Abstract base class for all 1-arg math functions that return numeric values.
     internal abstract class MathOneArgFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -16,6 +17,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Mod(number:n, divisor:n)
     internal sealed class ModFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Mod(number:n, divisor:n)
     internal sealed class ModFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -16,6 +17,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX function: Power
     internal sealed class PowerFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool SupportsParamCoercion => true;
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX function: Power
     internal sealed class PowerFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         // Multiple invocations may produce different return values.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
@@ -12,6 +13,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: RandBetween
     internal sealed class RandBetweenFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         // Multiple invocations may produce different return values.
         public override bool IsStateless => false;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
@@ -13,9 +13,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: RandBetween
     internal sealed class RandBetweenFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         // Multiple invocations may produce different return values.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsTrackedInTelemetry => false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -12,9 +12,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // RGBA(red, green, blue, alpha)
     internal sealed class RGBAFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsTrackedInTelemetry => false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -5,12 +5,18 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // RGBA(red, green, blue, alpha)
     internal sealed class RGBAFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsTrackedInTelemetry => false;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -17,9 +17,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Abstract base for all scalar flavors of round (Round, RoundUp, RoundDown)
     internal abstract class ScalarRoundingFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -16,6 +17,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Abstract base for all scalar flavors of round (Round, RoundUp, RoundDown)
     internal abstract class ScalarRoundingFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
@@ -12,6 +13,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Sequence(records:n, start:n, step:n): *[Value:n]
     internal sealed class SequenceFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -13,9 +13,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Sequence(records:n, start:n, step:n): *[Value:n]
     internal sealed class SequenceFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
@@ -17,6 +18,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Truncate by rounding toward zero.
     internal sealed class TruncFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        {
+            return base.GetDefaultArgBlankHandlerPolicy(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
-using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgPreprocessor(index);
+            return base.GetGenericArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -18,9 +18,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Truncate by rounding toward zero.
     internal sealed class TruncFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgBlankHandlerPolicy(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index)
         {
-            return base.GetDefaultArgBlankHandlerPolicy(index);
+            return base.GetDefaultArgPreprocessor(index);
         }
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/ArgPreprocessor.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerFx.Core.Types.Enums
+{
+    internal enum ArgPreprocessor
+    {
+        None = 0,
+        ReplaceWithZero = 1,
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Abs.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -87,7 +87,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Acos.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -98,7 +98,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Acot.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -124,7 +124,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Asin.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -135,7 +135,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Atan.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -146,7 +146,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Atan2.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -250,7 +250,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Char.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
@@ -309,7 +309,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Cos.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -320,7 +320,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Cot.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -388,7 +388,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Date.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
@@ -433,7 +433,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.DateTime.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 7, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -499,7 +499,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Degrees.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -510,7 +510,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Dec2Hex.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -567,7 +567,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Exp.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -741,7 +741,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Int.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -915,7 +915,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Ln.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -926,7 +926,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Log.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 10)),
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1038,7 +1038,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Mod.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeTypeChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1094,7 +1094,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Power.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1105,7 +1105,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Radians.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1120,7 +1120,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.RandBetween.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1150,7 +1150,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.RGBA.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1176,7 +1176,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Round.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1187,7 +1187,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.RoundUp.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1198,7 +1198,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.RoundDown.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1220,7 +1220,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Sequence.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 3, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
@@ -1242,7 +1242,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Sin.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1278,7 +1278,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Sqrt.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeTypeChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1386,7 +1386,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Tan.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1419,7 +1419,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Time.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 4, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1490,7 +1490,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<NumberValue>(
                     BuiltinFunctionsCore.Trunc.Name,
                     expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
-                    replaceBlankValues: ReplaceBlankWithZero,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<NumberValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1584,7 +1584,14 @@ namespace Microsoft.PowerFx.Functions
         {
             {
                 BuiltinFunctionsCore.AbsT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AbsT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Abs])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AbsT.Name, StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Abs.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Abs))
             },
             {
                 BuiltinFunctionsCore.Boolean_T,
@@ -1603,31 +1610,80 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.CharT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CharT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Char])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CharT.Name, StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Char.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: Char))
             },
             {
                 BuiltinFunctionsCore.ExpT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.ExpT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Exp])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.ExpT.Name, StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Exp.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Exp))
             },
             {
                 BuiltinFunctionsCore.Hex2DecT,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Hex2DecT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Hex2Dec])
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Hex2DecT.Name, StandardErrorHandling<StringValue>(
+                    BuiltinFunctionsCore.Hex2Dec.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Hex2Dec))
             },
             {
                 BuiltinFunctionsCore.IntT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.IntT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Int])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.IntT.Name, StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Int.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Int))
             },
             {
                 BuiltinFunctionsCore.LenT,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.LenT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Len])
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.LenT.Name, StandardErrorHandling<StringValue>(
+                    BuiltinFunctionsCore.Len.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueType<StringValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Len))
             },
             {
                 BuiltinFunctionsCore.LnT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.LnT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Ln])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.LnT.Name, StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Ln.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Ln))
             },
             {
                 BuiltinFunctionsCore.SqrtT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Sqrt])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Sqrt.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeTypeChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Sqrt))
             },
         };
 
@@ -1643,7 +1699,14 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Dec2HexT,
-                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Dec2Hex]))
+                NoErrorHandling(MultiSingleColumnTable(StandardErrorHandling<NumberValue>(
+                                BuiltinFunctionsCore.Dec2Hex.Name,
+                                expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
+                                replaceBlankValues: ReplaceBlankWithZero,
+                                checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
+                                checkRuntimeValues: DeferRuntimeValueChecking,
+                                returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                                targetFunction: Dec2Hex)))
             },
             {
                 BuiltinFunctionsCore.FindT,
@@ -1651,7 +1714,14 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.RoundT,
-                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Round]))
+                NoErrorHandling(MultiSingleColumnTable(StandardErrorHandling<NumberValue>(
+                    BuiltinFunctionsCore.Round.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: ReplaceBlankWithZero,
+                    checkRuntimeTypes: ExactValueType<NumberValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: Round)))
             },
         };
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1584,106 +1584,50 @@ namespace Microsoft.PowerFx.Functions
         {
             {
                 BuiltinFunctionsCore.AbsT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AbsT.Name, StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Abs.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Abs))
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AbsT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Abs], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.Boolean_T,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Boolean_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Boolean])
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Boolean_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Boolean], DoNotReplaceBlank)
             },
             {
                 BuiltinFunctionsCore.BooleanN_T,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.BooleanN_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanN])
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.BooleanN_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanN], DoNotReplaceBlank)
             },
 
             // This implementation is not actually used for this as this is handled at IR level. 
             // This is a placeholder, so that RecalcEngine._interpreterSupportedFunctions can add it for txt tests.
             {
                 BuiltinFunctionsCore.BooleanB_T,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.BooleanB_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanB])
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.BooleanB_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.BooleanB], DoNotReplaceBlank)
             },
             {
                 BuiltinFunctionsCore.CharT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CharT.Name, StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Char.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Char))
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CharT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Char], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.ExpT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.ExpT.Name, StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Exp.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Exp))
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.ExpT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Exp], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.Hex2DecT,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Hex2DecT.Name, StandardErrorHandling<StringValue>(
-                    BuiltinFunctionsCore.Hex2Dec.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Hex2Dec))
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Hex2DecT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Hex2Dec], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.IntT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.IntT.Name, StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Int.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Int))
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.IntT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Int], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.LenT,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.LenT.Name, StandardErrorHandling<StringValue>(
-                    BuiltinFunctionsCore.Len.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueType<StringValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Len))
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.LenT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Len], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.LnT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.LnT.Name, StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Ln.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Ln))
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.LnT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Ln], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.SqrtT,
-                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Sqrt.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueType<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeTypeChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Sqrt))
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Sqrt], ReplaceBlankWithZero)
             },
         };
 
@@ -1691,37 +1635,23 @@ namespace Microsoft.PowerFx.Functions
         {
             {
                 BuiltinFunctionsCore.ColorFadeT,
-                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.ColorFade]))
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.ColorFade], DoNotReplaceBlank))
             },
             {
                 BuiltinFunctionsCore.ConcatenateT,
-                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate]))
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate], DoNotReplaceBlank))
             },
             {
                 BuiltinFunctionsCore.Dec2HexT,
-                NoErrorHandling(MultiSingleColumnTable(StandardErrorHandling<NumberValue>(
-                                BuiltinFunctionsCore.Dec2Hex.Name,
-                                expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
-                                replaceBlankValues: ReplaceBlankWithZero,
-                                checkRuntimeTypes: ExactValueTypeOrBlank<NumberValue>,
-                                checkRuntimeValues: DeferRuntimeValueChecking,
-                                returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                                targetFunction: Dec2Hex)))
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Dec2Hex], ReplaceBlankWithZero))
             },
             {
                 BuiltinFunctionsCore.FindT,
-                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Find]))
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Find], DoNotReplaceBlank))
             },
             {
                 BuiltinFunctionsCore.RoundT,
-                NoErrorHandling(MultiSingleColumnTable(StandardErrorHandling<NumberValue>(
-                    BuiltinFunctionsCore.Round.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithZero,
-                    checkRuntimeTypes: ExactValueType<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: Round)))
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Round], ReplaceBlankWithZero))
             },
         };
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -655,12 +655,6 @@ namespace Microsoft.PowerFx.Functions
         public static FormulaValue Abs(IRContext irContext, NumberValue[] args)
         {
             var arg0 = args[0];
-
-            if (arg0 == null)
-            {
-                return new NumberValue(irContext, 0d);
-            }
-
             var x = arg0.Value;
             var val = Math.Abs(x);
             return new NumberValue(irContext, val);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
@@ -189,8 +191,17 @@ namespace Microsoft.PowerFx.Functions
             });
         }
 
-        // Wraps a scalar function into its tabular overload
-        private static AsyncFunctionPtr StandardErrorHandlingTabularOverload<TScalar>(string functionName, AsyncFunctionPtr targetFunction)
+        /// <summary>
+        /// Wraps a scalar function into its tabular overload.
+        /// </summary>
+        /// <param name="functionName">Function name.</param>
+        /// <param name="targetFunction">Target function to execute.</param>
+        /// <param name="replaceBlankValues">Only supply this if its scaler function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scaler has handled this via IR.</param>
+        /// <returns></returns>
+        private static AsyncFunctionPtr StandardErrorHandlingTabularOverload<TScalar>(
+            string functionName, 
+            AsyncFunctionPtr targetFunction,
+            Func<IRContext, int, FormulaValue> replaceBlankValues)
             where TScalar : FormulaValue => StandardErrorHandlingAsync<TableValue>(
                 functionName: functionName,
                 expandArguments: NoArgExpansion,
@@ -198,7 +209,7 @@ namespace Microsoft.PowerFx.Functions
                 checkRuntimeTypes: ExactValueTypeOrBlank<TableValue>,
                 checkRuntimeValues: DeferRuntimeValueChecking,
                 returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                targetFunction: StandardSingleColumnTable<TScalar>(targetFunction));
+                targetFunction: StandardSingleColumnTable<TScalar>(targetFunction, replaceBlankValues));
 
         // A wrapper for a function with no error handling behavior whatsoever.
         private static AsyncFunctionPtr NoErrorHandling(
@@ -222,7 +233,16 @@ namespace Microsoft.PowerFx.Functions
         }
 
         #region Single Column Table Functions
-        public static Func<EvalVisitor, EvalVisitorContext, IRContext, TableValue[], ValueTask<FormulaValue>> StandardSingleColumnTable<T>(AsyncFunctionPtr targetFunction)
+
+        /// <summary>
+        /// Wrapper for single column table argument functions.
+        /// </summary>
+        /// <param name="targetFunction">Target function to execute.</param>
+        /// <param name="replaceBlankValues">Only supply this if its scaler function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scaler has handled this via IR.</param>
+        /// <returns></returns>
+        public static Func<EvalVisitor, EvalVisitorContext, IRContext, TableValue[], ValueTask<FormulaValue>> StandardSingleColumnTable<T>(
+            AsyncFunctionPtr targetFunction,
+            Func<IRContext, int, FormulaValue> replaceBlankValues)
             where T : FormulaValue
         {
             return async (runner, context, irContext, args) =>
@@ -241,6 +261,13 @@ namespace Microsoft.PowerFx.Functions
                     if (row.IsValue)
                     {
                         var value = row.Value.GetField(inputColumnNameStr);
+
+                        if (value is BlankValue)
+                        {
+                            // since this is for single column table arg, index is passed as 0
+                            value = replaceBlankValues(value.IRContext, 0);
+                        }
+
                         NamedValue namedValue;
                         namedValue = value switch
                         {
@@ -270,7 +297,7 @@ namespace Microsoft.PowerFx.Functions
         public static Func<EvalVisitor, EvalVisitorContext, IRContext, TableValue[], ValueTask<FormulaValue>> StandardSingleColumnTable<T>(Func<IRContext, T[], FormulaValue> targetFunction)
             where T : FormulaValue
         {
-            return StandardSingleColumnTable<T>(async (runner, context, irContext, args) => targetFunction(irContext, args.OfType<T>().ToArray()));
+            return StandardSingleColumnTable<T>(async (runner, context, irContext, args) => targetFunction(irContext, args.OfType<T>().ToArray()), DoNotReplaceBlank);
         }
 
         private static (int minTableSize, int maxTableSize, FormulaValue errorOrBlankTable) AnalyzeTableArguments(FormulaValue[] args, IRContext irContext)
@@ -299,18 +326,22 @@ namespace Microsoft.PowerFx.Functions
             return (minTableSize, maxTableSize, null);
         }
 
-        /*
-         * A standard error handling wrapper function that handles functions that can accept one or more table values.
-         * The standard behavior for this type of function is to expand all scalars and tables into a set of tables
-         * with the same size, where that size is the length of the longest table, if any. The result is always a table
-         * where some operation has been performed on the transpose of the input tables.
-         * 
-         * For example given the table function F and the operation F' and inputs [a, b] and [c, d], the transpose is [a, c], [b, d]
-         * F([a, b], [c, d]) => [F'([a, c]), F'([b, d])]
-         * As a concrete example, Concatenate(["a", "b"], ["1", "2"]) => ["a1", "b2"]
-        */
+        /// <summary>
+        /// A standard error handling wrapper function that handles functions that can accept one or more table values.
+        /// The standard behavior for this type of function is to expand all scalars and tables into a set of tables
+        /// with the same size, where that size is the length of the longest table, if any.The result is always a table
+        /// where some operation has been performed on the transpose of the input tables.
+        ///
+        /// For example given the table function F and the operation F' and inputs [a, b] and [c, d], the transpose is [a, c], [b, d]
+        /// F([a, b], [c, d]) => [F'([a, c]), F'([b, d])]
+        /// As a concrete example, Concatenate(["a", "b"], ["1", "2"]) => ["a1", "b2"].
+        /// </summary>
+        /// <param name="targetFunction">Target function to execute.</param>
+        /// <param name="replaceBlankValues">Only supply this if its scaler function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scaler has handled this via IR.</param>
+        /// <returns></returns>
         public static Func<EvalVisitor, EvalVisitorContext, IRContext, FormulaValue[], ValueTask<FormulaValue>> MultiSingleColumnTable(
-            AsyncFunctionPtr targetFunction)
+            AsyncFunctionPtr targetFunction,
+            Func<IRContext, int, FormulaValue> replaceBlankValues)
         {
             return async (runner, context, irContext, args) =>
             {
@@ -386,7 +417,19 @@ namespace Microsoft.PowerFx.Functions
                     }
                     else
                     {
-                        var rowResult = await targetFunction(runner, context, IRContext.NotInSource(itemType), functionArgs);
+                        var blankValuesReplaced = functionArgs.Select((arg, i) =>
+                        {
+                            if (arg is BlankValue)
+                            {
+                                return replaceBlankValues(arg.IRContext, i);
+                            }
+                            else
+                            {
+                                return arg;
+                            }
+                        });
+
+                        var rowResult = await targetFunction(runner, context, IRContext.NotInSource(itemType), blankValuesReplaced.ToArray());
                         var namedValue = new NamedValue(columnNameStr, rowResult);
                         var record = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedValue });
                         resultRows.Add(DValue<RecordValue>.Of(record));

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -709,6 +709,11 @@ namespace Microsoft.PowerFx.Functions
             return new BlankValue(irContext);
         }
 
+        private static FormulaValue NoOpAlreadyHandledByIR(IRContext irContext, int index)
+        {
+            return new BlankValue(irContext);
+        }
+
         // This function should be used when type checking is too unique and needs to be located
         // within the body of the builtin function itself
         private static FormulaValue DeferRuntimeTypeChecking(IRContext irContext, int index, FormulaValue arg)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.IR;
@@ -196,7 +194,7 @@ namespace Microsoft.PowerFx.Functions
         /// </summary>
         /// <param name="functionName">Function name.</param>
         /// <param name="targetFunction">Target function to execute.</param>
-        /// <param name="replaceBlankValues">Only supply this if its scaler function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scaler has handled this via IR.</param>
+        /// <param name="replaceBlankValues">Only supply this if its scalar function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scalar has handled this via IR.</param>
         /// <returns></returns>
         private static AsyncFunctionPtr StandardErrorHandlingTabularOverload<TScalar>(
             string functionName, 
@@ -238,7 +236,7 @@ namespace Microsoft.PowerFx.Functions
         /// Wrapper for single column table argument functions.
         /// </summary>
         /// <param name="targetFunction">Target function to execute.</param>
-        /// <param name="replaceBlankValues">Only supply this if its scaler function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scaler has handled this via IR.</param>
+        /// <param name="replaceBlankValues">Only supply this if its scalar function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scalar has handled this via IR.</param>
         /// <returns></returns>
         public static Func<EvalVisitor, EvalVisitorContext, IRContext, TableValue[], ValueTask<FormulaValue>> StandardSingleColumnTable<T>(
             AsyncFunctionPtr targetFunction,
@@ -337,7 +335,7 @@ namespace Microsoft.PowerFx.Functions
         /// As a concrete example, Concatenate(["a", "b"], ["1", "2"]) => ["a1", "b2"].
         /// </summary>
         /// <param name="targetFunction">Target function to execute.</param>
-        /// <param name="replaceBlankValues">Only supply this if its scaler function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scaler has handled this via IR.</param>
+        /// <param name="replaceBlankValues">Only supply this if its scalar function has <see cref="NoOpAlreadyHandledByIR(IRContext, int)"/>, meaning scalar has handled this via IR.</param>
         /// <returns></returns>
         public static Func<EvalVisitor, EvalVisitorContext, IRContext, FormulaValue[], ValueTask<FormulaValue>> MultiSingleColumnTable(
             AsyncFunctionPtr targetFunction,

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -803,7 +803,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var recalcEngine = new RecalcEngine(new PowerFxConfig(null)
             {
-                MaxCallDepth = 80
+                MaxCallDepth = 81
             });
             recalcEngine.DefineFunctions(
                 "A(x: Number): Number = If(Mod(x, 2) = 0, B(x/2), B(x));" +

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var config = new PowerFxConfig(null)
             {
-                MaxCallDepth = 5
+                MaxCallDepth = 10
             };
             var recalcEngine = new RecalcEngine(config);
             Assert.IsType<ErrorValue>(recalcEngine.Eval("Abs(Abs(Abs(Abs(Abs(Abs(1))))))"));


### PR DESCRIPTION
Fixes #1006 
- This moves the Trivial BlankToZero argument handler from interpreter to IR Phase so other backends don't have to implement it.
- BlankToZero is wrapping arg in IR as `arg` => `Coalesce(arg, 0)`
- To Improve efficiency if arg was already wrapped in that fashion we don't wrap it again.
- This PR also improves Concatenate Operator as below
Before: `"1"&"2"&"3"...` => `Concatenate(Concatenate("1", "2"), "3"))...`
Now: `"1"&"2"&"3"...` => `Concatenate("1","2","3",...)`

NOTE:Other Preprocessing will be moved to IRPhase in followup PRs.