### PR TITLE
Updated multiarg tabular function handler to return first error or blank tabular arg

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1583,73 +1583,23 @@ namespace Microsoft.PowerFx.Functions
         {
             {
                 BuiltinFunctionsCore.ColorFadeT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.ColorFadeT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactSequence(
-                        ExactValueTypeOrTableOrBlank<ColorValue>,
-                        ExactValueTypeOrBlank<NumberValue>),
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.ColorFade]),
-                    isMultiArgTabularOverload: true)
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.ColorFade]))
             },
             {
                 BuiltinFunctionsCore.ConcatenateT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.ConcatenateT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<StringValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate]),
-                    isMultiArgTabularOverload: true)
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Concatenate]))
             },
             {
                 BuiltinFunctionsCore.Dec2HexT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.Dec2HexT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Dec2Hex]),
-                    isMultiArgTabularOverload: true)
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Dec2Hex]))
             },
             {
                 BuiltinFunctionsCore.FindT,
-                StandardErrorHandlingAsync<FormulaValue>(
-                    BuiltinFunctionsCore.FindT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactSequence(
-                        ExactValueTypeOrTableOrBlank<StringValue>,
-                        ExactValueTypeOrTableOrBlank<StringValue>,
-                        ExactValueTypeOrTableOrBlank<NumberValue>),
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Find]),
-                    isMultiArgTabularOverload: true)
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Find]))
             },
             {
                 BuiltinFunctionsCore.RoundT,
-                StandardErrorHandlingAsync(
-                    BuiltinFunctionsCore.RoundT.Name,
-                    expandArguments: NoArgExpansion,
-                    replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrTableOrBlank<NumberValue>,
-                    checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
-                    targetFunction: MultiSingleColumnTable(
-                            SimpleFunctionImplementations[BuiltinFunctionsCore.Round]),
-                    isMultiArgTabularOverload: true)
+                NoErrorHandling(MultiSingleColumnTable(SimpleFunctionImplementations[BuiltinFunctionsCore.Round]))
             },
         };
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -42,7 +42,6 @@ namespace Microsoft.PowerFx.Functions
         /// <param name="checkRuntimeValues">This stage can be used to generate errors if specific values occur in the arguments, for example infinity, NaN, etc.</param>
         /// <param name="returnBehavior">A flag that can be used to activate pre-defined early return behavior, such as returning Blank() if any argument is Blank().</param>
         /// <param name="targetFunction">The implementation of the builtin function.</param>
-        /// <param name="isMultiArgTabularOverload">If True returns error table in case of error args.</param>
         /// <returns></returns>
         private static AsyncFunctionPtr StandardErrorHandlingAsync<T>(
                 string functionName,
@@ -51,8 +50,7 @@ namespace Microsoft.PowerFx.Functions
                 Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeTypes,
                 Func<IRContext, int, FormulaValue, FormulaValue> checkRuntimeValues,
                 ReturnBehavior returnBehavior,
-                Func<EvalVisitor, EvalVisitorContext, IRContext, T[], ValueTask<FormulaValue>> targetFunction,
-                bool isMultiArgTabularOverload = false)
+                Func<EvalVisitor, EvalVisitorContext, IRContext, T[], ValueTask<FormulaValue>> targetFunction)
             where T : FormulaValue
         {
             return async (runner, context, irContext, args) =>
@@ -60,33 +58,6 @@ namespace Microsoft.PowerFx.Functions
                 var nonFiniteArgError = FiniteArgumentCheck(functionName, irContext, args);
                 if (nonFiniteArgError != null)
                 {
-                    (var maxSize, var minsSize, _, var errorTable) = AnalyzeTableArguments(args, irContext);
-
-                    // In case Tabular overload has one scalar error arg and another Table arg we want to
-                    // return table of error. else If error arg is table then return table error args.
-                    if (isMultiArgTabularOverload && maxSize > 0 && errorTable == null)
-                    {
-                        var tableType = (TableType)irContext.ResultType;
-                        var resultType = tableType.ToRecord();
-                        var namedValue = new NamedValue(tableType.SingleColumnFieldName, nonFiniteArgError);
-                        var record = DValue<RecordValue>.Of(new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedValue }));
-                        var resultRows = Enumerable.Repeat(record, maxSize).ToList();
-
-                        return new InMemoryTableValue(irContext, resultRows);
-                    }
-                    else if (isMultiArgTabularOverload && errorTable != null)
-                    {
-                        return errorTable;
-                    }
-                    else if (isMultiArgTabularOverload)
-                    {
-                        // nonFiniteArgError!=null && maxSize == 0 && errorTable == null would means there are
-                        // no Table with rows and there is scaler error but no error table
-                        // in that case we return empty table
-                        // e.g. Concatenate(Filter([1,2], Value<>Value), If(1/0<0, "test"))
-                        return new InMemoryTableValue(irContext, new List<DValue<RecordValue>>());
-                    }
-
                     return nonFiniteArgError;
                 }
 
@@ -302,13 +273,10 @@ namespace Microsoft.PowerFx.Functions
             return StandardSingleColumnTable<T>(async (runner, context, irContext, args) => targetFunction(irContext, args.OfType<T>().ToArray()));
         }
 
-        private static (int maxTableSize, int minTableSize, bool blankTablePresent, ErrorValue errorTable) AnalyzeTableArguments(FormulaValue[] args, IRContext irContext)
+        private static (int minTableSize, int maxTableSize, FormulaValue errorOrBlankTable) AnalyzeTableArguments(FormulaValue[] args, IRContext irContext)
         {
             var maxTableSize = 0;
             var minTableSize = int.MaxValue;
-            var blankTablePresent = false;
-
-            List<ErrorValue> errors = null;
 
             foreach (var arg in args)
             {
@@ -320,76 +288,15 @@ namespace Microsoft.PowerFx.Functions
                 }
                 else if (arg is BlankValue bv && bv.IRContext.ResultType._type.IsTable)
                 {
-                    blankTablePresent = true;
+                    return (minTableSize, maxTableSize, new BlankValue(irContext));
                 }
                 else if (arg is ErrorValue ev && ev.IRContext.ResultType._type.IsTable)
                 {
-                    if (errors == null)
-                    {
-                        errors = new List<ErrorValue>();
-                    }
-
-                    errors.Add(ev);
+                    return (minTableSize, maxTableSize, ev);
                 }
             }
 
-            var errorTable = errors != null ? ErrorValue.Combine(irContext, errors) : null;
-            return (maxTableSize, minTableSize, blankTablePresent, errorTable);
-        }
-
-        private class ShrinkToSizeResult
-        {
-            public readonly string Name;
-            public readonly IEnumerable<DValue<RecordValue>> Rows;
-
-            public ShrinkToSizeResult(string name, IEnumerable<DValue<RecordValue>> rows)
-            {
-                Name = name;
-                Rows = rows;
-            }
-        }
-
-        private static ShrinkToSizeResult ShrinkToSize(FormulaValue arg, int size)
-        {
-            if (arg is TableValue tv)
-            {
-                var tvType = (TableType)tv.Type;
-                var name = tvType.SingleColumnFieldName;
-
-                var count = tv.Rows.Count();
-                if (count > size)
-                {
-                    return new ShrinkToSizeResult(name, tv.Rows.Take(size));
-                }
-                else
-                {
-                    return new ShrinkToSizeResult(name, tv.Rows);
-                }
-            }
-            else
-            {
-                var name = BuiltinFunction.ColumnName_ValueStr;
-                var inputRecordType = RecordType.Empty().Add(name, arg.Type);
-                var inputRecordNamedValue = new NamedValue(name, arg);
-                var inputRecord = new InMemoryRecordValue(IRContext.NotInSource(inputRecordType), new List<NamedValue>() { inputRecordNamedValue });
-                var inputDValue = DValue<RecordValue>.Of(inputRecord);
-                var rows = Enumerable.Repeat(inputDValue, size);
-                return new ShrinkToSizeResult(name, rows);
-            }
-        }
-
-        // Transpose a matrix (list of lists) so that the rows become columns and the columns become rows
-        // The column length is uniform and known
-        private static List<List<T>> Transpose<T>(List<List<T>> columns, int columnSize)
-        {
-            var rows = new List<List<T>>();
-
-            for (var i = 0; i < columnSize; i++)
-            {
-                rows.Add(columns.Select(column => column[i]).ToList());
-            }
-
-            return rows;
+            return (minTableSize, maxTableSize, null);
         }
 
         /*
@@ -407,18 +314,18 @@ namespace Microsoft.PowerFx.Functions
         {
             return async (runner, context, irContext, args) =>
             {
-                var resultRows = new List<DValue<RecordValue>>();
+                (var minTableSize, var maxTableSize, var errorOrBlankTable) = AnalyzeTableArguments(args, irContext);
 
-                (var maxSize, var minSize, var blankTablePresent, _) = AnalyzeTableArguments(args, irContext);
-
-                // If one arg is blank table and among all other args, return blank.
-                // e.g. Concatenate(Blank(), []), Concatenate(Blank(), "test"), Concatenate(Blank(), ["test"], []) => Blank()
-                if (blankTablePresent)
+                // If one of the arguments is a blank or error table, return it.
+                // e.g. Concatenate(If(1<0,["this is a blank table"]), "hello") ==> Blank() or Concatenate(["test"], If(Sqrt(-1)<0,["this is an error table"])) ==> Error
+                if (errorOrBlankTable != null)
                 {
-                    return FormulaValue.NewBlank();
+                    return errorOrBlankTable;
                 }
 
-                if (maxSize == 0)
+                var resultRows = new List<DValue<RecordValue>>();
+
+                if (maxTableSize == 0)
                 {
                     // maxSize == 0 means there are no tables with rows. This can happen if we receive a Filter expression where no rows were return,
                     // or all tables in args are empty. 
@@ -427,41 +334,80 @@ namespace Microsoft.PowerFx.Functions
                     return new InMemoryTableValue(irContext, resultRows);
                 }
 
-                var allResults = args.Select(arg => ShrinkToSize(arg, minSize));
-
                 var tableType = (TableType)irContext.ResultType;
                 var resultType = tableType.ToRecord();
                 var columnNameStr = tableType.SingleColumnFieldName;
                 var itemType = resultType.GetFieldType(columnNameStr);
 
-                var transposed = Transpose(allResults.Select(result => result.Rows.ToList()).ToList(), minSize);
-                var names = allResults.Select(result => result.Name).ToList();
-                foreach (var list in transposed)
+                var tabularArgRows = new DValue<RecordValue>[args.Length][];
+                for (var i = 0; i < args.Length; i++)
                 {
-                    var errorRow = list.FirstOrDefault(dv => dv.IsError);
-                    if (errorRow != null)
+                    if (args[i] is TableValue tv)
                     {
-                        resultRows.Add(DValue<RecordValue>.Of(errorRow.Error));
-                        continue;
+                        tabularArgRows[i] = tv.Rows
+                            .Take(Math.Min(tv.Count(), minTableSize))
+                            .ToArray();
                     }
-
-                    var targetArgs = list.Select((dv, i) => dv.IsValue ? dv.Value.GetField(names[i]) : dv.ToFormulaValue()).ToArray();
-                    var namedValue = new NamedValue(tableType.SingleColumnFieldName, await targetFunction(runner, context, IRContext.NotInSource(itemType), targetArgs));
-                    var record = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedValue });
-                    resultRows.Add(DValue<RecordValue>.Of(record));
                 }
 
-                // Add error nodes for different table length
-                // e.g. Concatenate(["a"],["1","2"] => ["a1", <error>]
-                var namedErrorValue = new NamedValue(columnNameStr, FormulaValue.NewError(new ExpressionError()
+                for (var i = 0; i < minTableSize; i++)
                 {
-                    Kind = ErrorKind.NotApplicable,
-                    Severity = ErrorSeverity.Critical,
-                    Message = "Not Applicable"
-                }));
-                var errorRecord = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedErrorValue });
-                var errorRowCount = maxSize - minSize;
-                resultRows.AddRange(Enumerable.Repeat(DValue<RecordValue>.Of(errorRecord), errorRowCount));
+                    var functionArgs = new FormulaValue[args.Length];
+                    ErrorValue errorRow = null;
+                    for (var j = 0; j < args.Length; j++)
+                    {
+                        var arg = args[j];
+                        if (arg is TableValue tv)
+                        {
+                            var argRow = tabularArgRows[j][i];
+                            if (argRow.IsError)
+                            {
+                                errorRow = argRow.Error;
+                                break;
+                            }
+                            else if (argRow.IsBlank)
+                            {
+                                functionArgs[j] = argRow.Blank;
+                            }
+                            else
+                            {
+                                functionArgs[j] = argRow.Value.Fields.First().Value;
+                            }
+                        }
+                        else
+                        {
+                            functionArgs[j] = arg;
+                        }
+                    }
+
+                    if (errorRow != null)
+                    {
+                        resultRows.Add(DValue<RecordValue>.Of(errorRow));
+                    }
+                    else
+                    {
+                        var rowResult = await targetFunction(runner, context, IRContext.NotInSource(itemType), functionArgs);
+                        var namedValue = new NamedValue(columnNameStr, rowResult);
+                        var record = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedValue });
+                        resultRows.Add(DValue<RecordValue>.Of(record));
+                    }    
+                }
+
+                if (maxTableSize != minTableSize)
+                {
+                    // Add error nodes for different table length
+                    // e.g. Concatenate(["a"],["1","2"] => ["a1", <error>]
+                    var namedErrorValue = new NamedValue(columnNameStr, FormulaValue.NewError(new ExpressionError()
+                    {
+                        Kind = ErrorKind.NotApplicable,
+                        Severity = ErrorSeverity.Critical,
+                        Message = "Not Applicable"
+                    }));
+                    var errorRecord = new InMemoryRecordValue(IRContext.NotInSource(resultType), new List<NamedValue>() { namedErrorValue });
+                    var errorRowCount = maxTableSize - minTableSize;
+                    resultRows.AddRange(Enumerable.Repeat(DValue<RecordValue>.Of(errorRecord), errorRowCount));
+                }
+
                 return new InMemoryTableValue(irContext, resultRows);
             };
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -241,7 +241,7 @@ Error({Kind:ErrorKind.Numeric})
 Error({Kind:ErrorKind.Div0})
 
 >> Concatenate( If(Sqrt(-1)<0,["Hi", "hello"]), If(1/0<2, [" world", "people"]) )
-Error(Table({Kind:ErrorKind.Numeric}))
+Error({Kind:ErrorKind.Numeric})
 
 >> Concatenate(Filter([1,2], Value<>Value), If(1/0<0, "test"))
 Table()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TabularOverloadsBlanksAndErrors.txt
@@ -232,7 +232,7 @@ Blank()
 Blank()
 
 >> Concatenate(If(1<0,["a","b"]), If(1/0<2,["abcdef", "ghijkl"]))
-Error({Kind:ErrorKind.Div0})
+Blank()
 
 >> Concatenate( If(Sqrt(-1)<0,["Hi", "hello"]), If(1/0<2, " world") )
 Error({Kind:ErrorKind.Numeric})
@@ -241,7 +241,7 @@ Error({Kind:ErrorKind.Numeric})
 Error({Kind:ErrorKind.Div0})
 
 >> Concatenate( If(Sqrt(-1)<0,["Hi", "hello"]), If(1/0<2, [" world", "people"]) )
-Error(Table({Kind:ErrorKind.Numeric},{Kind:ErrorKind.Div0}))
+Error(Table({Kind:ErrorKind.Numeric}))
 
 >> Concatenate(Filter([1,2], Value<>Value), If(1/0<0, "test"))
 Table()


### PR DESCRIPTION
Currently the implementation of the tabular function handler needs to make two passes over the function arguments to determine whether a blank or error value will be returned (if passed in a tabular context). This is inefficient, so we are updating the implementation to return the first of those values.

This change also simplifies the implementation of the tabular handler, to avoid copying the arguments multiple times.