### PR TITLE
Fix #958 - allow LSP to enforce expected types

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -577,6 +577,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrTypeError = new ErrorResourceKey("ErrTypeError");
         public static ErrorResourceKey ErrTypeError_Ex1_Ex2_Found = new ErrorResourceKey("ErrTypeError_Ex1_Ex2_Found");
         public static ErrorResourceKey ErrTypeError_Arg_Expected_Found = new ErrorResourceKey("ErrTypeError_Arg_Expected_Found");
+        public static ErrorResourceKey ErrTypeError_WrongType = new ErrorResourceKey("ErrTypeError_WrongType");
         public static ErrorResourceKey ErrTypeErrorRecordIncompatibleWithSource = new ErrorResourceKey("ErrTypeErrorRecordIncompatibleWithSource");
         public static ErrorResourceKey ErrExpectedStringLiteralArg_Name = new ErrorResourceKey("ErrExpectedStringLiteralArg_Name");
         public static ErrorResourceKey ErrExpectedIdentifierArg_Name = new ErrorResourceKey("ErrExpectedIdentifierArg_Name");

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -155,6 +155,14 @@ namespace Microsoft.PowerFx
             return this.SetBindingInfo(symbolTable);
         }
 
+        private FormulaType _expectedReturnType;
+
+        public CheckResult SetExpectedReturnValue(FormulaType type)
+        {
+            _expectedReturnType = type;
+            return this;
+        }
+
         // No additional binding is required
         public CheckResult SetBindingInfo()
         {
@@ -404,6 +412,26 @@ namespace Microsoft.PowerFx
                     if (binding.ResultType.Kind != DKind.Enum)
                     {
                         this.ReturnType = FormulaType.Build(binding.ResultType);
+                    }
+                }
+
+                if (this.ReturnType != null && this._expectedReturnType != null)
+                {
+                    var sameType = this._expectedReturnType == this.ReturnType;
+                    if (!sameType)
+                    {
+                        _errors.Add(new ExpressionError
+                        {
+                            Kind = ErrorKind.Validation,
+                            Severity = ErrorSeverity.Critical,
+                            Span = new Span(0, this._expression.Length),
+                            MessageKey = TexlStrings.ErrTypeError_WrongType.Key,
+                            _messageArgs = new object[]
+                            {
+                                this._expectedReturnType._type.GetKindString(),
+                                this.ReturnType._type.GetKindString()
+                            }
+                        });
                     }
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ExpressionError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ExpressionError.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerFx
 
         // localize message lazily 
         private string _message; 
-        private object[] _messageArgs;
+        internal object[] _messageArgs;
         private CultureInfo _messageLocale;
 
         internal CultureInfo MessageLocale => _messageLocale;

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/EditorContextScope.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/EditorContextScope.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerFx
             ReadOnlySymbolTable symbols = null)
         {
             return new EditorContextScope(engine, parserOptions, symbols);
-        }
+        }                  
     }
 
     /// <summary>
@@ -37,23 +37,29 @@ namespace Microsoft.PowerFx
     ///  This includes helpers to aide in customizing the editing experience. 
     /// </summary>
     public sealed class EditorContextScope : IPowerFxScope
-    {
-        private readonly Engine _engine;
-        private readonly ParserOptions _parserOptions;
-        private readonly ReadOnlySymbolTable _symbols;
-        
+    {        
         // List of handlers to get code-fix suggestions. 
         // Key is CodeFixHandler.HandlerName
         private readonly Dictionary<string, CodeFixHandler> _handlers = new Dictionary<string, CodeFixHandler>();
+
+        // Map string (from formula bar) to a CheckResult.
+        // The checkResult has all other context (parser options, symbols, engine, etc)
+        // This captures the critical invariant: EditorContextScope corresponds to a formula bar where the user just types text, all other context is provided; 
+        private readonly Func<string, CheckResult> _getCheckResult;
 
         internal EditorContextScope(
             Engine engine,
             ParserOptions parserOptions,
             ReadOnlySymbolTable symbols)
+            : this((string expr) => new CheckResult(engine)
+                    .SetText(expr, parserOptions)
+                    .SetBindingInfo(symbols))
+        {            
+        }        
+
+        public EditorContextScope(Func<string, CheckResult> getCheckResult)
         {
-            _engine = engine ?? throw new ArgumentNullException(nameof(engine));
-            _parserOptions = parserOptions ?? new ParserOptions();
-            _symbols = symbols ?? new SymbolTable();
+            _getCheckResult = getCheckResult ?? throw new ArgumentNullException(nameof(getCheckResult));
         }
 
         #region IPowerFxScope
@@ -62,22 +68,31 @@ namespace Microsoft.PowerFx
         // text in the editor. 
         public CheckResult Check(string expression)
         {
-            return _engine.Check(expression, _parserOptions, _symbols);
+            var check = _getCheckResult(expression);
+
+            // By default ...
+            check.ApplyBindingInternal();
+            check.ApplyErrors();
+            check.ApplyDependencyAnalysis();
+
+            return check;
         }
 
         string IPowerFxScope.ConvertToDisplay(string expression)
         {
-            return _engine.GetDisplayExpression(expression, _symbols);
+            var check = _getCheckResult(expression);
+            var symbols = check._symbols;
+            var engine = check.Engine;
+
+            return engine.GetDisplayExpression(expression, symbols);
         }
 
         IIntellisenseResult IPowerFxScope.Suggest(string expression, int cursorPosition)
         {
             // Suggestions just need the binding, not other things like Dependency Info or errors. 
-            var check = new CheckResult(this._engine)
-                .SetText(expression, _parserOptions)
-                .SetBindingInfo(_symbols);
+            var check = _getCheckResult(expression);
 
-            return _engine.Suggest(check, cursorPosition);
+            return check.Engine.Suggest(check, cursorPosition);
         }
 
         #endregion
@@ -121,6 +136,7 @@ namespace Microsoft.PowerFx
         internal CodeActionResult[] SuggestFixes(string expression, OnLogUnhandledExceptionHandler logUnhandledExceptionHandler)
         {
             var check = Check(expression);
+            var engine = check.Engine;
 
             var list = new List<CodeActionResult>();
 
@@ -129,7 +145,7 @@ namespace Microsoft.PowerFx
             {
                 try
                 {
-                    var task = handler.Value.SuggestFixesAsync(_engine, check, CancellationToken.None);
+                    var task = handler.Value.SuggestFixesAsync(engine, check, CancellationToken.None);
                     var fixes = task.Result;
 
                     if (fixes != null)

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1869,6 +1869,10 @@
     <value>The type of this argument '{0}' does not match the expected type '{1}'. Found type '{2}'.</value>
     <comment>Error Message.</comment>
   </data>
+  <data name="ErrTypeError_WrongType" xml:space="preserve">
+    <value>The type of this expression does not match the expected type '{0}'. Found type '{1}'.</value>
+    <comment>Error Message.</comment>
+  </data>
   <data name="ErrTypeErrorRecordIncompatibleWithSource" xml:space="preserve">
     <value>The type of the record is incompatible with the source.</value>
     <comment>Error Message.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/CheckResultTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/CheckResultTests.cs
@@ -242,6 +242,23 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void BindingCheckReturnType()
+        {
+            var check = new CheckResult(new Engine())
+                .SetText("123")
+                .SetBindingInfo()
+                .SetExpectedReturnValue(FormulaType.String);
+
+            var errors = check.ApplyErrors();
+
+            Assert.False(check.IsSuccess);
+
+            Assert.Single(errors);
+            var error = errors.First();
+            Assert.Equal("Error 0-3: The type of this expression does not match the expected type 'Text'. Found type 'Number'.", error.ToString());
+        }
+
+        [Fact]
         public void BindingSetRecordType()
         {
             var check = new CheckResult(new Engine());

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
@@ -137,6 +137,42 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             Assert.Equal(0, engine.PostCheckCounter);            
         }
 
+        [Fact]
+        public void NullCtor()
+        {
+            Assert.Throws<ArgumentNullException>(() => new EditorContextScope(null));
+        }
+
+        [Fact]
+        public void Ctor()
+        {
+            var check = new CheckResult(new Engine());
+            var editor = new EditorContextScope(
+                (expr) => check.SetText(expr).SetBindingInfo());
+
+            var check2 = editor.Check("1+2");
+            Assert.Same(check, check2);
+
+            Assert.True(check2.IsSuccess);
+        }
+
+        // Fail if the getter doesn't fully create the CheckResult
+        [Fact]
+        public void MissingInit()
+        {
+            var check = new CheckResult(new Engine());
+
+            var editor = new EditorContextScope(
+                (expr) => check.SetText(expr));
+
+            Assert.Throws<InvalidOperationException>(() => editor.Check("1+2"));
+
+            editor = new EditorContextScope(
+                (expr) => check);
+
+            Assert.Throws<InvalidOperationException>(() => editor.Check("3+4"));
+        }
+
         private class MyEngine : Engine
         {
             public MyEngine()


### PR DESCRIPTION
Fix #958 - see for details. 

Also creates better symmetry between LSP's EditorContextScope and CheckResult.
This makes new CheckResult features (such as this one) available to LSP. 