### PR TITLE
Implement First/Last and FirstN/LastN for UntypedObject

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -93,6 +93,8 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction FindT = _library.Append(new FindTFunction());
         public static readonly TexlFunction First = _library.Append(new FirstLastFunction(isFirst: true));
         public static readonly TexlFunction FirstN = _library.Append(new FirstLastNFunction(isFirst: true));
+        public static readonly TexlFunction First_UO = _library.Append(new FirstLastFunction_UO(isFirst: true));
+        public static readonly TexlFunction FirstN_UO = _library.Append(new FirstLastNFunction_UO(isFirst: true));
         public static readonly TexlFunction ForAll = _library.Append(new ForAllFunction());
         public static readonly TexlFunction ForAll_UO = _library.Append(new ForAllFunction_UO());
         public static readonly TexlFunction GUIDPure = _library.Append(new GUIDPureFunction());
@@ -117,6 +119,8 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction ISOWeekNum = _library.Append(new ISOWeekNumFunction());
         public static readonly TexlFunction Last = _library.Append(new FirstLastFunction(isFirst: false));
         public static readonly TexlFunction LastN = _library.Append(new FirstLastNFunction(isFirst: false));
+        public static readonly TexlFunction Last_UO = _library.Append(new FirstLastFunction_UO(isFirst: false));
+        public static readonly TexlFunction LastN_UO = _library.Append(new FirstLastNFunction_UO(isFirst: false));
         public static readonly TexlFunction Left = _library.Append(new LeftRightScalarFunction(isLeft: true));
         public static readonly TexlFunction LeftTS = _library.Append(new LeftRightTableScalarFunction(isLeft: true));
         public static readonly TexlFunction LeftTT = _library.Append(new LeftRightTableTableFunction(isLeft: true));

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
@@ -100,6 +100,32 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return false;
         }
     }
+
+    // First(source:*)
+    // Last(source:*)
+    internal sealed class FirstLastFunction_UO : BuiltinFunction
+    {
+        public override bool IsSelfContained => true;
+
+        public override bool SupportsParamCoercion => false;
+
+        // Note this function does not inherit from FunctionWithTableInput so there cannot be a common
+        // base class with the above function
+        public FirstLastFunction_UO(bool isFirst)
+            : base(isFirst ? "First" : "Last", isFirst ? TexlStrings.AboutFirst : TexlStrings.AboutLast, FunctionCategories.Table, DType.UntypedObject, 0, 1, 1, DType.UntypedObject)
+        {
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.FirstLastArg1 };
+        }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
+    }
 }
 
 #pragma warning restore SA1402 // File may only contain a single type

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
@@ -66,5 +66,32 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return fArgsValid;
         }
     }
+
+    // FirstN(source:*, [count:n])
+    // LastN(source:*, [count:n])
+    internal sealed class FirstLastNFunction_UO : BuiltinFunction
+    {
+        public override bool IsSelfContained => true;
+
+        public override bool SupportsParamCoercion => false;
+
+        // Note this function does not inherit from FunctionWithTableInput so there cannot be a common
+        // base class with the above function
+        public FirstLastNFunction_UO(bool isFirst)
+            : base(isFirst ? "FirstN" : "LastN", isFirst ? TexlStrings.AboutFirstN : TexlStrings.AboutLastN, FunctionCategories.Table, DType.UntypedObject, 0, 1, 2, DType.UntypedObject, DType.Number)
+        {
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.FirstLastNArg1 };
+            yield return new[] { TexlStrings.FirstLastNArg1, TexlStrings.FirstLastNArg2 };
+        }
+
+        public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
+        {
+            return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
+    }
 }
 #pragma warning restore SA1649 // File name should match first type name

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
@@ -73,18 +73,20 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         // Note this function does not inherit from FunctionWithTableInput so there cannot be a common
         // base class with the above function
         public FirstLastNFunction_UO(bool isFirst)
-            : base(isFirst ? "FirstN" : "LastN", isFirst ? TexlStrings.AboutFirstN : TexlStrings.AboutLastN, FunctionCategories.Table, DType.UntypedObject, 0, 1, 2, DType.UntypedObject, DType.Number)
+            : base(isFirst ? "FirstN" : "LastN", isFirst ? TexlStrings.AboutFirstN : TexlStrings.AboutLastN, FunctionCategories.Table, DType.UntypedObject, 0, 2, 2, DType.UntypedObject, DType.Number)
         {
+        }
+
+        public override bool SupportCoercionForArg(int argIndex)
+        {
+            return argIndex == 1;
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
-            yield return new[] { TexlStrings.FirstLastNArg1 };
             yield return new[] { TexlStrings.FirstLastNArg1, TexlStrings.FirstLastNArg2 };
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ArrayUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/ArrayUntypedObject.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Functions
+{
+    internal class ArrayUntypedObject : IUntypedObject
+    {
+        private readonly List<IUntypedObject> _list;
+
+        public ArrayUntypedObject(List<IUntypedObject> list)
+        {
+            _list = list;
+        }
+
+        public FormulaType Type => ExternalType.ArrayType;
+
+        public IUntypedObject this[int index] => _list[index];
+
+        public int GetArrayLength()
+        {
+            return _list.Count;
+        }
+
+        public double GetDouble()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetString()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool GetBoolean()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetProperty(string value, out IUntypedObject result)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -645,7 +645,7 @@ namespace Microsoft.PowerFx.Functions
                 BuiltinFunctionsCore.FirstN_UO,
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.FirstN.Name,
-                    expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
+                    expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithZeroForSpecificIndices(1),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueTypeOrBlank<UntypedObjectValue>,
@@ -873,7 +873,7 @@ namespace Microsoft.PowerFx.Functions
                 BuiltinFunctionsCore.LastN_UO,
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.LastN.Name,
-                    expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
+                    expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithZeroForSpecificIndices(1),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueTypeOrBlank<UntypedObjectValue>,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -631,6 +631,32 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: FirstN)
             },
             {
+                BuiltinFunctionsCore.First_UO,
+                StandardErrorHandling<UntypedObjectValue>(
+                    BuiltinFunctionsCore.First_UO.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeValues: UntypedObjectArrayChecker,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: First_UO)
+            },
+            {
+                BuiltinFunctionsCore.FirstN_UO,
+                StandardErrorHandling<FormulaValue>(
+                    BuiltinFunctionsCore.FirstN.Name,
+                    expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
+                    replaceBlankValues: ReplaceBlankWithZeroForSpecificIndices(1),
+                    checkRuntimeTypes: ExactSequence(
+                        ExactValueTypeOrBlank<UntypedObjectValue>,
+                        ExactValueTypeOrBlank<NumberValue>),
+                    checkRuntimeValues: ExactSequence(
+                        UntypedObjectArrayChecker,
+                        DeferRuntimeValueChecking),
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: FirstN_UO)
+            },
+            {
                 BuiltinFunctionsCore.ForAll,
                 StandardErrorHandlingAsync<FormulaValue>(
                     BuiltinFunctionsCore.ForAll.Name,
@@ -831,6 +857,32 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: LastN)
+            },
+            {
+                BuiltinFunctionsCore.Last_UO,
+                StandardErrorHandling<UntypedObjectValue>(
+                    BuiltinFunctionsCore.Last_UO.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeValues: UntypedObjectArrayChecker,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: Last_UO)
+            },
+            {
+                BuiltinFunctionsCore.LastN_UO,
+                StandardErrorHandling<FormulaValue>(
+                    BuiltinFunctionsCore.LastN.Name,
+                    expandArguments: InsertDefaultValues(outputArgsCount: 2, fillWith: new NumberValue(IRContext.NotInSource(FormulaType.Number), 1)),
+                    replaceBlankValues: ReplaceBlankWithZeroForSpecificIndices(1),
+                    checkRuntimeTypes: ExactSequence(
+                        ExactValueTypeOrBlank<UntypedObjectValue>,
+                        ExactValueTypeOrBlank<NumberValue>),
+                    checkRuntimeValues: ExactSequence(
+                        UntypedObjectArrayChecker,
+                        DeferRuntimeValueChecking),
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: LastN_UO)
             },
             {
                 BuiltinFunctionsCore.Left,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -104,11 +104,6 @@ namespace Microsoft.PowerFx.Functions
             var element = arg0.Impl;
             var len = element.GetArrayLength();
 
-            if (len == 0)
-            {
-                return new BlankValue(irContext);
-            }
-
             var list = new List<IUntypedObject>();
             for (int i = 0; i < (int)arg1.Value && i < len; i++)
             {
@@ -133,11 +128,6 @@ namespace Microsoft.PowerFx.Functions
 
             var element = arg0.Impl;
             var len = element.GetArrayLength();
-
-            if (len == 0)
-            {
-                return new BlankValue(irContext);
-            }
 
             var list = new List<IUntypedObject>();
             for (int i = 1; i <= (int)arg1.Value && len - i >= 0; i++)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -65,12 +65,6 @@ namespace Microsoft.PowerFx.Functions
 
             var result = element[0];
 
-            // Map null to blank
-            if (result == null || result.Type == FormulaType.Blank)
-            {
-                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
-            }
-
             return new UntypedObjectValue(irContext, result);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -112,12 +112,6 @@ namespace Microsoft.PowerFx.Functions
 
             var result = new ArrayUntypedObject(list);
 
-            // Map null to blank
-            if (result == null || result.Type == FormulaType.Blank)
-            {
-                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
-            }
-
             return new UntypedObjectValue(irContext, result);
         }
 
@@ -137,12 +131,6 @@ namespace Microsoft.PowerFx.Functions
 
             list.Reverse();
             var result = new ArrayUntypedObject(list);
-
-            // Map null to blank
-            if (result == null || result.Type == FormulaType.Blank)
-            {
-                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
-            }
 
             return new UntypedObjectValue(irContext, result);
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -52,6 +52,111 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
+        public static FormulaValue First_UO(IRContext irContext, UntypedObjectValue[] args)
+        {
+            var arg0 = (UntypedObjectValue)args[0];
+            var element = arg0.Impl;
+            var len = element.GetArrayLength();
+
+            if (len == 0)
+            {
+                return new BlankValue(irContext);
+            }
+
+            var result = element[0];
+
+            // Map null to blank
+            if (result == null || result.Type == FormulaType.Blank)
+            {
+                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
+            }
+
+            return new UntypedObjectValue(irContext, result);
+        }
+
+        public static FormulaValue Last_UO(IRContext irContext, UntypedObjectValue[] args)
+        {
+            var arg0 = (UntypedObjectValue)args[0];
+            var element = arg0.Impl;
+            var len = element.GetArrayLength();
+
+            if (len == 0)
+            {
+                return new BlankValue(irContext);
+            }
+
+            var result = element[len - 1];
+
+            // Map null to blank
+            if (result == null || result.Type == FormulaType.Blank)
+            {
+                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
+            }
+
+            return new UntypedObjectValue(irContext, result);
+        }
+
+        public static FormulaValue FirstN_UO(IRContext irContext, FormulaValue[] args)
+        {
+            var arg0 = (UntypedObjectValue)args[0];
+            var arg1 = (NumberValue)args[1];
+
+            var element = arg0.Impl;
+            var len = element.GetArrayLength();
+
+            if (len == 0)
+            {
+                return new BlankValue(irContext);
+            }
+
+            var list = new List<IUntypedObject>();
+            for (int i = 0; i < (int)arg1.Value && i < len; i++)
+            {
+                list.Add(element[i]);
+            }
+
+            var result = new ArrayUntypedObject(list);
+
+            // Map null to blank
+            if (result == null || result.Type == FormulaType.Blank)
+            {
+                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
+            }
+
+            return new UntypedObjectValue(irContext, result);
+        }
+
+        public static FormulaValue LastN_UO(IRContext irContext, FormulaValue[] args)
+        {
+            var arg0 = (UntypedObjectValue)args[0];
+            var arg1 = (NumberValue)args[1];
+
+            var element = arg0.Impl;
+            var len = element.GetArrayLength();
+
+            if (len == 0)
+            {
+                return new BlankValue(irContext);
+            }
+
+            var list = new List<IUntypedObject>();
+            for (int i = 1; i <= (int)arg1.Value && len - i >= 0; i++)
+            {
+                list.Add(element[len - i]);
+            }
+
+            list.Reverse();
+            var result = new ArrayUntypedObject(list);
+
+            // Map null to blank
+            if (result == null || result.Type == FormulaType.Blank)
+            {
+                return new BlankValue(IRContext.NotInSource(FormulaType.Blank));
+            }
+
+            return new UntypedObjectValue(irContext, result);
+        }
+
         public static FormulaValue Value_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
             var uo = args[0] as UntypedObjectValue;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -124,12 +124,16 @@ namespace Microsoft.PowerFx.Functions
             var len = element.GetArrayLength();
 
             var list = new List<IUntypedObject>();
-            for (int i = 1; i <= (int)arg1.Value && len - i >= 0; i++)
+            var takeCount = (int)arg1.Value;
+            for (int i = 0; i < takeCount; i++)
             {
-                list.Add(element[len - i]);
+                var takeIndex = len - takeCount + i;
+                if (takeIndex >= 0)
+                {
+                    list.Add(element[takeIndex]);
+                }
             }
 
-            list.Reverse();
             var result = new ArrayUntypedObject(list);
 
             return new UntypedObjectValue(irContext, result);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -404,3 +404,15 @@ false
 
 >> Text(ParseJSON("{""a"":null,""b"":""""}").c) = Blank()
 true
+
+>> Value(First(ParseJSON("[1, 2, 3, 4]")))
+1
+
+>> Value(Last(ParseJSON("[1, 2, 3, 4]")))
+4
+
+>> Value(Last(FirstN(ParseJSON("[1, 2, 3, 4]"), 2)))
+2
+
+>> Value(First(LastN(ParseJSON("[1, 2, 3, 4]"), 2)))
+3

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -476,3 +476,9 @@ Blank()
 
 >> CountRows(LastN(ParseJSON("[]"), 1))
 0
+
+>> CountRows(FirstN(ParseJSON("[1, 2, 3, 4]"), "3"))
+3
+
+>> CountRows(LastN(ParseJSON("[1, 2, 3, 4]"), "3"))
+3

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -408,11 +408,71 @@ true
 >> Value(First(ParseJSON("[1, 2, 3, 4]")))
 1
 
+>> Value(First(ParseJSON("[1, 2, 3, 4]"))) = First([1, 2, 3, 4]).Value
+true
+
 >> Value(Last(ParseJSON("[1, 2, 3, 4]")))
 4
+
+>> Value(Last(ParseJSON("[1, 2, 3, 4]"))) = Last([1, 2, 3, 4]).Value
+true
 
 >> Value(Last(FirstN(ParseJSON("[1, 2, 3, 4]"), 2)))
 2
 
+>> Value(Last(FirstN(ParseJSON("[1, 2, 3, 4]"), 2))) = Last(FirstN([1, 2, 3, 4], 2)).Value
+true
+
 >> Value(First(LastN(ParseJSON("[1, 2, 3, 4]"), 2)))
 3
+
+>> Value(First(LastN(ParseJSON("[1, 2, 3, 4]"), 2))) = First(LastN([1, 2, 3, 4], 2)).Value
+true
+
+>> Value(First(FirstN(ParseJSON("[1, 2, 3, 4]"), 2)))
+1
+
+>> Value(First(FirstN(ParseJSON("[1, 2, 3, 4]"), 2))) = First(FirstN([1, 2, 3, 4], 2)).Value
+true
+
+>> Value(Last(LastN(ParseJSON("[1, 2, 3, 4]"), 2)))
+4
+
+>> Value(Last(LastN(ParseJSON("[1, 2, 3, 4]"), 2))) = Last(LastN([1, 2, 3, 4], 2)).Value
+true
+
+>> CountRows(FirstN(ParseJSON("[1, 2, 3, 4]"), 2))
+2
+
+>> CountRows(FirstN(ParseJSON("[1, 2, 3, 4]"), 2)) = CountRows(FirstN([1, 2, 3, 4], 2))
+true
+
+>> CountRows(LastN(ParseJSON("[1, 2, 3, 4]"), 2))
+2
+
+>> CountRows(LastN(ParseJSON("[1, 2, 3, 4]"), 2)) = CountRows(LastN([1, 2, 3, 4], 2))
+true
+
+>> CountRows(FirstN(ParseJSON("[1, 2, 3, 4]"), 5))
+4
+
+>> CountRows(FirstN(ParseJSON("[1, 2, 3, 4]"), 5)) = CountRows(FirstN([1, 2, 3, 4], 5))
+true
+
+>> CountRows(LastN(ParseJSON("[1, 2, 3, 4]"), 5))
+4
+
+>> CountRows(LastN(ParseJSON("[1, 2, 3, 4]"), 5)) = CountRows(LastN([1, 2, 3, 4], 5))
+true
+
+>> First(ParseJSON("[]"))
+Blank()
+
+>> Last(ParseJSON("[]"))
+Blank()
+
+>> FirstN(ParseJSON("[]"), 1)
+Blank()
+
+>> LastN(ParseJSON("[]"), 1)
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -471,8 +471,8 @@ Blank()
 >> Last(ParseJSON("[]"))
 Blank()
 
->> FirstN(ParseJSON("[]"), 1)
-Blank()
+>> CountRows(FirstN(ParseJSON("[]"), 1))
+0
 
->> LastN(ParseJSON("[]"), 1)
-Blank()
+>> CountRows(LastN(ParseJSON("[]"), 1))
+0


### PR DESCRIPTION
First/Last for UO returns a UO containing the single item. FirstN/LastN returns a UO containing an array, even if only one item is requested. Should have similar Blank/Error handling semantics to the classic First(N)/Last(N) functions.