### PR TITLE
Revert SortByColumns changes to use identifiers as column names

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -472,12 +472,6 @@ namespace Microsoft.PowerFx.Core.Functions
             // Type check the args
             for (var i = 0; i < count; i++)
             {
-                // Identifiers don't have a type
-                if (IsIdentifierParam(i))
-                {
-                    continue;
-                }
-
                 var typeChecks = CheckType(args[i], argTypes[i], ParamTypes[i], errors, SupportCoercionForArg(i), out DType coercionType);
                 if (typeChecks && coercionType != null)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -421,17 +421,6 @@ namespace Microsoft.PowerFx.Intellisense
             }
         }
 
-        internal static IEnumerable<KeyValuePair<string, DType>> GetColumnNameIdentifierSuggestions(DType scopeType)
-        {
-            Contracts.AssertValid(scopeType);
-
-            foreach (var name in scopeType.GetRootFieldNames()
-                .Select(field => (Type: scopeType.GetType(field), Name: field)))
-            {
-                yield return new KeyValuePair<string, DType>(CharacterUtils.ExcelEscapeString(name.Name.Value), name.Type);
-            }
-        }
-
         internal static IEnumerable<KeyValuePair<string, DType>> GetSuggestionsFromType(DType typeToSuggestFrom, DType suggestionType)
         {
             Contracts.AssertValid(typeToSuggestFrom);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -179,55 +179,6 @@ namespace Microsoft.PowerFx.Tests
             AssertContainsError(result, expected);
         }
 
-        [Theory]
-
-        [InlineData("SortByColumns(table, \"First\")", false)]
-        [InlineData("SortByColumns(table, First)", true)]
-        [InlineData("SortByColumns(table, 'Has Dog')", true)]
-        [InlineData("SortByColumns(table, 'Has Do')", false)]
-        [InlineData("SortByColumns(table, 'Has Dog', SortOrder.Ascending)", true)]
-        [InlineData("SortByColumns(table, First, SortOrder.Ascending)", true)]
-        [InlineData("SortByColumns(table, First, SortOrder.Ascending, Last, SortOrder.Descending, 'Has Dog')", true)]
-        [InlineData("SortByColumns(tableWithBlanks, Flavor, SortOrder.Ascending, Quantity, SortOrder.Descending, OnOrder)", true)]
-        [InlineData("SortByColumns(tableWithBlanks, Flavor, SortOrder.Ascending, Quant, SortOrder.Descending, OnOrder)", false)]
-        [InlineData("SortByColumns([1],\"Value\")", false)]
-        [InlineData("SortByColumns([1],Value)", true)]
-        [InlineData("SortByColumns([\"a\", \"b\", \"D\", \"x\", \"J\", \"C\"], Value)", true)]
-        [InlineData("SortByColumns([true,false,true,false,true], Value)", true)]
-        [InlineData("SortByColumns([Date(2020, 01, 05), Date(2020, 01, 01), Date(1995, 01, 01)], Value)", true)]
-        [InlineData("SortByColumns([Blank(),Blank()], Value, SortOrder.Descending)", true)]
-        public void CheckSortByColumnsWithColumnNamesAsIdentifiers(string expression, bool shouldSucceed)
-        {
-            var engine = new Engine(new PowerFxConfig(CultureInfo.GetCultureInfo("en-US"), features: Features.SupportColumnNamesAsIdentifiers));
-            var table = @"Table(
-                          { First: ""Bob"", Last: ""Smith"", Age: 2, Gender: ""Male"", Vaccinated: true, 'Has Dog': true },
-                          { First: ""Alice"", Last: ""Smith"", Age: 5, Gender: ""Female"", Vaccinated: true, 'Has Dog': true },
-                          { First: Blank(), Last: ""Clark"", Age: Blank(), Gender: ""Male"", Vaccinated: Blank(), 'Has Dog': Blank() },
-                          { First: Blank(), Last: ""Allen"", Age: Blank(), Gender: ""Male"", Vaccinated: Blank(), 'Has Dog': Blank() },
-                          { First: Blank(), Last: ""Brown"", Age: Blank(), Gender: ""Female"", Vaccinated: Blank(), 'Has Dog': Blank() },
-                          { First: ""John"", Last: ""Batali"", Age: 17, Gender: ""Male"", Vaccinated: false, 'Has Dog': false },
-                          { First: ""Emily"", Last: ""Jones"", Age: 29, Gender: ""Female"", Vaccinated: true, 'Has Dog': Blank() }
-                        )";
-            var tableWithBlanks = @"Table(
-                                      {Flavor: ""Chocolate"", Quantity:100, OnOrder:150},
-                                      Blank(),
-                                      {Flavor: ""Vanilla"", Quantity:200, OnOrder:20},
-                                      Blank()
-                                    )";
-            if (expression.Contains("tableWithBlanks"))
-            {
-                expression = expression.Replace("tableWithBlanks", tableWithBlanks);
-            }
-            else if (expression.Contains("table"))
-            {
-                expression = expression.Replace("table", table);
-            }
-            
-            var result = engine.Check(expression);
-
-            Assert.Equal(result.IsSuccess, shouldSucceed);
-        }
-
         [Fact]
         public void CheckBadFunctionError()
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -243,10 +243,14 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         }
 
         [Theory]
-        [InlineData("SortByColumns(|", 2, "The table to sort", "SortByColumns(source, column, order, ...)")]
+        [InlineData("SortByColumns(|", 2, "The table to sort.", "SortByColumns(source, column, ...)")]
+        [InlineData("SortByColumns(tbl1,|", 2, "A unique column name.", "SortByColumns(source, column, ...)")]
+        [InlineData("SortByColumns(tbl1,col1,|", 1, "Ascending or Descending", "SortByColumns(source, column, order, ...)")]
+        [InlineData("SortByColumns(tbl1,col1,SortOrder.Ascending,|", 2, "A unique column name.", "SortByColumns(source, column, order, column, ...)")]
         public void TestIntellisenseFunctionParameterDescription(string expression, int expectedOverloadCount, string expectedDescription, string expectedDisplayText)
         {
-            var result = Suggest(expression, Default);
+            var context = "![tbl1:*[col1:n,col2:n]]";
+            var result = Suggest(expression, Default, context);
             Assert.Equal(expectedOverloadCount, result.FunctionOverloads.Count());
             var currentOverload = result.FunctionOverloads.ToArray()[result.CurrentFunctionOverloadIndex];
             Assert.Equal(expectedDisplayText, currentOverload.DisplayText.Text);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -242,6 +242,17 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             Assert.Equal(expectedSuggestions, actualSuggestions);
         }
 
+        [Theory]
+        [InlineData("SortByColumns(|", 2, "The table to sort", "SortByColumns(source, column, order, ...)")]
+        public void TestIntellisenseFunctionParameterDescription(string expression, int expectedOverloadCount, string expectedDescription, string expectedDisplayText)
+        {
+            var result = Suggest(expression, Default);
+            Assert.Equal(expectedOverloadCount, result.FunctionOverloads.Count());
+            var currentOverload = result.FunctionOverloads.ToArray()[result.CurrentFunctionOverloadIndex];
+            Assert.Equal(expectedDisplayText, currentOverload.DisplayText.Text);
+            Assert.Equal(expectedDescription, currentOverload.FunctionParameterDescription);
+        }
+
         // Add an extra (empy) symbol table into the config and ensure we get the same results. 
         private void AdjustConfig(PowerFxConfig config)
         {


### PR DESCRIPTION
The [PR 1036](https://github.com/microsoft/Power-Fx/pull/1036) caused a regression in the intellisense for the SortByColumns function. This PR reverts that change, and adds a test that validates the previous behavior.