### PR TITLE
Today() did not honor engine's timezone.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -17,11 +17,10 @@ namespace Microsoft.PowerFx.Functions
 {
     internal static partial class Library
     {
-        public static FormulaValue Today(IRContext irContext, FormulaValue[] args)
+        public static async ValueTask<FormulaValue> Today(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
-            // $$$ timezone?
-            var date = DateTime.Today;
-
+            var timeZoneInfo = runner.TimeZoneInfo;
+            var date = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZoneInfo).Date;
             return new DateValue(irContext, date);
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DateTimeUTCTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DateTimeUTCTests.cs
@@ -139,6 +139,21 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Fact]
+        public async void TodayTest()
+        {
+            var utcToday = DateTime.UtcNow;
+            var istToday = TimeZoneInfo.ConvertTime(utcToday, _istTimeZone).Date;
+            utcToday = utcToday.Date;
+            
+            var evaluator = _engine.Check("Today()", options: null, _symbolTable).GetEvaluator();
+            var result = await evaluator.EvalAsync(default, _localSymbol);
+            Assert.Equal(istToday, ((DateValue)result).GetConvertedValue(_istTimeZone));
+
+            var utcResult = await evaluator.EvalAsync(default, _utcSymbol);
+            Assert.Equal(utcToday, ((DateValue)utcResult).GetConvertedValue(TimeZoneInfo.Utc));
+        }
+
+        [Fact]
         public void GetConvertedDateTimeValueTest()
         {
             var result = DateTimeValue.GetConvertedDateTimeValue(_utcNow, _istTimeZone);


### PR DESCRIPTION
-Fixes `Today()` to honor the engine's timezone.