### PR TITLE
Allow parameter coercion in the FirstN/LastN functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public FirstLastNFunction(bool isFirst)
             : base(
                   isFirst ? "FirstN" : "LastN",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Index.cs
@@ -17,8 +17,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public IndexFunction()
             : base(
                   "Index",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/UntypedObject.cs
@@ -35,8 +35,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public IndexFunction_UO()
             : base(IndexInvariantFunctionName, TexlStrings.AboutIndex, FunctionCategories.Table, DType.UntypedObject, 0, 2, 2, DType.UntypedObject, DType.Number)
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
@@ -82,9 +82,3 @@ Table({Value:1})
 
 >> LastN([1,2,3,4,5], true)
 Table({Value:5})
-
->> FirstN([1,2,3,4,5], Date(1900,1,1))
-Table({Value:1},{Value:2})
-
->> LastN([1,2,3,4,5], Date(1900,1,1))
-Table({Value:4},{Value:5})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
@@ -69,3 +69,22 @@ Blank()
 
 >> FirstN(Filter([1,2,3],Value=4),2)
 Table()
+
+// ********** Coercions ************
+>> FirstN([1,2,3,4,5], "3")
+Table({Value:1},{Value:2},{Value:3})
+
+>> LastN([1,2,3,4,5], "3")
+Table({Value:3},{Value:4},{Value:5})
+
+>> FirstN([1,2,3,4,5], true)
+Table({Value:1})
+
+>> LastN([1,2,3,4,5], true)
+Table({Value:5})
+
+>> FirstN([1,2,3,4,5], Date(1900,1,1))
+Table({Value:1},{Value:2})
+
+>> LastN([1,2,3,4,5], Date(1900,1,1))
+Table({Value:4},{Value:5})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Index.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Index.txt
@@ -51,3 +51,16 @@ Error({Kind:ErrorKind.Validation})
 
 >> Index([1, 2, 3, 4, 5], Error({Kind: 11}))
 Error({Kind:ErrorKind.Validation})
+
+// ********** Coercions ************
+>> Index([1,2,3,4,5], "3")
+{Value:3}
+
+>> Index([1,2,3,4,5], "4").Value
+4
+
+>> Index([1,2,3,4,5], true)
+{Value:1}
+
+>> Index([1,2,3,4,5], false)
+Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -482,3 +482,9 @@ Blank()
 
 >> CountRows(LastN(ParseJSON("[1, 2, 3, 4]"), "3"))
 3
+
+>> Value(Index(ParseJSON("[1,2,3,4]"), "2")) // Coercion from string
+2
+
+>> Text(Index(ParseJSON("[""one"",""two"",""three""]"),true)) // Coercion from boolean
+"one"


### PR DESCRIPTION
Functions with scalar arguments should support coercions. Currently FirstN/LastN don't, so this PR changes it.