### PR TITLE
Adds truncate arg preprocessing in IR.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
@@ -13,6 +13,6 @@ namespace Microsoft.PowerFx.Core.Functions
         ReplaceWithZero = 1,
         
         // This also includes ReplaceWithZero
-        Trurncate = 2,
+        Truncate = 2,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
@@ -11,5 +11,8 @@ namespace Microsoft.PowerFx.Core.Functions
     {
         None = 0,
         ReplaceWithZero = 1,
+        
+        // This also includes ReplaceWithZero
+        Trurncate = 2,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -361,7 +361,7 @@ namespace Microsoft.PowerFx.Core.IR
                         case ArgPreprocessor.ReplaceWithZero:
                             convertedNode = ReplaceBlankWithZero(args[i]);
                             break;
-                        case ArgPreprocessor.Trurncate:
+                        case ArgPreprocessor.Truncate:
                             convertedNode = TruncatePreProcessor(args[i]);
                             break;
                         default:

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -361,6 +361,9 @@ namespace Microsoft.PowerFx.Core.IR
                         case ArgPreprocessor.ReplaceWithZero:
                             convertedNode = ReplaceBlankWithZero(args[i]);
                             break;
+                        case ArgPreprocessor.Trurncate:
+                            convertedNode = TruncatePreProcessor(args[i]);
+                            break;
                         default:
                             convertedNode = args[i];
                             break;
@@ -387,6 +390,16 @@ namespace Microsoft.PowerFx.Core.IR
                 var zeroNumLitNode = new NumberLiteralNode(convertedIRContext, 0);
                 var convertedNode = new CallNode(convertedIRContext, BuiltinFunctionsCore.Coalesce, arg, zeroNumLitNode);
                 return convertedNode;
+            }
+
+            /// <summary>
+            /// Wraps node arg => Truc(Coalesce(arg , 0)).
+            /// </summary>
+            private static IntermediateNode TruncatePreProcessor(IntermediateNode arg)
+            {
+                var blankToZeroNode = ReplaceBlankWithZero(arg);
+                var truncateNode = new CallNode(blankToZeroNode.IRContext, BuiltinFunctionsCore.Trunc, blankToZeroNode);
+                return truncateNode;
             }
 
             /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -17,6 +17,16 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     //  Right(arg:s, count:n)
     internal sealed class LeftRightScalarFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgPreprocessor(int index)
+        {
+            if (index == 1)
+            {
+                return ArgPreprocessor.Trurncate;
+            }
+
+            return ArgPreprocessor.None;
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             if (index == 1)
             {
-                return ArgPreprocessor.Trurncate;
+                return ArgPreprocessor.Truncate;
             }
 
             return ArgPreprocessor.None;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -890,8 +890,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Left.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWith(
-                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
+                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty)),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueType<StringValue>,
                         ExactValueType<NumberValue>),
@@ -1162,8 +1161,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Right.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWith(
-                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty),
-                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
+                        new StringValue(IRContext.NotInSource(FormulaType.String), string.Empty)),
                     checkRuntimeTypes: ExactSequence(
                         ExactValueType<StringValue>,
                         ExactValueType<NumberValue>),

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -638,6 +638,11 @@ namespace Microsoft.PowerFx.Functions
                 return CommonErrors.GenericInvalidArgument(irContext);
             }
 
+            if ((count.Value % 1) != 0)
+            {
+                throw new NotImplementedException("Should have been handled by IR");
+            }
+
             return new StringValue(irContext, leftOrRight(source.Value, (int)count.Value));
         }
 


### PR DESCRIPTION
Fixes #808 
Follow-up to #1059 
This moves arg truncating for `Right()` and `Left()` which truncates the 2nd arg.

Now. in IR `arg => Truc(Coalesce(arg, 0))`

NOTE: Truncate Preprocessor also means it would add BlankToZero preprocessing as well.