### PR TITLE
Add rounding to trig table tests

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions.txt
@@ -1,49 +1,49 @@
->> Sin(Table({a:0},{a:Pi()/6},{a:Pi()/2}))
+>> Round(Sin(Table({a:0},{a:Pi()/6},{a:Pi()/2})),3)
 Table({a:0},{a:0.5},{a:1})
 
->> Sin([0, Pi()/6, Pi()/2)])
+>> Round(Sin([0, Pi()/6, Pi()/2)]),3)
 Table({Value:0},{Value:0.5},{Value:1})
 
->> Sin(Table({a:0},{a:1/0},{a:Pi()/2}))
+>> Round(Sin(Table({a:0},{a:1/0},{a:Pi()/2})),3)
 Table({a:0},{a:Error({Kind:ErrorKind.Div0})},{a:1})
 
->> Sin(Table({a:0},{a:Pi()/6},If(1/0<2,{a:Pi()})))
+>> Round(Sin(Table({a:0},{a:Pi()/6},If(1/0<2,{a:Pi()}))),3)
 Table({a:0},{a:0.5},Error({Kind:ErrorKind.Div0}))
 
 >> Round(Sin([0, Pi(), Pi()/2, -Pi()/2, 3*Pi()/2, 2*Pi(), Pi()/4, -Pi()/4, Blank()]), 4)
 Table({Value:0},{Value: 0},{Value: 1},{Value: -1},{Value: -1},{Value: -0},{Value: 0.7071},{Value: -0.7071},{Value: 0})
 
->> Cos(Table({a:0},{a:Pi()/3},{a:Pi()/2}))
+>> Round(Cos(Table({a:0},{a:Pi()/3},{a:Pi()/2})),3)
 Table({a:1},{a:0.5},{a:0})
 
->> Cos(Table({a:1/0},{a:Pi()/3},{a:Pi()/2}))
+>> Round(Cos(Table({a:1/0},{a:Pi()/3},{a:Pi()/2})),3)
 Table({a:Error({Kind:ErrorKind.Div0})},{a:0.5},{a:0})
 
->> Cos(Table({a:0},If(1/0<2,{a:Pi()/3}),{a:Pi()/2}))
+>> Round(Cos(Table({a:0},If(1/0<2,{a:Pi()/3}),{a:Pi()/2})),3)
 Table({a:1},Error({Kind:ErrorKind.Div0}),{a:0})
 
 >> Round(Cos([0, Pi(), Pi()/2, -Pi()/2, 3*Pi()/2, 2*Pi(), Pi()/4, -Pi()/4, Blank()]), 4)
 Table({Value:1},{Value: -1},{Value: 0},{Value: 0},{Value: -0},{Value: 1},{Value: 0.7071},{Value: 0.7071},{Value: 1})
 
->> Tan(Table({a:0},{a:Pi()/4},{a:-Pi()/4}))
+>> Round(Tan(Table({a:0},{a:Pi()/4},{a:-Pi()/4})),3)
 Table({a:0},{a:1},{a:-1})
 
->> Tan(Table({a:1/0},{a:Pi()/4},{a:-Pi()/4}))
+>> Round(Tan(Table({a:1/0},{a:Pi()/4},{a:-Pi()/4})),3)
 Table({a:Error({Kind:ErrorKind.Div0})},{a:1},{a:-1})
 
->> Tan(Table(If(1/0<2,{a:0}),{a:Pi()/4},{a:-Pi()/4}))
+>> Round(Tan(Table(If(1/0<2,{a:0}),{a:Pi()/4},{a:-Pi()/4})),3)
 Table(Error({Kind:ErrorKind.Div0}),{a:1},{a:-1})
 
 >> Round(Tan([0, Pi(), 2*Pi(), Pi()/4, -Pi()/4, Blank()]), 4)
 Table({Value:0},{Value: -0},{Value: -0},{Value: 1},{Value: -1},{Value: 0})
 
->> Cot(Table({a:Pi()/2},{a:Pi()/4},{a:-Pi()/4}))
+>> Round(Cot(Table({a:Pi()/2},{a:Pi()/4},{a:-Pi()/4})),3)
 Table({a:0},{a:1},{a:-1})
 
->> Cot(Table({a:Pi()/2},{a:0},{a:-Pi()/4}))
+>> Round(Cot(Table({a:Pi()/2},{a:0},{a:-Pi()/4})),3)
 Table({a:0},{a:Error({Kind:ErrorKind.Div0})},{a:-1})
 
->> Cot(Table({a:Pi()/2},If(Sqrt(-1)<1,{a:Pi()/4}),{a:-Pi()/4}))
+>> Round(Cot(Table({a:Pi()/2},If(Sqrt(-1)<1,{a:Pi()/4}),{a:-Pi()/4})),3)
 Table({a:0},Error({Kind:ErrorKind.Div0}),{a:-1})
 
 >> Round(Cot([Pi()/2, -Pi()/2, 3*Pi()/2, Pi()/4, -Pi()/4]), 4)


### PR DESCRIPTION
The trigonometric tabular tests use functions that don't return whole numbers (such as Pi() and other trig functions). This can make the results not match exactly depending on floating point behavior, so we're adding a Round call to those tests to make sure that the results are the expected ones in all platforms.