### PR TITLE
Add trig tabular function implementations, enable tests

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/NumberValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/NumberValue.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerFx.Types
 
         public override void ToExpression(StringBuilder sb, FormulaValueSerializerSettings settings)
         {
-            sb.Append(Value.ToString());
+            sb.Append((Value == 0) ? "0" : Value.ToString());
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1595,6 +1595,22 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AbsT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Abs], ReplaceBlankWithZero)
             },
             {
+                BuiltinFunctionsCore.AcosT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AcosT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Acos], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.AcotT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AcotT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Acot], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.AsinT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AsinT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Asin], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.AtanT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.AtanT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Atan], ReplaceBlankWithZero)
+            },
+            {
                 BuiltinFunctionsCore.Boolean_T,
                 StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Boolean_T.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Boolean], DoNotReplaceBlank)
             },
@@ -1612,6 +1628,18 @@ namespace Microsoft.PowerFx.Functions
             {
                 BuiltinFunctionsCore.CharT,
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CharT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Char], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.CosT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CosT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Cos], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.CotT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.CotT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Cot], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.DegreesT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.DegreesT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Degrees], ReplaceBlankWithZero)
             },
             {
                 BuiltinFunctionsCore.ExpT,
@@ -1634,8 +1662,20 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.LnT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Ln], ReplaceBlankWithZero)
             },
             {
+                BuiltinFunctionsCore.RadiansT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.RadiansT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Radians], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.SinT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SinT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Sin], ReplaceBlankWithZero)
+            },
+            {
                 BuiltinFunctionsCore.SqrtT,
                 StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.SqrtT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Sqrt], ReplaceBlankWithZero)
+            },
+            {
+                BuiltinFunctionsCore.TanT,
+                StandardErrorHandlingTabularOverload<NumberValue>(BuiltinFunctionsCore.TanT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Tan], ReplaceBlankWithZero)
             },
         };
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMath.cs
@@ -862,7 +862,8 @@ namespace Microsoft.PowerFx.Functions
                 return GetDiv0Error(irContext);
             }
 
-            return new NumberValue(irContext, 1 / tan);
+            var cot = 1 / tan;
+            return new NumberValue(irContext, cot);
         }
 
         // Given the absence of Math.Acot function, we compute acot(x) as pi/2 - atan(x)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions_ConsistentOneColumnTableResult.txt
@@ -1,50 +1,52 @@
+#SETUP: ConsistentOneColumnTableResult
+
 >> Round(Sin(Table({a:0},{a:Pi()/6},{a:Pi()/2})),3)
-Table({a:0},{a:0.5},{a:1})
+Table({Value:0},{Value:0.5},{Value:1})
 
 >> Round(Sin([0, Pi()/6, Pi()/2]),3)
 Table({Value:0},{Value:0.5},{Value:1})
 
 >> Round(Sin(Table({a:0},{a:1/0},{a:Pi()/2})),3)
-Table({a:0},{a:Error({Kind:ErrorKind.Div0})},{a:1})
+Table({Value:0},{Value:Error({Kind:ErrorKind.Div0})},{Value:1})
 
 >> Round(Sin(Table({a:0},{a:Pi()/6},If(1/0<2,{a:Pi()}))),3)
-Table({a:0},{a:0.5},Error({Kind:ErrorKind.Div0}))
+Table({Value:0},{Value:0.5},Error({Kind:ErrorKind.Div0}))
 
 >> Round(Sin([0, Pi(), Pi()/2, -Pi()/2, 3*Pi()/2, 2*Pi(), Pi()/4, -Pi()/4, Blank()]), 4)
 Table({Value:0},{Value:0},{Value:1},{Value:-1},{Value:-1},{Value:0},{Value:0.7071},{Value:-0.7071},{Value:0})
 
 >> Round(Cos(Table({a:0},{a:Pi()/3},{a:Pi()/2})),3)
-Table({a:1},{a:0.5},{a:0})
+Table({Value:1},{Value:0.5},{Value:0})
 
 >> Round(Cos(Table({a:1/0},{a:Pi()/3},{a:Pi()/2})),3)
-Table({a:Error({Kind:ErrorKind.Div0})},{a:0.5},{a:0})
+Table({Value:Error({Kind:ErrorKind.Div0})},{Value:0.5},{Value:0})
 
 >> Round(Cos(Table({a:0},If(1/0<2,{a:Pi()/3}),{a:Pi()/2})),3)
-Table({a:1},Error({Kind:ErrorKind.Div0}),{a:0})
+Table({Value:1},Error({Kind:ErrorKind.Div0}),{Value:0})
 
 >> Round(Cos([0, Pi(), Pi()/2, -Pi()/2, 3*Pi()/2, 2*Pi(), Pi()/4, -Pi()/4, Blank()]), 4)
 Table({Value:1},{Value:-1},{Value:0},{Value:0},{Value:0},{Value:1},{Value:0.7071},{Value:0.7071},{Value:1})
 
 >> Round(Tan(Table({a:0},{a:Pi()/4},{a:-Pi()/4})),3)
-Table({a:0},{a:1},{a:-1})
+Table({Value:0},{Value:1},{Value:-1})
 
 >> Round(Tan(Table({a:1/0},{a:Pi()/4},{a:-Pi()/4})),3)
-Table({a:Error({Kind:ErrorKind.Div0})},{a:1},{a:-1})
+Table({Value:Error({Kind:ErrorKind.Div0})},{Value:1},{Value:-1})
 
 >> Round(Tan(Table(If(1/0<2,{a:0}),{a:Pi()/4},{a:-Pi()/4})),3)
-Table(Error({Kind:ErrorKind.Div0}),{a:1},{a:-1})
+Table(Error({Kind:ErrorKind.Div0}),{Value:1},{Value:-1})
 
 >> Round(Tan([0, Pi(), 2*Pi(), Pi()/4, -Pi()/4, Blank()]), 4)
 Table({Value:0},{Value:0},{Value:0},{Value:1},{Value:-1},{Value:0})
 
 >> Round(Cot(Table({a:Pi()/2},{a:Pi()/4},{a:-Pi()/4})),3)
-Table({a:0},{a:1},{a:-1})
+Table({Value:0},{Value:1},{Value:-1})
 
 >> Round(Cot(Table({a:Pi()/2},{a:0},{a:-Pi()/4})),3)
-Table({a:0},{a:Error({Kind:ErrorKind.Div0})},{a:-1})
+Table({Value:0},{Value:Error({Kind:ErrorKind.Div0})},{Value:-1})
 
 >> Round(Cot(Table({a:Pi()/2},If(Sqrt(-1)<1,{a:Pi()/4}),{a:-Pi()/4})),3)
-Table({a:0},Error({Kind:ErrorKind.Numeric}),{a:-1})
+Table({Value:0},Error({Kind:ErrorKind.Numeric}),{Value:-1})
 
 >> Round(Cot([Pi()/2, -Pi()/2, 3*Pi()/2, Pi()/4, -Pi()/4]), 4)
 Table({Value:0},{Value:0},{Value:0},{Value:1},{Value:-1})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions_ConsistentOneColumnTableResult.txt
@@ -68,3 +68,9 @@ Table({Value:0},{Value:180},{Value:90},{Value:-90},{Value:270},{Value:360},{Valu
 
 >> Round(Radians([0, 1, -1, 180, 90, -180, -90, -360, Blank()]), 4)
 Table({Value:0},{Value:0.0175},{Value:-0.0175},{Value:3.1416},{Value:1.5708},{Value:-3.1416},{Value:-1.5708},{Value:-6.2832},{Value:0})
+
+>> Round(Degrees(Table({a:0}, {a:Pi()}, {a:Pi()/2}, {a:-Pi()/2}, {a:3*Pi()/2}, {a:2*Pi()}, {a:Pi()/4}, {a:-Pi()/4}, {a:Pi()*10}, {a:1}, {a:-1}, {a:Blank()})), 4)
+Table({Value:0},{Value:180},{Value:90},{Value:-90},{Value:270},{Value:360},{Value:45},{Value:-45},{Value:1800},{Value:57.2958},{Value:-57.2958},{Value:0})
+
+>> Round(Radians(Table({a:0}, {a:1}, {a:-1}, {a:180}, {a:90}, {a:-180}, {a:-90}, {a:-360}, {a:Blank()})), 4)
+Table({Value:0},{Value:0.0175},{Value:-0.0175},{Value:3.1416},{Value:1.5708},{Value:-3.1416},{Value:-1.5708},{Value:-6.2832},{Value:0})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/Disabled.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/Disabled.txt
@@ -1,3 +1,2 @@
 ﻿// List files that aren't supported in interpreter.
 #disable: Weekday.txt
-#disable: TrigTableFunctions.txt


### PR DESCRIPTION
We had a test for trig tabular functions that was never enabled, because those functions were not implemented. Added the implementation for the tabular functions, fixed the test and enabled it.