### PR TITLE
Add missing case to TryGetDataSourceNode

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionArgValidators/DataSourceArgNodeValidator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionArgValidators/DataSourceArgNodeValidator.cs
@@ -31,6 +31,8 @@ namespace Microsoft.PowerFx.Core.Functions.FunctionArgValidators
                     return TryGetDsNodes(argNode.AsCall(), binding, out dsNodes);
                 case NodeKind.DottedName:
                     return TryGetDsNode(argNode.AsDottedName(), binding, out dsNodes);
+                case NodeKind.As:
+                    return TryGetValidValue(argNode.AsAsNode().Left, binding, out dsNodes);
             }
 
             return dsNodes.Count > 0;


### PR DESCRIPTION
As nodes aren't handled when trying to find the Data Source TexlNode from a function call. This breaks legacy analysis ECS in some scenarios.