### PR TITLE
Moves BlankToEmptyString arg preprocessing to IR Phase.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
@@ -12,5 +12,6 @@ namespace Microsoft.PowerFx.Core.Functions
         None = 0,
         ReplaceBlankWithZero = 1,
         ReplaceBlankWithZeroAndTruncate = 2,
+        ReplaceBlankWithEmptyString = 3,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1432,6 +1432,10 @@ namespace Microsoft.PowerFx.Core.Functions
             {
                 return ArgPreprocessor.ReplaceBlankWithZero;
             }
+            else if (paramType == DType.String)
+            {
+                return ArgPreprocessor.ReplaceBlankWithEmptyString;
+            }
 
             return ArgPreprocessor.None;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PowerFx.Core.IR
                     return arg;
                 }
 
-                // need a new context since when arg is Blank IRContext.Returntype is not a Number but a Blank.
+                // need a new context since when arg is Blank IRContext.ResultType is not a Number but a Blank.
                 var convertedIRContext = new IRContext(arg.IRContext.SourceContext, FormulaType.Number);
                 var zeroNumLitNode = new NumberLiteralNode(convertedIRContext, 0);
                 var convertedNode = new CallNode(convertedIRContext, BuiltinFunctionsCore.Coalesce, arg, zeroNumLitNode);
@@ -408,7 +408,7 @@ namespace Microsoft.PowerFx.Core.IR
             /// </summary>
             private static IntermediateNode BlankToEmptyString(IntermediateNode arg)
             {
-                // need a new context since when arg is Blank IRContext.Returntype is not a String but a Blank.
+                // need a new context since when arg is Blank IRContext.ResultType is not a String but a Blank.
                 var convertedIRContext = new IRContext(arg.IRContext.SourceContext, FormulaType.String);
 
                 // We are not using coalesce, because coalesce doesn't considers empty string as blank.

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -410,6 +410,8 @@ namespace Microsoft.PowerFx.Core.IR
             {
                 // need a new context since when arg is Blank IRContext.Returntype is not a String but a Blank.
                 var convertedIRContext = new IRContext(arg.IRContext.SourceContext, FormulaType.String);
+
+                // We are not using coalesce, because coalesce doesn't considers empty string as blank.
                 return new UnaryOpNode(convertedIRContext, UnaryOpKind.BlankToEmptyString, arg);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
@@ -58,5 +58,13 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
 
         BooleanToOptionSet,
         AggregateToDataEntity,
+
+        // Argument pre-processesor in IR Phase.
+
+        /// <summary>
+        /// Used for pre-processing function arguments from blank to empty string.
+        /// All Interpreter(backed) must implement this.
+        /// </summary>
+        BlankToEmptyString,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Hex2Dec.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Hex2Dec.cs
@@ -12,6 +12,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Hex2Dec(number:n)
     internal sealed class Hex2DecFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgPreprocessor(int index)
+        {
+            return base.GetGenericArgPreprocessor(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool IsStateless => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
@@ -15,6 +15,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Split(text:s, separator:s)
     internal class SplitFunction : StringTwoArgFunction
     {
+        public override ArgPreprocessor GetArgPreprocessor(int index)
+        {
+            return base.GetGenericArgPreprocessor(index);
+        }
+
         public SplitFunction()
             : base("Split", TexlStrings.AboutSplit, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -16,6 +16,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     internal abstract class StringOneArgFunction : BuiltinFunction
     {
+        public override ArgPreprocessor GetArgPreprocessor(int index)
+        {
+            return base.GetGenericArgPreprocessor(index);
+        }
+
         public override bool IsSelfContained => true;
 
         public override bool SupportsParamCoercion => true;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -719,7 +719,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Hex2Dec.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -911,7 +911,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Len.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -958,7 +958,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Lower.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1097,7 +1097,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Proper.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1284,7 +1284,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Split.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1485,7 +1485,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Trim.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1496,7 +1496,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.TrimEnds.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1518,7 +1518,7 @@ namespace Microsoft.PowerFx.Functions
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.Upper.Name,
                     expandArguments: NoArgExpansion,
-                    replaceBlankValues: ReplaceBlankWithEmptyString,
+                    replaceBlankValues: NoOpAlreadyHandledByIR,
                     checkRuntimeTypes: ExactValueType<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
@@ -1656,7 +1656,7 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Hex2DecT,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Hex2DecT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Hex2Dec], ReplaceBlankWithZero)
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.Hex2DecT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Hex2Dec], ReplaceBlankWithEmptyString)
             },
             {
                 BuiltinFunctionsCore.IntT,
@@ -1664,7 +1664,7 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.LenT,
-                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.LenT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Len], ReplaceBlankWithZero)
+                StandardErrorHandlingTabularOverload<StringValue>(BuiltinFunctionsCore.LenT.Name, SimpleFunctionImplementations[BuiltinFunctionsCore.Len], ReplaceBlankWithEmptyString)
             },
             {
                 BuiltinFunctionsCore.LnT,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -281,7 +281,18 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: BooleanOptionSetToBoolean)
-            }
+            },
+            {
+                UnaryOpKind.BlankToEmptyString,
+                StandardErrorHandling<FormulaValue>(
+                    functionName: null, // internal function, no user-facing name
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<FormulaValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: BlankToEmptyString)
+            },
         };
         #endregion
 
@@ -573,6 +584,16 @@ namespace Microsoft.PowerFx.Functions
                 var errorMessage = ErrorUtils.FormatMessage(StringResources.Get(TexlStrings.BooleanOptionSetOptionNotSupported), null, arg0.Option);
                 return CommonErrors.CustomError(IRContext.NotInSource(FormulaType.Boolean), errorMessage);
             }
+        }
+
+        public static FormulaValue BlankToEmptyString(IRContext irContext, FormulaValue[] args)
+        {
+            if (args[0] is BlankValue)
+            {
+                return new StringValue(irContext, string.Empty);
+            }
+
+            return args[0];
         }
         #endregion
     }


### PR DESCRIPTION
-Follow up to #1006 #1059 
-This introduces a new UNaryOpKind `BlankToEmptyString`, since no current function satisfies the BlankToEmptyString behavior.
-Note: Other backends must implement this new UNaryOpKind `BlankToEmptyString` for these functions to work.

NOTE: In this PR 3 function are left out purposefully. 
`Concatenate()` due to its frequency of use with `&` operator and because of that it may generate very long IR
 `StartsWith()` and `EndsWith()` due to complexity with support of these function in delegation. 

Corrsponding Dataverse PR: https://github.com/microsoft/Power-Fx-Dataverse/pull/81