### PR TITLE
Proper validation of RGBA arguments

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
@@ -10,9 +10,7 @@ namespace Microsoft.PowerFx.Core.Functions
     internal enum ArgPreprocessor
     {
         None = 0,
-        ReplaceWithZero = 1,
-        
-        // This also includes ReplaceWithZero
-        Truncate = 2,
+        ReplaceBlankWithZero = 1,
+        ReplaceBlankWithZeroAndTruncate = 2,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1433,7 +1433,7 @@ namespace Microsoft.PowerFx.Core.Functions
             var paramType = ParamTypes[index] ?? DType.Unknown;
             if (paramType == DType.Number)
             {
-                return ArgPreprocessor.ReplaceWithZero;
+                return ArgPreprocessor.ReplaceBlankWithZero;
             }
 
             return ArgPreprocessor.None;

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -358,11 +358,11 @@ namespace Microsoft.PowerFx.Core.IR
 
                     switch (argPreprocessor)
                     {
-                        case ArgPreprocessor.ReplaceWithZero:
+                        case ArgPreprocessor.ReplaceBlankWithZero:
                             convertedNode = ReplaceBlankWithZero(args[i]);
                             break;
-                        case ArgPreprocessor.Truncate:
-                            convertedNode = TruncatePreProcessor(args[i]);
+                        case ArgPreprocessor.ReplaceBlankWithZeroAndTruncate:
+                            convertedNode = ReplaceBlankWithZeroAndTruncatePreProcessor(args[i]);
                             break;
                         default:
                             convertedNode = args[i];
@@ -395,7 +395,7 @@ namespace Microsoft.PowerFx.Core.IR
             /// <summary>
             /// Wraps node arg => Truc(Coalesce(arg , 0)).
             /// </summary>
-            private static IntermediateNode TruncatePreProcessor(IntermediateNode arg)
+            private static IntermediateNode ReplaceBlankWithZeroAndTruncatePreProcessor(IntermediateNode arg)
             {
                 var blankToZeroNode = ReplaceBlankWithZero(arg);
                 var truncateNode = new CallNode(blankToZeroNode.IRContext, BuiltinFunctionsCore.Trunc, blankToZeroNode);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             if (index == 1)
             {
-                return ArgPreprocessor.Truncate;
+                return ArgPreprocessor.ReplaceBlankWithZeroAndTruncate;
             }
 
             return ArgPreprocessor.None;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -13,6 +13,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override ArgPreprocessor GetArgPreprocessor(int index)
         {
+            if (index >= 0 && index <= 2)
+            {
+                return ArgPreprocessor.ReplaceBlankWithZeroAndTruncate;
+            }
+
             return base.GetGenericArgPreprocessor(index);
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
@@ -62,28 +62,29 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue RGBA(IRContext irContext, NumberValue[] args)
         {
+            // Truncate (strip decimals)
+            var red = (int)args[0].Value;
+            var green = (int)args[1].Value;
+            var blue = (int)args[2].Value;
+            var alpha = args[3].Value;
+
             // Ensure rgb numbers are in range (0-255)
-            if (args[0].Value < 0.0d || args[0].Value > 255.0d
-                || args[1].Value < 0.0d || args[1].Value > 255.0d
-                || args[2].Value < 0.0d || args[2].Value > 255.0d)
+            if (red < 0.0d || red > 255.0d
+                || green < 0.0d || green > 255.0d
+                || blue < 0.0d || blue > 255.0d)
             {
                 return CommonErrors.ArgumentOutOfRange(irContext);
             }
-
-            // Truncate (strip decimals)
-            var r = (int)args[0].Value;
-            var g = (int)args[1].Value;
-            var b = (int)args[2].Value;
 
             // Ensure alpha is between 0 and 1
-            if (args[3].Value < 0.0d || args[3].Value > 1.0d)
+            if (alpha < 0.0d || alpha > 1.0d)
             {
                 return CommonErrors.ArgumentOutOfRange(irContext);
             }
 
-            var a = System.Convert.ToInt32(args[3].Value * 255.0d);
+            var alpha255 = System.Convert.ToInt32(alpha * 255.0d);
 
-            return new ColorValue(irContext, Color.FromArgb(a, r, g, b));
+            return new ColorValue(irContext, Color.FromArgb(alpha255, red, green, blue));
         }
 
         public static FormulaValue ColorFade(IRContext irContext, FormulaValue[] args)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryColor.cs
@@ -62,16 +62,15 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue RGBA(IRContext irContext, NumberValue[] args)
         {
-            // Truncate (strip decimals)
             var red = (int)args[0].Value;
             var green = (int)args[1].Value;
             var blue = (int)args[2].Value;
             var alpha = args[3].Value;
 
             // Ensure rgb numbers are in range (0-255)
-            if (red < 0.0d || red > 255.0d
-                || green < 0.0d || green > 255.0d
-                || blue < 0.0d || blue > 255.0d)
+            if (red < 0 || red > 255
+                || green < 0 || green > 255
+                || blue < 0 || blue > 255)
             {
                 return CommonErrors.ArgumentOutOfRange(irContext);
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RGBA.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RGBA.txt
@@ -22,9 +22,11 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> RGBA(255, 1.5, 255, 1.0)
 RGBA(255,1,255,1)
 
+// Decimal values are truncated
 >> RGBA(255.5, 1.5, 255.9, 1.0)
 RGBA(255,1,255,1)
 
+// First three arguments need to be between 0 and 255; last argument must be between 0 and 1
 >> RGBA(255, 256, 255, 1.0)
 Error({Kind:ErrorKind.InvalidArgument})
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RGBA.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RGBA.txt
@@ -22,6 +22,9 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> RGBA(255, 1.5, 255, 1.0)
 RGBA(255,1,255,1)
 
+>> RGBA(255.5, 1.5, 255.9, 1.0)
+RGBA(255,1,255,1)
+
 >> RGBA(255, 256, 255, 1.0)
 Error({Kind:ErrorKind.InvalidArgument})
 


### PR DESCRIPTION
The first three arguments to the RGBA function are integer values, and as such are truncated when used - `RGBA(123.45, 0, 0, 1)` is the same as `RGBA(123, 0, 0, 1)`. However, the validation is done prior to the truncation, which makes some inputs to be considered invalid that should be valid, such as `RGBA(255.1, 0, 0, 1)`.