### PR TITLE
Wrap Log/Exp tabular tests with Round to avoid rounding errors

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ExpT_ConsistentOneColumnTableResultDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ExpT_ConsistentOneColumnTableResultDisabled.txt
@@ -1,7 +1,7 @@
 >> Exp([false, 0])
 Table({Value:1},{Value:1})
 
->> Exp(Table({a: Ln(3)}, {a: 0}))
+>> Round(Exp(Table({a: Ln(3)}, {a: 0})),4)
 Table({a:3},{a:1})
 
 >> Exp(Table({a: 1/0}, {a: -750}))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Exp_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Exp_ConsistentOneColumnTableResult.txt
@@ -3,7 +3,7 @@
 >> Exp([false, 0])
 Table({Value:1},{Value:1})
 
->> Exp(Table({a: Ln(3)}, {a: 0}))
+>> Round(Exp(Table({a: Ln(3)}, {a: 0})),4)
 Table({Value:3},{Value:1})
 
 >> Exp(Table({a: 1/0}, {a: -750}))


### PR DESCRIPTION
The value of an expression such as `Ln(Exp(3))` or `Exp(Ln(3))` is 3, but due to rounding / floating point errors in different platforms it can be a little different. Wrapping the expression with the Round function to make sure that we get the same result everywhere.