### PR TITLE
Fix version hash -shouldn't use timer.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/VersionHash.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/VersionHash.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.App;
 using Microsoft.PowerFx.Core.Binding;
@@ -33,11 +34,15 @@ namespace Microsoft.PowerFx
             _value = value;
         }
 
+        private static int _hashStarter;
+
         public static VersionHash New()
         {
             // Give psuedo-random seed.
-            // This can help protect against 2 objects accidentally appearing the same. 
-            var value = (int)DateTime.UtcNow.Ticks;
+            // This can help protect against 2 objects accidentally appearing the same.    
+            var x = Interlocked.Increment(ref _hashStarter);
+            var value = x * 7919; // will wrap on overflow
+
             return new VersionHash(value);
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ThreadingTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ThreadingTests.cs
@@ -24,6 +24,9 @@ namespace Microsoft.PowerFx.Core.Tests
 
             var bugNames = new HashSet<string>
             {
+                // Threading.InterlockedIncrement.
+                "VersionHash._hashStarter",
+
                 // readonly arrays / dictionary - is there an IReadOnly type to changes these too instead? 
                 "LazyList`1.Empty",
                 "DType._kindToSuperkindMapping",

--- a/src/tests/Microsoft.PowerFx.Core.Tests/VersionHashTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/VersionHashTests.cs
@@ -65,5 +65,31 @@ namespace Microsoft.PowerFx.Core.Tests
 
             Assert.NotEqual(v1.Combine(vx), v1.Combine(vy));
         }
+
+        // Hash doesn't *need* to be unique, but it is highly desirably to help catch checks. 
+        [Fact]
+        public void Unique()
+        {
+            var set = new HashSet<VersionHash>();
+            for (int i = 0; i < 10 * 1000; i++)
+            {
+                // Create 2 in rapid succession to look for timer issues. 
+                var v1 = VersionHash.New();
+                var v2 = VersionHash.New();
+
+                Assert.NotEqual(v1, v2);
+
+                // Ensure these are unique with all previous ones. 
+                Assert.True(set.Add(v1));
+                Assert.True(set.Add(v2));
+
+                // Incremented values should also be unique. 
+                for (int j = 0; j < 10; j++)
+                {
+                    v1.Inc();
+                    Assert.True(set.Add(v1));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
VersionHashTests used UtcNow which was non-deterministic and were randomly failing in CI. 

Add test to help verify uniqueness.