### PR TITLE
Fix intellisense for IfError with 3 or more arguments

### DIFF
--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -795,7 +795,7 @@
     <comment>function_parameter - Argument to the IfError function - a value to fallback on if the previous args are errors.</comment>
   </data>
   <data name="AboutIfError_fallback" xml:space="preserve">
-    <value>Value that is returned if it is the first non error argument.</value>
+    <value>Value that is returned if the previous argument is an error.</value>
     <comment>Description of the repeated parameter: a value to fallback on if the previous args are errors</comment>
   </data>
   <data name="AboutSubstitute" xml:space="preserve">

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -242,6 +242,12 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("SortByColumns(tbl1,|", 2, "A unique column name.", "SortByColumns(source, column, ...)")]
         [InlineData("SortByColumns(tbl1,col1,|", 1, "Ascending or Descending", "SortByColumns(source, column, order, ...)")]
         [InlineData("SortByColumns(tbl1,col1,SortOrder.Ascending,|", 2, "A unique column name.", "SortByColumns(source, column, order, column, ...)")]
+        [InlineData("IfError(1|", 1, "Value that is returned if it is not an error.", "IfError(value, fallback, ...)")]
+        [InlineData("IfError(1,2|", 1, "Value that is returned if the previous argument is an error.", "IfError(value, fallback, ...)")]
+        [InlineData("IfError(1,2,3|", 1, "Value that is returned if it is not an error.", "IfError(value, fallback, value, ...)")]
+        [InlineData("IfError(1,2,3,4|", 1, "Value that is returned if the previous argument is an error.", "IfError(value, fallback, value, fallback, ...)")]
+        [InlineData("IfError(1,2,3,4,5|", 1, "Value that is returned if it is not an error.", "IfError(value, fallback, value, fallback, value, ...)")]
+        [InlineData("IfError(1,2,3,4,5,6,7,8,9,0,1,2,3,4,5|", 1, "Value that is returned if it is not an error.", "IfError(value, fallback, value, fallback, ..., value, fallback, value, ...)")]
         public void TestIntellisenseFunctionParameterDescription(string expression, int expectedOverloadCount, string expectedDescription, string expectedDisplayText)
         {
             var context = "![tbl1:*[col1:n,col2:n]]";


### PR DESCRIPTION
When used with more than 2 arguments, the Intellisense shown for the IfError function does not show the parameter names properly. This fixes it and also updates the parameter description to better match what the function does.