### PR TITLE
Clean-up SupportsParamCoercion overrides from functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
@@ -157,8 +157,6 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
 
         public int CacheTimeoutMs { get { return _cacheTimeoutMs; } }
 
-        public override bool SupportsParamCoercion { get { return true; } }
-
         // Service functions currently require all columns to be filled.
         public override bool RequireAllParamColumns { get { return true; } }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -40,8 +40,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             yield return new[] { TexlStrings.AboutAtan2Arg1, TexlStrings.AboutAtan2Arg2 };
         }
-
-        public override bool SupportsParamCoercion => true;
     }
 }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Blank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Blank.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public BlankFunction()
             : base(
             "Blank",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Calendar.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Calendar.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public CalendarFunction(string functionInvariantName, TexlStrings.StringGetter functionDescription)
             : base(new DPath().Append(new DName(LanguageConstants.InvariantCalendarNamespace)), functionInvariantName, functionDescription, FunctionCategories.DateTime, DType.CreateTable(new TypedName(DType.String, new DName("Value"))), 0, 0, 0)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -26,8 +26,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public CharFunction()
             : base("Char", TexlStrings.AboutChar, FunctionCategories.Text, DType.String, 0, 1, 1, DType.Number)
         {
@@ -43,8 +41,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class CharTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public CharTFunction()
             : base("Char", TexlStrings.AboutCharT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Clock.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Clock.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ClockFunction(string functionInvariantName, TexlStrings.StringGetter functionDescription)
             : base(new DPath().Append(new DName(LanguageConstants.InvariantClockNamespace)), functionInvariantName, functionDescription, FunctionCategories.DateTime, DType.CreateTable(new TypedName(DType.String, new DName("Value"))), 0, 0, 0)
         {
@@ -51,8 +49,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class IsClock24Function : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public IsClock24Function()
             : base(new DPath().Append(new DName(LanguageConstants.InvariantClockNamespace)), "IsClock24", TexlStrings.AboutClock__IsClock24, FunctionCategories.DateTime, DType.Boolean, 0, 0, 0)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public CoalesceFunction()
             : base("Coalesce", TexlStrings.AboutCoalesce, FunctionCategories.Information, DType.Unknown, 0, 1, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFade.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFade.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ColorFadeFunction()
             : base("ColorFade", TexlStrings.AboutColorFade, FunctionCategories.Color, DType.Color, 0, 2, 2, DType.Color, DType.Number)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ColorFadeT.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ColorFadeTFunction()
             : base("ColorFade", TexlStrings.AboutColorFadeT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Concatenate.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ConcatenateFunction()
             : base("Concatenate", TexlStrings.AboutConcatenate, FunctionCategories.Text, DType.String, 0, 1, int.MaxValue)
         {
@@ -90,8 +88,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ConcatenateTableFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public ConcatenateTableFunction()
             : base("Concatenate", TexlStrings.AboutConcatenateT, FunctionCategories.Table | FunctionCategories.Text, DType.EmptyTable, 0, 1, int.MaxValue)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Count.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public CountFunction()
             : base("Count", TexlStrings.AboutCount, FunctionCategories.Table | FunctionCategories.MathAndStat, DType.Number, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountA.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public CountAFunction()
             : base("CountA", TexlStrings.AboutCountA, FunctionCategories.Table | FunctionCategories.MathAndStat, DType.Number, 0, 1, 1, DType.EmptyTable)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding DAX function: CountAX, CountX
     internal sealed class CountIfFunction : FilterFunctionBase
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool HasPreciseErrors => true;
 
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Filter | DelegationCapability.Count;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountRows.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountRows.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Count;
 
         public CountRowsFunction()
@@ -112,8 +110,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class CountRowsFunction_UO : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => false;
 
         public CountRowsFunction_UO()
             : base(CountRowsFunction.CountRowsInvariantFunctionName, TexlStrings.AboutCountRows, FunctionCategories.Table | FunctionCategories.MathAndStat, DType.Number, 0, 1, 1, DType.UntypedObject)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -30,8 +30,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public DateFunction()
             : base("Date", TexlStrings.AboutDate, FunctionCategories.DateTime, DType.Date, 0, 3, 3, DType.Number, DType.Number, DType.Number)
         {
@@ -49,8 +47,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool HasPreciseErrors => true;
 
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public ExtractDateTimeFunctionBase(string name, TexlStrings.StringGetter description, FunctionCategories fc, DType returnType, BigInteger maskLambdas, int arityMin, int arityMax, params DType[] paramTypes)
             : base(name, description, fc, returnType, maskLambdas, arityMin, arityMax, paramTypes)
@@ -83,8 +79,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public TimeFunction()
             : base("Time", TexlStrings.AboutTime, FunctionCategories.DateTime, DType.Time, 0, 3, 4, DType.Number, DType.Number, DType.Number, DType.Number)
         {
@@ -108,8 +102,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public DateTimeFunction()
             : base("DateTime", TexlStrings.AboutDateTime, FunctionCategories.DateTime, DType.DateTime, 0, 6, 7, DType.Number, DType.Number, DType.Number, DType.Number, DType.Number, DType.Number, DType.Number)
@@ -233,8 +225,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public WeekdayFunction()
             : base("Weekday", TexlStrings.AboutWeekday, FunctionCategories.DateTime, DType.Number, 0, 1, 2, DType.DateTime, DType.Number)
         {
@@ -260,8 +250,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public WeekNumFunction()
             : base("WeekNum", TexlStrings.AboutWeekNum, FunctionCategories.DateTime, DType.Number, 0, 1, 2, DType.DateTime, DType.Number)
         {
@@ -284,8 +272,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ISOWeekNumFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public ISOWeekNumFunction()
             : base("ISOWeekNum", TexlStrings.AboutISOWeekNum, FunctionCategories.DateTime, DType.Number, 0, 1, 1, DType.DateTime)
@@ -327,8 +313,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public DateValueFunction()
             : base(DateValueInvariantFunctionName, TexlStrings.AboutDateValue, DType.Date)
         {
@@ -347,8 +331,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public const string TimeValueFunctionInvariantName = "TimeValue";
 
         public override bool HasPreciseErrors => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public TimeValueFunction()
             : base(TimeValueFunctionInvariantName, TexlStrings.AboutTimeValue, DType.Time)
@@ -369,8 +351,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public DateTimeValueFunction()
             : base(DateTimeValueInvariantFunctionName, TexlStrings.AboutDateTimeValue, DType.DateTime)
         {
@@ -387,8 +367,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class DateAddFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         internal static readonly List<string> SubDayStringList = new List<string>() { "Hours", "Minutes", "Seconds", "Milliseconds" };
 
@@ -458,8 +436,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class DateAddTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public DateAddTFunction()
             : base("DateAdd", TexlStrings.AboutDateAddT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)
@@ -582,8 +558,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public DateDiffFunction()
             : base("DateDiff", TexlStrings.AboutDateDiff, FunctionCategories.DateTime, DType.Number, 0, 2, 3, DType.DateTime, DType.DateTime, DType.String)
         {
@@ -613,8 +587,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class DateDiffTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public DateDiffTFunction()
             : base("DateDiff", TexlStrings.AboutDateDiffT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)
@@ -716,8 +688,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public override bool IsSelfContained => true;
 
         public DateValueFunction_UO()
@@ -741,8 +711,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public override bool IsSelfContained => true;
 
         public TimeValueFunction_UO()
@@ -765,8 +733,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class DateTimeValueFunction_UO : BuiltinFunction
     {
         public override bool HasPreciseErrors => true;
-
-        public override bool SupportsParamCoercion => false;
 
         public override bool IsSelfContained => true;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -25,8 +25,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsStateless => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public override bool HasPreciseErrors => true;
 
         public Dec2HexFunction()
@@ -46,8 +44,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public override bool IsStateless => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public override bool HasPreciseErrors => true;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -26,8 +26,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ErrorFunction()
             : base("Error", TexlStrings.AboutError, FunctionCategories.Logical, DType.ObjNull, 0, 1, 1)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             ScopeInfo = new FunctionScopeInfo(this, acceptsLiteralPredicates: false);
         }
 
-        public override bool SupportsParamCoercion => true;
-
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             // Enumerate just the base overloads (the first 3 possibilities).

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Find.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public FindFunction()
             : base("Find", TexlStrings.AboutFind, FunctionCategories.Text, DType.Number, 0, 2, 3, DType.String, DType.String, DType.Number)
         {
@@ -40,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class FindTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public FindTFunction()
             : base("Find", TexlStrings.AboutFindT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLast.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         private readonly bool _isFirst;
 
         public FirstLastFunction(bool isFirst)
@@ -106,8 +104,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class FirstLastFunction_UO : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => false;
 
         // Note this function does not inherit from FunctionWithTableInput so there cannot be a common
         // base class with the above function

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/GUID.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/GUID.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public GUIDNoArgFunction()
             : base(GUIDFunctionInvariantName, TexlStrings.AboutGUID, FunctionCategories.Text, DType.Guid, 0, 0, 0)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -28,8 +28,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public IfFunction()
             : base("If", TexlStrings.AboutIf, FunctionCategories.Logical, DType.Unknown, 0, 2, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsAsync => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public IfErrorFunction()
             : base("IfError", TexlStrings.AboutIfError, FunctionCategories.Logical, DType.Unknown, 0, 2, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     internal abstract class IsBlankFunctionBase : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public override DelegationCapability FunctionDelegationCapability => DelegationCapability.Null | DelegationCapability.Filter;
@@ -129,8 +127,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel and DAX function: IsBlank
     internal sealed class IsBlankOptionSetValueFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public IsBlankOptionSetValueFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlankOrError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlankOrError.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel and DAX function: IsBlank
     internal sealed class IsBlankOrErrorOptionSetValueFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public IsBlankOrErrorOptionSetValueFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsError.cs
@@ -17,8 +17,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public IsErrorFunction()
             : base("IsError", TexlStrings.AboutIsError, FunctionCategories.Logical, DType.Boolean, 0, 1, 1)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsNumeric.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsNumeric.cs
@@ -13,8 +13,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => false;
-
         public IsNumericFunction()
             : base("IsNumeric", TexlStrings.AboutIsNumeric, FunctionCategories.Information, DType.Boolean, 0, 1, 1)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsToday.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsToday.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public IsTodayFunction()
             : base("IsToday", TexlStrings.AboutIsToday, FunctionCategories.Information, DType.Boolean, 0, 1, 1, DType.DateTime)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsUTCToday.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsUTCToday.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public IsUTCTodayFunction()
             : base("IsUTCToday", TexlStrings.AboutIsUTCToday, FunctionCategories.Information, DType.Boolean, 0, 1, 1, DType.DateTime)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public LeftRightScalarFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeft : TexlStrings.AboutRight, FunctionCategories.Text, DType.String, 0, 2, 2, DType.String, DType.Number)
         {
@@ -48,8 +46,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LeftRightTableScalarFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public LeftRightTableScalarFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeftT : TexlStrings.AboutRightT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2, DType.EmptyTable, DType.Number)
@@ -98,8 +94,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LeftRightTableTableFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public LeftRightTableTableFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeftT : TexlStrings.AboutRightT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2, DType.EmptyTable, DType.EmptyTable)
@@ -151,8 +145,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LeftRightScalarTableFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public LeftRightScalarTableFunction(bool isLeft)
             : base(isLeft ? "Left" : "Right", isLeft ? TexlStrings.AboutLeftT : TexlStrings.AboutRightT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2, DType.String, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Len.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool HasPreciseErrors => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public LenFunction()
             : base("Len", TexlStrings.AboutLen, FunctionCategories.Text, DType.Number)
         {
@@ -43,8 +41,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class LenTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public LenTFunction()
             : base("Len", TexlStrings.AboutLenT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Log.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetGenericArgPreprocessor(index);
         }
 
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
@@ -43,8 +41,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Log
     internal sealed class LogTFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public LogTFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         internal readonly bool _isAnd;
 
         public VariadicLogicalFunction(bool isAnd)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // LookUp(source:*, predicate, [projectionFunc])
     internal sealed class LookUpFunction : FilterFunctionBase
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool HasPreciseErrors => true;
 
         public LookUpFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetGenericArgPreprocessor(index);
         }
 
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public MathOneArgFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc)
@@ -38,8 +36,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
     internal abstract class MathOneArgTableFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public MathOneArgTableFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mid.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public MidFunction()
             : base("Mid", TexlStrings.AboutMid, FunctionCategories.Text, DType.String, 0, 2, 3, DType.String, DType.Number, DType.Number)
         {
@@ -36,8 +34,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class MidTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public MidTFunction()
             : base("Mid", TexlStrings.AboutMidT, FunctionCategories.Table, DType.EmptyTable, 0, 2, 3)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding Excel functions: Min, Max
     internal sealed class MinMaxFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool HasPreciseErrors => true;
 
         public override bool IsSelfContained => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Mod.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetGenericArgPreprocessor(index);
         }
 
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public ModFunction()
@@ -39,8 +37,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Mod(number:n|*[n], divisor:n|*[n])
     internal sealed class ModTFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public ModTFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/NotFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/NotFunction.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public NotFunction()
             : base("Not", TexlStrings.AboutNot, FunctionCategories.Logical, DType.Boolean, 0, 1, 1, DType.Boolean)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Now.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Now.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public NowFunction()
             : base("Now", TexlStrings.AboutNow, FunctionCategories.DateTime, DType.DateTime, 0, 0, 0)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Pi.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Pi.cs
@@ -14,8 +14,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public PiFunction()
             : base(
                 "Pi",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Power.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetGenericArgPreprocessor(index);
         }
 
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public PowerFunction()
@@ -40,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX function: Power
     internal sealed class PowerTFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public PowerTFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rand.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rand.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public RandFunction()
             : base("Rand", TexlStrings.AboutRand, FunctionCategories.MathAndStat, DType.Number, 0, 0, 0)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RandBetween.cs
@@ -22,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public RandBetweenFunction()
             : base(
                 "RandBetween",

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Replace.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ReplaceFunction()
             : base("Replace", TexlStrings.AboutReplace, FunctionCategories.Text, DType.String, 0, 4, 4, DType.String, DType.Number, DType.Number, DType.String)
         {
@@ -35,8 +33,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ReplaceTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public ReplaceTFunction()
             : base("Replace", TexlStrings.AboutReplaceT, FunctionCategories.Table, DType.EmptyTable, 0, 4, 4)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsTrackedInTelemetry => false;
 
-        public override bool SupportsParamCoercion => true;
-
         public override bool SupportsInlining => true;
 
         // This is important to set so that calls to RGBA(consts,...) are also considered const

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Round.cs
@@ -23,8 +23,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ScalarRoundingFunction(string name, TexlStrings.StringGetter description)
             : base(name, description, FunctionCategories.MathAndStat, DType.Number, 0, 2, 2, DType.Number, DType.Number)
         {
@@ -40,8 +38,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal abstract class TableRoundingFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public TableRoundingFunction(string name, TexlStrings.StringGetter description)
             : base(name, description, FunctionCategories.Table, DType.EmptyTable, 0, 2, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public SequenceFunction()
             : base("Sequence", TexlStrings.AboutSequence, FunctionCategories.MathAndStat, DType.CreateTable(new TypedName(DType.Number, new DName("Value"))), 0, 1, 3, DType.Number, DType.Number, DType.Number)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Shuffle.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Shuffle.cs
@@ -12,14 +12,12 @@ using Microsoft.PowerFx.Syntax;
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // Shuffle(source:*)
-    internal sealed class ShuffleFunction : BuiltinFunction
+    internal sealed class ShuffleFunction : FunctionWithTableInput
     {
         // Multiple invocations with the same args may result in different results.
         public override bool IsStateless => false;
 
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => false;
 
         public ShuffleFunction()
             : base("Shuffle", TexlStrings.AboutShuffle, FunctionCategories.Table, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
@@ -16,8 +16,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // scalar arguments.
     internal abstract class StatisticalFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public StatisticalFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StatisticalTableFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StatisticalTableFunction.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // a table as the first argument, and a value function as the second argument.
     internal abstract class StatisticalTableFunction : FunctionWithTableInput
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public StatisticalTableFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public StringOneArgFunction(string name, TexlStrings.StringGetter description, FunctionCategories functionCategories)
             : base(name, description, functionCategories, DType.String, 0, 1, 1, DType.String)
         {
@@ -88,8 +86,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal abstract class StringOneArgTableFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public StringOneArgTableFunction(string name, TexlStrings.StringGetter description, FunctionCategories functionCategories)
             : base(name, description, functionCategories, DType.EmptyTable, 0, 1, 1, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringTwoArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringTwoArgFunction.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public StringTwoArgFunction(string name, TexlStrings.StringGetter description)
             : this(name, description, DType.Boolean)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Substitute.cs
@@ -18,8 +18,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public SubstituteFunction()
             : base("Substitute", TexlStrings.AboutSubstitute, FunctionCategories.Text, DType.String, 0, 3, 4, DType.String, DType.String, DType.String, DType.Number)
         {
@@ -36,8 +34,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class SubstituteTFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public SubstituteTFunction()
             : base("Substitute", TexlStrings.AboutSubstituteT, FunctionCategories.Table, DType.EmptyTable, 0, 3, 4)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
@@ -27,10 +27,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        // Note, switch has a very custom checkinvocation implementation
-        // We do not support coercion for the 1st param, or the match params, only the result params. 
-        public override bool SupportsParamCoercion => true;
-
         public SwitchFunction()
             : base("Switch", TexlStrings.AboutSwitch, FunctionCategories.Logical, DType.Unknown, 0, 3, int.MaxValue)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding DAX functions: Format, Fixed
     internal sealed class TextFunction : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => true;
-
         public override bool IsSelfContained => true;
 
         public TextFunction()
@@ -181,8 +179,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Text(arg:O)
     internal sealed class TextFunction_UO : BuiltinFunction
     {
-        public override bool SupportsParamCoercion => false;
-
         public override bool IsSelfContained => true;
 
         public TextFunction_UO()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/TimezoneOffset.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/TimezoneOffset.cs
@@ -13,8 +13,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public TimeZoneOffsetFunction()
             : base("TimeZoneOffset", TexlStrings.AboutTimeZoneOffset, FunctionCategories.DateTime, DType.Number, 0, 0, 1, DType.DateTime)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Today.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Today.cs
@@ -20,8 +20,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public TodayFunction()
             : base("Today", TexlStrings.AboutToday, FunctionCategories.DateTime, DType.Date, 0, 0, 0)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Trunc.cs
@@ -24,8 +24,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public TruncFunction()
             : base("Trunc", TexlStrings.AboutTrunc, FunctionCategories.MathAndStat, DType.Number, 0, 1, 2, DType.Number, DType.Number)
         {
@@ -41,8 +39,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class TruncTableFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => true;
 
         public TruncTableFunction()
             : base("Trunc", TexlStrings.AboutTruncT, FunctionCategories.Table, DType.EmptyTable, 0, 1, 2)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Value.cs
@@ -21,8 +21,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool SupportsParamCoercion => true;
-
         public ValueFunction()
             : base(ValueInvariantFunctionName, TexlStrings.AboutValue, FunctionCategories.Text, DType.Number, 0, 1, 2, DType.String, DType.String)
         {
@@ -85,8 +83,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class ValueFunction_UO : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool SupportsParamCoercion => false;
 
         public ValueFunction_UO()
             : base(ValueFunction.ValueInvariantFunctionName, TexlStrings.AboutValue, FunctionCategories.Text, DType.Number, 0, 1, 2, DType.UntypedObject, DType.String)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ReflectionFunction.cs
@@ -34,8 +34,6 @@ namespace Microsoft.PowerFx
 
         internal BigInteger LamdaParamMask;
 
-        public override bool SupportsParamCoercion => true;
-
         public CustomTexlFunction(string name, FormulaType returnType, params FormulaType[] paramTypes)
             : this(name, returnType._type, Array.ConvertAll(paramTypes, x => x._type))
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
@@ -89,3 +89,6 @@ Blank()
 
 >> First(Table(If(false, {x:1, y:1}, {x:1, z:"str"}), {x:9,z:9})).z
 Blank()
+
+>> First({a:1,b:2})
+Errors: Error 0-16: The function 'First' has some invalid arguments.|Error 6-15: Invalid argument type (Record). Expecting a Table value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
@@ -55,3 +55,6 @@ Blank()
 
 >> LastN(Filter([1,2,3],Value=4),2)
 Table()
+
+>> Last({a:1,b:2})
+Errors: Error 0-15: The function 'Last' has some invalid arguments.|Error 5-14: Invalid argument type (Record). Expecting a Table value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Shuffle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Shuffle.txt
@@ -28,3 +28,5 @@ Blank()
 >> Shuffle([])
 Table()
 
+>> Shuffle({a:1,b:2})
+Errors: Error 8-17: Invalid argument type (Record). Expecting a Table value instead.|Error 0-18: The function 'Shuffle' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
@@ -243,8 +243,6 @@ namespace Microsoft.PowerFx.Tests
     {
         public Func<FormulaValue[], CancellationToken, Task<FormulaValue>> _impl;
 
-        public override bool SupportsParamCoercion => true;
-
         public CustomAsyncTexlFunction(string name, FormulaType returnType, params FormulaType[] paramTypes)
             : this(name, returnType._type, Array.ConvertAll(paramTypes, x => x._type))
         {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -761,8 +761,6 @@ namespace Microsoft.PowerFx.Tests
         {
             public override bool IsSelfContained => true;
 
-            public override bool SupportsParamCoercion => true;
-
             public TestFunctionMultiply()
                 : base("Func", DType.Number, DType.Number, DType.String)
             {
@@ -785,8 +783,6 @@ namespace Microsoft.PowerFx.Tests
         private class TestFunctionSubstract : CustomTexlFunction
         {
             public override bool IsSelfContained => true;
-
-            public override bool SupportsParamCoercion => true;
 
             public TestFunctionSubstract()
                 : base("Func", DType.Number, DType.String, DType.Number)


### PR DESCRIPTION
The default value is true for the functions, but many functions override this property with the same value anyway. This PR removes such overrides, and also some other overrides which are not necessary.