### PR TITLE
Introduces a new Void type so that we can remove IsArgTypeInconsequential

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -5164,7 +5164,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         {
                             _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, node.Children[i], TexlStrings.ErrMultipleValuesForField_Name, displayName);
                         }
-                        else if (_txb.GetType(node.Children[i]).IsDeferred)
+                        else if (_txb.GetType(node.Children[i]).IsDeferred || _txb.GetType(node.Children[i]).IsVoid)
                         {
                             _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, node.Children[i], TexlStrings.ErrRecordDoesNotAcceptThisType);
                         }
@@ -5192,16 +5192,16 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     var childType = _txb.GetType(child);
                     isSelfContainedConstant &= _txb.IsSelfContainedConstant(child);
-
-                    if (!childType.IsDeferred && !exprType.IsValid)
+                    var isNotDeferredOrVoid = !childType.IsDeferred && !childType.IsVoid;
+                    if (isNotDeferredOrVoid && !exprType.IsValid)
                     {
                         exprType = childType;
                     }
-                    else if (!childType.IsDeferred && exprType.CanUnionWith(childType))
+                    else if (isNotDeferredOrVoid && exprType.CanUnionWith(childType))
                     {
                         exprType = DType.Union(exprType, childType);
                     }
-                    else if (!childType.IsDeferred && childType.CoercesTo(exprType))
+                    else if (isNotDeferredOrVoid && childType.CoercesTo(exprType))
                     {
                         _txb.SetCoercedType(child, exprType);
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -5192,16 +5192,18 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     var childType = _txb.GetType(child);
                     isSelfContainedConstant &= _txb.IsSelfContainedConstant(child);
-                    var isNotDeferredOrVoid = !childType.IsDeferred && !childType.IsVoid;
-                    if (isNotDeferredOrVoid && !exprType.IsValid)
+
+                    // Deferred and void types are not allowed in tables.
+                    var isChildTypeAllowedInTable = !childType.IsDeferred && !childType.IsVoid;
+                    if (isChildTypeAllowedInTable && !exprType.IsValid)
                     {
                         exprType = childType;
                     }
-                    else if (isNotDeferredOrVoid && exprType.CanUnionWith(childType))
+                    else if (isChildTypeAllowedInTable && exprType.CanUnionWith(childType))
                     {
                         exprType = DType.Union(exprType, childType);
                     }
-                    else if (isNotDeferredOrVoid && childType.CoercesTo(exprType))
+                    else if (isChildTypeAllowedInTable && childType.CoercesTo(exprType))
                     {
                         _txb.SetCoercedType(child, exprType);
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -24,6 +24,8 @@ using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Logging.Trackers;
+using Microsoft.PowerFx.Core.Texl;
+using Microsoft.PowerFx.Core.Texl.Builtins;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
@@ -496,7 +498,8 @@ namespace Microsoft.PowerFx.Core.Functions
                 }
 
                 var type = argTypes[i];
-                if (type.IsError)
+                if (type.IsError || 
+                    type.IsVoid)
                 {
                     errors.EnsureError(args[i], TexlStrings.ErrBadType);
                     fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerFx
             DName displayDName = default;
             DName varDName = ValidateName(name);
 
-            if (type is VoidType)
+            if (type is Types.Void)
             {
                 throw new NotSupportedException();
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -87,6 +87,11 @@ namespace Microsoft.PowerFx
             DName displayDName = default;
             DName varDName = ValidateName(name);
 
+            if (type is VoidType)
+            {
+                throw new NotSupportedException();
+            }
+
             if (displayName != null)
             {
                 displayDName = ValidateName(displayName);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Types
 
         public static FormulaType BindingError { get; } = new BindingErrorType();
 
-        public static FormulaType Void { get; } = new VoidType();
+        public static FormulaType Void { get; } = new Void();
 
         /// <summary>
         /// Internal use only to represent an arbitrary (un-backed) option set value.

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -54,7 +54,9 @@ namespace Microsoft.PowerFx.Types
         public static FormulaType Deferred { get; } = new DeferredType();
 
         public static FormulaType BindingError { get; } = new BindingErrorType();
-        
+
+        public static FormulaType Void { get; } = new VoidType();
+
         /// <summary>
         /// Internal use only to represent an arbitrary (un-backed) option set value.
         /// Should be removed if possible.
@@ -189,6 +191,10 @@ namespace Microsoft.PowerFx.Types
                     }
 
                     return new TableType(type);
+                case DKind.Deferred:
+                    return Deferred;
+                case DKind.Void: 
+                    return Void;
                 default:
                     return new UnsupportedType(type);
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/ITypeVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/ITypeVisitor.cs
@@ -47,5 +47,7 @@ namespace Microsoft.PowerFx.Types
         void Visit(DeferredType type);
 
         void Visit(BindingErrorType type);
+
+        void Visit(VoidType type);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/ITypeVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/ITypeVisitor.cs
@@ -48,6 +48,6 @@ namespace Microsoft.PowerFx.Types
 
         void Visit(BindingErrorType type);
 
-        void Visit(VoidType type);
+        void Visit(Void type);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/Void.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/Void.cs
@@ -9,9 +9,9 @@ namespace Microsoft.PowerFx.Types
     /// <summary>
     /// Special Type which can't be coerced or accepted by any types.
     /// </summary>
-    public sealed class VoidType : FormulaType
+    public sealed class Void : FormulaType
     {
-        internal VoidType()
+        internal Void()
             : base(DType.Void)
         {
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/VoidType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/VoidType.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Types
+{
+    public sealed class VoidType : FormulaType
+    {
+        internal VoidType()
+            : base(DType.Void)
+        {
+        }
+
+        /// <inheritdoc />
+        public override void Visit(ITypeVisitor visitor) => visitor.Visit(this);
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/VoidType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/VoidType.cs
@@ -6,6 +6,9 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Types
 {
+    /// <summary>
+    /// Special Type which can't be coerced or accepted by any types.
+    /// </summary>
     public sealed class VoidType : FormulaType
     {
         internal VoidType()

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNew.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/FormulaValueNew.cs
@@ -130,5 +130,10 @@ namespace Microsoft.PowerFx.Types
         {
             return new ColorValue(IRContext.NotInSource(FormulaType.Color), value);
         }
+
+        public static VoidValue NewVoid()
+        {
+            return new VoidValue(IRContext.NotInSource(FormulaType.Void));
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Text;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Types;
@@ -14,11 +15,12 @@ namespace Microsoft.PowerFx.Types
         internal VoidValue(IRContext irContext) 
             : base(irContext)
         {
+            Contract.Assert(irContext.ResultType == FormulaType.Void);
         }
 
         public override void ToExpression(StringBuilder sb, FormulaValueSerializerSettings settings)
         {
-            sb.Append($"\"Void\"");
+            sb.Append($"If(true, {{test:1}}, \"Mismatched args\")");
         }
 
         public override object ToObject()
@@ -28,7 +30,7 @@ namespace Microsoft.PowerFx.Types
 
         public override string ToString()
         {
-            return "Void";
+            return "-";
         }
 
         public override void Visit(IValueVisitor visitor)

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
@@ -16,7 +16,6 @@ namespace Microsoft.PowerFx.Types
         /// Initializes a new instance of the <see cref="VoidValue"/> class.
         /// The void value should be used when the result of an expression is not used or is null.
         /// </summary>
-        /// <param name="irContext"></param>
         internal VoidValue(IRContext irContext) 
             : base(irContext)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerFx.Types
 
         public override void ToExpression(StringBuilder sb, FormulaValueSerializerSettings settings)
         {
-            sb.Append($"If(true, {{test:1}}, \"Mismatched args\")");
+            sb.Append($"If(true, {{test:1}}, \"Mismatched args (result of the expression can't be used).\")");
         }
 
         public override object ToObject()

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
@@ -12,6 +12,11 @@ namespace Microsoft.PowerFx.Types
 {
     public class VoidValue : ValidFormulaValue
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VoidValue"/> class.
+        /// The void value should be used when the result of an expression is not used or is null.
+        /// </summary>
+        /// <param name="irContext"></param>
         internal VoidValue(IRContext irContext) 
             : base(irContext)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
@@ -29,7 +29,7 @@ namespace Microsoft.PowerFx.Types
 
         public override object ToObject()
         {
-            return null;
+            throw new InvalidOperationException();
         }
 
         public override string ToString()

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/VoidValue.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Types
+{
+    public class VoidValue : ValidFormulaValue
+    {
+        internal VoidValue(IRContext irContext) 
+            : base(irContext)
+        {
+        }
+
+        public override void ToExpression(StringBuilder sb, FormulaValueSerializerSettings settings)
+        {
+            sb.Append($"\"Void\"");
+        }
+
+        public override object ToObject()
+        {
+            return null;
+        }
+
+        public override string ToString()
+        {
+            return "Void";
+        }
+
+        public override void Visit(IValueVisitor visitor)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -109,21 +109,17 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     type = typeSuper;
                     fArgsValid = false;
                 }
-                else if (!type.IsError)
+                else if (!type.IsError && !type.IsVoid)
                 {
                     if (typeArg.CoercesTo(type))
                     {
                         CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
                     }
-                    else if (!isBehavior || !IsArgTypeInconsequential(nodeArg))
+                    else
                     {
-                        errors.EnsureError(
-                            DocumentErrorSeverity.Severe,
-                            nodeArg,
-                            TexlStrings.ErrBadType_ExpectedType_ProvidedType,
-                            type.GetKindString(),
-                            typeArg.GetKindString());
-                        fArgsValid = false;
+                        // If the types are incompatible, the result type is void.
+                        type = DType.Void;
+                        break;
                     }
                 }
                 else if (typeArg.Kind != DKind.Unknown)
@@ -152,94 +148,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(argumentIndex >= 0);
 
             return argumentIndex > 1;
-        }
-
-        // When IsArgTypeInconsequential returns true, the runtime result of If may not match the binder's expectation.
-        // So use this helper to skip asserts comparing runtime and bind time types.
-        // Also other function, that can wrap If statement inside can face the same issue.
-        internal static bool CanCheckIfReturn(TexlFunction func)
-        {
-            return func is not IfFunction && 
-                func is not WithFunction;
-        }
-
-        private bool IsArgTypeInconsequential(TexlNode arg)
-        {
-            Contracts.AssertValue(arg);
-            Contracts.Assert(arg.Parent is ListNode);
-            Contracts.Assert(arg.Parent.Parent is CallNode);
-            Contracts.Assert(arg.Parent.Parent.AsCall().Head.Name == Name);
-
-            var call = arg.Parent.Parent.AsCall().VerifyValue();
-
-            // Pattern: OnSelect = If(cond, argT, argF)
-            // Pattern: OnSelect = If(cond, arg1, cond, arg2, ..., argK, argF)
-            // Pattern: OnSelect = If(cond, arg1, If(cond, argT, argF))
-            // Pattern: OnSelect = If(cond, arg1, If(cond, arg2, cond, arg3, ...))
-            // Pattern: OnSelect = If(cond, arg1, cond, If(cond, arg2, cond, arg3, ...), ...)
-            // ...etc.
-            var ancestor = call;
-            while (ancestor.Head.Name == Name)
-            {
-                if (ancestor.Parent == null && ancestor.Args.Children.Length > 0)
-                {
-                    for (var i = 0; i < ancestor.Args.Children.Length; i += 2)
-                    {
-                        // If the given node is part of a condition arg of an outer If invocation,
-                        // then it's NOT inconsequential. Note that the very last arg to an If
-                        // is not a condition -- it's the "else" branch, hence the test below.
-                        if (i != ancestor.Args.Children.Length - 1 && arg.InTree(ancestor.Args.Children[i]))
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                }
-
-                // Deal with the possibility that the ancestor may be contributing to a chain.
-                // This also lets us cover the following patterns:
-                // Pattern: OnSelect = X; If(cond, arg1, arg2); Y; Z
-                // Pattern: OnSelect = X; If(cond, arg1;arg11;...;arg1k, arg2;arg21;...;arg2k); Y; Z
-                // ...etc.
-                VariadicOpNode chainNode;
-                if ((chainNode = ancestor.Parent.AsVariadicOp()) != null && chainNode.Op == VariadicOp.Chain)
-                {
-                    // Top-level chain in a behavior rule.
-                    if (chainNode.Parent == null)
-                    {
-                        return true;
-                    }
-
-                    // A chain nested within a larger non-call structure.
-                    if (!(chainNode.Parent is ListNode) || !(chainNode.Parent.Parent is CallNode))
-                    {
-                        return false;
-                    }
-
-                    // Only the last chain segment is consequential.
-                    var numSegments = chainNode.Children.Length;
-                    if (numSegments > 0 && !arg.InTree(chainNode.Children[numSegments - 1]))
-                    {
-                        return true;
-                    }
-
-                    // The node is in the last segment of a chain nested within a larger invocation.
-                    ancestor = chainNode.Parent.Parent.AsCall();
-                    continue;
-                }
-
-                // Walk up the parent chain to the outer invocation.
-                if (!(ancestor.Parent is ListNode) || !(ancestor.Parent.Parent is CallNode))
-                {
-                    return false;
-                }
-
-                ancestor = ancestor.Parent.Parent.AsCall();
-            }
-
-            // Exhausted all supported patterns.
-            return false;
         }
 
         // Gets the overloads for the If function for the specified arity.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -94,6 +94,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 var nodeArg = args[i];
                 var typeArg = argTypes[i];
+                if (typeArg.IsVoid)
+                {
+                    type = DType.Void;
+                    break;
+                }
+
                 if (typeArg.IsError)
                 {
                     errors.EnsureError(args[i], TexlStrings.ErrTypeError);
@@ -109,7 +115,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     type = typeSuper;
                     fArgsValid = false;
                 }
-                else if (!type.IsError && !type.IsVoid)
+                else if (!type.IsError)
                 {
                     if (typeArg.CoercesTo(type))
                     {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -85,34 +85,25 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var type = ReturnType;
 
-            // Are we on a behavior property?
-            var isBehavior = context.AllowsSideEffects;
-
             // Compute the result type by joining the types of all non-predicate args.
             Contracts.Assert(type == DType.Unknown);
             for (var i = 1; i < count;)
             {
                 var nodeArg = args[i];
                 var typeArg = argTypes[i];
-                if (typeArg.IsVoid)
-                {
-                    type = DType.Void;
-                    break;
-                }
-
-                if (typeArg.IsError)
-                {
-                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
-                }
 
                 var typeSuper = DType.Supertype(type, typeArg);
                 if (!typeSuper.IsError)
                 {
                     type = typeSuper;
                 }
-                else if (type.Kind == DKind.Unknown)
+                else if (typeArg.IsVoid)
                 {
-                    type = typeSuper;
+                    type = DType.Void;
+                }
+                else if (typeArg.IsError)
+                {
+                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
                     fArgsValid = false;
                 }
                 else if (!type.IsError)
@@ -125,7 +116,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     {
                         // If the types are incompatible, the result type is void.
                         type = DType.Void;
-                        break;
                     }
                 }
                 else if (typeArg.Kind != DKind.Unknown)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
@@ -44,8 +44,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            // Base call yields unknown return type, so we set it accordingly below
-            var fArgsValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            var fArgsValid = base.CheckType(args[0], argTypes[0], ParamTypes[0], errors, SupportCoercionForArg(0), out DType coercionType);
+            nodeToCoercedTypeMap = null;
 
             // Return type determined by second argument (function)
             // Since CheckTypes is called on partial functions, return type should be error when a second argument is undefined

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/With.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fArgsValid = base.CheckType(args[0], argTypes[0], ParamTypes[0], errors, SupportCoercionForArg(0), out DType coercionType);
+            var fArgsValid = base.CheckType(args[0], argTypes[0], ParamTypes[0], errors, SupportCoercionForArg(0), out DType _);
             nodeToCoercedTypeMap = null;
 
             // Return type determined by second argument (function)

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DKind.cs
@@ -88,7 +88,9 @@ namespace Microsoft.PowerFx.Core.Types
 
         Deferred = 38,
 
-        _Lim = 39,
+        Void = 39,
+
+        _Lim = 40,
 #pragma warning restore SA1300 // Element should begin with upper-case letter
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -53,6 +53,7 @@ namespace Microsoft.PowerFx.Core.Types
         public static readonly DType MinimalLargeImage = CreateMinimalLargeImageType();
         public static readonly DType UntypedObject = new DType(DKind.UntypedObject);
         public static readonly DType Deferred = new DType(DKind.Deferred);
+        public static readonly DType Void = new DType(DKind.Void);
 
         public static readonly DType Invalid = new DType();
 
@@ -571,6 +572,8 @@ namespace Microsoft.PowerFx.Core.Types
         public bool IsUnknown => Kind == DKind.Unknown;
 
         public bool IsDeferred => Kind == DKind.Deferred;
+
+        public bool IsVoid => Kind == DKind.Void;
 
         public bool IsError => Kind == DKind.Error;
 
@@ -1859,6 +1862,12 @@ namespace Microsoft.PowerFx.Core.Types
             schemaDifference = new KeyValuePair<string, DType>(null, Invalid);
             schemaDifferenceType = Invalid;
 
+            if (Kind == DKind.Void || type.Kind == DKind.Void)
+            {
+                // No types accept a void type, void type doesn't accept any type
+                return false;
+            }
+
             // We accept ObjNull as any DType (but subtypes can override).
             if (type.Kind == DKind.ObjNull)
             {
@@ -3078,6 +3087,13 @@ namespace Microsoft.PowerFx.Core.Types
 
             isSafe = true;
 
+            if (Kind == DKind.Void || typeDest.Kind == DKind.Void)
+            {
+                // No types coerces to a void type, void type doesn't coerce to any type.
+                coercionType = this;
+                return false;
+            }
+
             if (typeDest.Accepts(this))
             {
                 coercionType = typeDest;
@@ -3408,6 +3424,8 @@ namespace Microsoft.PowerFx.Core.Types
                     return "V";
                 case DKind.UntypedObject:
                     return "O";
+                case DKind.Void:
+                    return "-";
             }
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DTypeSpecParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DTypeSpecParser.cs
@@ -11,14 +11,14 @@ namespace Microsoft.PowerFx.Core.Types
 {
     internal static class DTypeSpecParser
     {
-        private const string _typeEncodings = "?ebnshdipmgo$cDT!*%lLNZPQqVOX";
+        private const string _typeEncodings = "?ebnshdipmgo$cDT!*%lLNZPQqVOX-";
         private static readonly DType[] _types = new DType[]
         {
             DType.Unknown, DType.Error, DType.Boolean, DType.Number, DType.String, DType.Hyperlink,
             DType.DateTime, DType.Image, DType.PenImage, DType.Media, DType.Guid, DType.Blob, DType.Currency, DType.Color,
             DType.Date, DType.Time, DType.EmptyRecord, DType.EmptyTable, DType.EmptyEnum,
             DType.OptionSetValue, DType.OptionSet, DType.ObjNull, DType.DateTimeNoTimeZone, DType.Polymorphic, DType.View, DType.ViewValue,
-            DType.NamedValue, DType.UntypedObject, DType.Deferred
+            DType.NamedValue, DType.UntypedObject, DType.Deferred, DType.Void
         };
 
         // Parses a type specification, returns true and sets 'type' on success.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -287,11 +287,8 @@ namespace Microsoft.PowerFx
                                 Kind = ex.ErrorKind
                             });
                     }
-
-                    if (IfFunction.CanCheckIfReturn(func))
-                    {
-                        Contract.Assert(result.IRContext.ResultType == node.IRContext.ResultType || result is ErrorValue || result.IRContext.ResultType is BlankType);
-                    }
+                    
+                    Contract.Assert(result.IRContext.ResultType == node.IRContext.ResultType || result is ErrorValue || result.IRContext.ResultType is BlankType);
                 }
                 else
                 {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1901,35 +1901,16 @@ namespace Microsoft.PowerFx.Functions
             return new BlankValue(irContext);
         }
 
-        /// <summary>
-        /// If the <paramref name="result"/> is a record value, and the IRContext result type is a record type,
-        /// then this helper may wrap it in CompileTimeTypeWrapperRecordValue, else return the result it self.
-        /// e.g. If(false, {x:1, y:1}, {x:1, z:2}) has compile time type ![x:n] while runtime type ![x:n, z:n].
-        /// </summary>
-        private static FormulaValue MaybeWrapRecordValue(FormulaValue result, IRContext irContext)
-        {
-            if (result is RecordValue recordValue && irContext.ResultType is RecordType compileTimeType)
-            {
-                return CompileTimeTypeWrapperRecordValue.AdjustType(compileTimeType, recordValue);
-            }
-            else if (result is TableValue tableValue && irContext.ResultType is TableType compileTimeTableType)
-            {
-                return CompileTimeTypeWrapperTableValue.AdjustType(compileTimeTableType, tableValue);
-            }
-
-            return result;
-        }
-
         private static FormulaValue MaybeAdjustToCompileTimeType(FormulaValue result, IRContext irContext)
         {
-            if (irContext.ResultType is VoidType)
+            if (irContext.ResultType is Types.Void)
             {
                 if (result is ErrorValue ev)
                 {
                     return new ErrorValue(IRContext.NotInSource(FormulaType.Void), (List<ExpressionError>)ev.Errors);
                 }
 
-                return new VoidValue(IRContext.NotInSource(FormulaType.Void));
+                return new VoidValue(irContext);
             }
             else if (result is RecordValue recordValue && irContext.ResultType is RecordType compileTimeType)
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1922,8 +1922,13 @@ namespace Microsoft.PowerFx.Functions
 
         private static FormulaValue MaybeAdjustToCompileTimeType(FormulaValue result, IRContext irContext)
         {
-            if (irContext.ResultType is VoidType && result is not ErrorValue)
+            if (irContext.ResultType is VoidType)
             {
+                if (result is ErrorValue ev)
+                {
+                    return new ErrorValue(IRContext.NotInSource(FormulaType.Void), (List<ExpressionError>)ev.Errors);
+                }
+
                 return new VoidValue(IRContext.NotInSource(FormulaType.Void));
             }
             else if (result is RecordValue recordValue && irContext.ResultType is RecordType compileTimeType)

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeSchema.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeSchema.cs
@@ -32,7 +32,8 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             EntityTable,
             Unknown,
             Error,
-            Deferred
+            Deferred,
+            Void
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                 Result = new FormulaTypeSchema() { Type = FormulaTypeSchema.ParamType.Error };
             }
 
-            public void Visit(VoidType type)
+            public void Visit(Types.Void type)
             {
                 Result = new FormulaTypeSchema() { Type = FormulaTypeSchema.ParamType.Void };
             }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
@@ -100,6 +100,11 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                 Result = new FormulaTypeSchema() { Type = FormulaTypeSchema.ParamType.Error };
             }
 
+            public void Visit(VoidType type)
+            {
+                Result = new FormulaTypeSchema() { Type = FormulaTypeSchema.ParamType.Void };
+            }
+
             #endregion
             #region Complex Types
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/First.txt
@@ -92,3 +92,9 @@ Blank()
 
 >> First({a:1,b:2})
 Errors: Error 0-16: The function 'First' has some invalid arguments.|Error 6-15: Invalid argument type (Record). Expecting a Table value instead.
+
+>> First(If(false, Table({a:1}), Table({b:2})))
+{}
+
+>> FirstN(If(false, Table({a:1}), Table({b:2})), 1)
+Table({})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
@@ -77,3 +77,6 @@ Table({x:1,y:2},Blank())
 >> Last(ForAll([true,false], If(ThisRecord.Value, {x:1,y:2}, Blank()))).x
 Blank()
 
+>> ForAll([1], If(false, {a:1}, {b:2}))
+Table({})
+

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
@@ -60,3 +60,7 @@ Error({Kind:ErrorKind.Div0})
 
 >> If(true, {x:1, y:1}, {x:2, z:2})
 {x:1}
+
+// Demos expression that generates Void value.
+>> If(true, {a:1}, "test")
+If(true, {test:1}, "Mismatched args")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
@@ -63,4 +63,4 @@ Error({Kind:ErrorKind.Div0})
 
 // Demos expression that generates Void value.
 >> If(true, {a:1}, "test")
-If(true, {test:1}, "Mismatched args")
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
@@ -68,3 +68,9 @@ If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 // Void can be passed through another If statment
 >> If( true, If(1<0, {x:3}, 1), 1)
 If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+>> If(true, 1, x)
+Errors: Error 12-13: Name isn't valid. 'x' isn't recognized.|Error 0-14: The function 'If' has some invalid arguments.
+
+>> If(true, x, 1)
+Errors: Error 9-10: Name isn't valid. 'x' isn't recognized.|Error 0-14: The function 'If' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
@@ -64,3 +64,7 @@ Error({Kind:ErrorKind.Div0})
 // Demos expression that generates Void value.
 >> If(true, {a:1}, "test")
 If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+// Void can be passed through another If statment
+>> If( true, If(1<0, {x:3}, 1), 1)
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -8,25 +8,25 @@
 // b) it's verified nobody is actually using the return value.
 
 >> If(1<0, "abc1", {x:3})
-If(true, {test:1}, "Mismatched args")
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 
 >> If(1>0, 100, {x:3}) + 1
-Errors: Error 0-19: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
+Errors: Error 0-19: Invalid argument type. Expecting one of the following: Number, Text, Boolean, UntypedObject.
 
 >> If(1>0, 100; 30, {x:3}) + 1
-Errors: Error 0-23: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
+Errors: Error 0-23: Invalid argument type. Expecting one of the following: Number, Text, Boolean, UntypedObject.
 
 >> If(1>0, 100; 30, {x:3}; 60) + 1
 31
 
 >> Value(If(1>0, 100; 30, {x:3}) + 1)
-Errors: Error 6-29: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
+Errors: Error 6-29: Invalid argument type. Expecting one of the following: Number, Text, Boolean, UntypedObject.
 
 >> Value(1 + If(1>0, 100; 30, {x:3}))
-Errors: Error 10-33: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
+Errors: Error 10-33: Invalid argument type. Expecting one of the following: Number, Text, Boolean, UntypedObject.
 
 >> If(1<0, "abc2", {x:3}; {x:2})
-If(true, {test:1}, "Mismatched args")
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 
 >> If(false, "abc3", {x:3}; If(true, Value(10); {x:3})); Value(101)
 101
@@ -50,4 +50,35 @@ Error({Kind:ErrorKind.Div0})
 Errors: Error 15-32: Invalid argument type (Void). Expecting a Boolean value instead.|Error 0-41: The function 'If' has some invalid arguments.
 
 >> If(1<0, {x:3}, 1/0)
+Error({Kind:ErrorKind.Div0})
+
+>> If(Sqrt(-1)<0, { a: 1 }, 2)
+Error({Kind:ErrorKind.Numeric})
+
+>> If(1<0, { a: 1 }, Sqrt(-1))
+Error({Kind:ErrorKind.Numeric})
+
+>> IfError( If(1<0, { a: 1 }, Sqrt(-1)), $"Error {FirstError.Kind}", "No errors")
+"Error 24"
+
+>> IsError( If(false, { a: 1 }, 2 ) )
+false
+
+>> IsError( If(1<0, {x:3}, 1/0) )
+true
+
+// result of If can't be used (even inside another If).
+>> IsBlankOrError( If(1<0, If(false, {x:3}, 1/0)) )
+Errors: Error 16-46: The function 'If' has some invalid arguments.|Error 0-48: The function 'IsBlankOrError' has some invalid arguments.|Error 16-46: Invalid argument type.
+
+>> IsBlankOrError( If(false, { a: 1 }, 2 ) )
+false
+
+>> IsNumeric( If(false, { a: 1 }, 2 ) )
+false
+
+>> If( true, With({a:1},Switch(a, 1, { prop:"complex" }, "scalar")) )
+{prop:"complex"}
+
+>> If( true, With({a:1},Switch(a, 1, 1/0, { prop:"complex" })) )
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -67,15 +67,15 @@ false
 >> IsError( If(1<0, {x:3}, 1/0) )
 true
 
-// result of If can't be used (even inside another If).
+// result of If can't be used.
 >> IsBlankOrError( If(1<0, If(false, {x:3}, 1/0)) )
-Errors: Error 16-46: The function 'If' has some invalid arguments.|Error 0-48: The function 'IsBlankOrError' has some invalid arguments.|Error 16-46: Invalid argument type.
+Errors: Error 0-48: The function 'IsBlankOrError' has some invalid arguments.
 
 >> IsBlankOrError( If(false, { a: 1 }, 2 ) )
-false
+Errors: Error 0-41: The function 'IsBlankOrError' has some invalid arguments.|Error 16-39: Invalid argument type.
 
 >> IsNumeric( If(false, { a: 1 }, 2 ) )
-false
+Errors: Error 11-34: Invalid argument type.|Error 0-36: The function 'IsNumeric' has some invalid arguments.
 
 >> If( true, With({a:1},Switch(a, 1, { prop:"complex" }, "scalar")) )
 {prop:"complex"}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -8,25 +8,25 @@
 // b) it's verified nobody is actually using the return value.
 
 >> If(1<0, "abc1", {x:3})
-{x:3}
+"Void"
 
 >> If(1>0, 100, {x:3}) + 1
-Errors: Error 13-18: Invalid argument type (Record). Expecting a Number value instead.|Error 0-19: The function 'If' has some invalid arguments.
+Errors: Error 0-19: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
 >> If(1>0, 100; 30, {x:3}) + 1
-Errors: Error 17-22: Invalid argument type (Record). Expecting a Number value instead.
+Errors: Error 0-23: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
 >> If(1>0, 100; 30, {x:3}; 60) + 1
 31
 
 >> Value(If(1>0, 100; 30, {x:3}) + 1)
-Errors: Error 23-28: Invalid argument type (Record). Expecting a Number value instead.|Error 6-29: The function 'If' has some invalid arguments.
+Errors: Error 6-29: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
 >> Value(1 + If(1>0, 100; 30, {x:3}))
-Errors: Error 27-32: Invalid argument type (Record). Expecting a Number value instead.|Error 10-33: The function 'If' has some invalid arguments.
+Errors: Error 10-33: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
 >> If(1<0, "abc2", {x:3}; {x:2})
-{x:2}
+"Void"
 
 >> If(false, "abc3", {x:3}; If(true, Value(10); {x:3})); Value(101)
 101
@@ -44,4 +44,10 @@ Blank()
 5
 
 >> If(Value("1")>Value("0"), Blank(); 1/0; Blank(), 3)
+Error({Kind:ErrorKind.Div0})
+
+>> If(1<0, "abc", If(1<0, {x:3}, 1), 1>0, 2)
+Errors: Error 15-32: Invalid argument type (Void). Expecting a Boolean value instead.|Error 0-41: The function 'If' has some invalid arguments.
+
+>> If(1<0, {x:3}, 1/0)
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -8,7 +8,7 @@
 // b) it's verified nobody is actually using the return value.
 
 >> If(1<0, "abc1", {x:3})
-"Void"
+If(true, {test:1}, "Mismatched args")
 
 >> If(1>0, 100, {x:3}) + 1
 Errors: Error 0-19: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
@@ -26,7 +26,7 @@ Errors: Error 6-29: Invalid argument type. Expecting one of the following: Numbe
 Errors: Error 10-33: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
 
 >> If(1<0, "abc2", {x:3}; {x:2})
-"Void"
+If(true, {test:1}, "Mismatched args")
 
 >> If(false, "abc3", {x:3}; If(true, Value(10); {x:3})); Value(101)
 101

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Last.txt
@@ -58,3 +58,9 @@ Table()
 
 >> Last({a:1,b:2})
 Errors: Error 0-15: The function 'Last' has some invalid arguments.|Error 5-14: Invalid argument type (Record). Expecting a Table value instead.
+
+>> Last(If(false, Table({a:1}), Table({b:2})))
+{}
+
+>> LastN(If(false, Table({a:1}), Table({b:2})), 1)
+Table({})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnums.txt
@@ -61,4 +61,4 @@ Date(2011,1,16)
 "A"
 
 >> If(true, 1, TimeUnit.Seconds)
-Errors: Error 20-28: Invalid argument type (Enum (TimeUnit)). Expecting a Number value instead.|Error 0-29: The function 'If' has some invalid arguments.
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With.txt
@@ -16,3 +16,7 @@ Error(Table({Kind:ErrorKind.Div0},{Kind:ErrorKind.Div0}))
 // since If uses the interaction of types, If(false, {x:1}, {z:2}) => {} hence the below is {}
 >> With({y:1}, If(false, {x:1}, {z:2}))
 {}
+
+// void values are allowed in With function's argument.
+>> With({y:1}, If(true, {a:1}, "test"))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Types.UntypedObjectType",
                 "Microsoft.PowerFx.Types.UntypedObjectValue",
                 "Microsoft.PowerFx.Types.ValidFormulaValue",
-                "Microsoft.PowerFx.Types.VoidType",
+                "Microsoft.PowerFx.Types.Void",
                 "Microsoft.PowerFx.Types.VoidValue",
 
                 // Intellisense classes. Used primarily by the Language Service Provider.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -143,6 +143,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Types.UntypedObjectType",
                 "Microsoft.PowerFx.Types.UntypedObjectValue",
                 "Microsoft.PowerFx.Types.ValidFormulaValue",
+                "Microsoft.PowerFx.Types.VoidType",
+                "Microsoft.PowerFx.Types.VoidValue",
 
                 // Intellisense classes. Used primarily by the Language Service Provider.
                 // Most evaluators should never need these. 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/SymbolTableTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/SymbolTableTests.cs
@@ -292,5 +292,12 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.NotNull(func3);
             Assert.Equal(2, func3.Count());
         }
+
+        [Fact]
+        public void VoidIsNotAllowed()
+        {
+            var symbol = new SymbolTable();
+            Assert.Throws<NotSupportedException>(() => symbol.AddVariable("x", FormulaType.Void, mutable: true));
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection.Metadata;
+using Microsoft.CodeAnalysis;
 using Microsoft.PowerFx.Core.App.Controls;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
@@ -27,7 +28,7 @@ using Microsoft.PowerFx.Types;
 using Xunit;
 
 namespace Microsoft.PowerFx.Core.Tests
-{    
+{
     public class TexlTests : PowerFxTest
     {
         private readonly CultureInfo _defaultLocale = new ("en-US");
@@ -80,8 +81,8 @@ namespace Microsoft.PowerFx.Core.Tests
             // TestBindingErrors(script, DType.Error);
             var engine = new Engine(new PowerFxConfig());
             var result = engine.Check(script);
-            
-            Assert.Equal(DType.Error, result.Binding.ResultType);            
+
+            Assert.Equal(DType.Error, result.Binding.ResultType);
             Assert.False(result.IsSuccess);
         }
 
@@ -515,38 +516,41 @@ namespace Microsoft.PowerFx.Core.Tests
                 symbol);
         }
 
-        [Fact]
-        public void TexlFunctionTypeSemanticsIfWithArgumentCoercion()
+        [Theory]
+        [InlineData("If(A < 10, 1, \"2\")", "n", true)]
+        [InlineData("If(A < 1, \"one\", A < 2, 2, A < 3, true, false)", "s", true)]
+        [InlineData("If(A < 1, true, A < 2, 2, A < 3, false, \"true\")", "b", true)]
+        [InlineData("If(A < 10, 1, [1,2,3])", "-", true)]
+        [InlineData("If(A < 10, 1, {Value: 2})", "-", true)]
+        [InlineData("If(0 < 1, [1], 2)", "-", true)]
+
+        // negative cases, when if produces void type
+
+        // void type is not allowed in aggregate type.
+        [InlineData("{test: If(A < 10, 1, {Value: 2})}", "![]", false)]
+        [InlineData("[If(A < 10, 1, {Value: 2})]", "*[]", false)]
+
+        // void type can't be consumed.
+        [InlineData("If(0 < 1, [1], 2) + 1", "n", false)]
+        public void TexlFunctionTypeSemanticsIfWithArgumentCoercion(string expression, string expectedType, bool checkSuccess)
         {
             var symbol = new SymbolTable();
             symbol.AddVariable("A", FormulaType.Number);
-            
-            TestSimpleBindingSuccess(
-                "If(A < 10, 1, \"2\")",
-                DType.Number,
-                symbol);
 
-            TestSimpleBindingSuccess(
-                "If(A < 1, \"one\", A < 2, 2, A < 3, true, false)",
-                DType.String,
-                symbol);
-
-            TestSimpleBindingSuccess(
-                "If(A < 1, true, A < 2, 2, A < 3, false, \"true\")",
-                DType.Boolean,
-                symbol);
-
-            // Negative cases -- when args cannot be coerced.
-
-            TestBindingErrors(
-                "If(A < 10, 1, [1,2,3])",
-                DType.Number,
-                symbol);
-
-            TestBindingErrors(
-                "If(A < 10, 1, {Value: 2})",
-                DType.Number,
-                symbol);
+            if (checkSuccess)
+            {
+                TestSimpleBindingSuccess(
+                                    expression,
+                                    TestUtils.DT(expectedType),
+                                    symbol);
+            }
+            else
+            {
+                TestBindingErrors(
+                    expression,
+                    TestUtils.DT(expectedType),
+                    symbol);
+            }
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -525,13 +525,33 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("If(0 < 1, [1], 2)", "-", true)]
 
         // negative cases, when if produces void type
+        // If(1 < 0, [1], 2) => V which is void value
 
         // void type is not allowed in aggregate type.
-        [InlineData("{test: If(A < 10, 1, {Value: 2})}", "![]", false)]
-        [InlineData("[If(A < 10, 1, {Value: 2})]", "*[]", false)]
+        // {test: V}
+        [InlineData("{test: If(1 < 0, [1], 2)}", "![]", false)]
+
+        // [V]
+        [InlineData("[If(1 < 0, [1], 2)]", "*[]", false)]
 
         // void type can't be consumed.
-        [InlineData("If(0 < 1, [1], 2) + 1", "n", false)]
+        // V + 1 
+        [InlineData("If(1 < 0, [1], 2) + 1", "n", false)]
+
+        // Abs(V)
+        [InlineData("Abs(If(1 < 0, [1], 2))", "n", false)]
+
+        // Len(V)
+        [InlineData("Len(If(1 < 0, [1], 2))", "n", false)]
+
+        // If(V, 0, 1)
+        [InlineData("If(If(1 < 0, [1], 2), 0, 1)", "n", false)]
+
+        // Hour(V)
+        [InlineData("Hour(If(1 < 0, [1], 2))", "n", false)]
+
+        // ForAll([1,2,3], V)
+        [InlineData("ForAll([1,2,3], If(1 < 0, [1], 2))", "e", false)]
         public void TexlFunctionTypeSemanticsIfWithArgumentCoercion(string expression, string expectedType, bool checkSuccess)
         {
             var symbol = new SymbolTable();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ValueTests.cs
@@ -377,6 +377,18 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             yield return new NamedValue("Str", FormulaValue.New("test string"));
             yield return new NamedValue("Bool", FormulaValue.New(true));
         }
+
+        [Fact]
+        public void VoidValueTest()
+        {
+            var formulaValue = FormulaValue.NewVoid();
+            Assert.Throws<InvalidOperationException>(() => formulaValue.ToObject());
+
+            Assert.Equal(FormulaType.Void, formulaValue.Type);
+
+            var resultStr = formulaValue.Dump();
+            Assert.Equal("If(true, {test:1}, \"Mismatched args (result of the expression can't be used).\")", resultStr);
+        }
     }
 
     public static class FormulaValueExtensions


### PR DESCRIPTION
- Fixes https://github.com/microsoft/Power-Fx/issues/1092 and #843 
- Corresponding PA PR: https://msazure.visualstudio.com/OneAgile/_git/PowerApps-Client/pullrequest/7705536
- Introduces new `void` DType and corresponding `VoidValue` which currently is only produced by the `If` function when argument type mismatches (useful for behavior function) and removes IsArgTypeInconsequential hackery.

Notes:
- `Void` type is denoted by `-`. 
and it has a corresponding `VoidValue` even though it may sound counterintuitive. This keeps things straightforward.
- `Void` type can't be consumed. Ie `void + 1` is invalid.
- `Void` type isn't allowed in the aggregate type. Ie `[void]` or `{field: void}` is invalid.
- `Void` type can't be accepted by any type or coerced to any type.
- Currently, this PR is limited only to the `If()` function, the `Void` type would be leveraged with other functions like `IfError()` & `Switch()` in separate follow-up PRs.


Breaking Changes:

**Things that used to be illegal, that are now legal:**
- These kinds of previously failing cases would pass now,
e.g. `If(true, {x:3}, 1)`. 
But it is safe since the eval of above would be `VoidValue` (practically null). And which can't also be consumed.
Language breaking changes 

**Things that used to be legal and are now illegal:**  None

**Things that used to be legal still is legal, but behave differently:** 
- The expected type of expression would change to `Void` Type.
e.g.
https://github.com/microsoft/Power-Fx/pull/1113/files#diff-9b837be0ccd7fa3b97c4cbdd5e2e022d26543e3b2ae811b0f7fd0fbd906c8dcbR506
Would have returned the type `number` earlier, which is now `Void`.
- Error may change in certain circumstances. (Since now `If` itself doesn't produce the error, rather the consumers do)
https://github.com/microsoft/Power-Fx/pull/1113/files#diff-93bb6d92ab7000b8d30b8fa252ce068cdd0f8b1319cddf68d6a30e8dd5613ae6L25