### PR TITLE
Initial work on UntypedObject coercions for binary operators

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -723,6 +723,16 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
             }
 
+            if (typeLeft.IsUntypedObject && typeRight.Kind == DKind.ObjNull)
+            {
+                coercions.Add(new BinderCoercionResult() { Node = left, CoercedType = DType.Number });
+            }
+
+            if (typeRight.IsUntypedObject && typeLeft.Kind == DKind.ObjNull)
+            {
+                coercions.Add(new BinderCoercionResult() { Node = right, CoercedType = DType.Number });
+            }
+
             return new BinderCheckTypeResult() { Coercions = coercions };
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -671,7 +671,7 @@ namespace Microsoft.PowerFx.Core.Binding
             }
         }
 
-        private static BinderCheckTypeResult CheckComparisonArgTypesCore(IErrorContainer errorContainer, TexlNode binaryOpNode, TexlNode left, TexlNode right, DType typeLeft, DType typeRight)
+        private static BinderCheckTypeResult CheckComparisonArgTypesCore(IErrorContainer errorContainer, TexlNode left, TexlNode right, DType typeLeft, DType typeRight)
         {
             // Excel's type coercion for inequality operators is inconsistent / borderline wrong, so we can't
             // use it as a reference. For example, in Excel '2 < TRUE' produces TRUE, but so does '2 < FALSE'.
@@ -687,11 +687,11 @@ namespace Microsoft.PowerFx.Core.Binding
             {
                 errorContainer.EnsureError(
                     DocumentErrorSeverity.Severe,
-                    binaryOpNode,
+                    left.Parent,
                     TexlStrings.ErrBadOperatorTypes,
                     typeLeft.GetKindString(),
                     typeRight.GetKindString());
-                return new BinderCheckTypeResult() { Node = binaryOpNode, NodeType = DType.Error };
+                return new BinderCheckTypeResult() { Node = left.Parent, NodeType = DType.Error };
             }
 
             if (!typeLeft.Accepts(typeRight) && !typeRight.Accepts(typeLeft))
@@ -736,7 +736,7 @@ namespace Microsoft.PowerFx.Core.Binding
             return new BinderCheckTypeResult() { Coercions = coercions };
         }
 
-        private static BinderCheckTypeResult CheckEqualArgTypesCore(IErrorContainer errorContainer, TexlNode binaryOpNode, TexlNode left, TexlNode right, DType typeLeft, DType typeRight)
+        private static BinderCheckTypeResult CheckEqualArgTypesCore(IErrorContainer errorContainer, TexlNode left, TexlNode right, DType typeLeft, DType typeRight)
         {
             Contracts.AssertValue(left);
             Contracts.AssertValue(right);
@@ -803,16 +803,13 @@ namespace Microsoft.PowerFx.Core.Binding
 
             if (typeLeft.IsUntypedObject && typeRight.IsUntypedObject)
             {
-                if (typeLeft.IsUntypedObject && typeRight.IsUntypedObject)
-                {
                     errorContainer.EnsureError(
                         DocumentErrorSeverity.Severe,
-                        binaryOpNode,
+                        left.Parent,
                         TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
                         typeLeft.GetKindString(),
                         typeRight.GetKindString());
-                    return new BinderCheckTypeResult() { Node = binaryOpNode, NodeType = DType.Error };
-                }
+                    return new BinderCheckTypeResult() { Node = left.Parent, NodeType = DType.Error };
             }
 
             var coercions = new List<BinderCoercionResult>();
@@ -926,7 +923,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 case BinaryOp.Equal:
                 case BinaryOp.NotEqual:
-                    var resEq = CheckEqualArgTypesCore(errorContainer, node, leftNode, rightNode, leftType, rightType);
+                    var resEq = CheckEqualArgTypesCore(errorContainer, leftNode, rightNode, leftType, rightType);
                     return new BinderCheckTypeResult() { Node = node, NodeType = DType.Boolean, Coercions = resEq.Coercions };
 
                 case BinaryOp.Less:
@@ -936,7 +933,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // Excel's type coercion for inequality operators is inconsistent / borderline wrong, so we can't
                     // use it as a reference. For example, in Excel '2 < TRUE' produces TRUE, but so does '2 < FALSE'.
                     // Sticking to a restricted set of numeric-like types for now until evidence arises to support the need for coercion.
-                    var resOrder = CheckComparisonArgTypesCore(errorContainer, node, leftNode, rightNode, leftType, rightType);
+                    var resOrder = CheckComparisonArgTypesCore(errorContainer, leftNode, rightNode, leftType, rightType);
                     return new BinderCheckTypeResult() { Node = node, NodeType = DType.Boolean, Coercions = resOrder.Coercions };
 
                 case BinaryOp.In:

--- a/src/libraries/Microsoft.PowerFx.Core/IR/BinaryOpMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/BinaryOpMatrix.cs
@@ -60,6 +60,30 @@ namespace Microsoft.PowerFx.Core.IR
                 }
             }
 
+            if (leftType.IsUntypedObject && rightType.Kind == DKind.ObjNull)
+            {
+                if (binding.TryGetCoercedType(node.Left, out var leftCoerced))
+                {
+                    kindToUse = leftCoerced.Kind;
+                }
+                else
+                {
+                    return BinaryOpKind.Invalid;
+                }
+            }
+
+            if (rightType.IsUntypedObject && leftType.Kind == DKind.ObjNull)
+            {
+                if (binding.TryGetCoercedType(node.Right, out var rightCoerced))
+                {
+                    kindToUse = rightCoerced.Kind;
+                }
+                else
+                {
+                    return BinaryOpKind.Invalid;
+                }
+            }
+
             switch (kindToUse)
             {
                 case DKind.Number:

--- a/src/libraries/Microsoft.PowerFx.Core/IR/BinaryOpMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/BinaryOpMatrix.cs
@@ -68,7 +68,13 @@ namespace Microsoft.PowerFx.Core.IR
                 }
                 else
                 {
-                    return BinaryOpKind.Invalid;
+                    switch (node.Op)
+                    {
+                        case BinaryOp.NotEqual:
+                            return BinaryOpKind.NeqNullUntyped;
+                        case BinaryOp.Equal:
+                            return BinaryOpKind.EqNullUntyped;
+                    }
                 }
             }
 
@@ -80,7 +86,13 @@ namespace Microsoft.PowerFx.Core.IR
                 }
                 else
                 {
-                    return BinaryOpKind.Invalid;
+                    switch (node.Op)
+                    {
+                        case BinaryOp.NotEqual:
+                            return BinaryOpKind.NeqNullUntyped;
+                        case BinaryOp.Equal:
+                            return BinaryOpKind.EqNullUntyped;
+                    }
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/BinaryOpKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/BinaryOpKind.cs
@@ -49,6 +49,7 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
         EqViewValue,
         EqNamedValue,
         EqNull,
+        EqNullUntyped,
 
         NeqNumbers,
         NeqBoolean,
@@ -67,6 +68,7 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
         NeqViewValue,
         NeqNamedValue,
         NeqNull,
+        NeqNullUntyped,
 
         LtNumbers,
         LeqNumbers,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -332,6 +332,8 @@ namespace Microsoft.PowerFx
                 case BinaryOpKind.EqTime:
                 case BinaryOpKind.EqNull:
                     return OperatorBinaryEq(this, context, node.IRContext, args);
+                case BinaryOpKind.EqNullUntyped:
+                    return OperatorBinaryEqNullUntyped(this, context, node.IRContext, args);
 
                 case BinaryOpKind.NeqBlob:
                 case BinaryOpKind.NeqBoolean:
@@ -349,6 +351,8 @@ namespace Microsoft.PowerFx
                 case BinaryOpKind.NeqTime:
                 case BinaryOpKind.NeqNull:
                     return OperatorBinaryNeq(this, context, node.IRContext, args);
+                case BinaryOpKind.NeqNullUntyped:
+                    return OperatorBinaryNeqNullUntyped(this, context, node.IRContext, args);
 
                 case BinaryOpKind.GtNumbers:
                     return OperatorBinaryGt(this, context, node.IRContext, args);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryOperators.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryOperators.cs
@@ -523,7 +523,7 @@ namespace Microsoft.PowerFx.Functions
                 return new BooleanValue(irContext, false);
             }
 
-            Contracts.Assert(arg1 is UntypedObjectValue ^ arg2 is UntypedObjectValue, "UO = UO is undefined");
+            Contracts.Assert(arg1 is UntypedObjectValue ^ arg2 is UntypedObjectValue, "UO <> UO is undefined");
 
             if (arg1 is UntypedObjectValue uo1)
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BasicCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BasicCoercion.txt
@@ -46,7 +46,7 @@ true
 
 // Erroneous Date -> Bool coercion
 >> Date(2000,1,2) && 1
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Boolean, Number, Text, OptionSetValue.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Boolean, Number, Text, OptionSetValue, UntypedObject.
 
 >> If(Date(2000,1,1),1,2)
 Errors: Error 3-17: Invalid argument type (Date). Expecting a Boolean value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -196,34 +196,34 @@ Table({Value:1},{Value:2},{Value:3})
 Errors: Error 29-37: Name isn't valid. 'ThisItem' isn't recognized.|Error 0-38: The function 'ForAll' has some invalid arguments.
 
 >> ParseJSON("5") + ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
+10
 
 >> ParseJSON("5") - ParseJSON("5")
-Errors: Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean.|Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean.
+0
 
 >> ParseJSON("5") * ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.
+25
 
 >> ParseJSON("5") / ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime.
+1
 
 >> ParseJSON("5") = ParseJSON("5")
 Errors: Error 15-16: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
 
 >> ParseJSON("5") > ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
+Errors: Error 15-16: This operation isn't valid on these types: UntypedObject, UntypedObject.
 
 >> ParseJSON("5") < ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 17-31: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
+Errors: Error 15-16: This operation isn't valid on these types: UntypedObject, UntypedObject.
 
 >> ParseJSON("5") <> ParseJSON("5")
 Errors: Error 15-17: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
 
 >> ParseJSON("5") >= ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 18-32: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
+Errors: Error 15-17: This operation isn't valid on these types: UntypedObject, UntypedObject.
 
 >> ParseJSON("5") <= ParseJSON("5")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.|Error 18-32: Invalid argument type. Expecting one of the following: Number, Date, Time, DateTime.
+Errors: Error 15-17: This operation isn't valid on these types: UntypedObject, UntypedObject.
 
 >> CountRows(ParseJSON("[1, 2, 3]"))
 3

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -2,8 +2,14 @@
 >> 1+ParseJSON("2")
 3
 
+>> Blank()+ParseJSON("2")
+2
+
 >> ParseJSON("1")+2
 3
+
+>> ParseJSON("1")+Blank()
+1
 
 >> ParseJSON("1")+ParseJSON("2")
 3
@@ -14,8 +20,14 @@ Error({Kind:ErrorKind.Div0})
 >> 5-ParseJSON("3")
 2
 
+>> Blank()-ParseJSON("3")
+-3
+
 >> ParseJSON("5")-3
 2
+
+>> ParseJSON("5")-Blank()
+5
 
 >> ParseJSON("5")-ParseJSON("3")
 2
@@ -39,8 +51,14 @@ Error({Kind:ErrorKind.Div0})
 >> 2*ParseJSON("3")
 6
 
+>> Blank()*ParseJSON("3")
+0
+
 >> ParseJSON("2")*3
 6
+
+>> ParseJSON("2")*Blank()
+0
 
 >> ParseJSON("2")*ParseJSON("3")
 6
@@ -48,8 +66,14 @@ Error({Kind:ErrorKind.Div0})
 >> ParseJSON("15")/3
 5
 
+>> ParseJSON("15")/Blank()
+Error({Kind:ErrorKind.Div0})
+
 >> 15/ParseJSON("3")
 5
+
+>> Blank()/ParseJSON("3")
+0
 
 >> ParseJSON("15")/ParseJSON("3")
 5
@@ -100,6 +124,18 @@ false
 
 >> 1<>ParseJSON("1")
 false
+
+>> ParseJSON("1")=Blank()
+false
+
+>> Blank()=ParseJSON("1")
+false
+
+>> ParseJSON("1")<>Blank()
+true
+
+>> Blank()<>ParseJSON("1")
+true
 
 >> ParseJSON("6")>5
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -95,17 +95,10 @@ true
 >> 1=ParseJSON("1")
 true
 
->> ParseJSON("1")=ParseJSON("1")
-true
-
 >> ParseJSON("1")<>1
 false
 
 >> 1<>ParseJSON("1")
-false
-
-
->> ParseJSON("1")<>ParseJSON("1")
 false
 
 >> ParseJSON("6")>5
@@ -114,25 +107,28 @@ true
 >> 6>ParseJSON("5")
 true
 
->> ParseJSON("6")>ParseJSON("5")
-true
-
 >> ParseJSON("5")>6
 false
 
 >> 5>ParseJSON("6")
 false
 
->> ParseJSON("5")>ParseJSON("6")
+>> ParseJSON("5.0")>5
 false
 
->> 5.0>5
-false 
+>> 5.0>ParseJSON("5")
+false
 
->> 5>=5
+>> ParseJSON("5")>=5
 true
 
->> 5>=6
+>> 5>=ParseJSON("5")
+true
+
+>> ParseJSON("5")>=6
+false
+
+>> 5>=ParseJSON("6")
 false
 
 >> 5 < 7

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -293,3 +293,38 @@ Error({Kind:ErrorKind.NotSupported})
 
 >> Hour(ParseJSON("1") - Time(12, 34, 56))
 Error({Kind:ErrorKind.NotSupported})
+
+// blank should be coerced to 0 in `<`, `<=`, `>=`, `<=`, but not in equality or inequality
+>> ParseJSON("0") = Blank()
+false
+
+>> ParseJSON("0") <> Blank()
+true
+
+>> Blank() = ParseJSON("0")
+false
+
+>> Blank() <> ParseJSON("0")
+true
+
+>> ParseJSON("null") = Blank()
+true
+
+>> ParseJSON("null") <> Blank()
+false
+
+>> Blank() = ParseJSON("null")
+true
+
+>> Blank() <> ParseJSON("null")
+false
+
+// ^ operator
+>> ParseJSON("3") ^ 4
+81
+
+>> 3 ^ ParseJSON("4")
+81
+
+>> ParseJSON("3") ^ ParseJSON("4")
+81

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -257,3 +257,39 @@ true
 
 >> Blank() >= ParseJSON("0")
 true
+
+>> Day(Date(2011,1,15) + ParseJSON("1"))
+16
+
+>> Day(ParseJSON("1") + Date(2011,1,15))
+16
+
+>> Day(DateTime(2011,1,15,4,5,6) + ParseJSON("1"))
+16
+
+>> Day(ParseJSON("1") + DateTime(2011,1,15,4,5,6))
+16
+
+>> Hour(Time(12, 34, 56) + ParseJSON("1"))
+12
+
+>> Hour(ParseJSON("1") + Time(12, 34, 56))
+12
+
+>> Day(Date(2011,1,15) - ParseJSON("1"))
+14
+
+>> Day(ParseJSON("1") - Date(2011,1,15))
+Error({Kind:ErrorKind.NotSupported})
+
+>> Day(DateTime(2011,1,15,4,5,6) - ParseJSON("1"))
+14
+
+>> Day(ParseJSON("1") - DateTime(2011,1,15,4,5,6))
+Error({Kind:ErrorKind.NotSupported})
+
+>> Hour(Time(12, 34, 56) - ParseJSON("1"))
+-11
+
+>> Hour(ParseJSON("1") - Time(12, 34, 56))
+Error({Kind:ErrorKind.NotSupported})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -1,0 +1,215 @@
+﻿// Test simple arithmetic
+>> 1+ParseJSON("2")
+3
+
+>> ParseJSON("1")+2
+3
+
+>> ParseJSON("1")+ParseJSON("2")
+3
+
+>> 1 + (1/ParseJSON("0"))
+Error({Kind:ErrorKind.Div0})
+
+>> 5-ParseJSON("3")
+2
+
+>> ParseJSON("5")-3
+2
+
+>> ParseJSON("5")-ParseJSON("3")
+2
+
+// Unary minus
+>> -ParseJSON("3")
+-3
+
+>> -(1/ParseJSON("0"))
+Error({Kind:ErrorKind.Div0})
+
+>> 5 - -ParseJSON("3")
+8
+
+>> -(5+ParseJSON("3"))
+-8
+
+>> -(ParseJSON("5")+3)
+-8
+
+>> 2*ParseJSON("3")
+6
+
+>> ParseJSON("2")*3
+6
+
+>> ParseJSON("2")*ParseJSON("3")
+6
+
+>> ParseJSON("15")/3
+5
+
+>> 15/ParseJSON("3")
+5
+
+>> ParseJSON("15")/ParseJSON("3")
+5
+
+>> ParseJSON("1")/2
+0.5
+
+>> 1/ParseJSON("2")
+0.5
+
+>> ParseJSON("20")%
+0.2
+
+>> ParseJSON("200")%
+2
+
+>> (1/ParseJSON("0"))%
+Error({Kind:ErrorKind.Div0})
+
+>> ParseJSON("1") * 50%
+0.5
+
+>> 1 * ParseJSON("50")%
+0.5
+
+// Precedence
+>> ParseJSON("1")+2*3
+7
+
+>> 1+ParseJSON("2")*3
+7
+
+>> 1+2*ParseJSON("3")
+7
+
+>> ParseJSON("1")+ParseJSON("2")*ParseJSON("3")
+7
+
+// Comparison operations 
+>> ParseJSON("1")=1
+true
+
+>> 1=ParseJSON("1")
+true
+
+>> ParseJSON("1")=ParseJSON("1")
+true
+
+>> ParseJSON("1")<>1
+false
+
+>> 1<>ParseJSON("1")
+false
+
+
+>> ParseJSON("1")<>ParseJSON("1")
+false
+
+>> ParseJSON("6")>5
+true
+
+>> 6>ParseJSON("5")
+true
+
+>> ParseJSON("6")>ParseJSON("5")
+true
+
+>> ParseJSON("5")>6
+false
+
+>> 5>ParseJSON("6")
+false
+
+>> ParseJSON("5")>ParseJSON("6")
+false
+
+>> 5.0>5
+false 
+
+>> 5>=5
+true
+
+>> 5>=6
+false
+
+>> 5 < 7
+true
+
+>> -5 < 3
+true
+
+>> 5 < 5
+false
+
+>> 5 <= 7
+true
+
+>> 5 < 1/0
+Error({Kind:ErrorKind.Div0})
+
+>> 5 <= 1/0
+Error({Kind:ErrorKind.Div0})
+
+>> 5 > 1/0
+Error({Kind:ErrorKind.Div0})
+
+>> 5 >= 1/0
+Error({Kind:ErrorKind.Div0})
+
+>> 5 = 1/0
+Error({Kind:ErrorKind.Div0})
+
+>> 5 <> 1/0
+Error({Kind:ErrorKind.Div0})
+
+// Blank coercions
+>> 1 < If(1<0,1)
+false
+
+>> 1 > If(1<0,1)
+true
+
+>> 1 <= If(1<0,1)
+false
+
+>> 1 >= If(1<0,1)
+true
+
+>> If(1<0,1) < 0
+false
+
+>> If(1<0,1) > 0
+false
+
+>> If(1<0,1) <= 0
+true
+
+>> If(1<0,1) >= 0
+true
+
+>> 1 < Blank()
+false
+
+>> 1 > Blank()
+true
+
+>> 1 <= Blank()
+false
+
+>> 1 >= Blank()
+true
+
+>> Blank() < 0
+false
+
+>> Blank() > 0
+false
+
+>> Blank() <= 0
+true
+
+>> Blank() >= 0
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -131,81 +131,93 @@ false
 >> 5>=ParseJSON("6")
 false
 
->> 5 < 7
+>> ParseJSON("5") < 7
 true
 
->> -5 < 3
+>> 5 < ParseJSON("7")
 true
 
->> 5 < 5
+>> -5 < ParseJSON("3")
+true
+
+>> -ParseJSON("5") < 3
+true
+
+>> ParseJSON("5") < 5
 false
 
->> 5 <= 7
+>> 5 < ParseJSON("5")
+false
+
+>> 5 <= ParseJSON("7")
 true
 
->> 5 < 1/0
+>> ParseJSON("5") <= 7
+true
+
+>> 5 < 1/ParseJSON("0")
 Error({Kind:ErrorKind.Div0})
 
->> 5 <= 1/0
+>> 5 <= 1/ParseJSON("0")
 Error({Kind:ErrorKind.Div0})
 
->> 5 > 1/0
+>> 5 > 1/ParseJSON("0")
 Error({Kind:ErrorKind.Div0})
 
->> 5 >= 1/0
+>> 5 >= 1/ParseJSON("0")
 Error({Kind:ErrorKind.Div0})
 
->> 5 = 1/0
+>> 5 = 1/ParseJSON("0")
 Error({Kind:ErrorKind.Div0})
 
->> 5 <> 1/0
+>> 5 <> 1/ParseJSON("0")
 Error({Kind:ErrorKind.Div0})
 
 // Blank coercions
->> 1 < If(1<0,1)
+>> 1 < If(ParseJSON("1")<0,1)
 false
 
->> 1 > If(1<0,1)
+>> 1 > If(ParseJSON("1")<0,1)
 true
 
->> 1 <= If(1<0,1)
+>> 1 <= If(ParseJSON("1")<0,1)
 false
 
->> 1 >= If(1<0,1)
+>> 1 >= If(ParseJSON("1")<0,1)
 true
 
->> If(1<0,1) < 0
+>> If(ParseJSON("1")<0,1) < 0
 false
 
->> If(1<0,1) > 0
+>> If(ParseJSON("1")<0,1) > 0
 false
 
->> If(1<0,1) <= 0
+>> If(ParseJSON("1")<0,1) <= 0
 true
 
->> If(1<0,1) >= 0
+>> If(ParseJSON("1")<0,1) >= 0
 true
 
->> 1 < Blank()
+>> ParseJSON("1") < Blank()
 false
 
->> 1 > Blank()
+>> ParseJSON("1") > Blank()
 true
 
->> 1 <= Blank()
+>> ParseJSON("1") <= Blank()
 false
 
->> 1 >= Blank()
+>> ParseJSON("1") >= Blank()
 true
 
->> Blank() < 0
+>> Blank() < ParseJSON("0")
 false
 
->> Blank() > 0
+>> Blank() > ParseJSON("0")
 false
 
->> Blank() <= 0
+>> Blank() <= ParseJSON("0")
 true
 
->> Blank() >= 0
+>> Blank() >= ParseJSON("0")
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Arithmetic.txt
@@ -288,8 +288,8 @@ Error({Kind:ErrorKind.NotSupported})
 >> Day(ParseJSON("1") - DateTime(2011,1,15,4,5,6))
 Error({Kind:ErrorKind.NotSupported})
 
->> Hour(Time(12, 34, 56) - ParseJSON("1"))
--11
+>> Hour(Time(12, 34, 56) - ParseJSON("0.25"))
+6
 
 >> Hour(ParseJSON("1") - Time(12, 34, 56))
 Error({Kind:ErrorKind.NotSupported})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
@@ -49,10 +49,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="ExpressionTestCases\ParseJSON_Arithmetic.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\libraries\Microsoft.PowerFx.Core\Microsoft.PowerFx.Core.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
@@ -49,6 +49,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="ExpressionTestCases\ParseJSON_Arithmetic.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\libraries\Microsoft.PowerFx.Core\Microsoft.PowerFx.Core.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/CustomRecordTypeWithUndefinedFields.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/CustomRecordTypeWithUndefinedFields.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("IsBlank(obj.missing)", true, false)] // fields not defined in RecordType is treated as Blank.
         [InlineData("IsBlank(obj.missing.missing)", true, false)]
         [InlineData("IsBlank(obj.prop_not_defined_in_type)", true, false)] // fields not defined in RecordType is always Blank, regardless of whether it is defined in actual data.
-        [InlineData("IsError(obj.missing + 1)", null, true)] // type checking fails when operating on undefined field.
+        [InlineData("IsError(obj.missing + 1)", false, false)] // type checking fails when operating on undefined field.
         public async Task TestCustomRecordType(string expr, object expected, bool hasException)
         {
             var engine = new RecalcEngine();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/CustomRecordTypeWithUndefinedFields.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/CustomRecordTypeWithUndefinedFields.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("IsBlank(obj.missing)", true, false)] // fields not defined in RecordType is treated as Blank.
         [InlineData("IsBlank(obj.missing.missing)", true, false)]
         [InlineData("IsBlank(obj.prop_not_defined_in_type)", true, false)] // fields not defined in RecordType is always Blank, regardless of whether it is defined in actual data.
-        [InlineData("IsError(obj.missing + 1)", false, false)] // type checking fails when operating on undefined field.
+        [InlineData("IsError(obj.missing + 1)", false, false)] // undefined field produces blank, which should be coerced to 0.
         public async Task TestCustomRecordType(string expr, object expected, bool hasException)
         {
             var engine = new RecalcEngine();


### PR DESCRIPTION
Enables coercions from UntypedObject to other types in binary and unary operators. Untyped/Blank combinations often coerce to Number. Includes tests for Blank() for many operators.