### PR TITLE
Fix delegation for boolean fields and boolean option sets

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FilterDelegationBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FilterDelegationBase.cs
@@ -104,6 +104,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                     case NodeKind.FirstName:
                         {
+                            // Only boolean option sets and boolean fields are allowed to delegate
+                            var nodeDType = binding.GetType(dsNode);
+                            if (!((nodeDType.IsOptionSet && nodeDType.OptionSetInfo != null && nodeDType.OptionSetInfo.IsBooleanValued) || (nodeDType == DType.Boolean && dsNode.Kind != NodeKind.BoolLit))) 
+                            {
+                                SuggestDelegationHint(dsNode, binding);
+                                return false;
+                            }
+
                             if (!firstNameStrategy.IsValidFirstNameNode(dsNode.AsFirstName(), binding, null))
                             {
                                 return false;
@@ -114,6 +122,16 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                     case NodeKind.DottedName:
                         {
+                            // Only boolean option set, boolean fields and views are allowed to delegate
+                            var nodeDType = binding.GetType(dsNode);
+                            if (!((nodeDType.IsOptionSet && nodeDType.OptionSetInfo != null && nodeDType.OptionSetInfo.IsBooleanValued) 
+                                || (nodeDType == DType.Boolean && dsNode.Kind != NodeKind.BoolLit)
+                                || (nodeDType == DType.ViewValue)))
+                            {
+                                SuggestDelegationHint(dsNode, binding);
+                                return false;
+                            }
+
                             if (!dottedNameStrategy.IsValidDottedNameNode(dsNode.AsDottedName(), binding, filterMetadata, null))
                             {
                                 return false;


### PR DESCRIPTION
Fix delegation problems with -
1) Filter(SharepointDS, BooleanCol And <some other predicate>) which is not delegated as it is looking for And operation in column metadata and it is not present there for sharepoint columns and only at table level.
2) Filter(DS, TextColumn) is marked as delegable which it shouldn't be, so restricting the boolean checks to only boolean optionset and boolean fields (and views too for dotted node)