### PR TITLE
Removing coercion date to number within Collect.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -176,7 +176,7 @@ namespace Microsoft.PowerFx.Interpreter
             {
                 // The item type must be compatible with the collection schema.
                 var fError = false;
-                returnType = DType.Union(ref fError, collectionType.ToRecord(), collectedType, useLegacyDateTimeAccepts: true);
+                returnType = DType.Union(ref fError, collectionType.ToRecord(), collectedType);
                 if (fError)
                 {
                     fValid = false;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
@@ -30,3 +30,6 @@ Table({Value:1},{Value:2},{Value:3},{Value:99},{Value:88},{Value:77},{Value:77},
 
 >> Collect([1,2,3],{Value:200})
 {Value:200}
+
+>> Collect([1,2,3],{Value:Date(2023,3,1)})
+Errors: Error 16-38: Incompatible type. The 'Value' column in the data source you’re updating expects a 'Number' type and you’re using a 'Date' type.|Error 0-39: The function 'Collect' has some invalid arguments.


### PR DESCRIPTION
To support https://github.com/microsoft/Power-Fx-Dataverse/issues/79

Date to number is a special kind of coercion that is inconsistent with other conversions.
These changes are meant to prevent this coercion from within a record.