### PR TITLE
Add support for RuntimeConfig in TryCoerceTo and add CanCoerceToStringValue and allow Text(Guid)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 
 namespace Microsoft.PowerFx
 {
@@ -29,6 +30,16 @@ namespace Microsoft.PowerFx
         public static void SetCulture(this RuntimeConfig symbols, CultureInfo culture)
         {
             symbols.AddService(culture ?? throw new ArgumentNullException(nameof(culture)));
+        }
+
+        /// <summary>
+        /// Set CancellationToken.
+        /// </summary>
+        /// <param name="symbols">SymbolValues where to set the CancellationToken.</param>
+        /// <param name="cancellationToken">CancellationToken to set.</param>
+        public static void SetCancellationToken(this RuntimeConfig symbols, CancellationToken cancellationToken)
+        {
+            symbols.AddService(cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 
 namespace Microsoft.PowerFx
 {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
@@ -33,16 +33,6 @@ namespace Microsoft.PowerFx
         }
 
         /// <summary>
-        /// Set CancellationToken.
-        /// </summary>
-        /// <param name="symbols">SymbolValues where to set the CancellationToken.</param>
-        /// <param name="cancellationToken">CancellationToken to set.</param>
-        public static void SetCancellationToken(this RuntimeConfig symbols, CancellationToken cancellationToken)
-        {
-            symbols.AddService(cancellationToken);
-        }
-
-        /// <summary>
         /// Create a set of values against this symbol table.
         /// </summary>
         /// <returns></returns>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Functions
 
     internal static partial class Library
     {
-        internal static readonly List<FormulaType> AllowedListConvertToString = new List<FormulaType> { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean, FormulaType.Guid };
+        internal static readonly IReadOnlyList<FormulaType> AllowedListConvertToString = new List<FormulaType> { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean, FormulaType.Guid };
 
         private static readonly RegexOptions RegExFlags = LibraryFlags.RegExFlags;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Functions
 
     internal static partial class Library
     {
-        internal static readonly IReadOnlyList<FormulaType> AllowedListConvertToString = new List<FormulaType> { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean, FormulaType.Guid };
+        internal static readonly IReadOnlyList<FormulaType> AllowedListConvertToString = new FormulaType[] { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean, FormulaType.Guid };
 
         private static readonly RegexOptions RegExFlags = LibraryFlags.RegExFlags;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Functions
 
     internal static partial class Library
     {
-        internal static readonly List<FormulaType> AllowedListConvertToString = new List<FormulaType> { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean };
+        internal static readonly List<FormulaType> AllowedListConvertToString = new List<FormulaType> { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean, FormulaType.Guid };
 
         private static readonly RegexOptions RegExFlags = LibraryFlags.RegExFlags;
 
@@ -314,6 +314,9 @@ namespace Microsoft.PowerFx.Functions
                     break;
                 case BooleanValue b:
                     result = new StringValue(irContext, b.Value.ToString(culture).ToLower());
+                    break;
+                case GuidValue g:
+                    result = new StringValue(irContext, g.Value.ToString(formatString ?? "d", culture));
                     break;
             }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -31,6 +31,8 @@ namespace Microsoft.PowerFx.Functions
 
     internal static partial class Library
     {
+        internal static readonly List<FormulaType> AllowedListConvertToString = new List<FormulaType> { FormulaType.String, FormulaType.Number, FormulaType.DateTime, FormulaType.Date, FormulaType.Time, FormulaType.Boolean };
+
         private static readonly RegexOptions RegExFlags = LibraryFlags.RegExFlags;
 
         private static readonly Regex _ampmReplaceRegex = new Regex("[aA][mM]\\/[pP][mM]", RegExFlags);
@@ -47,7 +49,7 @@ namespace Microsoft.PowerFx.Functions
         private static readonly Regex _minutesDetokenizeRegex = new Regex("[\u000A][\u000A]+", RegExFlags);
         private static readonly Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegExFlags);
         private static readonly Regex _milisecondsDetokenizeRegex = new Regex("[\u000e]+", RegExFlags);
-
+        
         // Char is used for PA string escaping 
         public static FormulaValue Char(IRContext irContext, NumberValue[] args)
         {
@@ -250,6 +252,8 @@ namespace Microsoft.PowerFx.Functions
             {
                 return false;
             }
+
+            Contract.Assert(AllowedListConvertToString.Contains(value.Type));
 
             switch (value)
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Functions;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
@@ -16,15 +16,19 @@ namespace Microsoft.PowerFx
     /// </summary>
     public static class TypeCoercionProvider
     {
-        internal static FormattingInfo CreateFormattingInfo()
+        internal static FormattingInfo CreateFormattingInfo() => new FormattingInfo()
         {
-            return new FormattingInfo()
-            {
-                CultureInfo = CultureInfo.CurrentCulture,
-                CancellationToken = CancellationToken.None,
-                TimeZoneInfo = TimeZoneInfo.Local
-            };
-        }
+            CultureInfo = CultureInfo.CurrentCulture,
+            CancellationToken = CancellationToken.None,
+            TimeZoneInfo = TimeZoneInfo.Local
+        };
+
+        internal static FormattingInfo CreateFormattingInfoFromRuntimeConfig(RuntimeConfig runtimeConfig) => new FormattingInfo()
+        {
+            CultureInfo = runtimeConfig.GetService<CultureInfo>(),
+            CancellationToken = runtimeConfig.GetService<CancellationToken>(),
+            TimeZoneInfo = runtimeConfig.GetService<TimeZoneInfo>()
+        };
 
         /// <summary>
         /// Try to convert value to Boolean format.
@@ -46,6 +50,18 @@ namespace Microsoft.PowerFx
         public static bool TryCoerceTo(this FormulaValue value, out StringValue result)
         {
             return TryCoerceTo(value, CreateFormattingInfo(), out result);
+        }
+
+        /// <summary>
+        /// Try to convert value to String format.
+        /// </summary>
+        /// <param name="value">Input value.</param>
+        /// <param name="runtimeConfig">Runtime Config. Need to SetCulture, SetCancellationToken and SetTimeZone for RuntimeConfig.</param>
+        /// <param name="result">Result value.</param>
+        /// <returns>True/False based on whether function can convert from original type to String type.</returns> 
+        public static bool TryCoerceTo(this FormulaValue value, RuntimeConfig runtimeConfig, out StringValue result)
+        {
+            return TryText(CreateFormattingInfoFromRuntimeConfig(runtimeConfig), IRContext.NotInSource(FormulaType.String), value, null, out result);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx
             TimeZoneInfo = TimeZoneInfo.Local
         };
 
-        internal static FormattingInfo CreateFormattingInfoFromRuntimeConfig(RuntimeConfig runtimeConfig, CancellationToken cancellationToken) => new FormattingInfo()
+        internal static FormattingInfo CreateFormattingInfo(RuntimeConfig runtimeConfig, CancellationToken cancellationToken) => new FormattingInfo()
         {
             CultureInfo = runtimeConfig.GetService<CultureInfo>(),
             CancellationToken = cancellationToken,
@@ -74,7 +74,7 @@ namespace Microsoft.PowerFx
         /// <returns>True/False based on whether function can convert from original type to String type.</returns> 
         public static bool TryCoerceTo(this FormulaValue value, RuntimeConfig runtimeConfig, CancellationToken cancellationToken, out StringValue result)
         {
-            return TryText(CreateFormattingInfoFromRuntimeConfig(runtimeConfig, cancellationToken), IRContext.NotInSource(FormulaType.String), value, null, out result);
+            return TryCoerceTo(value, CreateFormattingInfo(runtimeConfig, cancellationToken), out result);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
@@ -42,6 +42,16 @@ namespace Microsoft.PowerFx
         }
 
         /// <summary>
+        /// Can convert value to String format or not.
+        /// </summary>
+        /// <param name="value">Input value.</param>
+        /// <returns>True/False based on whether function can convert from original type to String type.</returns> 
+        public static bool CanCoerceToStringValue(this FormulaValue value)
+        {
+            return AllowedListConvertToString.Contains(value.Type);
+        }
+
+        /// <summary>
         /// Try to convert value to String format.
         /// </summary>
         /// <param name="value">Input value.</param>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Marshal/TypeCoercionProvider.cs
@@ -23,10 +23,10 @@ namespace Microsoft.PowerFx
             TimeZoneInfo = TimeZoneInfo.Local
         };
 
-        internal static FormattingInfo CreateFormattingInfoFromRuntimeConfig(RuntimeConfig runtimeConfig) => new FormattingInfo()
+        internal static FormattingInfo CreateFormattingInfoFromRuntimeConfig(RuntimeConfig runtimeConfig, CancellationToken cancellationToken) => new FormattingInfo()
         {
             CultureInfo = runtimeConfig.GetService<CultureInfo>(),
-            CancellationToken = runtimeConfig.GetService<CancellationToken>(),
+            CancellationToken = cancellationToken,
             TimeZoneInfo = runtimeConfig.GetService<TimeZoneInfo>()
         };
 
@@ -56,12 +56,25 @@ namespace Microsoft.PowerFx
         /// Try to convert value to String format.
         /// </summary>
         /// <param name="value">Input value.</param>
-        /// <param name="runtimeConfig">Runtime Config. Need to SetCulture, SetCancellationToken and SetTimeZone for RuntimeConfig.</param>
+        /// <param name="runtimeConfig">Runtime Config.</param>
         /// <param name="result">Result value.</param>
         /// <returns>True/False based on whether function can convert from original type to String type.</returns> 
         public static bool TryCoerceTo(this FormulaValue value, RuntimeConfig runtimeConfig, out StringValue result)
         {
-            return TryText(CreateFormattingInfoFromRuntimeConfig(runtimeConfig), IRContext.NotInSource(FormulaType.String), value, null, out result);
+            return TryCoerceTo(value, runtimeConfig, CancellationToken.None, out result);
+        }
+
+        /// <summary>
+        /// Try to convert value to String format.
+        /// </summary>
+        /// <param name="value">Input value.</param>
+        /// <param name="runtimeConfig">Runtime Config.</param>
+        /// <param name="cancellationToken">Cancellation Token.</param>
+        /// <param name="result">Result value.</param>
+        /// <returns>True/False based on whether function can convert from original type to String type.</returns> 
+        public static bool TryCoerceTo(this FormulaValue value, RuntimeConfig runtimeConfig, CancellationToken cancellationToken, out StringValue result)
+        {
+            return TryText(CreateFormattingInfoFromRuntimeConfig(runtimeConfig, cancellationToken), IRContext.NotInSource(FormulaType.String), value, null, out result);
         }
 
         /// <summary>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
@@ -250,3 +250,24 @@ Error({Kind:ErrorKind.Div0})
 
 >> Text(1.2, "", "vi-Vn")
 "1,2"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"))
+"0f8fad5b-d9cb-469f-a165-70867728950e"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "b")
+"{0f8fad5b-d9cb-469f-a165-70867728950e}"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "d", "vi-Vn")
+"0f8fad5b-d9cb-469f-a165-70867728950e"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "p", "vi-Vn")
+"(0f8fad5b-d9cb-469f-a165-70867728950e)"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "n", "vi-Vn")
+"0f8fad5bd9cb469fa16570867728950e"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "b", "vi-Vn")
+"{0f8fad5b-d9cb-469f-a165-70867728950e}"
+
+>> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "", "vi-Vn")
+"0f8fad5b-d9cb-469f-a165-70867728950e"

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
@@ -69,12 +69,27 @@ namespace Microsoft.PowerFx.Tests
             Assert.Throws<CustomFunctionErrorException>(() => inputValue.TryCoerceTo(out DateTimeValue resultDateTime));
         }
 
+        // From Guid to String
+        [Theory]
+        [InlineData("0f8fad5bd9cb469fa16570867728950e", "0f8fad5b-d9cb-469f-a165-70867728950e")]
+        [InlineData("0f8fad5b-d9cb-469f-a165-70867728950e", "0f8fad5b-d9cb-469f-a165-70867728950e")]
+        public void TryCoerceFromGuidToStringTest(string value, string expectedValue)
+        {
+            GuidValue guidInput = new GuidValue(IRContext.NotInSource(FormulaType.Guid), new Guid(value));
+            bool isSucceeded = guidInput.TryCoerceTo(out StringValue resultValue);
+            Assert.True(isSucceeded);
+            Assert.Equal(expectedValue, resultValue.Value);
+        }
+
         // Test if it can coerce to String
         [Fact]
         public void CanCoerceToStringTest()
         {
+            ColorValue colorInput = new ColorValue(IRContext.NotInSource(FormulaType.Color), System.Drawing.Color.Red);
+            Assert.False(colorInput.CanCoerceToStringValue());
+
             GuidValue guidInput = new GuidValue(IRContext.NotInSource(FormulaType.Guid), Guid.NewGuid());
-            Assert.False(guidInput.CanCoerceToStringValue());
+            Assert.True(guidInput.CanCoerceToStringValue());
 
             NumberValue numberInput = new NumberValue(IRContext.NotInSource(FormulaType.Number), 12);
             Assert.True(numberInput.CanCoerceToStringValue());

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
@@ -108,9 +108,7 @@ namespace Microsoft.PowerFx.Tests
 
             var runtimeConfig = new RuntimeConfig();
             runtimeConfig.SetCulture(CultureInfo.CurrentCulture);
-            runtimeConfig.SetCancellationToken(CancellationToken.None);
             runtimeConfig.SetTimeZone(TimeZoneInfo.Utc);
-
             isSucceeded = inputValue.TryCoerceTo(runtimeConfig, out StringValue resultString);
             if (exprStr != null)
             {
@@ -121,6 +119,20 @@ namespace Microsoft.PowerFx.Tests
             {
                 Assert.False(isSucceeded);
                 Assert.IsType<ErrorValue>(resultString);
+            }
+
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(3000);
+            isSucceeded = inputValue.TryCoerceTo(runtimeConfig, cts.Token, out StringValue cResultString);
+            if (exprStr != null)
+            {
+                Assert.True(isSucceeded);
+                Assert.Equal(exprStr, cResultString.Value);
+            }
+            else
+            {
+                Assert.False(isSucceeded);
+                Assert.IsType<ErrorValue>(cResultString);
             }
 
             isSucceeded = inputValue.TryCoerceTo(out DateTimeValue resultDateTime);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Numerics;
+using System.Threading;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Interpreter;
@@ -102,6 +104,23 @@ namespace Microsoft.PowerFx.Tests
             {
                 Assert.False(isSucceeded);
                 Assert.IsType<ErrorValue>(resultValue);
+            }
+
+            var runtimeConfig = new RuntimeConfig();
+            runtimeConfig.SetCulture(CultureInfo.CurrentCulture);
+            runtimeConfig.SetCancellationToken(CancellationToken.None);
+            runtimeConfig.SetTimeZone(TimeZoneInfo.Utc);
+
+            isSucceeded = inputValue.TryCoerceTo(runtimeConfig, out StringValue resultString);
+            if (exprStr != null)
+            {
+                Assert.True(isSucceeded);
+                Assert.Equal(exprStr, resultString.Value);
+            }
+            else
+            {
+                Assert.False(isSucceeded);
+                Assert.IsType<ErrorValue>(resultString);
             }
 
             isSucceeded = inputValue.TryCoerceTo(out DateTimeValue resultDateTime);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TypeCoercionTest.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Threading;
 using Microsoft.PowerFx;
+using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Interpreter;
 using Microsoft.PowerFx.Types;
@@ -66,6 +67,17 @@ namespace Microsoft.PowerFx.Tests
             var inputValue = FormulaValue.New(value);
 
             Assert.Throws<CustomFunctionErrorException>(() => inputValue.TryCoerceTo(out DateTimeValue resultDateTime));
+        }
+
+        // Test if it can coerce to String
+        [Fact]
+        public void CanCoerceToStringTest()
+        {
+            GuidValue guidInput = new GuidValue(IRContext.NotInSource(FormulaType.Guid), Guid.NewGuid());
+            Assert.False(guidInput.CanCoerceToStringValue());
+
+            NumberValue numberInput = new NumberValue(IRContext.NotInSource(FormulaType.Number), 12);
+            Assert.True(numberInput.CanCoerceToStringValue());
         }
 
         private void TryCoerceToTargetTypes(FormulaValue inputValue, string exprBool, string exprNumber, string exprStr, string exprDateTime)


### PR DESCRIPTION
Fix issue https://github.com/microsoft/Power-Fx/issues/1126
and issue https://github.com/microsoft/Power-Fx/issues/1127
and issue https://github.com/microsoft/Power-Fx/issues/1137