### PR TITLE
Collect no longer accepts not existing fields

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Extensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Extensions.cs
@@ -38,6 +38,15 @@ namespace Microsoft.PowerFx.Functions
             return true;
         }
 
+        /// <summary>
+        /// Checks if all names within an aggregate DType exists.
+        /// </summary>
+        /// <param name="argType">Record DType.</param>
+        /// <param name="dataSourceType">Table DType.</param>
+        /// <param name="arg">Arg node.</param>
+        /// <param name="errors">Error object reference.</param>
+        /// <param name="supportsParamCoercion">Does the caller function support coercion.</param>
+        /// <returns></returns>
         internal static bool CheckAggregateNames(this DType argType, DType dataSourceType, TexlNode arg, IErrorContainer errors, bool supportsParamCoercion = false)
         {
             bool isValid = true;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Extensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Extensions.cs
@@ -2,8 +2,12 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Functions
 {
@@ -32,6 +36,41 @@ namespace Microsoft.PowerFx.Functions
 
             // ambiguous times (like 5 Nov 2023 01:10:00 is ambiguous in PST timezone) will be considered valid
             return true;
+        }
+
+        internal static bool CheckAggregateNames(this DType argType, DType dataSourceType, TexlNode arg, IErrorContainer errors, bool supportsParamCoercion = false)
+        {
+            bool isValid = true;
+
+            foreach (var typedName in argType.GetNames(DPath.Root))
+            {
+                DName name = typedName.Name;
+                DType type = typedName.Type;
+
+                if (!dataSourceType.TryGetType(name, out DType dsNameType))
+                {
+                    dataSourceType.ReportNonExistingName(FieldNameKind.Display, errors, typedName.Name, arg);
+                    isValid = false;
+                    continue;
+                }
+
+                if (!type.Accepts(dsNameType, out var schemaDifference, out var schemaDifferenceType) &&
+                    (!supportsParamCoercion || !type.CoercesTo(dsNameType, out var coercionIsSafe, aggregateCoercion: false) || !coercionIsSafe))
+                {
+                    if (dsNameType.Kind == type.Kind)
+                    {
+                        errors.Errors(arg, type, schemaDifference, schemaDifferenceType);
+                    }
+                    else
+                    {
+                        errors.EnsureError(DocumentErrorSeverity.Severe, arg, TexlStrings.ErrTypeError_Arg_Expected_Found, name, dsNameType.GetKindString(), type.GetKindString());
+                    }
+
+                    isValid = false;
+                }
+            }
+
+            return isValid;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -117,6 +117,7 @@ namespace Microsoft.PowerFx.Interpreter
                     argType = argType.ToRecord();
                 }
 
+                // Checks if all record names exist against table type and if its possible to coerce.
                 bool checkAggregateNames = argType.CheckAggregateNames(argTypes[0], args[i], errors, SupportsParamCoercion);
                 fValid = fValid && checkAggregateNames;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
-using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Errors;
@@ -18,7 +16,6 @@ using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 using static Microsoft.PowerFx.Core.Localization.TexlStrings;
-using static Microsoft.PowerFx.Syntax.PrettyPrintVisitor;
 
 namespace Microsoft.PowerFx.Interpreter
 {
@@ -119,6 +116,9 @@ namespace Microsoft.PowerFx.Interpreter
                 {
                     argType = argType.ToRecord();
                 }
+
+                bool checkAggregateNames = argType.CheckAggregateNames(argTypes[0], args[i], errors, SupportsParamCoercion);
+                fValid = fValid && checkAggregateNames;
 
                 if (!itemType.IsValid)
                 {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -177,6 +177,7 @@ namespace Microsoft.PowerFx.Functions
                     continue;
                 }
 
+                // Checks if all record names exist against table type and if its possible to coerce.
                 bool checkAggregateNames = curType.CheckAggregateNames(dataSourceType, args[i], errors, SupportsParamCoercion);
 
                 isValid = isValid && checkAggregateNames;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect.txt
@@ -42,13 +42,13 @@ Errors: Error 12-15: Invalid argument type (Text). Expecting a Record value inst
 Errors: Error 12-13: Invalid argument type (Number). Expecting a Record value instead.|Error 12-13: Invalid argument type. Cannot use Number values in this context.|Error 0-14: The function 'Collect' has some invalid arguments.
 
 >> Collect(Table({name: "VC"}), {surname: "textInput1"})
-{surname:"textInput1"}
+Errors: Error 29-52: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 0-53: The function 'Collect' has some invalid arguments.
 
 >> Collect(FirstN(Table({name: "hello"}), 0), {name: "textInput1"})
 {name:"textInput1"}
 
 >> Collect(Foo,r2)
-Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 0-15: The function 'Collect' has some invalid arguments.
+Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-14: The specified column 'Field1' does not exist.|Error 0-15: The function 'Collect' has some invalid arguments.
 
 >> Collect(Foo,Bar)
 Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-15: Name isn't valid. 'Bar' isn't recognized.|Error 0-16: The function 'Collect' has some invalid arguments.
@@ -57,13 +57,13 @@ Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-15: Name 
 Errors: Error 12-15: Name isn't valid. 'Foo' isn't recognized.
 
 >> Collect(Error({Kind:ErrorKind.Custom}), r2)
-Error({Kind:ErrorKind.Custom})
+Errors: Error 40-42: The specified column 'Field1' does not exist.|Error 0-43: The function 'Collect' has some invalid arguments.
 
 >> Collect(Error({Kind:ErrorKind.Custom}), Error({Kind:ErrorKind.Div0}))
 Error({Kind:ErrorKind.Custom})
 
 >> Collect(Blank(), r2)
-Blank()
+Errors: Error 17-19: The specified column 'Field1' does not exist.|Error 0-20: The function 'Collect' has some invalid arguments.
 
 >> Collect(Blank(), Blank())
 Blank()
@@ -75,7 +75,7 @@ Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instea
 Errors: Error 8-25: The function 'Collect' has some invalid arguments.
 
 >> Collect(t1,{Price:200}).Price
-200
+Errors: Error 11-22: The specified column 'Price' does not exist.|Error 0-23: The function 'Collect' has some invalid arguments.|Error 23-29: Name isn't valid. 'Price' isn't recognized.
 
 >> Collect([1,2,3],{Value:200}).Value
 200

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             if (result.Fail > 0)
             {
-                Assert.Equal(string.Empty, result.Output);
+                Assert.True(false, result.Output);
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
@@ -38,13 +38,13 @@ Errors: Error 17-20: Invalid argument type (Text). Expecting a Record value inst
 Errors: Error 17-18: Invalid argument type (Number). Expecting a Record value instead.|Error 17-18: Invalid argument type. Cannot use Number values in this context.|Error 0-19: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Table({name: "VC"}), {surname: "textInput1"})
-{surname:"textInput1"}
+Errors: Error 34-57: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 0-58: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(FirstN(Table({name: "hello"}), 0), {name: "textInput1"})
 {name:"textInput1"}
 
 >> ClearCollect(Foo,r1)
-Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 0-20: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-19: The specified column 'a' does not exist.|Error 0-20: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Foo,Bar)
 Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-20: Name isn't valid. 'Bar' isn't recognized.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
@@ -53,13 +53,13 @@ Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-20: Name
 Errors: Error 17-20: Name isn't valid. 'Foo' isn't recognized.|Error 14-15: Invalid argument type (Number). Expecting a Table value instead.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Error({Kind:ErrorKind.Custom}), r1)
-Error({Kind:ErrorKind.Custom})
+Errors: Error 45-47: The specified column 'a' does not exist.|Error 0-48: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Error({Kind:ErrorKind.Custom}), Error({Kind:ErrorKind.Div0}))
 Error({Kind:ErrorKind.Custom})
 
 >> ClearCollect(Blank(), r1)
-Blank()
+Errors: Error 22-24: The specified column 'a' does not exist.|Error 0-25: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Blank(), Blank())
 Blank()

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
@@ -33,4 +33,6 @@ Table({Value:1},{Value:2},{Value:3},{Value:99},{Value:88},{Value:77},{Value:77},
 
 >> Collect([1,2,3],{Value:Date(2023,3,1)})
 Errors: Error 16-38: The type of this argument 'Value' does not match the expected type 'Number'. Found type 'Date'.|Error 0-39: The function 'Collect' has some invalid arguments.
-//Errors: Error 16-38: The type of this argument 'Value' does not match the expected type 'Number'. Found type 'Date'.\r\nError 0-39: The function 'Collect' has some invalid arguments.
+
+>> Collect(Table({x:1,y:2}), {x: 3}).y 
+Blank()

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
@@ -32,4 +32,5 @@ Table({Value:1},{Value:2},{Value:3},{Value:99},{Value:88},{Value:77},{Value:77},
 {Value:200}
 
 >> Collect([1,2,3],{Value:Date(2023,3,1)})
-Errors: Error 16-38: Incompatible type. The 'Value' column in the data source you’re updating expects a 'Number' type and you’re using a 'Date' type.|Error 0-39: The function 'Collect' has some invalid arguments.
+Errors: Error 16-38: The type of this argument 'Value' does not match the expected type 'Number'. Found type 'Date'.|Error 0-39: The function 'Collect' has some invalid arguments.
+//Errors: Error 16-38: The type of this argument 'Value' does not match the expected type 'Number'. Found type 'Date'.\r\nError 0-39: The function 'Collect' has some invalid arguments.


### PR DESCRIPTION
Supports DV https://github.com/microsoft/Power-Fx-Dataverse/issues/84

Previously Collect, and Patch would handle non-existing fields differently. Collect used to allow, while Patch didn't.
When executing Collect, PA will determine whether the current data source is a DV instance. Then will decide how to behave based on that.
Power Fx will not handle different data source types differently. 