### PR TITLE
Allow IfError to accept UntypedObjects in the first argument

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4269,8 +4269,10 @@ namespace Microsoft.PowerFx.Core.Binding
                         maybeFunc = overloadWithUntypedObjectLambda;
                         scopeInfo = maybeFunc.ScopeInfo;
                     }
-                    else
+                    else if (numOverloads != 1)
                     {
+                        // We have multiple overloads, therefore we cannot pick one because it's impossible
+                        // to determine if the first argument is an untyped array or a scalar
                         UntypedObjectScopeError(node, maybeFunc, nodeInput);
 
                         PreVisitBottomUp(node, 1);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -488,3 +488,6 @@ Blank()
 
 >> Text(Index(ParseJSON("[""one"",""two"",""three""]"),true)) // Coercion from boolean
 "one"
+
+>> Boolean(IfError(ParseJSON("{""field1"":true}").field1, ParseJSON("false")))
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -39,7 +39,7 @@ Errors: Error 4-24: Untyped objects cannot be used as the first argument to func
 6
 
 >> Filter(ParseJSON("[1,2,3]"), true)
-Errors: Error 7-27: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Filter' has some invalid arguments.
+Errors: Error 7-27: Invalid argument type.|Error 0-34: The function 'Filter' has some invalid arguments.
 
 // Comparison tests
 >> Abs(5) = Abs(ParseJSON("5"))


### PR DESCRIPTION
In general, this changes Binder to allow normal type checking to occur in the case where:

1. Lambdas exist on one of the overrides to a function
2. The first argument is UntypedObject
3. There is only a single overload, i.e. no scalar overloads at all

The 3rd item in this list was not true before this change. We would give record scope errors in the binder. Normal type checking will fail for all functions where this error would have been seen before, with a single exception: the IfError function, where type checking will succeed.

This is not a breaking change.