### PR TITLE
Fix Text function handling of GUID values

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -316,7 +316,7 @@ namespace Microsoft.PowerFx.Functions
                     result = new StringValue(irContext, b.Value.ToString(culture).ToLower());
                     break;
                 case GuidValue g:
-                    result = new StringValue(irContext, g.Value.ToString(formatString ?? "d", culture));
+                    result = new StringValue(irContext, g.Value.ToString("d", CultureInfo.InvariantCulture));
                     break;
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text.txt
@@ -254,20 +254,21 @@ Error({Kind:ErrorKind.Div0})
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"))
 "0f8fad5b-d9cb-469f-a165-70867728950e"
 
+// GUID is always formatted the same way by the text function
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "b")
-"{0f8fad5b-d9cb-469f-a165-70867728950e}"
+"0f8fad5b-d9cb-469f-a165-70867728950e"
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "d", "vi-Vn")
 "0f8fad5b-d9cb-469f-a165-70867728950e"
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "p", "vi-Vn")
-"(0f8fad5b-d9cb-469f-a165-70867728950e)"
+"0f8fad5b-d9cb-469f-a165-70867728950e"
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "n", "vi-Vn")
-"0f8fad5bd9cb469fa16570867728950e"
+"0f8fad5b-d9cb-469f-a165-70867728950e"
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "b", "vi-Vn")
-"{0f8fad5b-d9cb-469f-a165-70867728950e}"
+"0f8fad5b-d9cb-469f-a165-70867728950e"
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "", "vi-Vn")
 "0f8fad5b-d9cb-469f-a165-70867728950e"


### PR DESCRIPTION
GUID-to-text conversion shouldn't be done based on .NET rules. This change updates the Text implementation to ignore the second argument for GUID values.