### PR TITLE
Remove 'accepts' relationship between Guid and string

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -913,8 +913,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     return new BinderCheckTypeResult() { Node = node, NodeType = DType.Boolean, Coercions = resLeftAnd.Coercions.Concat(resRightAnd.Coercions).ToList() };
 
                 case BinaryOp.Concat:
-                    var resLeftConcat = CheckTypeCore(errorContainer, leftNode, leftType, DType.String, /* coerced: */ DType.Number, DType.Date, DType.Time, DType.DateTimeNoTimeZone, DType.DateTime, DType.Boolean, DType.OptionSetValue, DType.ViewValue, DType.UntypedObject);
-                    var resRightConcat = CheckTypeCore(errorContainer, rightNode, rightType, DType.String, /* coerced: */ DType.Number, DType.Date, DType.Time, DType.DateTimeNoTimeZone, DType.DateTime, DType.Boolean, DType.OptionSetValue, DType.ViewValue, DType.UntypedObject);
+                    var resLeftConcat = CheckTypeCore(errorContainer, leftNode, leftType, DType.String, /* coerced: */ DType.Guid, DType.Number, DType.Date, DType.Time, DType.DateTimeNoTimeZone, DType.DateTime, DType.Boolean, DType.OptionSetValue, DType.ViewValue, DType.UntypedObject);
+                    var resRightConcat = CheckTypeCore(errorContainer, rightNode, rightType, DType.String, /* coerced: */ DType.Guid, DType.Number, DType.Date, DType.Time, DType.DateTimeNoTimeZone, DType.DateTime, DType.Boolean, DType.OptionSetValue, DType.ViewValue, DType.UntypedObject);
                     return new BinderCheckTypeResult() { Node = node, NodeType = DType.String, Coercions = resLeftConcat.Coercions.Concat(resRightConcat.Coercions).ToList() };
 
                 case BinaryOp.Error:

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionKind.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerFx.Core.IR
         DateToText,
         TimeToText,
         DateTimeToText,
+        GuidToText,
 
         NumberToBoolean,
         TextToBoolean,

--- a/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/CoercionMatrix.cs
@@ -351,6 +351,10 @@ namespace Microsoft.PowerFx.Core.IR
             {
                 return CoercionKind.ViewToText;
             }
+            else if (DType.Guid.Accepts(fromType))
+            {
+                return CoercionKind.GuidToText;
+            }
             else
             {
                 return CoercionKind.None; // Implicit coercion?

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -854,6 +854,9 @@ namespace Microsoft.PowerFx.Core.IR
                     case CoercionKind.BooleanToText:
                         unaryOpKind = UnaryOpKind.BooleanToText;
                         break;
+                    case CoercionKind.GuidToText:
+                        unaryOpKind = UnaryOpKind.GuidToText;
+                        break;
                     case CoercionKind.OptionSetToText:
                         unaryOpKind = UnaryOpKind.OptionSetToText;
                         break;

--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
         BooleanToText,
         OptionSetToText,
         ViewToText,
+        GuidToText,
 
         NumberToBoolean,
         TextToBoolean,

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -92,6 +92,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction FirstN_UO = _library.Add(new FirstLastNFunction_UO(isFirst: true));
         public static readonly TexlFunction ForAll = _library.Add(new ForAllFunction());
         public static readonly TexlFunction ForAll_UO = _library.Add(new ForAllFunction_UO());
+        public static readonly TexlFunction GUIDNoArg = _library.Add(new GUIDNoArgFunction());
         public static readonly TexlFunction GUIDPure = _library.Add(new GUIDPureFunction());
         public static readonly TexlFunction GUID_UO = _library.Add(new GUIDPureFunction_UO());
         public static readonly TexlFunction Hex2Dec = _library.Add(new Hex2DecFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1923,7 +1923,6 @@ namespace Microsoft.PowerFx.Core.Types
                         type.Kind == DKind.Blob ||
                         type.Kind == DKind.Unknown ||
                         type.Kind == DKind.Deferred ||
-                        type.Kind == DKind.Guid ||
                         (type.Kind == DKind.Enum && Accepts(type.GetEnumSupertype()));
                     break;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -693,6 +693,10 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: ForAll_UO)
             },
             {
+                BuiltinFunctionsCore.GUIDNoArg,
+                NoErrorHandling(GuidNoArg)
+            },
+            {
                 BuiltinFunctionsCore.GUIDPure,
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.GUIDPure.Name,
@@ -701,7 +705,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Guid)
+                    targetFunction: GuidPure)
             },
             {
                 BuiltinFunctionsCore.GUID_UO,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -902,7 +902,13 @@ namespace Microsoft.PowerFx.Functions
             return new StringValue(irContext, result);
         }
 
-        public static FormulaValue Guid(IRContext irContext, StringValue[] args)
+        public static FormulaValue GuidNoArg(IRContext irContext, FormulaValue[] args)
+        {
+            var guid = System.Guid.NewGuid();
+            return new GuidValue(irContext, guid);
+        }
+
+        public static FormulaValue GuidPure(IRContext irContext, StringValue[] args)
         {
             var text = args[0].Value;
             try

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -74,6 +74,17 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: BooleanToText)
             },
             {
+                UnaryOpKind.GuidToText,
+                StandardErrorHandling<GuidValue>(
+                    functionName: null, // internal function, no user-facing name
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<GuidValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: GuidToText)
+            },
+            {
                 UnaryOpKind.BooleanToNumber,
                 StandardErrorHandling<BooleanValue>(
                     functionName: null, // internal function, no user-facing name
@@ -312,6 +323,12 @@ namespace Microsoft.PowerFx.Functions
         public static FormulaValue NumberToText(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, NumberValue[] args)
         {
             return Text(runner, context, irContext, args);
+        }
+
+        public static FormulaValue GuidToText(IRContext irContext, GuidValue[] args)
+        {
+            var g = args[0].Value;
+            return new StringValue(irContext, g.ToString("d"));
         }
 
         public static BooleanValue NumberToBoolean(IRContext irContext, NumberValue[] args)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -344,7 +344,7 @@ namespace Microsoft.PowerFx.Functions
             if (impl.Type == FormulaType.String)
             {
                 var str = new StringValue(IRContext.NotInSource(FormulaType.String), impl.GetString());
-                return Guid(irContext, new StringValue[] { str });
+                return GuidPure(irContext, new StringValue[] { str });
             }
 
             return GetTypeMismatchError(irContext, BuiltinFunctionsCore.GUID_UO.Name, DType.String.GetKindString(), impl);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/GUID.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/GUID.txt
@@ -31,3 +31,23 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> GUID("thisisastringthatismuchlongerthanaguidshouldbeitisquitealongstringandwillfinderrorswithlongstringsinthisfunction")
 Error({Kind:ErrorKind.InvalidArgument})
+
+// Coercion to text
+>> If(1<0,"",GUID("C203B79B-B985-42F0-B523-C10EB64387C6"))
+"c203b79b-b985-42f0-b523-c10eb64387c6"
+
+// Coercion to text, dash positions
+>> With({g:GUID(),dashPositions:[9,14,19,24]},Concat(dashPositions,Mid(g,Value,1)))
+"----"
+
+// Parameterless constructor, creates different values
+>> GUID() = GUID()
+false
+
+// Parameterless constructor, creates valid GUID
+>> With(
+    {g:GUID(), digits:"0123456789abcdef", dashPositions:[9,14,19,24]},
+    Sum(
+        Filter(Sequence(Len(g)), !(Value in dashPositions)),
+        If(Find(Mid(g,Value,1),digits) > 0, 1, 100)))
+32

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TypeSystemTests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TypeSystemTests/DTypeTests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.PowerFx.Tests
 
             Assert.True(DType.String.Accepts(DType.String));
             Assert.True(DType.String.Accepts(DType.Hyperlink));
-            Assert.True(DType.String.Accepts(DType.Guid));
+            Assert.False(DType.String.Accepts(DType.Guid));
             Assert.True(DType.String.Accepts(DType.Image));
             Assert.True(DType.String.Accepts(DType.PenImage));
             Assert.True(DType.String.Accepts(DType.Media));
@@ -1229,7 +1229,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(DKind.Error, superType.Kind);
 
             superType = DType.Supertype(DType.Guid, DType.String);
-            Assert.Equal(DKind.String, superType.Kind);
+            Assert.Equal(DKind.Error, superType.Kind);
 
             superType = DType.Supertype(DType.Guid, DType.Number);
             Assert.Equal(DKind.Error, superType.Kind);
@@ -2160,8 +2160,8 @@ namespace Microsoft.PowerFx.Tests
             TestUnion("s", "m", "s");
             TestUnion("s", "o", "s");
             TestUnion("o", "s", "s");
-            TestUnion("s", "g", "s");
-            TestUnion("g", "s", "s");
+            TestUnion("s", "g", "e");
+            TestUnion("g", "s", "e");
 
             TestUnion("h", "m", "h");
             TestUnion("h", "s", "s");


### PR DESCRIPTION
We need a coercion node between Guid and string values. This removes the 'Accepts' relationship between the two types. It also adds the parameter-less GUID function.