### PR TITLE
Handle blank / error values in aggregate coercion scenarios

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -501,6 +501,11 @@ namespace Microsoft.PowerFx
         {
             var arg1 = await node.Child.Accept(this, context);
 
+            if (arg1 is BlankValue || arg1 is ErrorValue)
+            {
+                return arg1;
+            }
+
             if (node.Op == UnaryOpKind.TableToTable)
             {
                 var table = (TableValue)arg1;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions_ConsistentOneColumnTableResult.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TrigTableFunctions_ConsistentOneColumnTableResult.txt
@@ -74,3 +74,22 @@ Table({Value:0},{Value:180},{Value:90},{Value:-90},{Value:270},{Value:360},{Valu
 
 >> Round(Radians(Table({a:0}, {a:1}, {a:-1}, {a:180}, {a:90}, {a:-180}, {a:-90}, {a:-360}, {a:Blank()})), 4)
 Table({Value:0},{Value:0.0175},{Value:-0.0175},{Value:3.1416},{Value:1.5708},{Value:-3.1416},{Value:-1.5708},{Value:-6.2832},{Value:0})
+
+// ####### Coercions
+>> Sin(["0"])
+Table({Value:0})
+
+>> If(1<0,Sin(["0"]))
+Blank()
+
+>> Sin(If(Sqrt(-1)<0,["0"]))
+Error({Kind:ErrorKind.Numeric})
+
+>> Cos(["0"])
+Table({Value:1})
+
+>> If(1<0,Cos(["0"]))
+Blank()
+
+>> Cos(If(Sqrt(-1)<0,["0"]))
+Error({Kind:ErrorKind.Numeric})


### PR DESCRIPTION
The interpreter handling aggregate coercion for blank / null values is not working. This fixes it.