### PR TITLE
Update resource to remove unqualified enum references

### DIFF
--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -864,7 +864,8 @@
     <value>An expression that gets evaluated over rows in 'source' and provides values for sorting.</value>
   </data>
   <data name="AboutSort_order" xml:space="preserve">
-    <value>Ascending or Descending</value>
+    <value>SortOrder.Ascending or SortOrder.Descending</value>
+    <comment>{Locked=SortOrder.Ascending}{Locked=SortOrder.Descending} Possible values for the third argument of the Sort function</comment>
   </data>
   <data name="AboutSortByColumns" xml:space="preserve">
     <value>Sorts 'source' based on the column, optionally specifying a sort 'order'.</value>
@@ -889,7 +890,8 @@
     <value>A unique column name.</value>
   </data>
   <data name="AboutSortByColumns_order" xml:space="preserve">
-    <value>Ascending or Descending</value>
+    <value>SortOrder.Ascending or SortOrder.Descending</value>
+    <comment>{Locked=SortOrder.Ascending}{Locked=SortOrder.Descending} Possible values for the third argument of the Sort function</comment>
   </data>
   <data name="AboutSortByColumnsWithOrderValues" xml:space="preserve">
     <value>Sorts 'source' based on the index of matching values in the specified column.</value>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -2384,8 +2384,8 @@
     <value>A number of units to add. The number can be negative.</value>
   </data>
   <data name="AboutDateAdd_unit" xml:space="preserve">
-    <value>The unit to use, which can be one of Years, Quarters, Months, Days, Hours, Minutes, Seconds, Milliseconds.</value>
-    <comment>{Locked=Years}{Locked=Quarters}{Locked=Months}{Locked=Days}{Locked=Hours}{Locked=Minutes}{Locked=Seconds}{Locked=Milliseconds}</comment>
+    <value>The unit to use, which can be one of TimeUnit.Years, TimeUnit.Quarters, TimeUnit.Months, TimeUnit.Days, TimeUnit.Hours, TimeUnit.Minutes, TimeUnit.Seconds, TimeUnit.Milliseconds.</value>
+    <comment>{Locked=TimeUnit.Years}{Locked=TimeUnit.Quarters}{Locked=TimeUnit.Months}{Locked=TimeUnit.Days}{Locked=TimeUnit.Hours}{Locked=TimeUnit.Minutes}{Locked=TimeUnit.Seconds}{Locked=TimeUnit.Milliseconds}</comment>
   </data>
   <data name="DateDiffArg1" xml:space="preserve">
     <value>start_date</value>
@@ -2406,8 +2406,8 @@
     <value>An end date for the different operation.</value>
   </data>
   <data name="AboutDateDiff_unit" xml:space="preserve">
-    <value>The unit to express the result in, which can be one of Years, Quarters, Months, Days, Hours, Minutes, Seconds, Milliseconds.</value>
-    <comment>{Locked=Years}{Locked=Quarters}{Locked=Months}{Locked=Days}{Locked=Hours}{Locked=Minutes}{Locked=Seconds}{Locked=Milliseconds}</comment>
+    <value>The unit to express the result in, which can be one of TimeUnit.Years, TimeUnit.Quarters, TimeUnit.Months, TimeUnit.Days, TimeUnit.Hours, TimeUnit.Minutes, TimeUnit.Seconds, TimeUnit.Milliseconds.</value>
+    <comment>{Locked=TimeUnit.Years}{Locked=TimeUnit.Quarters}{Locked=TimeUnit.Months}{Locked=TimeUnit.Days}{Locked=TimeUnit.Hours}{Locked=TimeUnit.Minutes}{Locked=TimeUnit.Seconds}{Locked=TimeUnit.Milliseconds}</comment>
   </data>
   <data name="AboutDateAddT" xml:space="preserve">
     <value>Add the specified number of units to a column of dates.</value>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -260,7 +260,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [Theory]
         [InlineData("SortByColumns(|", 2, "The table to sort.", "SortByColumns(source, column, ...)")]
         [InlineData("SortByColumns(tbl1,|", 2, "A unique column name.", "SortByColumns(source, column, ...)")]
-        [InlineData("SortByColumns(tbl1,col1,|", 1, "Ascending or Descending", "SortByColumns(source, column, order, ...)")]
+        [InlineData("SortByColumns(tbl1,col1,|", 1, "SortOrder.Ascending or SortOrder.Descending", "SortByColumns(source, column, order, ...)")]
         [InlineData("SortByColumns(tbl1,col1,SortOrder.Ascending,|", 2, "A unique column name.", "SortByColumns(source, column, order, column, ...)")]
         [InlineData("IfError(1|", 1, "Value that is returned if it is not an error.", "IfError(value, fallback, ...)")]
         [InlineData("IfError(1,2|", 1, "Value that is returned if the previous argument is an error.", "IfError(value, fallback, ...)")]


### PR DESCRIPTION
Following the change to remove support for unqualified enums, we need to update the parameter description for the Sort[ByColumns] argument that controls the sort order, and the Date[Add|Diff] ones that determines the units to use in the addition / difference.