### PR TITLE
Tabular Dec2Hex doesn't work with coercion

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -80,7 +80,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 var type = argTypes[0];
                 var arg = args[0];
-                if (!type.IsTable)
+                if (type.IsTable)
+                {
+                    // Ensure we have a one-column table of numerics
+                    fValid &= CheckNumericColumnType(type, arg, errors, ref nodeToCoercedTypeMap);
+                }
+                else
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, arg, TexlStrings.ErrTypeError);
                     return false;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Dec2Hex.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Dec2Hex.txt
@@ -190,3 +190,6 @@ Table({Value:"A"},{Value:"FF"},{Value:"FFFFFFFFF0"})
 
 >> Dec2Hex(Table({a:10},{a:11},{a:12}), Table({b:2},{b:5},{b:10}))
 Table({Value:"0A"},{Value:"0000B"},{Value:"000000000C"})
+
+>> Dec2Hex(["10","255","-16"])
+Table({Value:"A"},{Value:"FF"},{Value:"FFFFFFFFF0"})


### PR DESCRIPTION
Dec2Hex(["10","255","-16"]) works correctly in Canvas, returning ["A", "FF", "FFFFFFFFF0" ] as it should