### PR TITLE
adds void type support to Switch()

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
@@ -112,19 +112,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var type = ReturnType;
             nodeToCoercedTypeMap = null;
 
-            // Are we on a behavior property?
-            var isBehavior = context.AllowsSideEffects;
-
             // Compute the result type by joining the types of all non-predicate args.
             Contracts.Assert(type == DType.Unknown);
             for (var i = 2; i < count;)
             {
                 var nodeArg = args[i];
                 var typeArg = argTypes[i];
-                if (typeArg.IsError)
-                {
-                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
-                }
 
                 var typeSuper = DType.Supertype(type, typeArg);
 
@@ -132,9 +125,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 {
                     type = typeSuper;
                 }
-                else if (type.Kind == DKind.Unknown)
+                else if (typeArg.IsVoid)
                 {
-                    type = typeSuper;
+                    type = DType.Void;
+                }
+                else if (typeArg.IsError)
+                {
+                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
                     fArgsValid = false;
                 }
                 else if (!type.IsError)
@@ -143,15 +140,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     {
                         CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
                     }
-                    else if (!isBehavior)
+                    else
                     {
-                        errors.EnsureError(
-                            DocumentErrorSeverity.Severe,
-                            nodeArg,
-                            TexlStrings.ErrBadType_ExpectedType_ProvidedType,
-                            type.GetKindString(),
-                            typeArg.GetKindString());
-                        fArgsValid = false;
+                        // If the types are incompatible, the result type is void.
+                        type = DType.Void;
                     }
                 }
                 else if (typeArg.Kind != DKind.Unknown)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2227,7 +2227,7 @@ namespace Microsoft.PowerFx.Functions
                     }
                     else
                     {
-                        return result;
+                        return MaybeAdjustToCompileTimeType(result, irContext);
                     }
                 }
             }
@@ -2245,7 +2245,7 @@ namespace Microsoft.PowerFx.Functions
                 }
                 else
                 {
-                    return result;
+                    return MaybeAdjustToCompileTimeType(result, irContext);
                 }
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -79,7 +79,7 @@ Errors: Error 0-41: The function 'IsBlankOrError' has some invalid arguments.|Er
 Errors: Error 11-34: Invalid argument type.|Error 0-36: The function 'IsNumeric' has some invalid arguments.
 
 >> If( true, With({a:1},Switch(a, 1, { prop:"complex" }, "scalar")) )
-{prop:"complex"}
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 
 >> If( true, With({a:1},Switch(a, 1, 1/0, { prop:"complex" })) )
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects_NumberIsFloat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects_NumberIsFloat.txt
@@ -79,7 +79,7 @@ Errors: Error 0-41: The function 'IsBlankOrError' has some invalid arguments.|Er
 Errors: Error 11-34: Invalid argument type.|Error 0-36: The function 'IsNumeric' has some invalid arguments.
 
 >> If( true, With({a:1},Switch(a, 1, { prop:"complex" }, "scalar")) )
-{prop:"complex"}
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 
 >> If( true, With({a:1},Switch(a, 1, 1/0, { prop:"complex" })) )
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
@@ -309,3 +309,24 @@ Error({Kind:ErrorKind.InvalidArgument})
 //DateTime-DateTime
 >> Switch("Case1","Case2",DateTimeValue("4/1/2001 10:00:00"),"Case1",DateTimeValue("4/1/2001 10:00:00"))
 DateTime(2001,4,1,10,0,0,0)
+
+// Result of switch can't be consumed.
+>> Switch(1, 1, 2, {x:4}) + 1
+Errors: Error 0-22: Invalid argument type. Expecting one of the following: Number, Text, Boolean, UntypedObject.
+
+// Expression generating void value can be used inside of the switch. If(1<0, 1, {x:1}) => void value
+>> Switch(1, 1, 2, If(1<0, 1, {x:4}))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+>> Switch(1, 1, 1/0, 10, {x:4})
+Error({Kind:ErrorKind.Div0})
+
+>> Switch(1, 1, 2, {x:4}, 3)
+Errors: Error 16-21: Invalid argument type (Record). Expecting a Number value instead.|Error 0-25: The function 'Switch' has some invalid arguments.
+
+>> Switch(1, 2, 2, 3, b)
+Errors: Error 19-20: Name isn't valid. 'b' isn't recognized.|Error 0-21: The function 'Switch' has some invalid arguments.
+
+>> Switch(10, 1, 1/0, 10, {x:4})
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
@@ -311,8 +311,8 @@ Error({Kind:ErrorKind.InvalidArgument})
 DateTime(2001,4,1,10,0,0,0)
 
 // Result of switch can't be consumed.
->> Switch(1, 1, 2, {x:4}) + 1
-Errors: Error 0-22: Invalid argument type. Expecting one of the following: Number, Text, Boolean, UntypedObject.
+>> Abs(Switch(1, 1, -2, {x:4}))
+Errors: Error 0-28: The function 'Abs' has some invalid arguments.|Error 4-27: Invalid argument type (Void). Expecting a Number value instead.
 
 // Expression generating void value can be used inside of the switch. If(1<0, 1, {x:1}) => void value
 >> Switch(1, 1, 2, If(1<0, 1, {x:4}))
@@ -321,8 +321,8 @@ If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 >> Switch(1, 1, 1/0, 10, {x:4})
 Error({Kind:ErrorKind.Div0})
 
->> Switch(1, 1, 2, {x:4}, 3)
-Errors: Error 16-21: Invalid argument type (Record). Expecting a Number value instead.|Error 0-25: The function 'Switch' has some invalid arguments.
+>> Switch("a", "a", 2, {x:4}, 3)
+Errors: Error 20-25: Invalid argument type (Record). Expecting a Text value instead.|Error 0-29: The function 'Switch' has some invalid arguments.
 
 >> Switch(1, 2, 2, 3, b)
 Errors: Error 19-20: Name isn't valid. 'b' isn't recognized.|Error 0-21: The function 'Switch' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
@@ -318,15 +318,16 @@ Errors: Error 0-28: The function 'Abs' has some invalid arguments.|Error 4-27: I
 >> Switch(1, 1, 2, If(1<0, 1, {x:4}))
 If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 
+// Void expressions can become error
 >> Switch(1, 1, 1/0, 10, {x:4})
 Error({Kind:ErrorKind.Div0})
+
+// Void expressions that are not errors have a void value
+>> Switch(10, 1, 1/0, 10, {x:4})
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 
 >> Switch("a", "a", 2, {x:4}, 3)
 Errors: Error 20-25: Invalid argument type (Record). Expecting a Text value instead.|Error 0-29: The function 'Switch' has some invalid arguments.
 
 >> Switch(1, 2, 2, 3, b)
 Errors: Error 19-20: Name isn't valid. 'b' isn't recognized.|Error 0-21: The function 'Switch' has some invalid arguments.
-
->> Switch(10, 1, 1/0, 10, {x:4})
-If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
-


### PR DESCRIPTION
-Fixes #1201 
-Currently in Switch()'s check type we allow usage of the result of the switch statement even when arg is mismatched, we shouldn't be doing that.
e.g. `Set(x, Switch(20, 20, 1, 21, {x:1}))` should not be allowed.

-Return void when the switch() has the arg type mismatch.