### PR TITLE
adds void type to IfError()

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -123,11 +123,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             In this case, we prefer the type of the last v_i as the return type.
             */
 
-            var prefereedTypeIndex = (count % 2) == 0 ? count - 2 : count - 1;
-            var type = argTypes[prefereedTypeIndex];
+            var preferredTypeIndex = (count % 2) == 0 ? count - 2 : count - 1;
+            var type = argTypes[preferredTypeIndex];
             if (type.IsError)
             {
-                errors.EnsureError(args[prefereedTypeIndex], TexlStrings.ErrTypeError);
+                errors.EnsureError(args[preferredTypeIndex], TexlStrings.ErrTypeError);
                 fArgsValid = false;
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -131,7 +131,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     {
                         // If the types are incompatible, the result type is void.
                         type = DType.Void;
-                        break;
                     }
                 }
                 else if (typeArg.Kind != DKind.Unknown)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2130,7 +2130,7 @@ namespace Microsoft.PowerFx.Functions
                 if (i + 2 == args.Length - 1)
                 {
                     var otherwiseBranch = args[i + 2];
-                    var otherwiseBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, context, falseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
+                    var otherwiseBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(otherwiseBranch, context, otherwiseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
                     return MaybeAdjustToCompileTimeType(otherwiseBranchResult, irContext);
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2129,9 +2129,9 @@ namespace Microsoft.PowerFx.Functions
 
                 if (i + 2 == args.Length - 1)
                 {
-                    var falseBranch = args[i + 2];
-                    var falseBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, context, falseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
-                    return MaybeAdjustToCompileTimeType(falseBranchResult, irContext);
+                    var otherwiseBranch = args[i + 2];
+                    var otherwiseBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, context, falseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
+                    return MaybeAdjustToCompileTimeType(otherwiseBranchResult, irContext);
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2118,18 +2118,20 @@ namespace Microsoft.PowerFx.Functions
 
                     var childContext = context.SymbolContext.WithScopeValues(new InMemoryRecordValue(IRContext.NotInSource(ifErrorScopeParamType), scopeVariables));
 
-                    return (await runner.EvalArgAsync<ValidFormulaValue>(errorHandlingBranch, context.NewScope(childContext), errorHandlingBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
+                    var errorHandlingBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(errorHandlingBranch, context.NewScope(childContext), errorHandlingBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
+                    return MaybeAdjustToCompileTimeType(errorHandlingBranchResult, irContext);
                 }
 
                 if (i + 1 == args.Length - 1)
                 {
-                    return res.ToFormulaValue();
+                    return MaybeAdjustToCompileTimeType(res.ToFormulaValue(), irContext);
                 }
 
                 if (i + 2 == args.Length - 1)
                 {
                     var falseBranch = args[i + 2];
-                    return (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, context, falseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
+                    var falseBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, context, falseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
+                    return MaybeAdjustToCompileTimeType(falseBranchResult, irContext);
                 }
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
@@ -149,6 +149,9 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> IfError(1/0, Time(12,0,0))
 0.5
 
+>> IfError(1, 1/0, Time(12,0,0))
+0.5
+
 // Number-DateTime
 >> IfError(1/0, DateTime(2022,8,1,12,0,0))
 44774.5
@@ -195,3 +198,24 @@ Time(11,30,59,0)
 // Error-DateTime
 >> IfError(Error({Kind: ErrorKind.Validation}), DateTime(2021, 12, 12, 17, 30, 0))
 DateTime(2021,12,12,17,30,0,0)
+
+>> IfError(1, {x:1}, {x:1}, {y:1}, 1)
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+// IfError can have mismatched arg types, but result can't be used.
+>> IfError(1/0, 1, {x:4})
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+// IfError accepts the void value. But then result of the expression can't be used. If(true, 1, {x:4}) => void value.
+>> IfError(1/0, 1, If(true, 1, {x:4}), 1)
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+// Errors are still returned.
+>> IfError(1, 2, 3/0, If(true, 1/0, {x:4}))
+Error({Kind:ErrorKind.Div0})
+
+>> IfError(1, a)
+Errors: Error 11-12: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
+
+>> IfError(a, 1)
+Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
@@ -150,7 +150,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 0.5
 
 >> IfError(1, 1/0, Time(12,0,0))
-0.5
+Time(12,0,0,0)
 
 // Number-DateTime
 >> IfError(1/0, DateTime(2022,8,1,12,0,0))
@@ -235,3 +235,6 @@ Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-13: The funct
 
 >> IfError( 1, "one", If(true,1,{a:1}), "two", "three")
 "three"
+
+>> IfError(1/0, 2, Time(12, 0, 0), 2)
+Time(0,0,0,0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
@@ -238,3 +238,21 @@ Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-13: The funct
 
 >> IfError(1/0, 2, Time(12, 0, 0), 2)
 Time(0,0,0,0)
+
+>> IfError(Blank(), 1)
+Blank()
+
+>> IfError(1, Blank())
+1
+
+>> IfError(1, 2, Blank())
+Blank()
+
+>> IfError(1, Blank(), 2)
+2
+
+>> IfError(Blank(), Blank())
+Blank()
+
+>> IfError(Blank(), Blank(), Blank())
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
@@ -214,8 +214,24 @@ If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
 >> IfError(1, 2, 3/0, If(true, 1/0, {x:4}))
 Error({Kind:ErrorKind.Div0})
 
+// Error is not returned.
+>> IfError(1, 2, 3/0, If(false, 1/0, {x:4}))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
 >> IfError(1, a)
 Errors: Error 11-12: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
 
 >> IfError(a, 1)
 Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
+
+>> IfError( If(true, 1, {a:1}), 1, 2 )
+2
+
+>> IfError( If(true, 1/0, {a:1}), 1, 2 )
+1
+
+>> IfError( 1, "hello", If(true,1/0,{a:1}), "great", "world")
+"great"
+
+>> IfError( 1, "one", If(true,1,{a:1}), "two", "three")
+"three"


### PR DESCRIPTION
-Fixes #1173 

`IfError()` has buggy implementation of CheckType(),

e.g. 
below expression should be an error (now error in the PR):
`IfError(1, {x:1}, {x:1}, {y:1}, 1)` Since it can potentially return a record or a number type

In both cases, it should have been consistent, since the possible result type can be either Number or Time type for both the expression and should have been super typed to the same thing...
`IfError(1, 1, Time(12,0,0)) => Time Type` 
`IfError(1, Time(12,0,0)) => Number Type`
Now Above both are Number Type.

-Also add void type support for mismatched args.