### PR TITLE
Restrict IsEmpty arguments to tables only

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -45,6 +45,12 @@ namespace Microsoft.PowerFx
         /// </summary>
         StronglyTypedBuiltinEnums = 0x10,
 
+        /// <summary>
+        /// Updates the IsEmpty function to only allow table arguments, since it
+        /// does not work properly with other types of arguments.
+        /// </summary>
+        RestrictedIsEmptyArguments = 0x20,
+
         /// <summary>        
         /// All features enabled
         /// [USE WITH CAUTION] In using this value, you expose your code to future features.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsEmpty.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsEmpty.cs
@@ -3,20 +3,22 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
-    // IsEmpty(expression:E)
+    // IsEmpty(expression:*[]) or legacy IsEmpty(expression:any)
     internal sealed class IsEmptyFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
 
         public override bool HasPreciseErrors => true;
-
-        public override bool SupportsParamCoercion => false;
 
         public IsEmptyFunction()
             : base("IsEmpty", TexlStrings.AboutIsEmpty, FunctionCategories.Table | FunctionCategories.Information, DType.Boolean, 0, 1, 1)
@@ -26,6 +28,44 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.IsEmptyArg1 };
+        }
+
+        public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+            Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
+
+            if (args.Length != 1)
+            {
+                return base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            }
+
+            nodeToCoercedTypeMap = null;
+            var fValid = true;
+            if (context.Features.HasFlag(Features.RestrictedIsEmptyArguments))
+            {
+                var typeCheck = CheckType(args[0], argTypes[0], DType.EmptyTable, errors, false, out DType coercionType);
+                if (typeCheck)
+                {
+                    if (coercionType != null)
+                    {
+                        CollectionUtils.Add(ref nodeToCoercedTypeMap, args[0], coercionType);
+                    }
+                }
+
+                fValid = typeCheck;
+            }
+            else
+            {
+                // Legacy behavior: all types are supported
+            }
+
+            returnType = ReturnType;
+            return fValid;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -828,6 +828,17 @@ namespace Microsoft.PowerFx.Functions
                 NoErrorHandling(IsBlankOrError)
             },
             {
+                BuiltinFunctionsCore.IsEmpty,
+                StandardErrorHandling<FormulaValue>(
+                    BuiltinFunctionsCore.IsEmpty.Name,
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: DeferRuntimeTypeChecking,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    targetFunction: IsEmpty)
+            },
+            {
                 BuiltinFunctionsCore.IsError,
                 NoErrorHandling(IsError)
             },
@@ -1821,6 +1832,23 @@ namespace Microsoft.PowerFx.Functions
             }
 
             return false;
+        }
+
+        private static FormulaValue IsEmpty(IRContext irContext, FormulaValue[] args)
+        {
+            if (args[0] is BlankValue)
+            {
+                return new BooleanValue(irContext, true);
+            }
+
+            if (args[0] is TableValue tv)
+            {
+                return new BooleanValue(irContext, !tv.Rows.Any());
+            }
+            else
+            {
+                return CommonErrors.RuntimeTypeMismatch(irContext);
+            }
         }
 
         public static FormulaValue IsNumeric(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsEmpty.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsEmpty.txt
@@ -1,3 +1,5 @@
+#SETUP: RestrictedIsEmptyArguments
+
 // NUMERIC RECORDS
 
 >> IsEmpty([1234])
@@ -43,7 +45,10 @@ false
 true
 
 >> IsEmpty(Blank())
-false
+true
+
+>> IsEmpty(If(1<0,[1,2,3]))
+true
 
 >> IsEmpty([Blank()])
 false
@@ -61,7 +66,7 @@ false
 false
 
 >> IsEmpty(LastN([1,2,3,4], Blank()))
-false
+true
 
 
 // ERROR RECORDS
@@ -103,8 +108,21 @@ true
 >> IsEmpty(
    Filter(
    Table(
-   {a:1,b:true,c:Date(2022,12,1),d:Time(12,34,56),e:DateTimeValue("2012-12-12 12:12:12")},
-   {a:5,b:false,c:Date(2022,12,1),d:TimeValue("5:00 AM"),e:DateTimeValue("2012-12-12 12:12:12")},
-   {a:6,b:true,c:Date(2022,12,1),d:Time(12,34,56),e:DateTimeValue("Jun 19 2022 4:00 PM")}
+   {a:1,b:true,c:Date(2022,12,1),d:Time(12,34,56),e:DateTime(2012,12,12,12,12,12)},
+   {a:5,b:false,c:Date(2022,12,1),d:Time(5,0,0),e:DateTime(2012,12,12,12,12,12)},
+   {a:6,b:true,c:Date(2022,12,1),d:Time(12,34,56),e:DateTime(2022,6,19,16,0,0)}
    ),a > 10))
 true
+
+// INVALID ARGUMENTS
+>> IsEmpty("")
+Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instead.
+
+>> IsEmpty({})
+Errors: Error 8-10: Invalid argument type (Record). Expecting a Table value instead.
+
+>> IsEmpty(0)
+Errors: Error 8-9: Invalid argument type (Number). Expecting a Table value instead.
+
+>> IsEmpty(false)
+Errors: Error 8-13: Invalid argument type (Boolean). Expecting a Table value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -3338,9 +3338,9 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.False(result.IsSuccess);
         }
 
-        private void TestBindingErrors(string script, DType expectedType, SymbolTable symbolTable = null, OptionSet[] optionSets = null)
+        private void TestBindingErrors(string script, DType expectedType, SymbolTable symbolTable = null, OptionSet[] optionSets = null, Features features = Features.None)
         {
-            var config = new PowerFxConfig
+            var config = new PowerFxConfig(features)
             {
                 SymbolTable = symbolTable
             };

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -2487,6 +2487,33 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
+        [InlineData("IsEmpty(\"Hello\")", true)]
+        [InlineData("IsEmpty(7)", true)]
+        [InlineData("IsEmpty([1,2,3,4])", false)]
+        [InlineData("IsEmpty({a:3, b:4})", true)]
+        [InlineData("IsEmpty(Blank())", false)]
+        public void TexlFunctionTypeSemanticsIsEmpty(string script, bool expectedError)
+        {
+            TestSimpleBindingSuccess(script, DType.Boolean); // Without restriction, all succeed
+
+            if (expectedError)
+            {
+                TestBindingErrors(
+                    script,
+                    DType.Boolean,
+                    symbolTable: null,
+                    features: Features.RestrictedIsEmptyArguments);
+            }
+            else
+            {
+                TestSimpleBindingSuccess(
+                    script,
+                    DType.Boolean,
+                    features: Features.RestrictedIsEmptyArguments);
+            }
+        }
+
+        [Theory]
         [InlineData("Sequence(20)", "*[Value:n]")]
         [InlineData("Sequence(20, 30)", "*[Value:n]")]
         [InlineData("Sequence(20, 30, 10)", "*[Value:n]")]


### PR DESCRIPTION
IsEmpty is supposed to check if a table is empty or not, but currently it accepts different types of arguments. Since it doesn't make sense to use it for other types, we will restrict it. But to avoid breaking Power Apps, we will make the change behind a new feature.

Also adding the implementation to the C# interpreter.