### PR TITLE
Support DataEntity type within mutation functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Extensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Extensions.cs
@@ -63,7 +63,16 @@ namespace Microsoft.PowerFx.Functions
                     continue;
                 }
 
-                if (!type.Accepts(dsNameType, out var schemaDifference, out var schemaDifferenceType) &&
+                // For patching entities, we expand the type and drop entities and attachments for the purpose of comparison.
+                if (dsNameType.Kind == DKind.DataEntity && type.Kind != DKind.DataEntity)
+                {
+                    if (dsNameType.TryGetExpandedEntityTypeWithoutDataSourceSpecificColumns(out var expandedType))
+                    {
+                        dsNameType = expandedType;
+                    }
+                }
+
+                if (!dsNameType.Accepts(type, out var schemaDifference, out var schemaDifferenceType, exact: false) &&
                     (!supportsParamCoercion || !type.CoercesTo(dsNameType, out var coercionIsSafe, aggregateCoercion: false) || !coercionIsSafe))
                 {
                     if (dsNameType.Kind == type.Kind)


### PR DESCRIPTION
To support https://github.com/microsoft/Power-Fx-Dataverse/issues/102.

Problem: Power Fx Dataverse would crash when we tried to Collect/Patch a record with a non-existing column. A new validation was placed to prevent this from happening. This validation checked if a column with the same name and type what present. If false, the mutation function returned an error. This new validation could not compare a LookUp field (Dtype.DataEntity) and a record type.

Solution: Expand the DataEntity type into a Record type and then compare the types.