### PR TITLE
AggregateCoercionNode  bug.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/AggregateCoercionNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/AggregateCoercionNode.cs
@@ -16,8 +16,14 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
     internal sealed class AggregateCoercionNode : IntermediateNode
     {
         public readonly UnaryOpKind Op;
+
+        // The original record. 
         public readonly IntermediateNode Child;
+
+        // The specific fields to be updated. 
+        // If a field is not present, then pull it's value from original Child object.
         public readonly IReadOnlyDictionary<DName, IntermediateNode> FieldCoercions;
+
         public readonly ScopeSymbol Scope;
 
         public AggregateCoercionNode(IRContext irContext, UnaryOpKind op, ScopeSymbol scope, IntermediateNode child, IReadOnlyDictionary<DName, IntermediateNode> fieldCoercions)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -545,17 +545,28 @@ namespace Microsoft.PowerFx
             else if (node.Op == UnaryOpKind.RecordToRecord)
             {
                 var fields = new List<NamedValue>();
+
                 var scopeContext = context.SymbolContext.WithScope(node.Scope);
                 var newScope = scopeContext.WithScopeValues((RecordValue)arg1);
 
-                foreach (var coercion in node.FieldCoercions)
+                var recordSrc = (RecordValue)arg1;
+                foreach (var f2 in recordSrc.Fields)
                 {
                     CheckCancel();
 
-                    var newValue = await coercion.Value.Accept(this, context.NewScope(newScope));
-                    var name = coercion.Key;
+                    // $$$ This would be better to resolve at IR generation time. 
+                    if (node.FieldCoercions.TryGetValue(new Core.Utils.DName(f2.Name), out var coercion))
+                    {
+                        var newValue = await coercion.Accept(this, context.NewScope(newScope));
 
-                    fields.Add(new NamedValue(name.Value, newValue));
+                        fields.Add(new NamedValue(f2.Name, newValue));
+                    }
+                    else
+                    {
+                        // Existing field, no coercion needed. 
+
+                        fields.Add(f2);
+                    }
                 }
 
                 return FormulaValue.NewRecordFromFields(fields);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -554,7 +554,6 @@ namespace Microsoft.PowerFx
                 {
                     CheckCancel();
 
-                    // $$$ This would be better to resolve at IR generation time. 
                     if (node.FieldCoercions.TryGetValue(new Core.Utils.DName(f2.Name), out var coercion))
                     {
                         var newValue = await coercion.Accept(this, context.NewScope(newScope));
@@ -564,7 +563,6 @@ namespace Microsoft.PowerFx
                     else
                     {
                         // Existing field, no coercion needed. 
-
                         fields.Add(f2);
                     }
                 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion.txt
@@ -41,3 +41,15 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> Hour(If(false, "hi", Blank()))
 0
+
+// Ensure record coercion doesn't prevent us from accessing non-coerced fields. 
+>> Last([{a:1,b:2}, {a:"1", b: 3}]).b
+3
+
+// extra nesting, a.x coerces. 
+>> Last([{a: { x:1},b:2}, {a:{x:"1"}, b: 3}]).b
+3
+
+// Coerce to 1st element in list; so middle element shouldn't impact  
+>> Last([{a:1,b:2}, {a:2, b: "2"}, {a:"1", b: 3}]).b
+3

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion.txt
@@ -53,3 +53,6 @@ Error({Kind:ErrorKind.InvalidArgument})
 // Coerce to 1st element in list; so middle element shouldn't impact  
 >> Last([{a:1,b:2}, {a:2, b: "2"}, {a:"1", b: 3}]).b
 3
+
+>> Last([ {a:2}, {a:true, b:true, c:20}, {a:2, b:2, c:true} ]).c
+true


### PR DESCRIPTION
We only add fields to AggregateCoercionNode that require a coercion. But eval only evals the fields listed in AggregateCoercionNode. So a field that doesn't require coercion gets skipped in eval!

This fixes it via eval - but should probalby be fixed at IR level. Since eval processes every time, whereas we know this statically.