### PR TITLE
Remove PowerFxConfig.Culture parameter

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
@@ -123,7 +123,7 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
 
                 var optionFormat = new StringBuilder(TexlLexer.PunctuatorCurlyOpen);
                 string sep = "";
-                string listSep = TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorListSeparator + " ";
+                string listSep = TexlLexer.GetLocalizedInstance(CultureInfo.InvariantCulture).LocalizedPunctuatorListSeparator + " ";
                 foreach (var option in optionalParamInfo)
                 {
                     optionFormat.Append(sep);

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -262,7 +262,7 @@ namespace Microsoft.PowerFx.Core.Binding
             bool updateDisplayNames = false,
             bool forceUpdateDisplayNames = false,
             IExternalRule rule = null,
-            Features features = Features.None)
+            Features features = Features.DefaultFeatures)
         {
             Contracts.AssertValue(node);
             Contracts.AssertValue(bindingConfig);
@@ -353,7 +353,7 @@ namespace Microsoft.PowerFx.Core.Binding
             DType ruleScope = null,
             bool forceUpdateDisplayNames = false,
             IExternalRule rule = null,
-            Features features = Features.None)
+            Features features = Features.DefaultFeatures)
         {
             Contracts.AssertValue(node);
             Contracts.AssertValueOrNull(resolver);
@@ -380,7 +380,7 @@ namespace Microsoft.PowerFx.Core.Binding
             DType ruleScope = null,
             bool forceUpdateDisplayNames = false,
             IExternalRule rule = null,
-            Features features = Features.None)
+            Features features = Features.DefaultFeatures)
         {
             return Run(glue, null, new DataSourceToQueryOptionsMap(), node, resolver, bindingConfig, updateDisplayNames, ruleScope, forceUpdateDisplayNames, rule, features);
         }
@@ -391,7 +391,7 @@ namespace Microsoft.PowerFx.Core.Binding
             INameResolver resolver,
             BindingConfig bindingConfig,
             DType ruleScope,
-            Features features = Features.None)
+            Features features = Features.DefaultFeatures)
         {
             return Run(glue, null, new DataSourceToQueryOptionsMap(), node, resolver, bindingConfig, false, ruleScope, false, null, features);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Errors/BaseError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/BaseError.cs
@@ -176,19 +176,19 @@ namespace Microsoft.PowerFx.Core.Errors
             return messages.Count == 0 ? null : messages;
         }
 
-        private void Format(StringBuilder sb)
+        private void Format(StringBuilder sb, CultureInfo culture)
         {
 #if DEBUG
             var lenStart = sb.Length;
 #endif
-            FormatCore(sb);
+            FormatCore(sb, culture);
 #if DEBUG
             Contracts.Assert(sb.Length > lenStart);
 #endif
-            FormatInnerError(sb);
+            FormatInnerError(sb, culture);
         }
 
-        internal virtual void FormatCore(StringBuilder sb)
+        internal virtual void FormatCore(StringBuilder sb, CultureInfo culture)
         {
             Contracts.AssertValue(sb);
 
@@ -196,7 +196,7 @@ namespace Microsoft.PowerFx.Core.Errors
             sb.Append(ShortMessage);
         }
 
-        private void FormatInnerError(StringBuilder sb)
+        private void FormatInnerError(StringBuilder sb, CultureInfo culture)
         {
             Contracts.AssertValue(sb);
 
@@ -208,14 +208,16 @@ namespace Microsoft.PowerFx.Core.Errors
             sb.AppendLine();
             var innerError = InnerError as BaseError;
             Contracts.AssertValue(innerError);
-            innerError?.Format(sb);
+            innerError?.Format(sb, culture);
         }
 
         public override string ToString()
         {
-            var sb = new StringBuilder();
-            Format(sb);
-            return sb.ToString();
+            throw new Exception();
+            
+            //var sb = new StringBuilder();
+            //Format(sb);
+            //return sb.ToString();
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Errors/ErrorUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/ErrorUtils.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerFx.Core.Errors
             {
                 try
                 {
-                    sb.AppendFormat(locale ?? CultureInfo.CurrentCulture, message, args);
+                    sb.AppendFormat(locale ?? CultureInfo.InvariantCulture, message, args);
                 }
                 catch (FormatException)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Errors/TexlError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/TexlError.cs
@@ -59,23 +59,23 @@ namespace Microsoft.PowerFx.Core.Errors
             _nameMapIDs.Add(name.Value);
         }
 
-        internal override void FormatCore(StringBuilder sb)
+        internal override void FormatCore(StringBuilder sb, CultureInfo culture)
         {
             Contracts.AssertValue(sb);
 
-            sb.AppendFormat(CultureInfo.CurrentCulture, TexlStrings.FormatSpan_Min_Lim(), Tok.Span.Min, Tok.Span.Lim);
+            sb.AppendFormat(culture, TexlStrings.FormatSpan_Min_Lim(), Tok.Span.Min, Tok.Span.Lim);
 
             if (Node != null)
             {
-                sb.AppendFormat(CultureInfo.CurrentCulture, TexlStrings.InfoNode_Node(), Node.ToString());
+                sb.AppendFormat(culture, TexlStrings.InfoNode_Node(), Node.ToString());
             }
             else
             {
-                sb.AppendFormat(CultureInfo.CurrentCulture, TexlStrings.InfoTok_Tok(), Tok.ToString());
+                sb.AppendFormat(culture, TexlStrings.InfoTok_Tok(), Tok.ToString());
             }
 
-            sb.AppendFormat(CultureInfo.CurrentCulture, TexlStrings.FormatErrorSeparator());
-            base.FormatCore(sb);
+            sb.AppendFormat(culture, TexlStrings.FormatErrorSeparator());
+            base.FormatCore(sb, culture);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -76,10 +76,6 @@ namespace Microsoft.PowerFx.Core.Functions
 
         private SignatureConstraint _signatureConstraint;
 
-        private TransportSchemas.FunctionInfo _cachedFunctionInfo;
-
-        private string _cachedLocaleName;
-
         // Return true if the function should be hidden from the formular bar, false otherwise.
         public virtual bool IsHidden => false;
 
@@ -1374,38 +1370,6 @@ namespace Microsoft.PowerFx.Core.Functions
         }
 
         #endregion
-
-        internal TransportSchemas.FunctionInfo Info(string locale)
-        {
-            // If the locale has changed, we want to reset the function info to one of the new locale
-            if (CurrentLocaleInfo.CurrentUILanguageName == _cachedLocaleName && _cachedFunctionInfo != null)
-            {
-                return _cachedFunctionInfo;
-            }
-
-            _cachedLocaleName = CurrentLocaleInfo.CurrentUILanguageName;
-            return _cachedFunctionInfo = new TransportSchemas.FunctionInfo()
-            {
-                Label = Name,
-                Detail = Description,
-                Signatures = GetSignatures().Select(signature => new FunctionSignature()
-                {
-                    Label = Name + (signature == null ?
-                        "()" :
-                        ("(" + string.Join(TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorListSeparator + " ", signature.Select(getter => getter(null))) + ")")),
-                    Parameters = signature?.Select(getter =>
-                    {
-                        TryGetParamDescription(getter(locale), out var description);
-
-                        return new ParameterInfo()
-                        {
-                            Label = getter(null),
-                            Documentation = description
-                        };
-                    }).ToArray()
-                }).ToArray()
-            };
-        }
 
         /// <summary>
         /// Override this method to rewrite the CallNode that is generated.

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/ExpressionLocalizationHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/ExpressionLocalizationHelper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Glue;
 using Microsoft.PowerFx.Core.Parser;
@@ -15,19 +14,10 @@ namespace Microsoft.PowerFx.Core
 {
     internal class ExpressionLocalizationHelper
     {
-        [Obsolete("Use ConvertExpression with PowerFxConfig parameter instead of CultureInfo", false)]
-        internal static string ConvertExpression(string expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, CultureInfo culture, bool toDisplay)
-        {
-            return ConvertExpression(expressionText, parameters, bindingConfig, resolver, binderGlue, new PowerFxConfig(culture), toDisplay);
-        }
-
-        internal static string ConvertExpression(string expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, PowerFxConfig fxConfig, bool toDisplay)
-        {
-            return ConvertExpression(expressionText, parameters, bindingConfig, resolver, binderGlue, fxConfig.CultureInfo, fxConfig.Features, toDisplay);
-        }
-
         internal static string ConvertExpression(string expressionText, RecordType parameters, BindingConfig bindingConfig, INameResolver resolver, IBinderGlue binderGlue, CultureInfo culture, Features flags, bool toDisplay)
         {
+            culture ??= CultureInfo.InvariantCulture;
+
             var targetLexer = toDisplay ? TexlLexer.GetLocalizedInstance(culture) : TexlLexer.InvariantLexer;
             var sourceLexer = toDisplay ? TexlLexer.InvariantLexer : TexlLexer.GetLocalizedInstance(culture);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerFx.Core.Localization
 
             if (string.IsNullOrEmpty(locale))
             {
-                locale = CultureInfo.CurrentUICulture.Name;
+                locale = "en-US";
                 Contracts.CheckNonEmpty(locale, "locale");
             }
 
@@ -211,7 +211,7 @@ namespace Microsoft.PowerFx.Core.Localization
             {
                 if (string.IsNullOrEmpty(locale))
                 {
-                    return _resourceManager.GetString(resourceKey, CultureInfo.CurrentUICulture);
+                    return _resourceManager.GetString(resourceKey, new CultureInfo("en-US"));
                 }
 
                 return _resourceManager.GetString(resourceKey, CultureInfo.CreateSpecificCulture(locale));

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
@@ -25,7 +25,11 @@ namespace Microsoft.PowerFx
         /// This primarily determines numeric decimal separator character
         /// as well as chaining operator. 
         /// </summary>
-        public CultureInfo Culture { get; set; }
+        public CultureInfo Culture
+        {
+            get => _culture ?? CultureInfo.InvariantCulture;
+            set => _culture = value ?? CultureInfo.InvariantCulture;
+        }
 
         /// <summary>
         /// If greater than 0, enforces a maximum length on a single expression. 
@@ -33,9 +37,18 @@ namespace Microsoft.PowerFx
         /// </summary>
         public int MaxExpressionLength { get; set; }
 
+        private CultureInfo _culture;
+
+        public ParserOptions(CultureInfo culture = null, bool allowsSideEffects = false, int maxExpressionLength = 0)
+        {
+            Culture = culture;
+            AllowsSideEffects = allowsSideEffects;
+            MaxExpressionLength = maxExpressionLength;
+        }
+
         internal ParseResult Parse(string script)
         {
-            return Parse(script, Features.None);
+            return Parse(script, Features.DefaultFeatures);
         }
 
         internal ParseResult Parse(string script, Features features)
@@ -43,7 +56,7 @@ namespace Microsoft.PowerFx
             if (MaxExpressionLength > 0 && script.Length > MaxExpressionLength)
             {
                 // If too long, don't even attempt to lex or parse it. 
-                var result2 = ParseResult.ErrorTooLarge(script, MaxExpressionLength);
+                var result2 = ParseResult.ErrorTooLarge(script, MaxExpressionLength, _culture);
                 result2.Options = this;
                 return result2;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerFx.Core.Parser
         // collected by the next call to ParseTrivia.
         private ITexlSource _extraTrivia;
 
-        private TexlParser(IReadOnlyList<Token> tokens, Flags flags, Features features = Features.None)
+        private TexlParser(IReadOnlyList<Token> tokens, Flags flags, Features features = Features.DefaultFeatures)
         {
             Contracts.AssertValue(tokens);
 
@@ -214,22 +214,22 @@ namespace Microsoft.PowerFx.Core.Parser
         // Parse the script
         // Parsing strips out parens used to establish precedence, but these may be helpful to the
         // caller, so precedenceTokens provide a list of stripped tokens.
-        internal static ParseResult ParseScript(string script, CultureInfo loc = null, Flags flags = Flags.None)
+        internal static ParseResult ParseScript(string script, CultureInfo culture = null, Flags flags = Flags.None)
         {
-            return ParseScript(script, Features.None, loc, flags);
+            return ParseScript(script, Features.DefaultFeatures, culture, flags);
         }
 
-        internal static ParseResult ParseScript(string script, Features features, CultureInfo loc = null, Flags flags = Flags.None)
+        internal static ParseResult ParseScript(string script, Features features, CultureInfo parseCulture = null, Flags flags = Flags.None)
         {
             Contracts.AssertValue(script);
-            Contracts.AssertValueOrNull(loc);
+            Contracts.AssertValueOrNull(parseCulture);
 
-            var tokens = TokenizeScript(script, loc, flags);
+            var tokens = TokenizeScript(script, parseCulture, flags);
             var parser = new TexlParser(tokens, flags, features);
             List<TexlError> errors = null;
             var parsetree = parser.Parse(ref errors);
 
-            return new ParseResult(parsetree, errors, errors?.Any() ?? false, parser._comments, parser._before, parser._after, script, loc);
+            return new ParseResult(parsetree, errors, errors?.Any() ?? false, parser._comments, parser._before, parser._after, script, parseCulture, parseCulture);
         }
 
         public static ParseFormulasResult ParseFormulasScript(string script, CultureInfo loc = null)

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -67,6 +67,16 @@ namespace Microsoft.PowerFx
         /// All features enabled
         /// [USE WITH CAUTION] In using this value, you expose your code to future features.
         /// </summary>
-        All = ~0
+        All = ~0,
+
+        /// <summary>
+        /// Default features enabled for Power Fx Version 1.0
+        /// </summary>        
+        PowerFx10Features = Features.TableSyntaxDoesntWrapRecords | Features.ConsistentOneColumnTableResult,
+
+        /// <summary>
+        /// List of features enabled by default
+        /// </summary>
+        DefaultFeatures = PowerFx10Features
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -34,17 +34,14 @@ namespace Microsoft.PowerFx
         [Obsolete("Use Config.EnumStore or symboltable directly")]
         internal EnumStoreBuilder EnumStoreBuilder => SymbolTable.EnumStoreBuilder;
 
-        internal IEnumStore EnumStore => ReadOnlySymbolTable.Compose(SymbolTable);
-
-        public CultureInfo CultureInfo { get; }
+        internal IEnumStore EnumStore => ReadOnlySymbolTable.Compose(SymbolTable);        
 
         public Features Features { get; }
 
         public int MaxCallDepth { get; set; }
 
-        private PowerFxConfig(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, Features features = Features.None)
-        {
-            CultureInfo = cultureInfo ?? CultureInfo.CurrentCulture;
+        private PowerFxConfig(EnumStoreBuilder enumStoreBuilder, Features features = Features.DefaultFeatures)
+        {            
             Features = features;
             SymbolTable.EnumStoreBuilder = enumStoreBuilder;
             MaxCallDepth = DefaultMaxCallDepth;
@@ -52,16 +49,10 @@ namespace Microsoft.PowerFx
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PowerFxConfig"/> class.        
-        /// </summary>
-        /// <param name="cultureInfo">Culture to use.</param>      
-        public PowerFxConfig(CultureInfo cultureInfo = null)
-            : this(cultureInfo, Features.None)
+        /// </summary>        
+        public PowerFxConfig()
+            : this(Features.DefaultFeatures)
         {
-        }
-
-        internal PowerFxConfig WithCulture(CultureInfo newCulture)
-        {
-            return new PowerFxConfig(newCulture, Features) { SymbolTable = this.SymbolTable };
         }
 
         /// <summary>
@@ -75,44 +66,34 @@ namespace Microsoft.PowerFx
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PowerFxConfig"/> class.
-        /// </summary>
-        /// <param name="cultureInfo">Culture to use.</param>
-        /// <param name="features">Features to use.</param>
-        public PowerFxConfig(CultureInfo cultureInfo, Features features)
-            : this(cultureInfo, new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library), features)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PowerFxConfig"/> class.
-        /// </summary>
+        /// </summary>        
         /// <param name="features">Features to use.</param>
         public PowerFxConfig(Features features)
-            : this(null, features)
+            : this(new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library), features)
         {
         }
 
         /// <summary>
         /// Stopgap until Enum Store is refactored. Do not rely on, this will be removed. 
         /// </summary>
-        internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder)
+        internal static PowerFxConfig BuildWithEnumStore(EnumStoreBuilder enumStoreBuilder)
         {
-            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, Features.None);
+            return BuildWithEnumStore(enumStoreBuilder, Features.DefaultFeatures);
         }
 
-        internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, Features features)
+        internal static PowerFxConfig BuildWithEnumStore(EnumStoreBuilder enumStoreBuilder, Features features)
         {
-            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, BuiltinFunctionsCore._library, features: features);
+            return BuildWithEnumStore(enumStoreBuilder, BuiltinFunctionsCore._library, features: features);
         }
 
-        internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, TexlFunctionSet coreFunctions)
+        internal static PowerFxConfig BuildWithEnumStore(EnumStoreBuilder enumStoreBuilder, TexlFunctionSet coreFunctions)
         {
-            return BuildWithEnumStore(cultureInfo, enumStoreBuilder, coreFunctions, Features.None);
+            return BuildWithEnumStore(enumStoreBuilder, coreFunctions, Features.DefaultFeatures);
         }
 
-        internal static PowerFxConfig BuildWithEnumStore(CultureInfo cultureInfo, EnumStoreBuilder enumStoreBuilder, TexlFunctionSet coreFunctions, Features features)
+        internal static PowerFxConfig BuildWithEnumStore(EnumStoreBuilder enumStoreBuilder, TexlFunctionSet coreFunctions, Features features)
         {
-            var config = new PowerFxConfig(cultureInfo, enumStoreBuilder, features);
+            var config = new PowerFxConfig(enumStoreBuilder, features);
 
             config.AddFunctions(coreFunctions);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -127,21 +127,17 @@ namespace Microsoft.PowerFx
 
         public virtual ParserOptions GetDefaultParserOptionsCopy()
         {
-            return new ParserOptions
-            {
-                 Culture = this.Config.CultureInfo,
-                 AllowsSideEffects = false,
-                 MaxExpressionLength = 0, // no limit
-            };
+            return new ParserOptions(CultureInfo.InvariantCulture, allowsSideEffects: false, maxExpressionLength: 0 /* no limit */);
         }
 
         /// <summary>
         ///     Tokenize an expression to a sequence of <see cref="Token" />s.
         /// </summary>
         /// <param name="expressionText"></param>
+        /// <param name="culture"></param>
         /// <returns></returns>
-        public IReadOnlyList<Token> Tokenize(string expressionText)
-            => TexlLexer.GetLocalizedInstance(Config.CultureInfo).GetTokens(expressionText);
+        public IReadOnlyList<Token> Tokenize(string expressionText, CultureInfo culture = null)
+            => TexlLexer.GetLocalizedInstance(culture ?? CultureInfo.InvariantCulture).GetTokens(expressionText);
 
         /// <summary>
         /// Parse the expression without doing any binding.
@@ -152,25 +148,13 @@ namespace Microsoft.PowerFx
         public ParseResult Parse(string expressionText, ParserOptions options = null)
         {
             options ??= this.GetDefaultParserOptionsCopy();
-            return Parse(expressionText, Config.Features, options, Config.CultureInfo);
+            return Parse(expressionText, Config.Features, options);
         }
 
         /// <summary>
         /// Parse the expression without doing any binding.
         /// </summary>
-        /// <param name="expressionText"></param>
-        /// <param name="options"></param>
-        /// <param name="cultureInfo"></param>
-        /// <returns></returns>
-        public static ParseResult Parse(string expressionText, ParserOptions options = null, CultureInfo cultureInfo = null)
-        {
-            return Parse(expressionText, Features.None, options, cultureInfo);
-        }
-
-        /// <summary>
-        /// Parse the expression without doing any binding.
-        /// </summary>
-        public static ParseResult Parse(string expressionText, Features features, ParserOptions options = null, CultureInfo cultureInfo = null)
+        public static ParseResult Parse(string expressionText, Features features = Features.DefaultFeatures, ParserOptions options = null)
         {
             if (expressionText == null)
             {
@@ -179,11 +163,8 @@ namespace Microsoft.PowerFx
 
             options ??= new ParserOptions();
 
-            // If culture isn't explicitly set, use the one from PowerFx Config
-            options.Culture ??= cultureInfo;
-
             var result = options.Parse(expressionText, features);
-            return result;            
+            return result;
         }
 
         /// <summary>
@@ -325,9 +306,9 @@ namespace Microsoft.PowerFx
         /// Optional hook to customize intellisense. 
         /// </summary>
         /// <returns></returns>
-        private protected virtual IIntellisense CreateIntellisense()
+        private protected virtual IIntellisense CreateIntellisense(CultureInfo culture)
         {
-            return IntellisenseProvider.GetIntellisense(Config);
+            return IntellisenseProvider.GetIntellisense(Config, culture);
         }
 
         public IIntellisenseResult Suggest(string expression, RecordType parameterType, int cursorPosition)
@@ -344,14 +325,14 @@ namespace Microsoft.PowerFx
             // Note that for completions, we just need binding,
             // but we don't need errors or dependency info. 
             var binding = checkResult.ApplyBindingInternal();
-                        
+
             var formula = checkResult.GetParseFormula();
             var expression = formula.Script;
 
             // CheckResult has the binding, which has already captured both the INameResolver and any row scope parameters. 
             // So these both become available to intellisense. 
             var context = new IntellisenseContext(expression, cursorPosition);
-            var intellisense = this.CreateIntellisense();
+            var intellisense = CreateIntellisense(checkResult.ParserCultureInfo);
             var suggestions = intellisense.Suggest(context, binding, formula);
 
             return suggestions;
@@ -362,15 +343,15 @@ namespace Microsoft.PowerFx
         /// </summary>
         [Obsolete("Use overload without expression")]
         public IIntellisenseResult Suggest(string expression, CheckResult checkResult, int cursorPosition)
-        {            
+        {
             var binding = checkResult.Binding;
-            var formula = new Formula(expression, Config.CultureInfo);
+            var formula = new Formula(expression, checkResult.ParserCultureInfo);
             formula.ApplyParse(checkResult.Parse);
 
             // CheckResult has the binding, which has already captured both the INameResolver and any row scope parameters. 
             // So these both become available to intellisense. 
             var context = new IntellisenseContext(expression, cursorPosition);
-            var intellisense = CreateIntellisense();
+            var intellisense = CreateIntellisense(checkResult.ParserCultureInfo);
             var suggestions = intellisense.Suggest(context, binding, formula);
 
             return suggestions;
@@ -383,8 +364,9 @@ namespace Microsoft.PowerFx
         /// be acecssed as top-level identifiers in the formula. Must be the names from before any rename operation is applied.</param>
         /// <param name="pathToRename">Path to the field to rename.</param>
         /// <param name="updatedName">New name. Replaces the last segment of <paramref name="pathToRename"/>.</param>
+        /// <param name="culture">Culture.</param>
         /// <returns></returns>
-        public RenameDriver CreateFieldRenamer(RecordType parameters, DPath pathToRename, DName updatedName)
+        public RenameDriver CreateFieldRenamer(RecordType parameters, DPath pathToRename, DName updatedName, CultureInfo culture = null)
         {
             Contracts.CheckValue(parameters, nameof(parameters));
             Contracts.CheckValid(pathToRename, nameof(pathToRename));
@@ -399,23 +381,24 @@ namespace Microsoft.PowerFx
             ** but that we don't return any display names for them. Thus, we clone a PowerFxConfig but without 
             ** display name support and construct a resolver from that instead, which we use for the rewrite binding.
             */
-            return new RenameDriver(parameters, pathToRename, updatedName, this, CreateResolverInternal(), CreateBinderGlue());
+            return new RenameDriver(parameters, pathToRename, updatedName, this, CreateResolverInternal(), CreateBinderGlue(), culture);
         }
 
         /// <summary>
         /// Convert references in an expression to the invariant form.
         /// </summary>
-        /// <param name="expressionText">textual representation of the formula.</param>
+        /// <param name="expressionText">textual representation of the formula.</param>        
         /// <param name="parameters">Type of parameters for formula. The fields in the parameter record can 
         /// be acecssed as top-level identifiers in the formula. If DisplayNames are used, make sure to have that mapping
         /// as part of the RecordType.</param>
+        /// <param name="parseCulture">Culture.</param>
         /// <returns>The formula, with all identifiers converted to invariant form.</returns>
-        public string GetInvariantExpression(string expressionText, RecordType parameters)
-        {            
+        public string GetInvariantExpression(string expressionText, RecordType parameters, CultureInfo parseCulture = null)
+        {
             var ruleScope = this.GetRuleScope();
             var symbolTable = (parameters == null) ? null : SymbolTable.NewFromRecord(parameters);
 
-            return GetInvariantExpressionWorker(expressionText, symbolTable, Config.CultureInfo);
+            return GetInvariantExpressionWorker(expressionText, symbolTable, parseCulture);
         }
 
         internal string GetInvariantExpressionWorker(string expressionText, ReadOnlySymbolTable symbolTable, CultureInfo parseCulture)
@@ -429,20 +412,23 @@ namespace Microsoft.PowerFx
         /// Convert references in an expression to the display form.
         /// </summary>
         /// <param name="expressionText">textual representation of the formula.</param>
+        /// <param name="culture">Culture.</param>
         /// <param name="parameters">Type of parameters for formula. The fields in the parameter record can 
         /// be acecssed as top-level identifiers in the formula. If DisplayNames are used, make sure to have that mapping
         /// as part of the RecordType.</param>
         /// <returns>The formula, with all identifiers converted to display form.</returns>
-        public string GetDisplayExpression(string expressionText, RecordType parameters)
+        public string GetDisplayExpression(string expressionText, RecordType parameters, CultureInfo culture = null)
         {
             var symbols = SymbolTable.NewFromRecord(parameters);
-            return GetDisplayExpression(expressionText, symbols);
+
+            return GetDisplayExpression(expressionText, symbols, culture);
         }
 
-        public string GetDisplayExpression(string expressionText, ReadOnlySymbolTable symbolTable)
+        public string GetDisplayExpression(string expressionText, ReadOnlySymbolTable symbolTable, CultureInfo culture = null)
         {
             var ruleScope = this.GetRuleScope();
-            return ExpressionLocalizationHelper.ConvertExpression(expressionText, ruleScope, GetDefaultBindingConfig(), CreateResolverInternal(symbolTable), CreateBinderGlue(), Config, toDisplay: true);
+
+            return ExpressionLocalizationHelper.ConvertExpression(expressionText, ruleScope, GetDefaultBindingConfig(), CreateResolverInternal(symbolTable), CreateBinderGlue(), culture, Config.Features, toDisplay: true);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Formula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Formula.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerFx.Syntax
 
         // The language settings used for parsing this script.
         // May be null if the script is to be parsed in the current locale.
-        public readonly CultureInfo Loc;
+        public readonly CultureInfo Culture;
         private List<TexlError> _errors;
 
         // This may be null if the script hasn't yet been parsed.
@@ -32,14 +32,14 @@ namespace Microsoft.PowerFx.Syntax
 
         internal List<CommentToken> Comments { get; private set; }
 
-        public Formula(string script, TexlNode tree, CultureInfo loc = null)
+        public Formula(string script, TexlNode tree, CultureInfo culture = null)
         {
             Contracts.AssertValue(script);
-            Contracts.AssertValueOrNull(loc);
+            Contracts.AssertValueOrNull(culture);
 
             Script = script;
             ParseTree = tree;
-            Loc = loc;
+            Culture = culture;
             AssertValid();
         }
 
@@ -67,7 +67,7 @@ namespace Microsoft.PowerFx.Syntax
 
             if (ParseTree == null)
             {
-                var result = TexlParser.ParseScript(Script, loc: Loc, flags: flags);
+                var result = TexlParser.ParseScript(Script, culture: Culture, flags: flags);
                 ApplyParse(result);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Globalization;
 using Microsoft.PowerFx.Core.Types.Enums;
 
 namespace Microsoft.PowerFx.Intellisense
@@ -25,9 +26,9 @@ namespace Microsoft.PowerFx.Intellisense
             new Intellisense.RecordNodeSuggestionHandler(),
         };
 
-        internal static IIntellisense GetIntellisense(PowerFxConfig config)
+        internal static IIntellisense GetIntellisense(PowerFxConfig config, CultureInfo culture)
         {
-            return new Intellisense(config, config.EnumStore, SuggestionHandlers);
+            return new Intellisense(config, culture, config.EnumStore, SuggestionHandlers);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -181,7 +182,7 @@ namespace Microsoft.PowerFx
 
             var udfDefinitions = result.UDFs.Select(udf => new UDFDefinition(
                 udf.Ident.ToString(),
-                new ParseResult(udf.Body, errors, result.HasError, comments, null, null, script),
+                new ParseResult(udf.Body, errors, result.HasError, comments, null, null, script, CultureInfo.InvariantCulture),
                 udf.ReturnType.GetFormulaType(),
                 udf.IsImperative,
                 udf.Args.Select(arg => new NamedFormulaType(arg.VarIdent.ToString(), arg.VarType.GetFormulaType())).ToArray())).ToArray();

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineScope.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngineScope.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx
 
         public string ConvertToDisplay(string expression)
         {
-            return _engine.GetDisplayExpression(expression, _contextType);
+            return _engine.GetDisplayExpression(expression, _contextType, _parserOptions.Culture);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/UDF/CheckWrapper.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/UDF/CheckWrapper.cs
@@ -25,11 +25,7 @@ namespace Microsoft.PowerFx.Interpreter.UDF
             _parseResult = parseResult;
             _parameterType = parameterType;
 
-            ParserOptions = new ParserOptions()
-            {
-                Culture = _engine.Config.CultureInfo,
-                AllowsSideEffects = isImperative,
-            };
+            ParserOptions = new ParserOptions(parseResult.ParseCulture, allowsSideEffects: isImperative);
 
             _parseResult.Options = ParserOptions;
         }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/EditorContextScope.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/EditorContextScope.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using System.Text;
+using System.Globalization;
 using System.Threading;
-using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Intellisense;
 using Microsoft.PowerFx.LanguageServerProtocol.Protocol;
 using static Microsoft.PowerFx.LanguageServerProtocol.LanguageServer;
@@ -47,15 +45,13 @@ namespace Microsoft.PowerFx
         // This captures the critical invariant: EditorContextScope corresponds to a formula bar where the user just types text, all other context is provided; 
         private readonly Func<string, CheckResult> _getCheckResult;
 
-        internal EditorContextScope(
-            Engine engine,
-            ParserOptions parserOptions,
-            ReadOnlySymbolTable symbols)
-            : this((string expr) => new CheckResult(engine)
-                    .SetText(expr, parserOptions)
-                    .SetBindingInfo(symbols))
-        {            
-        }        
+        private readonly CultureInfo _culture;
+
+        internal EditorContextScope(Engine engine, ParserOptions parserOptions, ReadOnlySymbolTable symbols)
+            : this((string expr) => new CheckResult(engine).SetText(expr, parserOptions).SetBindingInfo(symbols))
+        {
+            _culture = parserOptions?.Culture ?? CultureInfo.InvariantCulture;
+        }
 
         public EditorContextScope(Func<string, CheckResult> getCheckResult)
         {
@@ -84,7 +80,7 @@ namespace Microsoft.PowerFx
             var symbols = check._symbols;
             var engine = check.Engine;
 
-            return engine.GetDisplayExpression(expression, symbols);
+            return engine.GetDisplayExpression(expression, symbols, _culture);
         }
 
         IIntellisenseResult IPowerFxScope.Suggest(string expression, int cursorPosition)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -231,7 +231,7 @@ namespace Microsoft.PowerFx.Tests
             var result = await engine.EvalAsync(
                 @"AzureBlobStorage.CreateFile(""container"", ""bora4.txt"", ""abc"").Size",
                 CancellationToken.None,
-                options: new ParserOptions() { AllowsSideEffects = true });
+                options: new ParserOptions(allowsSideEffects: true));
 
             dynamic res = result.ToObject();
             var size = (double)res;
@@ -276,7 +276,7 @@ namespace Microsoft.PowerFx.Tests
             config.AddBehaviorFunction();
 
             var engine = new Engine(config);
-            var check = engine.Check(expr, RecordType.Empty(), withAllowSideEffects ? new ParserOptions() { AllowsSideEffects = true } : null);
+            var check = engine.Check(expr, RecordType.Empty(), withAllowSideEffects ? new ParserOptions(allowsSideEffects: true) : null);
 
             if (expectedBehaviorError)
             {
@@ -505,7 +505,7 @@ namespace Microsoft.PowerFx.Tests
             var engine = new RecalcEngine(config);
 
             testConnector.SetResponseFromFile(@"Responses\SQL Server GetProceduresV2.json");
-            var result = await engine.EvalAsync(@"SQL.GetProceduresV2(""pfxdev-sql.database.windows.net"", ""connectortest"")", CancellationToken.None, new ParserOptions() { AllowsSideEffects = true });
+            var result = await engine.EvalAsync(@"SQL.GetProceduresV2(""pfxdev-sql.database.windows.net"", ""connectortest"")", CancellationToken.None, new ParserOptions(allowsSideEffects: true));
 
             var record = result as RecordValue;
             Assert.NotNull(record);
@@ -553,7 +553,7 @@ namespace Microsoft.PowerFx.Tests
             var engine = new RecalcEngine(config);
 
             testConnector.SetResponseFromFile(@"Responses\SQL Server ExecuteStoredProcedureV2.json");
-            FormulaValue result = await engine.EvalAsync(@"SQL.ExecuteProcedureV2(""pfxdev-sql.database.windows.net"", ""connectortest"", ""sp_1"", { p1: 50 })", CancellationToken.None, new ParserOptions() { AllowsSideEffects = true });
+            FormulaValue result = await engine.EvalAsync(@"SQL.ExecuteProcedureV2(""pfxdev-sql.database.windows.net"", ""connectortest"", ""sp_1"", { p1: 50 })", CancellationToken.None, new ParserOptions(allowsSideEffects: true));
 
             Assert.Equal(FormulaType.UntypedObject, result.Type);
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -67,10 +67,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CheckChainingParseSuccess()
         {
-            var opts = new ParserOptions
-            {
-                AllowsSideEffects = true
-            };
+            var opts = new ParserOptions(allowsSideEffects: true);
 
             var config = new PowerFxConfig();
             var engine = new Engine(config);
@@ -113,8 +110,8 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CheckParseErrorCommaSeparatedLocale()
         {
-            var engine = new Engine(new PowerFxConfig(CultureInfo.GetCultureInfo("it-IT")));
-            var result = engine.Parse("3.145");
+            var engine = new Engine(new PowerFxConfig());
+            var result = engine.Parse("3.145", new ParserOptions(CultureInfo.GetCultureInfo("it-IT")));
 
             Assert.False(result.IsSuccess);
             Assert.StartsWith("Error 2-5: Caratteri non previsti", result.Errors.First().ToString());
@@ -123,8 +120,8 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CheckParseSuccessCommaSeparatedLocale()
         {
-            var engine = new Engine(new PowerFxConfig(CultureInfo.GetCultureInfo("de-DE")));
-            var result = engine.Parse("Function(args; separated; by; semicolons) + 123,456");
+            var engine = new Engine(new PowerFxConfig());
+            var result = engine.Parse("Function(args; separated; by; semicolons) + 123,456", new ParserOptions(CultureInfo.GetCultureInfo("de-DE")));
 
             Assert.True(result.IsSuccess);
         }
@@ -132,7 +129,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CheckParseSuccessCommaSeparatedLocaleUsingStatic()
         {
-            var result = Engine.Parse("Function(args; separated; by; semicolons) + 123,456", null, CultureInfo.GetCultureInfo("de-DE"));
+            var result = Engine.Parse("Function(args; separated; by; semicolons) + 123,456", options: new ParserOptions(CultureInfo.GetCultureInfo("de-DE")));
 
             Assert.True(result.IsSuccess);
         }
@@ -172,8 +169,8 @@ namespace Microsoft.PowerFx.Tests
         [InlineData("4E88888", "Error 0-7: Numeric value is too large.", "en-US")]
         public void CheckBindError2(string expression, string expected, string locale)
         {
-            var engine = new Engine(new PowerFxConfig(CultureInfo.GetCultureInfo(locale)));
-            var result = engine.Check(expression);
+            var engine = new Engine(new PowerFxConfig());
+            var result = engine.Check(expression, new ParserOptions(new CultureInfo(locale)));
 
             Assert.False(result.IsSuccess);
             AssertContainsError(result, expected);
@@ -246,7 +243,7 @@ namespace Microsoft.PowerFx.Tests
 
             var engine = new Engine(config);
             var formula = "Behavior(); Behavior()";
-            var options = new ParserOptions { AllowsSideEffects = true };
+            var options = new ParserOptions(allowsSideEffects: true);
 
             var result1 = engine.Check(formula, options: options);
             Assert.True(result1.IsSuccess);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/CheckResultTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/CheckResultTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Tests
     {
         // A non-default culture that  uses comma as a decimal separator
         private static readonly CultureInfo _frCulture = new CultureInfo("fr-FR");
-        private static readonly ParserOptions _frCultureOpts = new ParserOptions { Culture = _frCulture };
+        private static readonly ParserOptions _frCultureOpts = new ParserOptions(_frCulture);
 
         [Fact]
         public void Ctors()
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Empty(check.Errors);
 
             // Other operations will now fail
-            var parse = ParseResult.ErrorTooLarge("abc", 2); // any parse result
+            var parse = ParseResult.ErrorTooLarge("abc", 2, CultureInfo.InvariantCulture); // any parse result
 
             Assert.Throws<InvalidOperationException>(() => check.SetText("1+2"));
             Assert.Throws<InvalidOperationException>(() => check.SetText(parse));

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DerivedEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DerivedEngineTests.cs
@@ -83,10 +83,7 @@ namespace Microsoft.PowerFx.Tests
 
             public override ParserOptions GetDefaultParserOptionsCopy()
             {
-                return new ParserOptions
-                {
-                     MaxExpressionLength = 10
-                };
+                return new ParserOptions(maxExpressionLength: 10);                
             }
 
             public int PostCheckCounter = 0;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameOptionSetTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameOptionSetTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Tests;
@@ -25,7 +26,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("TopOSDisplay.option_1 <> OptionSet.Option2", "TopOSDisplay.Option1 <> TopOSDisplay.Option2", true, "TopOSDisplay")]
         public void OptionSetDisplayNames(string inputExpression, string outputExpression, bool toDisplay, string optionSetDisplayName)
         {            
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>() 
             {
                     { "option_1", "Option1" },
@@ -87,7 +88,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public void PowerFxConfigCollisionsThrow()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>() 
             {
                     { "option_1", "Option1" },

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerFx.Tests
             
             // Test same cases via CheckResult
             var check = new CheckResult(new Engine());
-            check.SetText(script, new ParserOptions { AllowsSideEffects = true });
+            check.SetText(script, new ParserOptions(allowsSideEffects: true));
             var result2 = check.ApplyGetLogging();
             Assert.Equal(expected, result2);
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/IntellisenseTestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.PowerFx.Core.Tests;
@@ -23,7 +24,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         /// <param name="expression"></param>
         /// <param name="contextTypeString"></param>
         /// <returns></returns>
-        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, string contextTypeString = null)
+        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, string contextTypeString = null, CultureInfo culture = null)
         {
             RecordType contextType;
             if (contextTypeString != null)
@@ -39,20 +40,20 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
                 contextType = RecordType.Empty();
             }
 
-            return Suggest(expression, config, contextType);
+            return Suggest(expression, config, contextType, culture);
         }
 
-        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, RecordType parameterType)
+        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, RecordType parameterType, CultureInfo culture = null)
         {
             (var expression2, var cursorPosition) = Decode(expression);
             var symTable = ReadOnlySymbolTable.NewFromRecord(parameterType);
-            return Suggest(expression2, symTable, cursorPosition, config);
+            return Suggest(expression2, symTable, cursorPosition, config, culture);
         }
 
-        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, ReadOnlySymbolTable symTable)
+        internal IIntellisenseResult Suggest(string expression, PowerFxConfig config, ReadOnlySymbolTable symTable, CultureInfo culture = null)
         {
             (var expression2, var cursorPosition) = Decode(expression);
-            return Suggest(expression2, symTable, cursorPosition, config);
+            return Suggest(expression2, symTable, cursorPosition, config, culture);
         }
 
         // Tests use | to indicate cursor position within an expression string. 
@@ -70,14 +71,14 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             return (expression, cursorPosition);
         }
 
-        internal IIntellisenseResult Suggest(string expression, ReadOnlySymbolTable symTable, int cursorPosition, PowerFxConfig config)
+        internal IIntellisenseResult Suggest(string expression, ReadOnlySymbolTable symTable, int cursorPosition, PowerFxConfig config, CultureInfo culture = null)
         {
             var engine = new Engine(config)
             {
                 SupportedFunctions = new SymbolTable()
             };
 
-            var checkResult = engine.Check(expression, symbolTable: symTable);
+            var checkResult = engine.Check(expression, new ParserOptions(culture), symbolTable: symTable);
             var suggestions = engine.Suggest(checkResult, cursorPosition);
             
             if (suggestions.Exception != null)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -57,15 +57,15 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             return intellisense.Suggestions.Select(suggestion => suggestion.DisplayText.Text).ToArray();
         }
 
-        internal static PowerFxConfig Default => PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder().WithDefaultEnums());
+        internal static PowerFxConfig Default => PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder().WithDefaultEnums());
 
-        internal static PowerFxConfig Default_DisableRowScopeDisambiguationSyntax => PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder().WithDefaultEnums(), Features.DisableRowScopeDisambiguationSyntax);
+        internal static PowerFxConfig Default_DisableRowScopeDisambiguationSyntax => PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder().WithDefaultEnums(), Features.DisableRowScopeDisambiguationSyntax);
 
         // No enums, no functions. Adding functions will add back in associated enums, so to be truly empty, ensure no functions. 
-        private PowerFxConfig EmptyEverything => PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder(), new TexlFunctionSet());
+        private PowerFxConfig EmptyEverything => PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder(), new TexlFunctionSet());
 
         // No extra enums, but standard functions (which will include some enums).
-        private PowerFxConfig MinimalEnums => PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library));
+        private PowerFxConfig MinimalEnums => PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library));
 
         /// <summary>
         /// Compares expected suggestions with suggestions made by PFx Intellisense for a given
@@ -250,7 +250,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
                     { "Field1", 1 },
                     { "Field2", 2 },
                 }));
-            var config = PowerFxConfig.BuildWithEnumStore(CultureInfo.InvariantCulture, enumStoreBuilder);
+            var config = PowerFxConfig.BuildWithEnumStore(enumStoreBuilder);
 
             var result = SuggestStrings("Fiel|", config);
             Assert.Equal(2, result.Length);
@@ -288,9 +288,9 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         {
             var context = $"![{string.Join(",", names.Split(',').Select(s => $"variable{s}:n"))}]";
             var expectedSuggestions = expectedOrder.Split(',').Select(s => "variable" + s).ToArray();
-            var config = PowerFxConfig.BuildWithEnumStore(new CultureInfo(culture), new EnumStoreBuilder().WithDefaultEnums());
+            var config = PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder().WithDefaultEnums());
 
-            var result = Suggest("variabl|", config, context);
+            var result = Suggest("variabl|", config, context, new CultureInfo(culture));
             var suggestions = result.Suggestions.ToList();
 
             Assert.Equal(expectedSuggestions.Length, suggestions.Count);
@@ -381,10 +381,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         public void TestSuggestLazyTypes(string expression, bool requiresExpansion, params string[] expectedSuggestions)
         {
             var lazyInstance = new LazyRecursiveRecordType();
-            var config = PowerFxConfig.BuildWithEnumStore(
-                null,
-                new EnumStoreBuilder(),
-                new TexlFunctionSet(new[] { BuiltinFunctionsCore.EndsWith, BuiltinFunctionsCore.Filter, BuiltinFunctionsCore.Table }));
+            var config = PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder(), new TexlFunctionSet(new[] { BuiltinFunctionsCore.EndsWith, BuiltinFunctionsCore.Filter, BuiltinFunctionsCore.Table }));
             var actualSuggestions = SuggestStrings(expression, config, lazyInstance);
             Assert.Equal(expectedSuggestions, actualSuggestions);
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -522,12 +522,9 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("1234+6789+++++")] // Invalid parse
         public void MaxExpressionLength(string expr)
         {
-            var opts = new ParserOptions
-            {
-                 MaxExpressionLength = 10
-            };
+            var opts = new ParserOptions(maxExpressionLength: 10);
 
-            var parseResult = Engine.Parse(expr, opts);
+            var parseResult = Engine.Parse(expr, options: opts);
             Assert.False(parseResult.IsSuccess);
             Assert.True(parseResult.HasError);
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
@@ -30,14 +30,11 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void TestResourceImportUsesCurrentUICulture()
         {
-            var initialCulture = CultureInfo.CurrentUICulture;
             var enUsERContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken);
-            var enUsBasicContent = StringResources.Get("AboutAbs");
+            var enUsBasicContent = StringResources.Get("AboutAbs");            
 
-            CultureInfo.CurrentUICulture = CultureInfo.CreateSpecificCulture("fr-FR");
-
-            var frERContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken);
-            var frBasicContent = StringResources.Get("AboutAbs");
+            var frERContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken, "fr-FR");
+            var frBasicContent = StringResources.Get("AboutAbs", "fr-FR");
 
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/InternalSetup.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TestRunnerTests/InternalSetup.cs
@@ -28,9 +28,8 @@ namespace Microsoft.PowerFx.Core.Tests
         internal static InternalSetup Parse(string setupHandlerName)
         {
             var iSetup = new InternalSetup
-            {
-                // Default features
-                Features = Features.TableSyntaxDoesntWrapRecords | Features.ConsistentOneColumnTableResult
+            {                
+                Features = Features.DefaultFeatures
             };
 
             if (string.IsNullOrWhiteSpace(setupHandlerName))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("DateDiff([Date(2000,1,1)],Date(2001,1,1),\"years\")", "*[Result:n]")]
         public void TexlDateTableFunctions(string expression, string expectedType)
         {
-            var engine = new Engine(new PowerFxConfig());
+            var engine = new Engine(new PowerFxConfig(Features.None));
             var result = engine.Check(expression);
 
             Assert.True(DType.TryParse(expectedType, out var expectedDType));
@@ -146,7 +146,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("DateDiff([Date(2000,1,1)],Date(2001,1,1),\"years\")", "*[Value:n]")]
         public void TexlDateTableFunctions_ConsistentOneColumnTableResult(string expression, string expectedType)
         {
-            var engine = new Engine(new PowerFxConfig(Features.ConsistentOneColumnTableResult));
+            var engine = new Engine(new PowerFxConfig(Features.DefaultFeatures));
             var result = engine.Check(expression);
 
             Assert.True(DType.TryParse(expectedType, out var expectedDType));

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ClearFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ClearFunctionTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class ClearFunctionTests : PowerFxTest
     {
-        private readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Fact]
         public async Task CheckArgsTestAsync()

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CollectFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CollectFunctionTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class CollectFunctionTests : PowerFxTest
     {
-        private readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Theory]
         [InlineData("Collect(t, r1)", 1)]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async Task CustomFunctionErrorTest()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new CustomFunctionError());
             config.AddFunction(new AsyncCustomFunctionError());
             var engine = new RecalcEngine(config);
@@ -123,7 +123,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async Task NullToBlankTest()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new NullFunctionReturn());
             var engine = new RecalcEngine(config);
 
@@ -142,7 +142,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CustomFunction()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new TestCustomFunction());
             var engine = new RecalcEngine(config);
 
@@ -168,7 +168,7 @@ namespace Microsoft.PowerFx.Tests
         [InlineData("TestCustom(0,true,If(false,\"test\"))", "0,True,", false, null)]
         public void CustomFunctionErrorOrBlank(string script, string expectedResult, bool isErrorExpected, string errorMessage)
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new TestCustomFunction());
             var engine = new RecalcEngine(config);
 
@@ -205,7 +205,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CustomRecordFunction()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new TestRecordCustomFunction());
 
             // Invalid function
@@ -250,7 +250,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void CustomTableArgFunction()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new TableArgCustomFunction());
 
             var engine = new RecalcEngine(config);
@@ -303,7 +303,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void InvalidDeferredFunctionTest()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             Assert.Throws<NotSupportedException>(() => config.AddFunction(new InvalidDeferredFunction()));
             Assert.Throws<NotSupportedException>(() => config.AddFunction(new InvalidArgDeferredFunction()));
         }
@@ -337,7 +337,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void CustomFunction_CallBack()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new TestCallbackFunction());
             var engine = new RecalcEngine(config);
 
@@ -362,7 +362,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void CustomFunctionAsync_CallBack()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new WaitFunction());
             config.AddFunction(new HelperFunction(x => FormulaValue.New(x.Value + 1)));
             var engine = new RecalcEngine(config);
@@ -414,7 +414,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void CustomFunctionAsync_CallBack_Invalid()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             Action act = () => config.AddFunction(new InvalidTestCallbackFunction());
             Exception exception = Assert.Throws<InvalidOperationException>(act);
             Assert.Equal("Unknown parameter type: expression, System.Func`1[System.Threading.Tasks.Task`1[Microsoft.PowerFx.Types.StringValue]]. Only System.Func`1[System.Threading.Tasks.Task`1[Microsoft.PowerFx.Types.BooleanValue]] is supported", exception.Message);
@@ -435,7 +435,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void CustomMockAndFunction_CallBack()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new MockAnd2ArgFunction());
             var engine = new RecalcEngine(config);
 
@@ -471,7 +471,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void SimpleCustomAsyncFuntion()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
 
             config.AddFunction(new TestCustomAsyncFunction());
             var engine = new RecalcEngine(config);
@@ -492,7 +492,7 @@ namespace Microsoft.PowerFx.Tests
         public async void VerifyCustomFunctionIsAsync()
         {
             var func = new TestCustomWaitAsyncFunction();
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(func);
 
             var engine = new RecalcEngine(config);
@@ -518,7 +518,7 @@ namespace Microsoft.PowerFx.Tests
         public async void VerifyCancellationInAsync()
         {
             var func = new InfiniteAsyncFunction();
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(func);
 
             var engine = new RecalcEngine(config);
@@ -569,7 +569,7 @@ namespace Microsoft.PowerFx.Tests
         public async void InvalidAsyncFunction()
         {
             var func = new TestCustomInvalidAsyncFunction();
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             Assert.Throws<InvalidOperationException>(() => config.AddFunction(func));
         }
 
@@ -577,7 +577,7 @@ namespace Microsoft.PowerFx.Tests
         public async void InvalidAsync2Function()
         {
             var func = new TestCustomInvalid2AsyncFunction();
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             Assert.Throws<InvalidOperationException>(() => config.AddFunction(func));
         }
 
@@ -619,7 +619,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void CustomAsyncFuntionUsingCtor()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
 
             config.AddFunction(new TestCtorCustomAsyncFunction());
             var engine = new RecalcEngine(config);
@@ -716,12 +716,12 @@ namespace Microsoft.PowerFx.Tests
             public bool BoolProp { get; set; }
         }
 
-        private static readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private static readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Fact]
         public void CustomSetPropertyFunction()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(new TestCustomSetPropFunction());
             var engine = new RecalcEngine(config);
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DatabaseSimulationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DatabaseSimulationTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var engine = new RecalcEngine();
             var runtimeConfig = new SymbolValues(symbols);
             runtimeConfig.Set(slot, databaseTable);
-            
-            CheckResult check = engine.Check(expr, symbolTable: symbols, options: new ParserOptions() { AllowsSideEffects = true });
+
+            CheckResult check = engine.Check(expr, symbolTable: symbols, options: new ParserOptions(allowsSideEffects: true));
             Assert.Equal(checkSuccess, check.IsSuccess);
 
             if (!check.IsSuccess)
@@ -70,7 +70,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var runtimeConfig = new SymbolValues(symbols);
             runtimeConfig.Set(slot, databaseTable);
 
-            CheckResult check = engine.Check(expr, symbolTable: symbols, options: new ParserOptions() { AllowsSideEffects = true });
+            CheckResult check = engine.Check(expr, symbolTable: symbols, options: new ParserOptions(allowsSideEffects: true));
             Assert.True(check.IsSuccess);
 
             IExpressionEvaluator run = check.GetEvaluator();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DateTimeUTCTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DateTimeUTCTests.cs
@@ -25,8 +25,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         public DateTimeUTCTests() 
         {
-            _engine = new RecalcEngine(
-               new PowerFxConfig(System.Globalization.CultureInfo.InvariantCulture));
+            _engine = new RecalcEngine(new PowerFxConfig());
             _symbolTable = new SymbolTable();
             _symbolValues = new SymbolValues(_symbolTable);
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DeferredTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DeferredTypeTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerFx.Interpreter
             symbolTable.AddVariable("N", FormulaType.Number, mutable: true);
             symbolTable.AddVariable("XM", FormulaType.Deferred, mutable: true);
 
-            TestDeferredTypeBindingWarning(script, Features.None, TestUtils.DT(expectedReturnType), symbolTable);
+            TestDeferredTypeBindingWarning(script, Features.DefaultFeatures, TestUtils.DT(expectedReturnType), symbolTable);
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace Microsoft.PowerFx.Interpreter
             symbolTable.AddVariable("X", FormulaType.Deferred);
             symbolTable.AddVariable("N", FormulaType.Number);
             symbolTable.AddVariable("R", RecordType.Empty());
-            TestBindingError(script, Features.None, errorMessage, symbolTable);
+            TestBindingError(script, Features.DefaultFeatures, errorMessage, symbolTable);
         }
 
         [Fact]
@@ -144,16 +144,12 @@ namespace Microsoft.PowerFx.Interpreter
             config.EnableParseJSONFunction();
 
             var engine = new RecalcEngine(config);
-            var result = engine.Check(script, options: new ParserOptions() { AllowsSideEffects = true });
+            var result = engine.Check(script, options: new ParserOptions(allowsSideEffects: true));
             
             Assert.True(result.IsSuccess);
-
             Assert.Equal(expected, result.ReturnType._type);
-
             Assert.True(result.Errors.Count() > 0);
-
             Assert.True(result.Errors.All(error => error.MessageKey.Equals(TexlStrings.WarnDeferredType.Key)));
-
             Assert.Throws<NotSupportedException>(() => CheckResultExtensions.GetEvaluator(result));
             Assert.Throws<AggregateException>(() => engine.Eval(script));
         }
@@ -169,7 +165,6 @@ namespace Microsoft.PowerFx.Interpreter
             var result = engine.Check(script);
 
             Assert.False(result.IsSuccess);
-
             Assert.Contains(result.Errors, error => error.MessageKey.Equals(errorMessageKey));
         }
     }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/GetTokensUtilsTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/GetTokensUtilsTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Tests
             var scope = FromJson(
                 new RecalcEngine(config), 
                 "{\"A\":1,\"B\":[1,2,3]}",
-                withAllowSideEffects ? new ParserOptions() { AllowsSideEffects = true } : null);
+                withAllowSideEffects ? new ParserOptions(allowsSideEffects: true) : null);
             var checkResult = scope.Check(expr);
 
             var result = GetTokensUtils.GetTokens(checkResult.Binding, GetTokensFlags.None);
@@ -73,7 +73,7 @@ namespace Microsoft.PowerFx.Tests
                     { "option_1", "Option1" },
                     { "option_2", "Option2" }
             }));
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddOptionSet(optionSet);
 
             var scope = FromJson(new RecalcEngine(config), "{\"A\":1,\"B\":[1,2,3]}");

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/IRTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var slot = symbols.AddVariable("MyTable", tableType);
 
             var engine = new RecalcEngine(new PowerFxConfig());
-            var checkResult = engine.Check("Patch(MyTable, { Currency: 1.2 }, { Currency: 1.5 })", new ParserOptions() { AllowsSideEffects = true }, symbolTable: symbols);
+            var checkResult = engine.Check("Patch(MyTable, { Currency: 1.2 }, { Currency: 1.5 })", new ParserOptions(allowsSideEffects: true), symbolTable: symbols);
 
             checkResult.ThrowOnErrors();
 
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             engine.Config.SymbolTable.AddConstant("integerVar", integerVar);
             engine.Config.SymbolTable.AddConstant("datetimeVar", datetimeVar);
 
-            var result = engine.Eval(expr, options: new ParserOptions() { AllowsSideEffects = true });
+            var result = engine.Eval(expr, options: new ParserOptions(allowsSideEffects: true));
 
             Assert.IsNotType<ErrorValue>(result);
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("TopOptionSetField <> Opt|", "OptionSet", "TopOptionSetField", "OtherOptionSet")]
         public void TestSuggestOptionSets(string expression, params string[] expectedSuggestions)
         {
-            var config = PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder());
+            var config = PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder());
 
             var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
             {
@@ -95,7 +95,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Dis|", "DisplayOpt", "DisplayRowScope")] // Match to row scope       
         public void TestSuggestOptionSetsDisplayName(string expression, params string[] expectedSuggestions)
         {
-            var config = PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder(), new TexlFunctionSet());
+            var config = PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder(), new TexlFunctionSet());
 
             var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
     {
         // Check() calls through to engine. 
         [Fact]
-        public void Test()
+        public void EditorContextScope_Test()
         {
             var engine = new Engine(new PowerFxConfig());
 
@@ -32,7 +32,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         }
 
         [Fact]
-        public void Fix()
+        public void EditorContextScope_Fix()
         {
             var engine = new Engine(new PowerFxConfig());
 
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 
         // Still report ecen when a handler throws. 
         [Fact]
-        public void FixHandlerFails()
+        public void EditorContextScope_FixHandlerFails()
         {
             var failHandler = new ExceptionQuickFixHandler();
 
@@ -87,7 +87,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 
         // Verify OnCommandExecuted callbacks is executed. 
         [Fact]
-        public void OnCommandExecuted()
+        public void EditorContextScope_OnCommandExecuted()
         {
             var handler = new MyHandler();
             var engine = new Engine(new PowerFxConfig());
@@ -127,7 +127,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 
         // Calling Suggest() on intellisense doesn't need to compute errors
         [Fact]
-        public void SuggestDoesntNeedErrors()
+        public void EditorContextScope_SuggestDoesntNeedErrors()
         {
             var engine = new MyEngine();
 
@@ -138,13 +138,13 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         }
 
         [Fact]
-        public void NullCtor()
+        public void EditorContextScope_NullCtor()
         {
             Assert.Throws<ArgumentNullException>(() => new EditorContextScope(null));
         }
 
         [Fact]
-        public void Ctor()
+        public void EditorContextScope_Ctor()
         {
             var check = new CheckResult(new Engine());
             var editor = new EditorContextScope(
@@ -158,7 +158,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 
         // Fail if the getter doesn't fully create the CheckResult
         [Fact]
-        public void MissingInit()
+        public void EditorContextScope_MissingInit()
         {
             var check = new CheckResult(new Engine());
 
@@ -190,7 +190,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         }
 
         [Fact]
-        public void HandlerName()
+        public void EditorContextScope_HandlerName()
         {
             var handler = new MyHandler();
             var name = handler.HandlerName;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Init();
         }
 
-        private void Init(Features features = Features.None, ParserOptions options = null)
+        private void Init(Features features = Features.DefaultFeatures, ParserOptions options = null)
         {
             var config = new PowerFxConfig(features: features);
             config.AddFunction(new BehaviorFunction());
@@ -304,7 +304,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
 
         private static ParserOptions GetParserOptions(bool withAllowSideEffects)
         {
-            return withAllowSideEffects ? new ParserOptions() { AllowsSideEffects = true } : null;
+            return withAllowSideEffects ? new ParserOptions(allowsSideEffects: true) : null;
         }
 
         private void TestPublishDiagnostics(string uri, string method, string formula, Diagnostic[] expectedDiagnostics)
@@ -1188,7 +1188,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
         [InlineData(false, "{}", "{ type: 123 }", @"{""Type"":""Record"",""Fields"":{""type"":{""Type"":""Number""}}}")]
         public void TestPublishExpressionType_AggregateShapes(bool tableSyntaxDoesntWrapRecords, string context, string expression, string expectedTypeJson)
         {
-            Init(tableSyntaxDoesntWrapRecords ? Features.TableSyntaxDoesntWrapRecords : Features.None);
+            Init(tableSyntaxDoesntWrapRecords ? Features.DefaultFeatures : Features.None);
             var documentUri = $"powerfx://app?context={context}&getExpressionType=true";
             _testServer.OnDataReceived(JsonSerializer.Serialize(new
             {
@@ -1278,7 +1278,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
 
             _sendToClientData = new List<string>();
             _scopeFactory = new TestPowerFxScopeFactory(
-                (string documentUri) => engine.CreateEditorScope(new ParserOptions() { Culture = locale }, GetFromUri(documentUri)));
+                (string documentUri) => engine.CreateEditorScope(new ParserOptions(locale), GetFromUri(documentUri)));
             _testServer = new TestLanguageServer(_sendToClientData.Add, _scopeFactory);
 
             _testServer.OnDataReceived(
@@ -1319,7 +1319,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             _scopeFactory = new TestPowerFxScopeFactory(
                 (string documentUri) => new EditorContextScope(
                     (expr) => new CheckResult(engine)
-                        .SetText(expr, new ParserOptions { Culture = parseLocale })
+                        .SetText(expr, new ParserOptions(parseLocale))
                         .SetBindingInfo()
                         .SetDefaultErrorCulture(errorLocale)));
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageTest.cs
@@ -65,8 +65,8 @@ namespace Microsoft.PowerFx.Tests
 
         private void TestDefaultCulture()
         {
-            var engine = new RecalcEngine(new PowerFxConfig(_defaultCulture));
-            var result = engine.Eval("Language()");
+            var engine = new RecalcEngine(new PowerFxConfig());
+            var result = engine.Eval("Language()", options: new ParserOptions(_defaultCulture));
 
             Assert.Equal("en-US", result.ToObject());
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationFunctionsTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationFunctionsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class MutationFunctionsTests : PowerFxTest
     {
-        private readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Theory]
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PADIntegrationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PADIntegrationTests.cs
@@ -124,7 +124,7 @@ First(
             Assert.IsType<BlankValue>(result4);
 
             var symbol = new SymbolTable();
-            var opt = new ParserOptions() { AllowsSideEffects = true };
+            var opt = new ParserOptions(allowsSideEffects: true);
 
             symbol.EnableMutationFunctions();
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PadUntypedObjectTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PadUntypedObjectTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             PadUntypedObject uo = new PadUntypedObject(dt);
             UntypedObjectValue uov = new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), uo);
 
-            PowerFxConfig config = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            PowerFxConfig config = new PowerFxConfig(Features.All);
             RecalcEngine engine = new RecalcEngine(config);
 
             engine.UpdateVariable("padTable", uov);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PatchFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PatchFunctionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class PatchFunctionTests : PowerFxTest
     {
-        private readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Theory]
         [InlineData(typeof(PatchFunction))]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,7 +34,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 
         private static (RecalcEngine engine, RecordValue parameters) AllEnumsSetup(PowerFxConfig config)
         {
-            return (new RecalcEngine(PowerFxConfig.BuildWithEnumStore(config.CultureInfo, new EnumStoreBuilder().WithDefaultEnums(), new TexlFunctionSet(), config.Features)), null);
+            return (new RecalcEngine(PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder().WithDefaultEnums(), new TexlFunctionSet(), config.Features)), null);
         }
 
         private static (RecalcEngine engine, RecordValue parameters) OptionSetTestSetup(PowerFxConfig config)
@@ -320,6 +321,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     runtimeConfig.AddService<Governor>(mem);
                 }
 
+                // TXT files are targetting en-US locale
+                runtimeConfig.AddService(new CultureInfo("en-US"));
+
                 var newValue = await check.GetEvaluator().EvalAsync(CancellationToken.None, runtimeConfig);
 
                 // UntypedObjectType type is currently not supported for serialization.
@@ -340,7 +344,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         internal class ReplRunner : BaseRunner
         {
             private readonly RecalcEngine _engine;
-            public ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+            public ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
             public ReplRunner(RecalcEngine engine)
             {
@@ -367,7 +371,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             // Pattern match for Set(x,y) so that we can define the variable
             public bool TryMatchSet(string expr, out RunResult runResult)
             {
-                var parserOptions = new ParserOptions { AllowsSideEffects = true };
+                var parserOptions = new ParserOptions(allowsSideEffects: true);
 
                 var parse = _engine.Parse(expr);
                 if (parse.IsSuccess)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerFx.Tests
                 _impl = Worker
             };
 
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(func);
 
             var engine = new RecalcEngine(config);
@@ -61,7 +61,7 @@ namespace Microsoft.PowerFx.Tests
                 _impl = Worker
             };
 
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(func);
 
             var engine = new RecalcEngine(config);
@@ -110,7 +110,7 @@ namespace Microsoft.PowerFx.Tests
             var helper = new WaitHelper();
             var func = helper.GetFunction("CustomAsync");
 
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(func);
 
             var engine = new RecalcEngine(config);
@@ -149,7 +149,7 @@ namespace Microsoft.PowerFx.Tests
                 _impl = WorkerWaitForCancel
             };
 
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(func);
 
             var engine = new RecalcEngine(config);
@@ -180,7 +180,7 @@ namespace Microsoft.PowerFx.Tests
             var helper2 = new WaitHelper();
             var func2 = helper2.GetFunction("F2");
 
-            var config1 = new PowerFxConfig(null);
+            var config1 = new PowerFxConfig();
             config1.AddFunction(func1);
             config1.AddFunction(func2);
             var engine = new RecalcEngine(config1);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -238,7 +238,7 @@ namespace Microsoft.PowerFx.Tests
             AssertUpdate("B-->9;C-->70;");
         }
 
-        private static readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private static readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Fact]
         public void SetFormula()
@@ -314,7 +314,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DefFunc()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
 
             IEnumerable<ExpressionError> enumerable = recalcEngine.DefineFunctions("foo(x:Number, y:Number): Number = x * y;").Errors;
@@ -325,7 +325,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DefFuncWithErrorsAndVerifySpans()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
 
             IEnumerable<ExpressionError> enumerable = recalcEngine.DefineFunctions("func1(x:Number/*comment*/): Number = x * 10;\nfunc2(x:Number): Number = y1 * 10;").Errors;
@@ -349,7 +349,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DefRecursiveFunc()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
             IEnumerable<ExpressionError> enumerable = recalcEngine.DefineFunctions("foo(x:Number):Number = If(x=0,foo(1),If(x=1,foo(2),If(x=2,2));").Errors;
             var result = recalcEngine.Eval("foo(0)");
@@ -360,7 +360,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DefSimpleRecursiveFunc()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
             Assert.False(recalcEngine.DefineFunctions("foo():Blank = foo();").Errors.Any());
             var result = recalcEngine.Eval("foo()");
@@ -370,7 +370,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DefHailstoneSequence()
         {
-            var config = new PowerFxConfig(null)
+            var config = new PowerFxConfig()
             {
                 MaxCallDepth = 100
             };
@@ -384,7 +384,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DefMutualRecursionFunc()
         {
-            var config = new PowerFxConfig(null)
+            var config = new PowerFxConfig()
             {
                 MaxCallDepth = 100
             };
@@ -400,7 +400,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void RedefinitionError()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
             Assert.Throws<InvalidOperationException>(() => recalcEngine.DefineFunctions("foo():Blank = foo(); foo():Number = x + 1;"));
         }
@@ -408,7 +408,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void UDFBodySyntaxErrorTest()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
             Assert.True(recalcEngine.DefineFunctions("foo():Blank = x[").Errors.Any());
         }
@@ -416,7 +416,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void UDFIncorrectParametersTest()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             var recalcEngine = new RecalcEngine(config);
             Assert.False(recalcEngine.DefineFunctions("foo(x:Number):Number = x + 1;").Errors.Any());
             Assert.False(recalcEngine.Check("foo(False)").IsSuccess);
@@ -673,7 +673,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void RecalcEngineMutateConfig()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.SymbolTable.AddFunction(BuiltinFunctionsCore.Blank);
 
             var recalcEngine = new Engine(config)
@@ -704,7 +704,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void RecalcEngine_AddFunction_Twice()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
             config.AddFunction(BuiltinFunctionsCore.Blank);
 
             Assert.Throws<ArgumentException>(() => config.AddFunction(BuiltinFunctionsCore.Blank));
@@ -713,7 +713,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void RecalcEngine_FunctionOrdering1()
         {
-            var config = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            var config = new PowerFxConfig(Features.All);
             config.AddFunction(new TestFunctionMultiply());
             config.AddFunction(new TestFunctionSubstract());
 
@@ -729,7 +729,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void RecalcEngine_FunctionOrdering2()
         {
-            var config = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            var config = new PowerFxConfig(Features.All);
             config.AddFunction(new TestFunctionSubstract());
             config.AddFunction(new TestFunctionMultiply());
 
@@ -791,7 +791,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void OptionSetChecks()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
 
             var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
             {
@@ -868,7 +868,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void OptionSetResultType()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
 
             var optionSet = new OptionSet("FooOs", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
             {
@@ -888,7 +888,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void OptionSetChecksWithMakeUniqueCollision()
         {
-            var config = new PowerFxConfig(null);
+            var config = new PowerFxConfig();
 
             var optionSet = new OptionSet("OptionSet", DisplayNameUtility.MakeUnique(new Dictionary<string, string>()
             {
@@ -907,7 +907,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void EmptyEnumStoreTest()
         {
-            var config = PowerFxConfig.BuildWithEnumStore(null, new EnumStoreBuilder());
+            var config = PowerFxConfig.BuildWithEnumStore(new EnumStoreBuilder());
 
             var recalcEngine = new RecalcEngine(config);
 
@@ -919,7 +919,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void UDFRecursionLimitTest()
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(null));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             recalcEngine.DefineFunctions("Foo(x: Number): Number = Foo(x);");
             Assert.IsType<ErrorValue>(recalcEngine.Eval("Foo(1)"));
         }
@@ -927,7 +927,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void UDFRecursionWorkingTest()
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(null));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             recalcEngine.DefineFunctions("Foo(x: Number): Number = If(x = 1, 1, If(Mod(x, 2) = 0, Foo(x/2), Foo(x*3 + 1)));");
             Assert.Equal(1.0, recalcEngine.Eval("Foo(5)").ToObject());
         }
@@ -935,7 +935,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void IndirectRecursionTest()
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(null)
+            var recalcEngine = new RecalcEngine(new PowerFxConfig()
             {
                 MaxCallDepth = 81
             });
@@ -951,14 +951,14 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void DoubleDefinitionTest()
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(null));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             Assert.Throws<InvalidOperationException>(() => recalcEngine.DefineFunctions("Foo(): Number = 10; Foo(x: Number): String = \"hi\";"));
         }
 
         [Fact]
         public void TestNumberBinding()
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(null));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             Assert.True(recalcEngine.DefineFunctions("Foo(): String = 10;").Errors.Any());
         }
 
@@ -996,10 +996,10 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void TestMultiReturn()
         {
-            var recalcEngine = new RecalcEngine(new PowerFxConfig(null));
+            var recalcEngine = new RecalcEngine(new PowerFxConfig());
             var str = "Foo(x: Number): Number { 1+1; 2+2; };";
             recalcEngine.DefineFunctions(str);
-            Assert.Equal(4.0, recalcEngine.Eval("Foo(1)", null, new ParserOptions { AllowsSideEffects = true }).ToObject());
+            Assert.Equal(4.0, recalcEngine.Eval("Foo(1)", null, new ParserOptions(allowsSideEffects: true)).ToObject());
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SandboxTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async void MaxRecursionDepthTest()
         {
-            var config = new PowerFxConfig(null)
+            var config = new PowerFxConfig()
             {
                 MaxCallDepth = 10
             };

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioMutation.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/Scenarios/ScenarioMutation.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var obj = MutableObject.New(d);
             engine.UpdateVariable("obj", obj);
 
-            var x = engine.Eval(expr, options: new ParserOptions() { AllowsSideEffects = true }); // Assert failures will throw.
+            var x = engine.Eval(expr, options: new ParserOptions(allowsSideEffects: true)); // Assert failures will throw.
 
             if (x is ErrorValue ev)
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SetFunctionTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class SetFunctionTests : PowerFxTest
     {
-        private readonly ParserOptions _opts = new ParserOptions { AllowsSideEffects = true };
+        private readonly ParserOptions _opts = new ParserOptions(allowsSideEffects: true);
 
         [Fact]
         public void SetVar()

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/SymbolValueTests.cs
@@ -698,7 +698,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 var symTableAll = ReadOnlySymbolTable.Compose(symTable2, symTableThisItem);
                 var symValuesAll = symTableAll.CreateValues(symValuesThisItem);
 
-                var opts = new ParserOptions { AllowsSideEffects = true };
+                var opts = new ParserOptions(allowsSideEffects: true);
 
                 var runtimeConfig = new RuntimeConfig(symValuesAll);
                 var result = await engine.EvalAsync("Set(counter, ThisItem);counter", CancellationToken.None, options: opts, runtimeConfig: runtimeConfig);

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/BasicPerformance.cs
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/BasicPerformance.cs
@@ -35,9 +35,9 @@ namespace Microsoft.PowerFx.Performance.Tests
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _powerFxConfig = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            _powerFxConfig = new PowerFxConfig(Features.All);
             _engine = new Engine(_powerFxConfig);
-            _parserOptions = new ParserOptions() { AllowsSideEffects = true, Culture = new CultureInfo("en-US") };
+            _parserOptions = new ParserOptions(new CultureInfo("en-US"), allowsSideEffects: true);
             _recalcEngine = new RecalcEngine(_powerFxConfig);
         }
 

--- a/src/tests/Microsoft.PowerFx.Performance.Tests/PvaPerformance.cs
+++ b/src/tests/Microsoft.PowerFx.Performance.Tests/PvaPerformance.cs
@@ -40,9 +40,8 @@ namespace Microsoft.PowerFx.Performance.Tests
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _parserOptions = new ParserOptions() { AllowsSideEffects = true, Culture = new CultureInfo("en-US") };
-
-            PowerFxConfig powerFxConfig = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            _parserOptions = new ParserOptions(new CultureInfo("en-US"), allowsSideEffects: true);
+            PowerFxConfig powerFxConfig = new PowerFxConfig(Features.All);
 
             for (int i = 0; i < 10000; i++)
             {
@@ -64,7 +63,7 @@ namespace Microsoft.PowerFx.Performance.Tests
         [Benchmark]
         public RecalcEngine PvaRecalcEngineConstructorWith10KOptionSets()
         {
-            PowerFxConfig powerFxConfig = new PowerFxConfig(new CultureInfo("en-US"), Features.All);
+            PowerFxConfig powerFxConfig = new PowerFxConfig(Features.All);
             RecalcEngine engine = null;
 
             for (int i = 0; i < 10000; i++)

--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerFx
 
             foreach (Features feature in (Features[])Enum.GetValues(typeof(Features)))
             {
-                if ((_engine.Config.Features & feature) == feature && feature != Features.None)
+                if ((_engine.Config.Features & feature) == feature && feature != Features.DefaultFeatures)
                 {
                     enabled.Append(" " + feature.ToString());
                 }
@@ -111,7 +111,7 @@ namespace Microsoft.PowerFx
             var parserOptions = _engine.GetDefaultParserOptionsCopy();
             parserOptions.AllowsSideEffects = true;
 
-            var parse = Engine.Parse(expr, parserOptions, parserOptions.Culture);
+            var parse = Engine.Parse(expr, Features.All, parserOptions);
             if (parse.IsSuccess)
             {
                 if (parse.Root.Kind == Microsoft.PowerFx.Syntax.NodeKind.Call)
@@ -171,7 +171,7 @@ namespace Microsoft.PowerFx
                     // IR pretty printer: IR( <expr> )
                     else if ((match = Regex.Match(expr, @"^\s*IR\((?<expr>.*)\)\s*$", RegexOptions.Singleline)).Success)
                     {
-                        var opts = new ParserOptions() { AllowsSideEffects = true };
+                        var opts = new ParserOptions(allowsSideEffects: true);
                         var cr = _engine.Check(match.Groups["expr"].Value, options: opts);
                         var ir = cr.PrintIR();
                         Console.WriteLine(ir);
@@ -206,7 +206,7 @@ namespace Microsoft.PowerFx
                     // eval and print everything else
                     else
                     {
-                        var opts = new ParserOptions() { AllowsSideEffects = true };
+                        var opts = new ParserOptions(allowsSideEffects: true);
                         var result = _engine.Eval(expr, options: opts);
 
                         if (output != null)
@@ -603,7 +603,7 @@ namespace Microsoft.PowerFx
                 {
                     if (option.Value.ToLower(CultureInfo.InvariantCulture) == feature.ToString().ToLower(CultureInfo.InvariantCulture))
                     {
-                        _features = _features & ~feature | (value.Value ? feature : Features.None);
+                        _features = _features & ~feature | (value.Value ? feature : Features.DefaultFeatures);
                         ResetEngine();
                         return value;
                     }


### PR DESCRIPTION
- Default culture
InvariantCulture

- Use of CurrentCulture/CurrentUICulture removed in all code

- PowerFxConfig Removal of Culture property as it's confusing

- Features 
Features.None isn't used anymore as a default value when a Features input parameters is used. Still defined but we now default to Features.DefaultFeatures, itself defined as PowerFx10Features. Features.PowerFx10Features is defined as Features.TableSyntaxDoesntWrapRecords | Features.ConsistentOneColumnTableResult. Later we can have PowerFx11Features, PowerFx20Features... and the default could evolve. Customers willing to stay on a given set of features will use these constants.

- ExpressionLocalizationHelper
Removal of 2 internal ConvertExpression APIs
Voluntary breaking change to ensure Culture and Features are explicitely provided

- ParseResult
New public ParseCulture property

- ParserOptions
New public constructor to facilite its creation
All code & tests updated to use this new constructor

- TexlFunction
Removed Info(string locale) internal method [dead code for PFX] 
Removed _cachedFunctionInfo and _cachedLocaleName props (unused) 
If needed in PA Client, will be added there (to be tested)

- Intellisense
Need a CultureInfo parameter in constructor