### PR TITLE
Fix #1266

### DIFF
--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -533,7 +533,7 @@ namespace Microsoft.PowerFx.Tests
 
             cts.Cancel();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => { await task; });
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => { await task; });
         }
 
         // Add a function that gets different runtime state per expression invoke

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DatabaseSimulationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DatabaseSimulationTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             using (var cts = new CancellationTokenSource(500))
             {
                 // Won't complete - should throw cancellation task 
-                await Assert.ThrowsAsync<TaskCanceledException>(async () => await run.EvalAsync(cts.Token, runtimeConfig));
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await run.EvalAsync(cts.Token, runtimeConfig));
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineAsyncTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Tests
 
             cts.Cancel();
 
-            await Assert.ThrowsAsync<TaskCanceledException>(async () => { await task; });
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => { await task; });
         }
 
         // Test interleaved concurrent runs. 


### PR DESCRIPTION
Test only update. Fix #1266 - Catch OperationCanceledException, not just TaskCanceledException