### PR TITLE
FaultException for missing privileges isn't displayed to user

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
@@ -632,7 +632,7 @@ namespace Microsoft.PowerFx.Functions
             }
             else
             {
-                return null;
+                childContext = context.SymbolContext.WithScopeValues(row.Error);
             }
 
             // Filter evals to a boolean 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions.txt
@@ -55,3 +55,6 @@ Error({Kind:ErrorKind.Div0})
 
 >> Filter(Table({a:1},{a:2},If(1<0,{a:3}),{a:4},{a:5}), IsBlank(a) Or a > 0)
 Table({a:1},{a:2},Blank(),{a:4},{a:5})
+
+>> CountIf(Filter([{a:1},If(1/0<2,{a:2}),{a:3}], IsError(a)), true)
+1

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
@@ -122,3 +122,9 @@ Errors: Error 36-41: Name isn't valid. 'Value' isn't recognized.
 
 >> LookUp(Table({x:1}, Error({Kind:ErrorKind.Custom}), {x:3}), ThisRecord.x = 3)
 Error({Kind:ErrorKind.Custom})
+
+>> LookUp( [{a:1},If(1/0<2,{a:2}),{a:3},If(Sqrt(-1)<0,{a:4}),{a:5}], IsError(a) && IfError(a, FirstError.Kind) > 20 )
+Error({Kind:ErrorKind.Numeric})
+
+>> IfError( LookUp( [{a:1},If(1/0<2,{a:2}),{a:3},If(Sqrt(-1)<0,{a:4}),{a:5}], IsError(a) && IfError(a, FirstError.Kind) > 20 ).a, FirstError.Kind )
+24

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
@@ -119,3 +119,6 @@ Errors: Error 23-28: Name isn't valid. 'Value' isn't recognized.
 
 >> LookUp([1, 2, 3] As X, X.Value > 2, Value)
 Errors: Error 36-41: Name isn't valid. 'Value' isn't recognized.
+
+>> LookUp(Table({x:1}, Error({Kind:ErrorKind.Custom}), {x:3}), ThisRecord.x = 3)
+Error({Kind:ErrorKind.Custom})


### PR DESCRIPTION
To support https://github.com/microsoft/Power-Fx-Dataverse/issues/119

When calling `LookUp` against a table from a user with missing privileges, DV returns a DValue<ErrorValue>, which was not previously handled by the filter. The final response from the engine was a BlankValue object.