### PR TITLE
Fix check of FirstN/LastN functions with new feature flag

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/FirstLastN.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var fArgsValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
-            if (context.Features.FirstLastNRequiresSecondArguments)
+            if (context.Features.FirstLastNRequiresSecondArguments && args.Length < 2)
             {
                 var callNode = args[0].Parent.Parent;
                 errors.Error(callNode, TexlStrings.ErrBadArity, args.Length, 2);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FirstLastN_RequiredSecondArgument.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FirstLastN_RequiredSecondArgument.txt
@@ -1,7 +1,78 @@
 #SETUP: FirstLastNRequiresSecondArguments
 
+// ######### FirstN ##########
+
+>> FirstN([1, 2, 3, 4, 5], 1)
+Table({Value:1})
+
+>> FirstN([1, 2, 3, 4, 5], 2)
+Table({Value:1},{Value:2})
+
 >> FirstN([1, 2, 3, 4, 5])
 Errors: Error 0-23: The function 'FirstN' has some invalid arguments.|Error 0-23: Invalid number of arguments: received 1, expected 2.
 
+>> FirstN([1, 2, 3, 4, 5], 6)
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> FirstN([1, 2, 3, 4, 5], -1)
+Table()
+
+>> FirstN([1, 2, 3, 4, 5], Blank())
+Table()
+
+>> FirstN(Blank(), 2)
+Blank()
+
+>> FirstN(Blank())
+Errors: Error 0-15: The function 'FirstN' has some invalid arguments.|Error 0-15: Invalid number of arguments: received 1, expected 2.
+
+>> FirstN(Sort([-2, -1, 0, 1, 2], 1 / Value), 2)
+Error({Kind:ErrorKind.Div0})
+
+>> FirstN([1, 2, 3, 4, 5], 1/0)
+Error({Kind:ErrorKind.Div0})
+
+>> First(LastN(Table({a:"1", b:"101"}, {a:"2"}, {a:"3"}), 1)).b
+Blank()
+
+>> FirstN(Filter([1,2,3],Value=4),2)
+Table()
+
+// ######### LastN ##########
+
+>> LastN([1, 2, 3, 4, 5], 2)
+Table({Value:4},{Value:5})
+
 >> LastN([1, 2, 3, 4, 5])
 Errors: Error 0-22: The function 'LastN' has some invalid arguments.|Error 0-22: Invalid number of arguments: received 1, expected 2.
+
+>> LastN([1, 2, 3, 4, 5], 6)
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> LastN([1, 2, 3, 4, 5], -1)
+Table()
+
+>> LastN([1, 2, 3, 4, 5], Blank())
+Table()
+
+>> LastN(Blank(), 2)
+Blank()
+
+>> LastN(Blank())
+Errors: Error 0-14: The function 'LastN' has some invalid arguments.|Error 0-14: Invalid number of arguments: received 1, expected 2.
+
+>> LastN(Sort([-2, -1, 0, 1, 2], 1 / Value), 2)
+Error({Kind:ErrorKind.Div0})
+
+>> LastN([1, 2, 3, 4, 5], 1/0)
+Error({Kind:ErrorKind.Div0})
+
+// Last2 have all values in column 'b' Blank(), but is still part of the type.
+>> LastN(Table({a:1, b:101}, {a:2}, {a:3}), 2)
+Table({a:2,b:Blank()},{a:3,b:Blank()})
+
+>> LastN(Table({a:1}, {a:2}, {a:3}), 2)
+Table({a:2},{a:3})
+
+>> LastN(Table({Value:1,Zulu:1}, {Value:2,Zulu:2}, {Value:3,Zulu:3}), 2)
+Table({Value:2,Zulu:2},{Value:3,Zulu:3})


### PR DESCRIPTION
Check for validity of calls to the FirstN/LastN function with the new feature flag that requires two arguments was broken. This fixes it.