### PR TITLE
Properly pass error and blank rows to Concat expression

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -75,37 +75,46 @@ namespace Microsoft.PowerFx.Functions
 
             foreach (var row in arg0.Rows)
             {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    sb.Append(separator);
+                }
+
+                SymbolContext childContext;
                 if (row.IsValue)
                 {
-                    if (first)
-                    {
-                        first = false;
-                    }
-                    else
-                    {
-                        sb.Append(separator);
-                    }
-
-                    var childContext = context.SymbolContext.WithScopeValues(row.Value);
-
-                    var result = await arg1.EvalInRowScopeAsync(context.NewScope(childContext)).ConfigureAwait(false);
-
-                    string str;
-                    if (result is ErrorValue ev)
-                    {
-                        return ev;
-                    }
-                    else if (result is BlankValue)
-                    {
-                        str = string.Empty;
-                    }
-                    else
-                    {
-                        str = ((StringValue)result).Value;
-                    }
-
-                    sb.Append(str);
+                    childContext = context.SymbolContext.WithScopeValues(row.Value);
                 }
+                else if (row.IsBlank)
+                {
+                    childContext = context.SymbolContext.WithScopeValues(RecordValue.Empty());
+                }
+                else
+                {
+                    childContext = context.SymbolContext.WithScopeValues(row.Error);
+                }
+
+                var result = await arg1.EvalInRowScopeAsync(context.NewScope(childContext)).ConfigureAwait(false);
+
+                string str;
+                if (result is ErrorValue ev)
+                {
+                    return ev;
+                }
+                else if (result is BlankValue)
+                {
+                    str = string.Empty;
+                }
+                else
+                {
+                    str = ((StringValue)result).Value;
+                }
+
+                sb.Append(str);
             }
 
             return new StringValue(irContext, sb.ToString());

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Concat.txt
@@ -132,3 +132,20 @@ Error({Kind:ErrorKind.Div0})
 // Coercion on separator
 >> Concat([1, 2, 3], $"-a{Value}-", false)
 "-a1-false-a2-false-a3-"
+
+// Concat handling errors
+>> Concat([1, 2, Sqrt(-1), 3, 4], IfError(Value, -FirstError.Kind), ",")
+"1,2,-24,3,4"
+
+>> Concat(Table({a:1},{a:2},If(1/0<2,{a:3}),{a:4},{a:5}), IfError(a, -FirstError.Kind), ",")
+"1,2,-13,4,5"
+
+>> Concat(Table({a:1},{a:1/0},{a:3},If(1/0<2,{a:4}),{a:5}), If(IsError(ThisRecord), -100, IfError(a, -FirstError.Kind)), ",")
+"1,-13,3,-100,5"
+
+// Concat handling blanks
+>> Concat([1, Blank(), 3], Coalesce(Value,0), ",")
+"1,0,3"
+
+>> Concat(Table({a:1},Blank(),{a:3}), Coalesce(a,0), ",")
+"1,0,3"


### PR DESCRIPTION
This doesn't work properly today. Fixes #1326 