### PR TITLE
Supporting multiple types

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -452,18 +452,14 @@ namespace Microsoft.PowerFx
                             throw new NotImplementedException();
                         }
 
-                        if (StringValue.AllowedListConvertToString.Contains(this.ReturnType))
-                        {
-                            this.ReturnType = FormulaType.String;
-                        }
-                        else
+                        if (!StringValue.AllowedListConvertToString.Contains(this.ReturnType))
                         {
                             notCoerceToType = true;
                         }
                     }
 
-                    var sameType = this._expectedReturnType == this.ReturnType;
-                    if (notCoerceToType || !sameType)
+                    var valid = this._expectedReturnType == this.ReturnType || (_allowCoerceToType && !notCoerceToType);
+                    if (!valid)
                     {
                         _errors.Add(new ExpressionError
                         {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -452,7 +452,11 @@ namespace Microsoft.PowerFx
                             throw new NotImplementedException();
                         }
 
-                        if (!StringValue.AllowedListConvertToString.Contains(this.ReturnType))
+                        if (StringValue.AllowedListConvertToString.Contains(this.ReturnType))
+                        {
+                            this.ReturnType = FormulaType.String;
+                        }
+                        else
                         {
                             notCoerceToType = true;
                         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
@@ -199,6 +199,18 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             Assert.Equal("Microsoft.PowerFx.Tests.LanguageServiceProtocol.EditorContextScopeTests+MyHandler", name);
         }
 
+        [Fact]
+        public void CheckExpectedReturnValueNumber()
+        {
+            var editorContextScope = new EditorContextScope(
+                            (expr) => new CheckResult(
+                                    new Engine()).SetText(expr).SetBindingInfo().SetExpectedReturnValue(FormulaType.String, true));
+
+            var check = editorContextScope.Check("123");
+
+            Assert.True(check.IsSuccess);
+        }
+
         private class MyEmptyHandler : CodeFixHandler
         {
             public override void OnCodeActionApplied(string actionId)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/EditorContextScopeTests.cs
@@ -209,6 +209,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             var check = editorContextScope.Check("123");
 
             Assert.True(check.IsSuccess);
+            Assert.Equal(FormulaType.Decimal, check.ReturnType);
         }
 
         private class MyEmptyHandler : CodeFixHandler


### PR DESCRIPTION
Supporting multiple types when Check function is ran with EditorContextScope.

Fix #1332 