### PR TITLE
Revert "adds void type to IfError()"

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IfError.cs
@@ -96,88 +96,149 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var count = args.Length;
             nodeToCoercedTypeMap = null;
 
+            // Check the predicates.
             var fArgsValid = true;
+            var type = ReturnType;
 
-            /*
-            If we were to write IfError(v1, f1, v2, f2, ..., vn, fn) in a try...catch way, it would look something like:
-                
-            var result
-            try {
-                result = v1();
-            } catch {
-                return f1();
-            }
-            try {
-                result = v2();
-            } catch {
-                return f2();
-            }
-            ...
-            try {
-                result = vn();
-            } catch {
-                return fn();  // omit this last catch if there is an odd number of arguments
-            }
-            return result;
+            var isBehavior = context.AllowsSideEffects;
 
-            In this case, we prefer the type of the last v_i as the return type.
-            Possible return values are:
-            Even case: f1, f2, ..., vn, fn
-            Odd case: f1, f2, ..., vn
-            */
-
-            var preferredTypeIndex = (count % 2) == 0 ? count - 2 : count - 1;
-            var type = argTypes[preferredTypeIndex];
-            if (type.IsError)
-            {
-                errors.EnsureError(args[preferredTypeIndex], TexlStrings.ErrTypeError);
-                fArgsValid = false;
-            }
-
-            for (var i = count - 1; i >= 0; i -= 2)
+            Contracts.Assert(type == DType.Unknown);
+            for (var i = 0; i < count;)
             {
                 var nodeArg = args[i];
                 var typeArg = argTypes[i];
 
-                var typeSuper = type.IsError ? typeArg : DType.Supertype(type, typeArg);
-
-                if (!typeSuper.IsError)
+                if (typeArg.IsError)
                 {
-                    // If preferred type was error or null (due to Blank or Error) assign new type in hierarchy
-                    if (type.IsError || type == DType.ObjNull)
+                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
+                }
+
+                // In an IfError expression, not all expressions can be returned to the caller:
+                // - If there is an even number of arguments, only the fallbacks or the last
+                //   value (the next-to-last argument) can be returned:
+                //   IfError(v1, f1, v2, f2, v3, f3) --> possible values to be returned are f1, f2, f3 or v3
+                // - If there is an odd number of arguments, only the fallbacks or the last
+                //   value (the last argument) can be returned:
+                //   IfError(v1, f1, v2, f2, v3) --> possible values to be returned are f1, f2 or v3
+                var typeCanBeReturned = (i % 2) == 1 || i == ((count % 2) == 0 ? (count - 2) : (count - 1));
+
+                if (typeCanBeReturned)
+                {
+                    // Let's check if it matches the other types that can be returned
+                    var typeSuper = DType.Supertype(type, typeArg);
+
+                    if (!typeSuper.IsError)
                     {
                         type = typeSuper;
                     }
-                }
-                else
-                {
-                    if (typeArg.IsVoid)
+                    else if (type.Kind == DKind.Unknown)
                     {
-                        type = DType.Void;
-                    }
-                    else if (typeArg.IsError)
-                    {
-                        errors.EnsureError(args[i], TexlStrings.ErrTypeError);
+                        // One of the args is also of unknown type, so we can't resolve the type of IfError
+                        type = typeSuper;
                         fArgsValid = false;
                     }
-                    else if (!type.IsError && typeArg.CoercesTo(type))
+                    else if (!type.IsError)
                     {
-                        CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
+                        // Types don't resolve normally, coercion needed
+                        if (typeArg.CoercesTo(type))
+                        {
+                            CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
+                        }
+                        else if (!isBehavior || !IsArgTypeInconsequential(nodeArg))
+                        {
+                            errors.EnsureError(
+                                DocumentErrorSeverity.Severe,
+                                nodeArg,
+                                TexlStrings.ErrBadType_ExpectedType_ProvidedType,
+                                type.GetKindString(),
+                                typeArg.GetKindString());
+                            fArgsValid = false;
+                        }
                     }
-                    else
+                    else if (typeArg.Kind != DKind.Unknown)
                     {
-                        type = DType.Void;
+                        type = typeArg;
+                        fArgsValid = false;
                     }
                 }
 
-                if ((count % 2) != 0 && i == count - 1)
+                // If there are an odd number of args, the last arg also participates.
+                i += 2;
+                if (i == count)
                 {
-                    i++;
+                    i--;
                 }
             }
 
             returnType = type;
             return fArgsValid;
+        }
+
+        // In behavior properties, the arg type is irrelevant if nothing actually depends
+        // on the output type of IfError (see If.cs, Switch.cs)
+        private bool IsArgTypeInconsequential(TexlNode arg)
+        {
+            Contracts.AssertValue(arg);
+            Contracts.Assert(arg.Parent is ListNode);
+            Contracts.Assert(arg.Parent.Parent is CallNode);
+            Contracts.Assert(arg.Parent.Parent.AsCall().Head.Name == Name);
+
+            var call = arg.Parent.Parent.AsCall().VerifyValue();
+
+            // Pattern: OnSelect = IfError(arg1, arg2, ... argK)
+            // Pattern: OnSelect = IfError(arg1, IfError(arg1, arg2,...), ... argK)
+            // ...etc.
+            var ancestor = call;
+            while (ancestor.Head.Name == Name)
+            {
+                if (ancestor.Parent == null && ancestor.Args.Children.Length > 0)
+                {
+                    return true;
+                }
+
+                // Deal with the possibility that the ancestor may be contributing to a chain.
+                // This also lets us cover the following patterns:
+                // Pattern: OnSelect = X; IfError(arg1, arg2); Y; Z
+                // Pattern: OnSelect = X; IfError(arg1;arg11;...;arg1k, arg2;arg21;...;arg2k); Y; Z
+                // ...etc.
+                VariadicOpNode chainNode;
+                if ((chainNode = ancestor.Parent.AsVariadicOp()) != null && chainNode.Op == VariadicOp.Chain)
+                {
+                    // Top-level chain in a behavior rule.
+                    if (chainNode.Parent == null)
+                    {
+                        return true;
+                    }
+
+                    // A chain nested within a larger non-call structure.
+                    if (!(chainNode.Parent is ListNode) || !(chainNode.Parent.Parent is CallNode))
+                    {
+                        return false;
+                    }
+
+                    // Only the last chain segment is consequential.
+                    var numSegments = chainNode.Children.Length;
+                    if (numSegments > 0 && !arg.InTree(chainNode.Children[numSegments - 1]))
+                    {
+                        return true;
+                    }
+
+                    // The node is in the last segment of a chain nested within a larger invocation.
+                    ancestor = chainNode.Parent.Parent.AsCall();
+                    continue;
+                }
+
+                // Walk up the parent chain to the outer invocation.
+                if (!(ancestor.Parent is ListNode) || !(ancestor.Parent.Parent is CallNode))
+                {
+                    return false;
+                }
+
+                ancestor = ancestor.Parent.Parent.AsCall();
+            }
+
+            // Exhausted all supported patterns.
+            return false;
         }
 
         public override bool IsLambdaParam(int index)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2129,20 +2129,18 @@ namespace Microsoft.PowerFx.Functions
 
                     var childContext = context.SymbolContext.WithScopeValues(new InMemoryRecordValue(IRContext.NotInSource(ifErrorScopeParamType), scopeVariables));
 
-                    var errorHandlingBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(errorHandlingBranch, context.NewScope(childContext), errorHandlingBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
-                    return MaybeAdjustToCompileTimeType(errorHandlingBranchResult, irContext);
+                    return (await runner.EvalArgAsync<ValidFormulaValue>(errorHandlingBranch, context.NewScope(childContext), errorHandlingBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
                 }
 
                 if (i + 1 == args.Length - 1)
                 {
-                    return MaybeAdjustToCompileTimeType(res.ToFormulaValue(), irContext);
+                    return res.ToFormulaValue();
                 }
 
                 if (i + 2 == args.Length - 1)
                 {
-                    var otherwiseBranch = args[i + 2];
-                    var otherwiseBranchResult = (await runner.EvalArgAsync<ValidFormulaValue>(otherwiseBranch, context, otherwiseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
-                    return MaybeAdjustToCompileTimeType(otherwiseBranchResult, irContext);
+                    var falseBranch = args[i + 2];
+                    return (await runner.EvalArgAsync<ValidFormulaValue>(falseBranch, context, falseBranch.IRContext).ConfigureAwait(false)).ToFormulaValue();
                 }
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError.txt
@@ -149,9 +149,6 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> IfError(1/0, Time(12,0,0))
 0.5
 
->> IfError(1, 1/0, Time(12,0,0))
-Time(12,0,0,0)
-
 // Number-DateTime
 >> IfError(1/0, DateTime(2022,8,1,12,0,0))
 44774.5
@@ -198,61 +195,3 @@ Time(11,30,59,0)
 // Error-DateTime
 >> IfError(Error({Kind: ErrorKind.Validation}), DateTime(2021, 12, 12, 17, 30, 0))
 DateTime(2021,12,12,17,30,0,0)
-
->> IfError(1, {x:1}, {x:1}, {y:1}, 1)
-If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
-
-// IfError can have mismatched arg types, but result can't be used.
->> IfError(1/0, 1, {x:4})
-If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
-
-// IfError accepts the void value. But then result of the expression can't be used. If(true, 1, {x:4}) => void value.
->> IfError(1/0, 1, If(true, 1, {x:4}), 1)
-If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
-
-// Errors are still returned.
->> IfError(1, 2, 3/0, If(true, 1/0, {x:4}))
-Error({Kind:ErrorKind.Div0})
-
-// Error is not returned.
->> IfError(1, 2, 3/0, If(false, 1/0, {x:4}))
-If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
-
->> IfError(1, a)
-Errors: Error 11-12: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
-
->> IfError(a, 1)
-Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
-
->> IfError( If(true, 1, {a:1}), 1, 2 )
-2
-
->> IfError( If(true, 1/0, {a:1}), 1, 2 )
-1
-
->> IfError( 1, "hello", If(true,1/0,{a:1}), "great", "world")
-"great"
-
->> IfError( 1, "one", If(true,1,{a:1}), "two", "three")
-"three"
-
->> IfError(1/0, 2, Time(12, 0, 0), 2)
-Time(0,0,0,0)
-
->> IfError(Blank(), 1)
-Blank()
-
->> IfError(1, Blank())
-1
-
->> IfError(1, 2, Blank())
-Blank()
-
->> IfError(1, Blank(), 2)
-2
-
->> IfError(Blank(), Blank())
-Blank()
-
->> IfError(Blank(), Blank(), Blank())
-Blank()


### PR DESCRIPTION
Reverts microsoft/Power-Fx#1230

Reverting because it was a breaking change - not ready to take in Power Apps yet. 
-Previously allowed now error:
expressions such as IfError(1, {x:1}, {x:1}, {y:1}, 1) Since it can potentially return a record or a number type.
