### PR TITLE
Updates to CheckType error handling in function CheckTypes

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -142,7 +142,10 @@ namespace Microsoft.PowerFx.Core.Functions
         // Same as the virtual overload, however all typechecks are done quietly, without posting document errors.
         public virtual bool CheckInput(Features features, TexlNode inputNode, DType inputSchema, out DType typeScope)
         {
-            return CheckInput(features, inputNode, inputSchema, TexlFunction.DefaultErrorContainer, out typeScope);
+            // A "no-op" or /dev/null error container that does not post document errors.
+            NullErrorContainer nullErrorContainer = new NullErrorContainer();
+
+            return CheckInput(features, inputNode, inputSchema, nullErrorContainer, out typeScope);
         }
 
         public void CheckLiteralPredicates(TexlNode[] args, IErrorContainer errors)

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/NullErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/NullErrorContainer.cs
@@ -10,9 +10,12 @@ using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Functions
 {
-    // Default "no-op" error container that does not post document errors.
-    // See the TexlFunction.DefaultErrorContainer property and its uses for more info.
-    internal sealed class DefaultNoOpErrorContainer : IErrorContainer
+    // Null error container that does not post document errors.
+    // See the TexlFunction.NullErrorContainer property and its uses for more info.
+    //
+    // In general, this error container should not be used in custom function CheckTypes.
+    // Instead, an argument should be checked once rather than multiple times.
+    internal sealed class NullErrorContainer : IErrorContainer
     {
         public DocumentErrorSeverity DefaultSeverity => DocumentErrorSeverity._Min;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -44,9 +44,6 @@ namespace Microsoft.PowerFx.Core.Functions
         // Column name when Features.ConsistentOneColumnTableResult is enabled.
         public const string ColumnName_ValueStr = "Value";
 
-        // A default "no-op" error container that does not post document errors.
-        public static IErrorContainer DefaultErrorContainer => new DefaultNoOpErrorContainer();
-
         // The information for scope if there is one.
         private FunctionScopeInfo _scopeInfo;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMax.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // Ensure that all the arguments are numeric/coercible to numeric.
                 for (var i = 0; i < argTypes.Length; i++)
                 {
-                    if (!CheckType(context, args[i], argTypes[i], returnType, DefaultErrorContainer, ref nodeToCoercedTypeMap))
+                    if (!CheckType(context, args[i], argTypes[i], returnType, errors, ref nodeToCoercedTypeMap))
                     {
                         errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrNumberExpected);
                         fArgsValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MinMaxTable.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             if (argTypes[1] != DType.Date && argTypes[1] != DType.DateTime && argTypes[1] != DType.Time)
             {
                 returnType = DetermineNumericFunctionReturnType(true, context.NumberIsFloat, argTypes[1]);
-                if (!CheckType(context, args[1], argTypes[1], returnType, DefaultErrorContainer, ref nodeToCoercedTypeMap))
+                if (!CheckType(context, args[1], argTypes[1], returnType, errors, ref nodeToCoercedTypeMap))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrNumberExpected);
                     nodeToCoercedTypeMap = null;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             //   * always a float, which could help with overload resolution in the future
             //   * does not determine the type of result (that's on the second arg)
             //   * is always an integer, as it is truncated by the argpreprocessor and the runtime
-            if (!CheckType(context, args[0], argTypes[0], DType.Number, DefaultErrorContainer, ref nodeToCoercedTypeMap))
+            if (!CheckType(context, args[0], argTypes[0], DType.Number, errors, ref nodeToCoercedTypeMap))
             {
                 errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrNumberExpected);
                 fArgsValid = false;
@@ -67,7 +67,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Ensure that start and step arguments are numeric/coercible to numeric.
             for (var i = 1; i < argTypes.Length; i++)
             {
-                if (!CheckType(context, args[i], argTypes[i], returnScalarType, DefaultErrorContainer, ref nodeToCoercedTypeMap))
+                if (!CheckType(context, args[i], argTypes[i], returnScalarType, errors, ref nodeToCoercedTypeMap))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrNumberExpected);
                     fArgsValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Ensure that all the arguments are numeric/coercible to numeric.
             for (var i = 0; i < argTypes.Length; i++)
             {
-                if (!CheckType(context, args[i], argTypes[i], returnType, DefaultErrorContainer, ref nodeToCoercedTypeMap))
+                if (!CheckType(context, args[i], argTypes[i], returnType, errors, ref nodeToCoercedTypeMap))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrNumberExpected);
                     fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StatisticalTableFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StatisticalTableFunction.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             returnType = DetermineNumericFunctionReturnType(_nativeDecimal, context.NumberIsFloat, argTypes[1]);
 
-            if (!CheckType(context, args[1], argTypes[1], returnType, DefaultErrorContainer, ref nodeToCoercedTypeMap))
+            if (!CheckType(context, args[1], argTypes[1], returnType, errors, ref nodeToCoercedTypeMap))
             {
                 errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrNumberExpected);
                 nodeToCoercedTypeMap = null;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -65,12 +65,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     usePowerFxV1CompatibilityRules: checkTypesContext.Features.PowerFxV1CompatibilityRules) &&
                 (checkTypesContext.NumberIsFloat || DType.Number.Accepts(arg0Type, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: checkTypesContext.Features.PowerFxV1CompatibilityRules)))
             {
-                isValidNumber = CheckType(checkTypesContext, arg0, arg0Type, DType.Number, DefaultErrorContainer, out matchedWithCoercion);
+                isValidNumber = CheckType(checkTypesContext, arg0, arg0Type, DType.Number, errors, out matchedWithCoercion);
                 arg0CoercedType = matchedWithCoercion ? DType.Number : DType.Invalid;
             }
             else
             {
-                isValidNumber = CheckType(checkTypesContext, arg0, arg0Type, DType.Decimal, DefaultErrorContainer, out matchedWithCoercion);
+                isValidNumber = CheckType(checkTypesContext, arg0, arg0Type, DType.Decimal, errors, out matchedWithCoercion);
                 arg0CoercedType = matchedWithCoercion ? DType.Decimal : DType.Invalid;
             }
 
@@ -85,7 +85,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
                 else
                 {
-                    isValidString = CheckType(checkTypesContext, arg0, arg0Type, DType.String, DefaultErrorContainer, out matchedWithCoercion);
+                    isValidString = CheckType(checkTypesContext, arg0, arg0Type, DType.String, errors, out matchedWithCoercion);
 
                     if (isValidString)
                     {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMax.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMax.txt
@@ -299,20 +299,20 @@ Error({Kind:ErrorKind.Numeric})
 // ****** Compiler errors ******
 
 >> Max(1, 2, {a:3})
-Errors: Error 10-15: Expected number. We expect a number at this point in the formula.
+Errors: Error 10-15: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Min(1, 2, {a:3})
-Errors: Error 10-15: Expected number. We expect a number at this point in the formula.
+Errors: Error 10-15: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Max({a:1}, {a:2}, {a:3})
-Errors: Error 4-9: Expected number. We expect a number at this point in the formula.|Error 11-16: Expected number. We expect a number at this point in the formula.|Error 18-23: Expected number. We expect a number at this point in the formula.
+Errors: Error 4-9: Invalid argument type (Record). Expecting a Decimal value instead.|Error 11-16: Invalid argument type (Record). Expecting a Decimal value instead.|Error 18-23: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Min({a:1}, {a:2}, {a:3})
-Errors: Error 4-9: Expected number. We expect a number at this point in the formula.|Error 11-16: Expected number. We expect a number at this point in the formula.|Error 18-23: Expected number. We expect a number at this point in the formula.
+Errors: Error 4-9: Invalid argument type (Record). Expecting a Decimal value instead.|Error 11-16: Invalid argument type (Record). Expecting a Decimal value instead.|Error 18-23: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Min([1,2,3], [1])
-Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-17: The function 'Min' has some invalid arguments.
+Errors: Error 13-16: Invalid argument type (Table). Expecting a Decimal value instead.|Error 0-17: The function 'Min' has some invalid arguments.
 
 >> Max([1,2,3], [1])
-Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-17: The function 'Max' has some invalid arguments.
+Errors: Error 13-16: Invalid argument type (Table). Expecting a Decimal value instead.|Error 0-17: The function 'Max' has some invalid arguments.
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMaxFloat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMaxFloat.txt
@@ -320,20 +320,20 @@ Error({Kind:ErrorKind.Numeric})
 // ****** Compiler errors ******
 
 >> Max(1, 2, {a:3})
-Errors: Error 10-15: Expected number. We expect a number at this point in the formula.
+Errors: Error 10-15: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Min(1, 2, {a:3})
-Errors: Error 10-15: Expected number. We expect a number at this point in the formula.
+Errors: Error 10-15: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Max({a:1}, {a:2}, {a:3})
-Errors: Error 4-9: Expected number. We expect a number at this point in the formula.|Error 11-16: Expected number. We expect a number at this point in the formula.|Error 18-23: Expected number. We expect a number at this point in the formula.
+Errors: Error 4-9: Invalid argument type (Record). Expecting a Decimal value instead.|Error 11-16: Invalid argument type (Record). Expecting a Decimal value instead.|Error 18-23: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Min({a:1}, {a:2}, {a:3})
-Errors: Error 4-9: Expected number. We expect a number at this point in the formula.|Error 11-16: Expected number. We expect a number at this point in the formula.|Error 18-23: Expected number. We expect a number at this point in the formula.
+Errors: Error 4-9: Invalid argument type (Record). Expecting a Decimal value instead.|Error 11-16: Invalid argument type (Record). Expecting a Decimal value instead.|Error 18-23: Invalid argument type (Record). Expecting a Decimal value instead.
 
 >> Min([1,2,3], [1])
-Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-17: The function 'Min' has some invalid arguments.
+Errors: Error 13-16: Invalid argument type (Table). Expecting a Decimal value instead.|Error 0-17: The function 'Min' has some invalid arguments.
 
 >> Max([1,2,3], [1])
-Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-17: The function 'Max' has some invalid arguments.
+Errors: Error 13-16: Invalid argument type (Table). Expecting a Decimal value instead.|Error 0-17: The function 'Max' has some invalid arguments.
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         public void InterpreterTestCase(ExpressionTestCase testCase)
         {
             // This is running against embedded resources, so if you're updating the .txt files,
-            // make sure they build is actually copying them over.
+            // make sure they build is actually copying them over.ab
             Assert.True(testCase.FailMessage == null, testCase.FailMessage);
 
             var runner = new InterpreterRunner() { NumberIsFloat = false };


### PR DESCRIPTION
Addresses https://github.com/microsoft/Power-Fx/issues/1375

Today, in some places, we call CheckTypes with "DefaultErrorHandler" as the error collection to catch the errors.  This is a /dev/null like error container where errors are not reported.  In general, we shouldn't need to use this - we should be calling CheckType once for each argument.  

Either:
1. The function's CheckTypes should take full responsibility for calling CheckType/CheckColumnType itself and not rely on the base.  This is done when the base didn't have good information about the parameters because their data types were not fixed, such as calling a function that can take/return Decimal vs. Number arguments.
2. The function's CheckTypes should defer to the base for argument processing and only augment with additional processing that does not involve calling CheckType/CheckColumnType.

The problem now is that it is confusing.  DefaultErrorHandler seemed like it was doing something useful when it was not.  The class and the one legit usage of it have been renamed to NullErrorHandler to better reflect how and when it would be used and the instance has been removed from TexlFunction.