### PR TITLE
Allow equality comparison between date/time values

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -1066,6 +1066,24 @@ namespace Microsoft.PowerFx.Core.Binding
                     return new BinderCheckTypeResult() { Coercions = coercions };
                 }
 
+                // Handle Date/Time <=> DateTime comparison
+                // Promote all sides to DateTime
+                if (IsAcceptedByDateOrTime(typeLeft, usePowerFxV1CompatibilityRules) &&
+                    IsAcceptedByDateOrTime(typeRight, usePowerFxV1CompatibilityRules))
+                {
+                    if (typeLeft.Kind != DKind.DateTime)
+                    {
+                        coercions.Add(new BinderCoercionResult { Node = left, CoercedType = DType.DateTime });
+                    }
+
+                    if (typeRight.Kind != DKind.DateTime)
+                    {
+                        coercions.Add(new BinderCoercionResult { Node = right, CoercedType = DType.DateTime });
+                    }
+
+                    return new BinderCheckTypeResult { Coercions = coercions };
+                }
+
                 // Handle UntypedObject comparisons
                 if (typeLeft.IsUntypedObject && CoercionMatrix.GetCoercionKind(typeLeft, typeRight, usePowerFxV1CompatibilityRules) != CoercionKind.None)
                 {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes.txt
@@ -1,0 +1,30 @@
+>> 1 = "1"
+false
+
+>> 0 = false
+false
+
+// Second comparison ensures the test doesn't fail if it runs exactly at midnight
+>> With({n:Now(),t:Today()}, (t = n) && (Mod(Value(n), 1) > 0))
+false
+
+>> Date(1899,12,31) = 1
+true
+
+>> DateTime(1899,12,30,12,0,0) = 0.5
+true
+
+>> Time(12,0,0) = 0.5
+true
+
+>> Date(2020,2,20) = DateTime(2020,2,20,0,0,0)
+true
+
+>> Date(2020,2,20) = DateTime(2020,2,20,0,0,0,1)
+false
+
+>> Date(1899,12,30) = Time(0,0,0)
+true
+
+>> Date(1899,12,29) = Time(0,0,0)
+false

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes_PowerFxV1FeatureEnabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes_PowerFxV1FeatureEnabled.txt
@@ -1,0 +1,39 @@
+#SKIPFILE: disable:NumberIsFloat
+#SETUP: PowerFxV1CompatibilityRules
+
+>> 1 = "1"
+Errors: Error 2-3: Incompatible types for comparison. These types can't be compared: Number, Text.
+
+>> 0 = false
+Errors: Error 2-3: Incompatible types for comparison. These types can't be compared: Number, Boolean.
+
+// Second comparison ensures the test doesn't fail if it runs exactly at midnight
+>> With({n:Now(),t:Today()}, (t = n) && (Mod(Value(n), 1) > 0))
+false
+
+>> Date(1899,12,31) = 1
+true
+
+>> DateTime(1899,12,30,12,0,0) = 0.5
+true
+
+>> Time(12,0,0) = 0.5
+true
+
+>> Date(2020,2,20) = DateTime(2020,2,20,0,0,0)
+true
+
+>> Date(2020,2,20) = DateTime(2020,2,20,0,0,0,1)
+false
+
+>> Date(1899,12,30) = Time(0,0,0)
+true
+
+>> Date(1899,12,29) = Time(0,0,0)
+false
+
+>> Time(12,0,0) = DateTime(1899,12,30,12,0,0)
+true
+
+>> Time(12,0,0) = DateTime(1899,12,31,12,0,0)
+false


### PR DESCRIPTION
With the new PowerFxV1 feature set, we are stricter with comparing values of different types. Something like `1 = "1"` has always returned false, which is probably not what the maker intended, so we are making them errors. Comparisons between dates and times, however, should be allowed, since for Excel compatibility they are equivalent to numbers. This change relaxes the restriction and makes the equality / inequality comparison between date/time values valid.