### PR TITLE
Fix Error function to work with strongly typed enums

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Error.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Error.txt
@@ -114,3 +114,6 @@ true
 
 >> Wyz("foo")
 Errors: Error 0-10: 'Wyz' is an unknown or unsupported function.
+
+>> Error(Table({Kind:ErrorKind.Div0},{Kind:ErrorKind.Numeric}))
+Error(Table({Kind:ErrorKind.Div0},{Kind:ErrorKind.Numeric}))


### PR DESCRIPTION
With the StronglyTypedBuiltinEnums on, the Error function wasn't working properly on its overload that takes a table. This change fixes it.