### PR TITLE
Updated option set value comparison to allow for decimal numbers

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -1023,6 +1023,20 @@ namespace Microsoft.PowerFx.Core.Binding
                 return new BinderCheckTypeResult() { Coercions = new[] { new BinderCoercionResult() { Node = right, CoercedType = typeLeft } } };
             }
 
+            // Special case for comparing option set values backed by numbers with decimal values
+            if ((typeLeft.Kind == DKind.OptionSetValue && typeLeft.OptionSetInfo?.BackingKind == DKind.Number && typeRight.Kind == DKind.Decimal) ||
+                (typeRight.Kind == DKind.OptionSetValue && typeRight.OptionSetInfo?.BackingKind == DKind.Number && typeLeft.Kind == DKind.Decimal))
+            {
+                return new BinderCheckTypeResult
+                {
+                    Coercions = new[]
+                    {
+                        new BinderCoercionResult { Node = left, CoercedType = DType.Number },
+                        new BinderCoercionResult { Node = right, CoercedType = DType.Number }
+                    }
+                };
+            }
+
             // Special case for view values, it should produce an error when the base views are different
             if (typeLeft.Kind == DKind.ViewValue && !typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes.txt
@@ -28,3 +28,15 @@ true
 
 >> Date(1899,12,29) = Time(0,0,0)
 false
+
+>> ErrorKind.Custom = 100
+false
+
+>> ErrorKind.Custom = 1000
+true
+
+>> 100 = ErrorKind.Custom
+false
+
+>> 1000 = ErrorKind.Custom
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes_PowerFxV1FeatureEnabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Eq_DifferentTypes_PowerFxV1FeatureEnabled.txt
@@ -37,3 +37,15 @@ true
 
 >> Time(12,0,0) = DateTime(1899,12,31,12,0,0)
 false
+
+>> ErrorKind.Custom = 100
+false
+
+>> ErrorKind.Custom = 1000
+true
+
+>> 100 = ErrorKind.Custom
+false
+
+>> 1000 = ErrorKind.Custom
+true


### PR DESCRIPTION
With the PowerFxV1 feature set and numbers defaulting to decimal, an expression such as `ErrorKind.Custom = 1000` fails. This should work, and this change fixes it.