### PR TITLE
Collection to display better error message

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -188,7 +188,7 @@ namespace Microsoft.PowerFx.Interpreter
                     fValid = false;
                     if (!SetErrorForMismatchedColumns(collectionType, collectedType, args[1], errors, context.Features))
                     {
-                        errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrNeedValidVariableName_Arg, Name);
+                        errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrTableDoesNotAcceptThisType);
                     }
                 }
             }


### PR DESCRIPTION
To mitigate issue #1360.

New error message:

> Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.

`Union` fails here:
https://github.com/microsoft/Power-Fx/blob/5b890ffe6bd07eff9a7671d01ca100316fcc3c2a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs#L2813

Then PFx tries to show which column has failed. The problem is that Union fails for a particular reason, but we use a different method to find the problematic column. PFx can accept Polymorphic/Record types. For some reason that I couldn't identify PA Client can't. This will result in `Owner:{e}` and PFx handling this scenario at
https://github.com/microsoft/Power-Fx/blob/5b890ffe6bd07eff9a7671d01ca100316fcc3c2a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs#L888
