### PR TITLE
Revert DType.Unknown for native decimal function return type

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         private readonly bool _nativeDecimal = false;
 
         public MathOneArgFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc, bool nativeDecimal = false)
-            : base(name, description, fc, nativeDecimal ? DType.Unknown : DType.Number, 0, 1, 1, nativeDecimal ? DType.Unknown : DType.Number)
+            : base(name, description, fc, DType.Number, 0, 1, 1, DType.Number)
         {
             _nativeDecimal = nativeDecimal;
         }
@@ -151,7 +151,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         private readonly bool _secondArgFloat = false;
 
         public MathTwoArgFunction(string name, TexlStrings.StringGetter description, int minArity, bool nativeDecimal = false, bool secondArgFloat = false)
-            : base(name, description, FunctionCategories.MathAndStat, nativeDecimal ? DType.Unknown : DType.Number, 0, minArity, 2, nativeDecimal ? DType.Unknown : DType.Number, nativeDecimal && !secondArgFloat ? DType.Unknown : DType.Number)
+            : base(name, description, FunctionCategories.MathAndStat, DType.Number, 0, minArity, 2, DType.Number, DType.Number)
         {
             _nativeDecimal = nativeDecimal;
             _secondArgFloat = secondArgFloat;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Statistical.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         private readonly bool _nativeDecimal = false;
 
         public StatisticalFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc, bool nativeDecimal = false)
-            : base(name, description, fc, nativeDecimal ? DType.Unknown : DType.Number, 0, 1, int.MaxValue, nativeDecimal ? DType.Unknown : DType.Number)
+            : base(name, description, fc, DType.Number, 0, 1, int.MaxValue, DType.Number)
         {
             _nativeDecimal = nativeDecimal;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StatisticalTableFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StatisticalTableFunction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         private readonly bool _nativeDecimal = false;
 
         public StatisticalTableFunction(string name, TexlStrings.StringGetter description, FunctionCategories fc, bool nativeDecimal = false)
-            : base(name, description, fc, nativeDecimal ? DType.Unknown : DType.Number, 0x02, 2, 2, DType.EmptyTable, nativeDecimal ? DType.Unknown : DType.Number)
+            : base(name, description, fc, DType.Number, 0x02, 2, 2, DType.EmptyTable, DType.Number)
         {
             ScopeInfo = new FunctionScopeInfo(this, usesAllFieldsInScope: false, acceptsLiteralPredicates: false);
             _nativeDecimal = nativeDecimal;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Mid.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Mid.txt
@@ -200,11 +200,5 @@ Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))
 >> Mid("asdf",1e28,2)
 ""
 
->> Mid("hello", Float(1e28), 2)
-""
-
 >> Mid("asdf",-1e28,2)
-Error({Kind:ErrorKind.InvalidArgument})
-
->> Mid("hello", Float(-1e28), 2)
 Error({Kind:ErrorKind.InvalidArgument})


### PR DESCRIPTION
Several functions can now return either DType.Decimal or DType.Number.  Reflecting this, these functions advertise their return type as DType.Unknown in the function info constructor.  This was causing problems for PA Client, and does not appear to actually impact the interpreter, so we are going to change it back to DType.Number which is all PA Client supports at the moment.  It isn't clear how this information would have been used anyway, as CheckTypes for each function ultimately determines the return type.  