### PR TITLE
Add Format/Language arguments to Text_UO

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/ArgPreprocessor.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace Microsoft.PowerFx.Core.Functions
 {
     // This enum provides the different ways that an argument to a function can be pre processed before entering the function.
-    // The function classes typically define public override ArgPreprocessor GetArgPreprocessor(int index) to provide which
+    // The function classes typically define public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node) to provide which
     // pro-processor should be used for each argument by index.
     // 
     // For example, an argument may speficy ReplaceBlankWithFloatZero.  All of these "ReplaceBlank" by injecting a Coalesce call 
@@ -31,5 +31,8 @@ namespace Microsoft.PowerFx.Core.Functions
         // Scalar and SingleColumnTable is for a function that returns a scalar number or a single column table of numbers, respectively.
         ReplaceBlankWithCallZero_Scalar = 6,
         ReplaceBlankWithCallZero_SingleColumnTable = 7,
+
+        // Untyped object to untyped object preprocessors
+        UntypedStringToUntypedNumber = 8,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1462,8 +1462,9 @@ namespace Microsoft.PowerFx.Core.Functions
         /// By default, function does not attach any pre-processing for arguments.
         /// </summary>
         /// <param name="index">0 based index of argument.</param>
+        /// <param name="node">The original call node.</param>
         /// <returns></returns>
-        public virtual ArgPreprocessor GetArgPreprocessor(int index)
+        public virtual ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return ArgPreprocessor.None;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -363,7 +363,7 @@ namespace Microsoft.PowerFx.Core.IR
                 for (var i = 0; i < len; i++)
                 {
                     IntermediateNode convertedNode;
-                    var argPreprocessor = func.GetArgPreprocessor(i);
+                    var argPreprocessor = func.GetArgPreprocessor(i, node);
 
                     switch (argPreprocessor)
                     {
@@ -389,6 +389,17 @@ namespace Microsoft.PowerFx.Core.IR
                         case ArgPreprocessor.ReplaceBlankWithCallZero_SingleColumnTable:
                             var callIRContext_SCT = context.GetIRContext(node);
                             convertedNode = ReplaceBlankWithCallTypedZero_Scalar(args[i], ((TableType)callIRContext_SCT.ResultType).SingleColumnFieldType);
+                            break;
+                        case ArgPreprocessor.UntypedStringToUntypedNumber:
+                            if (context.Binding.BindingConfig.NumberIsFloat)
+                            {
+                                convertedNode = new UnaryOpNode(IRContext.NotInSource(FormulaType.UntypedObject), UnaryOpKind.UntypedStringToUntypedFloat, args[i]);
+                            }
+                            else
+                            {
+                                convertedNode = new UnaryOpNode(IRContext.NotInSource(FormulaType.UntypedObject), UnaryOpKind.UntypedStringToUntypedDecimal, args[i]);
+                            }
+
                             break;
                         default:
                             convertedNode = args[i];

--- a/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/Nodes/UnaryOpKind.cs
@@ -104,5 +104,12 @@ namespace Microsoft.PowerFx.Core.IR.Nodes
         /// All Interpreter(backed) must implement this.
         /// </summary>
         BlankToEmptyString,
+
+        /// <summary>
+        /// Used for pre-processing untyped function arguments from string to number.
+        /// All Interpreter(backed) must implement this.
+        /// </summary>
+        UntypedStringToUntypedFloat,
+        UntypedStringToUntypedDecimal,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Atan2.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Syntax;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
@@ -15,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent Excel function: Atan2
     internal sealed class Atan2Function : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Char.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Corresponding Excel function: Char
     internal sealed class CharFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Date
     internal sealed class DateFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }
@@ -79,7 +79,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Equivalent DAX/Excel function: Time
     internal sealed class TimeFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }
@@ -103,7 +103,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // DateTime(year, month, day, hour, minute, second[, millisecond])
     internal sealed class DateTimeFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Dec2Hex.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Dec2Hex(number:n, [places:n])
     internal sealed class Dec2HexFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Hex2Dec.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Hex2Dec.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Hex2Dec(number:n)
     internal sealed class Hex2DecFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/LeftRight.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     //  Right(arg:s, count:n)
     internal sealed class LeftRightScalarFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             if (index == 1)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/MathFunction.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Abstract base class for all 1-arg math functions that return numeric values.
     internal abstract class MathOneArgFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return _nativeDecimal ? ArgPreprocessor.ReplaceBlankWithCallZero_Scalar : ArgPreprocessor.ReplaceBlankWithFloatZero;
         }
@@ -133,7 +133,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Abstract base class for all 2-arg math functions that return numeric values.
     internal abstract class MathTwoArgFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return _nativeDecimal && (index == 0 || !_secondArgFloat) ? 
                         ArgPreprocessor.ReplaceBlankWithCallZero_Scalar : ArgPreprocessor.ReplaceBlankWithFloatZero;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Rgba.cs
@@ -5,13 +5,14 @@ using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // RGBA(red, green, blue, alpha)
     internal sealed class RGBAFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             if (index >= 0 && index <= 2)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sequence.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Sequence(records:n, start:n, step:n): *[Value:n]
     internal sealed class SequenceFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return index == 0 ? ArgPreprocessor.ReplaceBlankWithFloatZeroAndTruncate : ArgPreprocessor.ReplaceBlankWithCallZero_SingleColumnTable;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Split.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     // Split(text:s, separator:s)
     internal class SplitFunction : StringTwoArgFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/StringOneArgFunction.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     internal abstract class StringOneArgFunction : BuiltinFunction
     {
-        public override ArgPreprocessor GetArgPreprocessor(int index)
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
         {
             return base.GetGenericArgPreprocessor(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public TextFunction_UO()
-            : base("Text", TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 3, DType.UntypedObject, DType.String, DType.String)
+            : base("Text", TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 2, DType.UntypedObject, DType.String)
         {
         }
 
@@ -234,7 +234,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             if (args.Length >= 2)
             {
-                // The 2nd and 3rd arguments can be validated using the same logic as the normal Text function
+                // The 2nd argument can be validated using the same logic as the normal Text function
                 TextFunction.ValidateFormatArgs(Name, context, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -60,8 +60,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             if (
                 !DType.Decimal.Accepts(
                     arg0Type,
-                    exact: true, 
-                    useLegacyDateTimeAccepts: false, 
+                    exact: true,
+                    useLegacyDateTimeAccepts: false,
                     usePowerFxV1CompatibilityRules: checkTypesContext.Features.PowerFxV1CompatibilityRules) &&
                 (checkTypesContext.NumberIsFloat || DType.Number.Accepts(arg0Type, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: checkTypesContext.Features.PowerFxV1CompatibilityRules)))
             {
@@ -121,6 +121,26 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return isValid;
             }
 
+            ValidateFormatArgs(Name, checkTypesContext, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
+
+            if (isValid)
+            {
+                if (arg0CoercedType.IsValid)
+                {
+                    CollectionUtils.Add(ref nodeToCoercedTypeMap, arg0, arg0CoercedType);
+                    return true;
+                }
+            }
+            else
+            {
+                nodeToCoercedTypeMap = null;
+            }
+
+            return isValid;
+        }
+
+        internal static void ValidateFormatArgs(string name, CheckTypesContext checkTypesContext, TexlNode[] args, DType[] argTypes, IErrorContainer errors, ref Dictionary<TexlNode, DType> nodeToCoercedTypeMap, ref bool isValid)
+        {
             if (BuiltInEnums.DateTimeFormatEnum.FormulaType._type.Accepts(argTypes[1], exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: checkTypesContext.Features.PowerFxV1CompatibilityRules))
             {
                 // Coerce enum values to string
@@ -158,7 +178,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                 if (hasDateTimeFmt && hasNumericFmt)
                 {
-                    errors.EnsureError(DocumentErrorSeverity.Moderate, args[1], TexlStrings.ErrIncorrectFormat_Func, Name);
+                    errors.EnsureError(DocumentErrorSeverity.Moderate, args[1], TexlStrings.ErrIncorrectFormat_Func, name);
                     isValid = false;
                 }
             }
@@ -172,21 +192,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     isValid = false;
                 }
             }
-
-            if (isValid)
-            {
-                if (arg0CoercedType.IsValid)
-                {
-                    CollectionUtils.Add(ref nodeToCoercedTypeMap, arg0, arg0CoercedType);
-                    return true;
-                }
-            }
-            else
-            {
-                nodeToCoercedTypeMap = null;
-            }
-
-            return isValid;
         }
 
         // This method returns true if there are special suggestions for a particular parameter of the function.
@@ -209,7 +214,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public TextFunction_UO()
-            : base("Text", TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 1, DType.UntypedObject)
+            : base("Text", TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 3, DType.UntypedObject, DType.String, DType.String)
         {
         }
 
@@ -221,6 +226,16 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override string GetUniqueTexlRuntimeName(bool isPrefetching = false)
         {
             return GetUniqueTexlRuntimeName(suffix: "_UO");
+        }
+
+        public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            var isValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+
+            // The 2nd and 3rd arguments can be validated using the same logic as the normal Text function
+            TextFunction.ValidateFormatArgs(Name, context, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
+
+            return isValid;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -216,7 +216,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public TextFunction_UO()
-            : base(TextFunction.TextInvariantFunctionName, TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 2, DType.UntypedObject, DType.String)
+            : base(TextFunction.TextInvariantFunctionName, TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 3, DType.UntypedObject, DType.String, DType.String)
         {
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             if (args.Length > 1)
             {
-                // The 2nd argument can be validated using the same logic as the normal Text function
+                // The 2nd and 3rd arguments can be validated using the same logic as the normal Text function
                 TextFunction.ValidateFormatArgs(Name, context, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -232,8 +232,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             var isValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
-            // The 2nd and 3rd arguments can be validated using the same logic as the normal Text function
-            TextFunction.ValidateFormatArgs(Name, context, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
+            if (args.Length >= 2)
+            {
+                // The 2nd and 3rd arguments can be validated using the same logic as the normal Text function
+                TextFunction.ValidateFormatArgs(Name, context, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
+            }
 
             return isValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Text.cs
@@ -25,8 +25,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     {
         public override bool IsSelfContained => true;
 
+        public const string TextInvariantFunctionName = "Text";
+
         public TextFunction()
-            : base("Text", TexlStrings.AboutText, FunctionCategories.Table | FunctionCategories.Text | FunctionCategories.DateTime, DType.String, 0, 1, 3, DType.Number, DType.String, DType.String)
+            : base(TextInvariantFunctionName, TexlStrings.AboutText, FunctionCategories.Table | FunctionCategories.Text | FunctionCategories.DateTime, DType.String, 0, 1, 3, DType.Number, DType.String, DType.String)
         {
         }
 
@@ -214,7 +216,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public TextFunction_UO()
-            : base("Text", TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 2, DType.UntypedObject, DType.String)
+            : base(TextFunction.TextInvariantFunctionName, TexlStrings.AboutText, FunctionCategories.Text, DType.String, 0, 1, 2, DType.UntypedObject, DType.String)
         {
         }
 
@@ -232,13 +234,23 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         {
             var isValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
-            if (args.Length >= 2)
+            if (args.Length > 1)
             {
                 // The 2nd argument can be validated using the same logic as the normal Text function
                 TextFunction.ValidateFormatArgs(Name, context, args, argTypes, errors, ref nodeToCoercedTypeMap, ref isValid);
             }
 
             return isValid;
+        }
+
+        public override ArgPreprocessor GetArgPreprocessor(int index, CallNode node)
+        {
+            if (index == 0 && node.Args.Count > 1)
+            {
+                return ArgPreprocessor.UntypedStringToUntypedNumber;
+            }
+
+            return base.GetArgPreprocessor(index, node);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/DecimalUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/DecimalUntypedObject.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Functions
+{
+    internal class DecimalUntypedObject : IUntypedObject
+    {
+        private readonly decimal _value;
+
+        public DecimalUntypedObject(decimal value)
+        {
+            _value = value;
+        }
+
+        public FormulaType Type => FormulaType.Decimal;
+
+        public IUntypedObject this[int index] => throw new NotImplementedException();
+
+        public int GetArrayLength()
+        {
+            throw new NotImplementedException();
+        }
+
+        public double GetDouble()
+        {
+            throw new NotImplementedException();
+        }
+
+        public decimal GetDecimal()
+        {
+            return _value;
+        }
+
+        public string GetUntypedNumber()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetString()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool GetBoolean()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetProperty(string value, out IUntypedObject result)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/FloatUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/FloatUntypedObject.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx.Functions
+{
+    internal class FloatUntypedObject : IUntypedObject
+    {
+        private readonly double _value;
+
+        public FloatUntypedObject(double value)
+        {
+            _value = value;
+        }
+
+        public FormulaType Type => FormulaType.Number;
+
+        public IUntypedObject this[int index] => throw new NotImplementedException();
+
+        public int GetArrayLength()
+        {
+            throw new NotImplementedException();
+        }
+
+        public double GetDouble()
+        {
+            return _value;
+        }
+
+        public decimal GetDecimal()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetUntypedNumber()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetString()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool GetBoolean()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryGetProperty(string value, out IUntypedObject result)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1528,13 +1528,13 @@ namespace Microsoft.PowerFx.Functions
             },
             {
                 BuiltinFunctionsCore.Text_UO,
-                StandardErrorHandling<UntypedObjectValue>(
+                StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.Text_UO.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: DoNotReplaceBlank,
-                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
                     targetFunction: Text_UO)
             },
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnEmptyStringIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Text_UO)
             },
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: DeferRuntimeTypeChecking,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Text_UO)
             },
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -470,6 +470,28 @@ namespace Microsoft.PowerFx.Functions
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: Text)
             },
+            {
+                UnaryOpKind.UntypedStringToUntypedFloat,
+                StandardErrorHandling<UntypedObjectValue>(
+                    functionName: null, // internal function, no user-facing name
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: UntypedStringToUntypedFloat)
+            },
+            {
+                UnaryOpKind.UntypedStringToUntypedDecimal,
+                StandardErrorHandling<UntypedObjectValue>(
+                    functionName: null, // internal function, no user-facing name
+                    expandArguments: NoArgExpansion,
+                    replaceBlankValues: DoNotReplaceBlank,
+                    checkRuntimeTypes: ExactValueTypeOrBlank<UntypedObjectValue>,
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: UntypedStringToUntypedDecimal)
+            },
         };
 #endregion
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -582,24 +582,13 @@ namespace Microsoft.PowerFx.Functions
         {
             var impl = args[0].Impl;
 
-            if (impl.Type == FormulaType.String || (impl.Type is ExternalType et && et.Kind == ExternalTypeKind.UntypedNumber))
+            if (impl.Type is ExternalType et && et.Kind == ExternalTypeKind.UntypedNumber)
             {
                 var valueRes = Value_UO(runner, context, IRContext.NotInSource(numberType), new UntypedObjectValue[] { args[0] });
 
                 if (valueRes is T nv)
                 {
                     return new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), constructUO(nv));
-                }
-
-                var dateTimeRes = DateTimeValue_UO(runner, context, IRContext.NotInSource(FormulaType.DateTime), new UntypedObjectValue[] { args[0] });
-
-                if (dateTimeRes is not ErrorValue)
-                {
-                    var valueRes2 = Value(runner, context, IRContext.NotInSource(numberType), new FormulaValue[] { dateTimeRes });
-                    if (valueRes2 is T nv2)
-                    {
-                        return new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), constructUO(nv2));
-                    }
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -306,40 +306,12 @@ namespace Microsoft.PowerFx.Functions
             if (impl.Type == FormulaType.String)
             {
                 var str = impl.GetString();
-                var stringArg0 = new StringValue(irContext, str);
-                newArg0 = stringArg0;
-
-                // The second argument to Text is a format, if it exists then we need to convert the string to a type that
-                // can be formatted. We try to convert to number first and if that fails we try dates.
-                if (args.Length > 1)
-                {
-                    var numArg0 = Value_UO(runner, context, IRContext.NotInSource(FormulaType.Number), new UntypedObjectValue[] { arg0 });
-                    if (numArg0 is not ErrorValue)
-                    {
-                        newArg0 = numArg0;
-                    }
-                    else
-                    {
-                        // Use DateTimeValue_UO to apply format restrictions
-                        var dateArg0 = DateTimeValue_UO(runner, context, IRContext.NotInSource(FormulaType.DateTime), new UntypedObjectValue[] { arg0 });
-                        if (dateArg0 is not ErrorValue)
-                        {
-                            newArg0 = dateArg0;
-                        }
-                    }
-                }
+                newArg0 = new StringValue(irContext, str);
             }
             else if (impl.Type is ExternalType et && et.Kind == ExternalTypeKind.UntypedNumber)
             {
                 var str = impl.GetUntypedNumber();
                 newArg0 = new StringValue(irContext, str);
-
-                // If a second argument is provided, then we cannot guarantee that the original precison will be
-                // preserved. We convert to a number, either Float or Decimal depending on the settings.
-                if (args.Length > 1)
-                {
-                    newArg0 = Value_UO(runner, context, IRContext.NotInSource(FormulaType.Number), new UntypedObjectValue[] { arg0 });
-                }
             }
             else if (impl.Type == FormulaType.Number)
             {
@@ -593,6 +565,62 @@ namespace Microsoft.PowerFx.Functions
             }
 
             return GetTypeMismatchError(irContext, BuiltinFunctionsCore.ColorValue_UO.Name, DType.String.GetKindString(), impl);
+        }
+
+        public static FormulaValue UntypedStringToUntypedFloat(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, UntypedObjectValue[] args)
+        {
+            var impl = args[0].Impl;
+
+            if (impl.Type == FormulaType.String || (impl.Type is ExternalType et && et.Kind == ExternalTypeKind.UntypedNumber))
+            {
+                var valueRes = Value_UO(runner, context, IRContext.NotInSource(FormulaType.Number), new UntypedObjectValue[] { args[0] });
+
+                if (valueRes is NumberValue nv)
+                {
+                    return new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), new FloatUntypedObject(nv.Value));
+                }
+
+                var dateTimeRes = DateTimeValue_UO(runner, context, IRContext.NotInSource(FormulaType.DateTime), new UntypedObjectValue[] { args[0] });
+
+                if (dateTimeRes is not ErrorValue)
+                {
+                    var valueRes2 = Value(runner, context, IRContext.NotInSource(FormulaType.Number), new FormulaValue[] { dateTimeRes });
+                    if (valueRes2 is NumberValue nv2)
+                    {
+                        return new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), new FloatUntypedObject(nv2.Value));
+                    }
+                }
+            }
+
+            return args[0];
+        }
+
+        public static FormulaValue UntypedStringToUntypedDecimal(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, UntypedObjectValue[] args)
+        {
+            var impl = args[0].Impl;
+
+            if (impl.Type == FormulaType.String || (impl.Type is ExternalType et && et.Kind == ExternalTypeKind.UntypedNumber))
+            {
+                var valueRes = Value_UO(runner, context, IRContext.NotInSource(FormulaType.Decimal), new UntypedObjectValue[] { args[0] });
+
+                if (valueRes is DecimalValue dv)
+                {
+                    return new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), new DecimalUntypedObject(dv.Value));
+                }
+
+                var dateTimeRes = DateTimeValue_UO(runner, context, IRContext.NotInSource(FormulaType.DateTime), new UntypedObjectValue[] { args[0] });
+
+                if (dateTimeRes is not ErrorValue)
+                {
+                    var valueRes2 = Value(runner, context, IRContext.NotInSource(FormulaType.Decimal), new FormulaValue[] { dateTimeRes });
+                    if (valueRes2 is DecimalValue dv2)
+                    {
+                        return new UntypedObjectValue(IRContext.NotInSource(FormulaType.UntypedObject), new DecimalUntypedObject(dv2.Value));
+                    }
+                }
+            }
+
+            return args[0];
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -299,12 +299,12 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue Text_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
-            if ((args[0] is UntypedObjectValue uo && uo.Type == FormulaType.Blank) || args[0] is BlankValue)
+            if ((args[0] is UntypedObjectValue uo && uo.Impl.Type == FormulaType.Blank) || args[0] is BlankValue)
             {
                 if (args.Length == 1)
                 {
                     // As a special case, blank propagates for the single argument only
-                    return args[0];
+                    return new BlankValue(irContext);
                 }
 
                 return new StringValue(irContext, string.Empty);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -297,37 +297,43 @@ namespace Microsoft.PowerFx.Functions
             return GetTypeMismatchError(irContext, BuiltinFunctionsCore.Value_UO.Name, DType.Number.GetKindString(), impl);
         }
 
-        public static FormulaValue Text_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, UntypedObjectValue[] args)
+        public static FormulaValue Text_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
-            var impl = args[0].Impl;
+            var arg0 = (UntypedObjectValue)args[0];
+            var impl = arg0.Impl;
 
+            FormulaValue newArg0 = null;
             if (impl.Type == FormulaType.String)
             {
                 var str = impl.GetString();
-                return new StringValue(irContext, str);
+                newArg0 = new StringValue(irContext, str);
             }
             else if (impl.Type is ExternalType et && et.Kind == ExternalTypeKind.UntypedNumber)
             {
                 var str = impl.GetUntypedNumber();
-                return new StringValue(irContext, str);
+                newArg0 = new StringValue(irContext, str);
             }
             else if (impl.Type == FormulaType.Number)
             {
-                var n = new NumberValue(IRContext.NotInSource(FormulaType.Number), impl.GetDouble());
-                return Text(runner, context, irContext, new FormulaValue[] { n });
+                newArg0 = new NumberValue(IRContext.NotInSource(FormulaType.Number), impl.GetDouble());
             }
             else if (impl.Type == FormulaType.Decimal)
             {
-                var n = new DecimalValue(IRContext.NotInSource(FormulaType.Decimal), impl.GetDecimal());
-                return Text(runner, context, irContext, new FormulaValue[] { n });
+                newArg0 = new DecimalValue(IRContext.NotInSource(FormulaType.Decimal), impl.GetDecimal());
             }
             else if (impl.Type == FormulaType.Boolean)
             {
                 var b = impl.GetBoolean();
-                return new StringValue(irContext, PowerFxBooleanToString(b));
+                newArg0 = new StringValue(irContext, PowerFxBooleanToString(b));
+            }
+            else
+            {
+                return GetTypeMismatchError(irContext, BuiltinFunctionsCore.Text_UO.Name, DType.String.GetKindString(), impl);
             }
 
-            return GetTypeMismatchError(irContext, BuiltinFunctionsCore.Text_UO.Name, DType.String.GetKindString(), impl);
+            var newArgs = new List<FormulaValue>() { newArg0 };
+            newArgs.AddRange(args.Skip(1));
+            return Text(runner, context, irContext, newArgs.ToArray());
         }
 
         public static FormulaValue Table_UO(IRContext irContext, UntypedObjectValue[] args)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -299,6 +299,27 @@ namespace Microsoft.PowerFx.Functions
 
         public static FormulaValue Text_UO(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
         {
+            if ((args[0] is UntypedObjectValue uo && uo.Type == FormulaType.Blank) || args[0] is BlankValue)
+            {
+                if (args.Length == 1)
+                {
+                    // As a special case, blank propagates for the single argument only
+                    return args[0];
+                }
+
+                return new StringValue(irContext, string.Empty);
+            }
+
+            if (args.Length >= 2 && args[1] is BlankValue)
+            {
+                return new StringValue(irContext, string.Empty);
+            }
+
+            if (args.Length == 3 && args[2] is BlankValue)
+            {
+                return new StringValue(irContext, string.Empty);
+            }
+
             var arg0 = (UntypedObjectValue)args[0];
             var impl = arg0.Impl;
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -396,13 +396,10 @@ true
 >> IsBlank(ParseJSON("{""a"":null,""b"":""""}").c)
 true
 
->> Text(ParseJSON("{""a"":null,""b"":""""}").a) = ""
-false
-
->> Text(ParseJSON("{""a"":null,""b"":""""}").b) = ""
+>> Text(ParseJSON("{""a"":null,""b"":""""}").a) = Blank()
 true
 
->> Text(ParseJSON("{""a"":null,""b"":""""}").c) = ""
+>> Text(ParseJSON("{""a"":null,""b"":""""}").b) = Blank()
 false
 
 >> Value(First(ParseJSON("[1, 2, 3, 4]")))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -402,6 +402,9 @@ true
 >> Text(ParseJSON("{""a"":null,""b"":""""}").b) = Blank()
 false
 
+>> Text(ParseJSON("{""a"":null,""b"":""""}").c) = Blank()
+true
+
 >> Value(First(ParseJSON("[1, 2, 3, 4]")))
 1
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -67,7 +67,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 true
 
 >> Text(ParseJSON("null"))
-Blank()
+""
 
 >> Text(ParseJSON("true"))
 "true"
@@ -157,7 +157,7 @@ Table({Value:Blank()},{Value:Blank()},{Value:Blank()})
 Table({Value:5},{Value:Blank()},{Value:7})
 
 >> ForAll(ParseJSON("[""hi"", null, ""hello""]"), Text(ThisRecord))
-Table({Value:"hi"},{Value:Blank()},{Value:"hello"})
+Table({Value:"hi"},{Value:""},{Value:"hello"})
 
 >> ForAll(ParseJSON("[true, null, false]"), Boolean(ThisRecord))
 Table({Value:true},{Value:Blank()},{Value:false})
@@ -346,7 +346,7 @@ Blank()
 "str"
 
 >> Text(Index(ParseJSON("[ { ""a"" : 10 }, { ""b"" : ""str"" } ]"),2).a)
-Blank()
+""
 
 >> ColorValue(ParseJSON("""#01020304"""))
 RGBA(1,2,3,0.016)
@@ -396,13 +396,13 @@ true
 >> IsBlank(ParseJSON("{""a"":null,""b"":""""}").c)
 true
 
->> Text(ParseJSON("{""a"":null,""b"":""""}").a) = Blank()
+>> Text(ParseJSON("{""a"":null,""b"":""""}").a) = ""
 true
 
->> Text(ParseJSON("{""a"":null,""b"":""""}").b) = Blank()
-false
+>> Text(ParseJSON("{""a"":null,""b"":""""}").b) = ""
+true
 
->> Text(ParseJSON("{""a"":null,""b"":""""}").c) = Blank()
+>> Text(ParseJSON("{""a"":null,""b"":""""}").c) = ""
 true
 
 >> Value(First(ParseJSON("[1, 2, 3, 4]")))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -67,7 +67,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 true
 
 >> Text(ParseJSON("null"))
-""
+Blank()
 
 >> Text(ParseJSON("true"))
 "true"
@@ -157,7 +157,7 @@ Table({Value:Blank()},{Value:Blank()},{Value:Blank()})
 Table({Value:5},{Value:Blank()},{Value:7})
 
 >> ForAll(ParseJSON("[""hi"", null, ""hello""]"), Text(ThisRecord))
-Table({Value:"hi"},{Value:""},{Value:"hello"})
+Table({Value:"hi"},{Value:Blank()},{Value:"hello"})
 
 >> ForAll(ParseJSON("[true, null, false]"), Boolean(ThisRecord))
 Table({Value:true},{Value:Blank()},{Value:false})
@@ -346,7 +346,7 @@ Blank()
 "str"
 
 >> Text(Index(ParseJSON("[ { ""a"" : 10 }, { ""b"" : ""str"" } ]"),2).a)
-""
+Blank()
 
 >> ColorValue(ParseJSON("""#01020304"""))
 RGBA(1,2,3,0.016)
@@ -397,13 +397,13 @@ true
 true
 
 >> Text(ParseJSON("{""a"":null,""b"":""""}").a) = ""
-true
+false
 
 >> Text(ParseJSON("{""a"":null,""b"":""""}").b) = ""
 true
 
 >> Text(ParseJSON("{""a"":null,""b"":""""}").c) = ""
-true
+false
 
 >> Value(First(ParseJSON("[1, 2, 3, 4]")))
 1

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -497,3 +497,15 @@ true
 
 >> Text(ParseJSON("1.234"), "#.##", "fr-fr")
 "1,23"
+
+>> Text(ParseJSON("null"), "#.##")
+Blank()
+
+>> Text(ParseJSON("null"), "#.##", "fr-fr")
+Blank()
+
+>> Text(ParseJSON("1.234"), Blank())
+Blank()
+
+>> Text(ParseJSON("1.234"), "#.##", Blank())
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -66,9 +66,6 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> Text(ParseJSON("""s""")) = Text("s")
 true
 
->> Text(ParseJSON("null"))
-Blank()
-
 >> Text(ParseJSON("true"))
 "true"
 
@@ -499,13 +496,16 @@ true
 "1,23"
 
 >> Text(ParseJSON("null"), "#.##")
-Blank()
+""
 
 >> Text(ParseJSON("null"), "#.##", "fr-fr")
-Blank()
+""
 
 >> Text(ParseJSON("1.234"), Blank())
-Blank()
+""
 
 >> Text(ParseJSON("1.234"), "#.##", Blank())
+""
+
+>> Text(ParseJSON("null"))
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -491,3 +491,12 @@ Blank()
 
 >> Boolean(IfError(ParseJSON("{""field1"":true}").field1, ParseJSON("false")))
 true
+
+>> Text(ParseJSON("1.234"), "#.##")
+"1.23"
+
+>> Text(ParseJSON("""1.234"""), "#.##")
+"1.23"
+
+>> Text(ParseJSON("""2011-01-30T08:00:00.000"""), "dddd mm/dd/yy")
+"Sunday 01/30/11"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -495,8 +495,5 @@ true
 >> Text(ParseJSON("1.234"), "#.##")
 "1.23"
 
->> Text(ParseJSON("""1.234"""), "#.##")
-"1.23"
-
->> Text(ParseJSON("""2011-01-30T08:00:00.000"""), "dddd mm/dd/yy")
-"Sunday 01/30/11"
+>> Text(ParseJSON("1.234"), "#.##", "fr-fr")
+"1,23"


### PR DESCRIPTION
These arguments are currently not used in any way by the C# interpreter. When the changes are incorporated into PAClient, new tests will need to be added.