### PR TITLE
GUID() support

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -106,6 +106,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction FirstN_UO = _library.Add(new FirstLastNFunction_UO(isFirst: true));
         public static readonly TexlFunction ForAll = _library.Add(new ForAllFunction());
         public static readonly TexlFunction ForAll_UO = _library.Add(new ForAllFunction_UO());
+        public static readonly TexlFunction GUIDNoArg = _library.Add(new GUIDNoArgFunction());
         public static readonly TexlFunction GUIDPure = _library.Add(new GUIDPureFunction());
         public static readonly TexlFunction GUID_UO = _library.Add(new GUIDPureFunction_UO());
         public static readonly TexlFunction Hex2Dec = _library.Add(new Hex2DecFunction());
@@ -239,7 +240,6 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Decimal_UO = _featureGateFunctions.Add(new DecimalFunction_UO());
         public static readonly TexlFunction Float = _featureGateFunctions.Add(new FloatFunction());
         public static readonly TexlFunction Float_UO = _featureGateFunctions.Add(new FloatFunction_UO());
-        public static readonly TexlFunction GUIDNoArg = _featureGateFunctions.Add(new GUIDNoArgFunction());
 
         // Slow API, only use for backward compatibility
 #pragma warning disable CS0618 // Type or member is obsolete        

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -239,6 +239,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Decimal_UO = _featureGateFunctions.Add(new DecimalFunction_UO());
         public static readonly TexlFunction Float = _featureGateFunctions.Add(new FloatFunction());
         public static readonly TexlFunction Float_UO = _featureGateFunctions.Add(new FloatFunction_UO());
+        public static readonly TexlFunction GUIDNoArg = _featureGateFunctions.Add(new GUIDNoArgFunction());
 
         // Slow API, only use for backward compatibility
 #pragma warning disable CS0618 // Type or member is obsolete        

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -775,6 +775,10 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: ForAll_UO)
             },
             {
+                BuiltinFunctionsCore.GUIDNoArg,
+                NoErrorHandling(GuidNoArg)
+            },
+            {
                 BuiltinFunctionsCore.GUIDPure,
                 StandardErrorHandling<StringValue>(
                     BuiltinFunctionsCore.GUIDPure.Name,
@@ -783,7 +787,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Guid)
+                    targetFunction: GuidPure)
             },
             {
                 BuiltinFunctionsCore.GUID_UO,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -1034,7 +1034,12 @@ namespace Microsoft.PowerFx.Functions
             return new StringValue(irContext, result);
         }
 
-        public static FormulaValue Guid(IRContext irContext, StringValue[] args)
+        public static FormulaValue GuidNoArg(IRContext irContext, FormulaValue[] args)
+        {
+            return new GuidValue(irContext, Guid.NewGuid());
+        }
+
+        public static FormulaValue GuidPure(IRContext irContext, StringValue[] args)
         {
             var text = args[0].Value;
             try

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUnary.cs
@@ -457,7 +457,7 @@ namespace Microsoft.PowerFx.Functions
                     checkRuntimeTypes: ExactValueTypeOrBlank<StringValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
-                    targetFunction: Guid)
+                    targetFunction: GuidPure)
             },
             {
                 UnaryOpKind.GUIDToText,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -485,7 +485,7 @@ namespace Microsoft.PowerFx.Functions
             if (impl.Type == FormulaType.String)
             {
                 var str = new StringValue(IRContext.NotInSource(FormulaType.String), impl.GetString());
-                return Guid(irContext, new StringValue[] { str });
+                return GuidPure(irContext, new StringValue[] { str });
             }
 
             return GetTypeMismatchError(irContext, BuiltinFunctionsCore.GUID_UO.Name, DType.String.GetKindString(), impl);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
@@ -3,3 +3,9 @@
 
 >> Last([ {a:2}, {a:true, b:true, c:20}, {a:2, b:2, c:true} ]).c
 1
+
+>> Len(GUID())
+36
+
+>> GUID() & GUID() <> ""
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
@@ -27,6 +27,3 @@ true
 // String representation - [0-9a-f]
 >> With({g:GUID()}, Sum(Sequence(Len(g)), If(Mid(g,Value,1) exactin "abcdef0123456789", 1, 0)))
 32
-
->> With({g:GUID()}, Len(g) + Len(GUID()))
-72

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
@@ -17,7 +17,7 @@ true
 72
 
 // String representation - only 4 dashes
->> With({g:GUID()}, Sum(Sequence(Len(GUID())), If(Mid(g,Value,1) = "-", 1, 0)))
+>> With({g:GUID()}, Sum(Sequence(Len(g)), If(Mid(g,Value,1) = "-", 1, 0)))
 4
 
 // String representation - position of dashes

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1Compat.txt
@@ -9,3 +9,24 @@
 
 >> GUID() & GUID() <> ""
 true
+
+>> Len(Lower(GUID()))
+36
+
+>> Len(GUID() & GUID())
+72
+
+// String representation - only 4 dashes
+>> With({g:GUID()}, Sum(Sequence(Len(GUID())), If(Mid(g,Value,1) = "-", 1, 0)))
+4
+
+// String representation - position of dashes
+>> With({g:GUID()}, Mid(g,9,1) = "-" And Mid(g,14,1) = "-" And Mid(g,19,1) = "-" And Mid(g,24,1) = "-")
+true
+
+// String representation - [0-9a-f]
+>> With({g:GUID()}, Sum(Sequence(Len(g)), If(Mid(g,Value,1) exactin "abcdef0123456789", 1, 0)))
+32
+
+>> With({g:GUID()}, Len(g) + Len(GUID()))
+72

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
@@ -16,15 +16,3 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> Len(GUID() & GUID())
 Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))
-
-// String representation - only 4 dashes
->> With({g:GUID()}, Sum(Sequence(Len(GUID())), If(Mid(g,Value,1) = "-", 1, 0)))
-Error({Kind:ErrorKind.InvalidArgument})
-
-// String representation - position of dashes
->> With({g:GUID()}, Mid(g,9,1) = "-" And Mid(g,14,1) = "-" And Mid(g,19,1) = "-" And Mid(g,24,1) = "-")
-Error({Kind:ErrorKind.InvalidArgument})
-
-// String representation - [0-9a-f]
->> With({g:GUID()}, Sum(Sequence(Len(g)), If(Mid(g,Value,1) exactin "abcdef0123456789", 1, 0)))
-Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
@@ -28,6 +28,3 @@ Error({Kind:ErrorKind.InvalidArgument})
 // String representation - [0-9a-f]
 >> With({g:GUID()}, Sum(Sequence(Len(g)), If(Mid(g,Value,1) exactin "abcdef0123456789", 1, 0)))
 Error({Kind:ErrorKind.InvalidArgument})
-
->> With({g:GUID()}, Len(g) + Len(GUID()))
-Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
@@ -3,3 +3,10 @@
 
 >> Last([ {a:2}, {a:true, b:true, c:20}, {a:2, b:2, c:true} ]).c
 true
+
+// Without PowerFxV1CompatibilityRules feature, the following coercions will fail
+>> Len(GUID())
+Error({Kind:ErrorKind.InvalidArgument})
+
+>> GUID() & GUID() <> ""
+Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ArgCoercion_V1CompatDisabled.txt
@@ -10,3 +10,24 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> GUID() & GUID() <> ""
 Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))
+
+>> Len(Lower(GUID()))
+Error({Kind:ErrorKind.InvalidArgument})
+
+>> Len(GUID() & GUID())
+Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))
+
+// String representation - only 4 dashes
+>> With({g:GUID()}, Sum(Sequence(Len(GUID())), If(Mid(g,Value,1) = "-", 1, 0)))
+Error({Kind:ErrorKind.InvalidArgument})
+
+// String representation - position of dashes
+>> With({g:GUID()}, Mid(g,9,1) = "-" And Mid(g,14,1) = "-" And Mid(g,19,1) = "-" And Mid(g,24,1) = "-")
+Error({Kind:ErrorKind.InvalidArgument})
+
+// String representation - [0-9a-f]
+>> With({g:GUID()}, Sum(Sequence(Len(g)), If(Mid(g,Value,1) exactin "abcdef0123456789", 1, 0)))
+Error({Kind:ErrorKind.InvalidArgument})
+
+>> With({g:GUID()}, Len(g) + Len(GUID()))
+Error(Table({Kind:ErrorKind.InvalidArgument},{Kind:ErrorKind.InvalidArgument}))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/GUID.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/GUID.txt
@@ -31,3 +31,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> GUID("thisisastringthatismuchlongerthanaguidshouldbeitisquitealongstringandwillfinderrorswithlongstringsinthisfunction")
 Error({Kind:ErrorKind.InvalidArgument})
+
+>> IsBlank(GUID())
+false
+
+>> IsError(GUID())
+false
+
+// Multiple invocations are unique
+>> GUID() <> GUID()
+true


### PR DESCRIPTION
Issue https://github.com/microsoft/Power-Fx/issues/1090.

`GUID()` is now supported but `guid` to `string` coercion is only possible when `PowerFxV1` feature is active.