### PR TITLE
Renamed HasErrors to HasErrorsOrWarnings.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
@@ -18,6 +18,6 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         TexlBinding Binding { get; }
 
-        bool HasErrors { get; }
+        bool HasErrorsOrWarnings { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3396,7 +3396,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // If the reference is to Control.Property and the rule for that Property is a constant,
                     // we need to mark the node as constant, and save the control info so we may look up the
                     // rule later.
-                    if (controlInfo?.GetRule(property.InvariantName) is { HasErrors: false } rule && rule.Binding.IsConstant(rule.Binding.Top))
+                    if (controlInfo?.GetRule(property.InvariantName) is { HasErrorsOrWarnings: false } rule && rule.Binding.IsConstant(rule.Binding.Top))
                     {
                         value = controlInfo;
                         isConstant = true;


### PR DESCRIPTION
HasErrors property name is misleading as it also returns true if there are only warnings on the rule. Hence renaming it to increase clarity. Recently we have seen a bug which was caused due to this misunderstanding.