### PR TITLE
Non row-scope pure sync nodes should always - t2304.2

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -111,6 +111,12 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return true;
             }
 
+            // Non row-scope, non async, pure nodes should always be valid because we can calculate value in runtime before delegation.
+            if (!binding.IsRowScope(node) && !binding.IsAsync(node) && binding.IsPure(node))
+            {
+                return true;
+            }
+            
             switch (node.Kind)
             {
                 case NodeKind.DottedName:


### PR DESCRIPTION
Rules that use binary op nodes for non-delegable ops are marked as invalid even if both sides of the op are literals (can be delegable since op can be handled by runtime before the delegated call is made)

original PR: https://github.com/microsoft/Power-Fx/pull/1446