### PR TITLE
Fix to delegation warning for named formula if it's non-delegable.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DelegationValidationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DelegationValidationStrategy.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Security.Authentication.ExtendedProtection;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Logging.Trackers;
@@ -136,6 +137,12 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
 
             if (node.Left.Kind == NodeKind.FirstName)
             {
+                var firstNameInfo = binding.GetInfo(node.Left.AsFirstName());
+                if (firstNameInfo != null && firstNameInfo.Kind == BindKind.PowerFxResolvedObject && firstNameInfo.Data is IExternalNamedFormula formula)
+                {
+                    return IsValidAsyncOrImpureNode(node.Left, binding);
+                }
+                
                 return true;
             }
 


### PR DESCRIPTION
This change brings the named formula to the same consistency for delegation warnings and marks the expression as non-delegable if it's a part of non-delegable expression.