### PR TITLE
Use 'prefer left type' if PFx v1 is enabled as well

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -5240,7 +5240,13 @@ namespace Microsoft.PowerFx.Core.Binding
 
                     if (usePFxV1CompatRules)
                     {
-                        if (DType.TryUnionWithCoerce(exprType, childType, usePowerFxV1CompatibilityRules: true, coerceToLeftTypeOnly: true, out var returnType, out var needCoercion))
+                        if (DType.TryUnionWithCoerce(
+                            exprType, 
+                            childType, 
+                            usePowerFxV1CompatibilityRules: true, 
+                            coerceToLeftTypeOnly: true, 
+                            out var returnType, 
+                            out var needCoercion))
                         {
                             exprType = returnType;
                             if (needCoercion)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -74,7 +74,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
                 else
                 {
-                    if (DType.TryUnionWithCoerce(rowType, argType, context.Features.PowerFxV1CompatibilityRules, coerceToLeftTypeOnly: context.Features.StronglyTypedBuiltinEnums, out var newType, out bool coercionNeeded))
+                    if (DType.TryUnionWithCoerce(
+                        rowType,
+                        argType,
+                        context.Features.PowerFxV1CompatibilityRules,
+                        coerceToLeftTypeOnly: context.Features.StronglyTypedBuiltinEnums || context.Features.PowerFxV1CompatibilityRules,
+                        out var newType,
+                        out bool coercionNeeded))
                     {
                         rowType = newType;
 


### PR DESCRIPTION
Follow-up to #1489 - using the 'only coerce to left type' on the Table function either if StronglyTypedEnums is enabled (the root cause of the bug it fixed), or if we are using the Power Fx V1 compat rules (since it moved to a "first-type" rule)