### PR TITLE
Make the If function follow the first-type rule

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -83,49 +83,88 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
             }
 
-            var type = ReturnType;
+            var type = context.Features.PowerFxV1CompatibilityRules ? argTypes[1] : ReturnType;
 
-            // Compute the result type by joining the types of all non-predicate args.
-            Contracts.Assert(type == DType.Unknown);
+            // For pre-PowerFxV1, compute the result type by joining the types of all non-predicate args.
+            // For PowerFxV1 compat rules, validate that all non-predicate args can be coerced to the first one
             for (var i = 1; i < count;)
             {
                 var nodeArg = args[i];
                 var typeArg = argTypes[i];
 
-                var typeSuper = DType.Supertype(
-                    type, 
-                    typeArg,
-                    useLegacyDateTimeAccepts: false,
-                    usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules);
-                if (!typeSuper.IsError)
+                if (context.Features.PowerFxV1CompatibilityRules)
                 {
-                    type = typeSuper;
-                }
-                else if (typeArg.IsVoid)
-                {
-                    type = DType.Void;
-                }
-                else if (typeArg.IsError)
-                {
-                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
-                    fArgsValid = false;
-                }
-                else if (!type.IsError)
-                {
-                    if (typeArg.CoercesTo(type, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
+                    if (typeArg.IsVoid)
+                    {
+                        type = DType.Void;
+                    }
+                    else if (typeArg.IsError)
+                    {
+                        errors.EnsureError(args[i], TexlStrings.ErrTypeError);
+                        fArgsValid = false;
+                    }
+                    else if (type.Kind == DKind.ObjNull)
+                    {
+                        // Anything goes with null
+                        type = typeArg;
+                    }
+                    else if (type.Accepts(typeArg, exact: false, useLegacyDateTimeAccepts: true, usePowerFxV1CompatibilityRules: true))
+                    {
+                        // Parameter accepted without problems
+                    }
+                    else if (typeArg.CoercesTo(
+                            type,
+                            aggregateCoercion: true,
+                            isTopLevelCoercion: false,
+                            usePowerFxV1CompatibilityRules: true))
                     {
                         CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
                     }
                     else
                     {
-                        // If the types are incompatible, the result type is void.
+                        // If types are incompatible, result is Void
                         type = DType.Void;
                     }
                 }
-                else if (typeArg.Kind != DKind.Unknown)
+                else
                 {
-                    type = typeArg;
-                    fArgsValid = false;
+                    // Legacy logic
+                    var typeSuper = DType.Supertype(
+                        type,
+                        typeArg,
+                        useLegacyDateTimeAccepts: false,
+                        usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules);
+
+                    if (!typeSuper.IsError)
+                    {
+                        type = typeSuper;
+                    }
+                    else if (typeArg.IsVoid)
+                    {
+                        type = DType.Void;
+                    }
+                    else if (typeArg.IsError)
+                    {
+                        errors.EnsureError(args[i], TexlStrings.ErrTypeError);
+                        fArgsValid = false;
+                    }
+                    else if (!type.IsError)
+                    {
+                        if (typeArg.CoercesTo(type, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
+                        {
+                            CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
+                        }
+                        else
+                        {
+                            // If the types are incompatible, the result type is void.
+                            type = DType.Void;
+                        }
+                    }
+                    else if (typeArg.Kind != DKind.Unknown)
+                    {
+                        type = typeArg;
+                        fArgsValid = false;
+                    }
                 }
 
                 // If there are an odd number of args, the last arg also participates.

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -2057,7 +2057,15 @@ namespace Microsoft.PowerFx.Core.Types
 
                     break;
                 case DKind.Currency:
-                    accepts = (!exact && type.Kind == DKind.Number) || DefaultReturnValue(type);
+                    if (usePowerFxV1CompatibilityRules)
+                    {
+                        accepts = DefaultReturnValue(type);
+                    }
+                    else
+                    {
+                        accepts = (!exact && type.Kind == DKind.Number) || DefaultReturnValue(type);
+                    }
+
                     break;
                 case DKind.DateTime:
                     if (usePowerFxV1CompatibilityRules)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/DisplayNameTests.cs
@@ -592,6 +592,64 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("If(true, r1, r1).Display1", true)]
         [InlineData("If(true, Blank(), r1).Display1", true)]
 
+        // If types are different, you have no access to Display name, except with PFxV1 rules
+        [InlineData("If(true, r1, r2).Display1", false, true)]
+        [InlineData("If(true, r1, r2).Display0", false, true)]
+        [InlineData("If(true, r1, {Display1 : 123}).Display1", false, true)] // With PFxV1 rules
+
+        // If types are different, you have access to logical name, only if the name and type are same!
+        [InlineData("If(true, r1, r2).F1", true)]
+        [InlineData("If(false, r1, r2).F1", true)]
+        [InlineData("If(true, r1, r2).F0", false, true)]
+
+        // With PFxV1 rules, result type of If is the first type
+        [InlineData("If(true, r1, r3).Display1", false, true)]
+        [InlineData("If(false, r1, r3).F1", false, true)]
+        [InlineData("If(true, r1, r3).Display3", false)]
+        [InlineData("If(true, r1, r3).F3", false)]
+        public void DisplayNameTest(string input, bool succeeds, bool? succeedsWithPFxV1 = null)
+        {
+            foreach (var usePFxV1Features in new[] { false, true })
+            {
+                var r1 = RecordType.Empty()
+                            .Add(new NamedFormulaType("F1", FormulaType.Number, "Display1"))
+                            .Add(new NamedFormulaType("F0", FormulaType.String, "Display0")); // F0 is Not a Common type
+
+                var r2 = RecordType.Empty()
+                            .Add(new NamedFormulaType("F1", FormulaType.Number, "Display1"))
+                            .Add(new NamedFormulaType("F0", FormulaType.Number, "Display0"));
+
+                var r3 = RecordType.Empty()
+                            .Add(new NamedFormulaType("F3", FormulaType.Number, "Display3"))
+                            .Add(new NamedFormulaType("F2", FormulaType.Number, "Display2"));
+
+                var parameters = RecordType.Empty()
+                    .Add("r1", r1)
+                    .Add("r2", r2)
+                    .Add("r3", r3);
+
+                var config = usePFxV1Features ? new PowerFxConfig() : new PowerFxConfig(Features.None);
+                var engine = new Engine(config);
+
+                var result = engine.Check(input, parameters);
+                var actual = result.IsSuccess;
+                if (usePFxV1Features && succeedsWithPFxV1.HasValue)
+                {
+                    succeeds = succeedsWithPFxV1.Value;
+                }
+
+                Assert.True(
+                    actual == succeeds,
+                    $"With {(usePFxV1Features ? "PFxV1" : "Legacy")} rules, actual={actual}, expected={succeeds}");
+            }
+        }
+
+        [Theory]
+        [InlineData("r1.Display1", true)]
+        [InlineData("If(true, r1).Display1", true)]
+        [InlineData("If(true, r1, r1).Display1", true)]
+        [InlineData("If(true, Blank(), r1).Display1", true)]
+
         // If types are different, you have no access to Display name.
         [InlineData("If(true, r1, r2).Display1", false)]
         [InlineData("If(true, r1, r2).Display0", false)]
@@ -601,10 +659,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("If(true, r1, r2).F1", true)]
         [InlineData("If(false, r1, r2).F1", true)]
         [InlineData("If(true, r1, r2).F0", false)]
-        public void DisplayNameTest(string input, bool succeeds)
+        public void DisplayNameTest_V1CompatDisabled(string input, bool succeeds)
         {
             var r1 = RecordType.Empty()
-                        .Add(new NamedFormulaType("F1", FormulaType.Number, "Display1"))    
+                        .Add(new NamedFormulaType("F1", FormulaType.Number, "Display1"))
                         .Add(new NamedFormulaType("F0", FormulaType.String, "Display0")); // F0 is Not a Common type
 
             var r2 = RecordType.Empty()
@@ -614,7 +672,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 .Add("r1", r1)
                 .Add("r2", r2);
 
-            var engine = new Engine(new PowerFxConfig());
+            var engine = new Engine(new PowerFxConfig(Features.None));
 
             var result = engine.Check(input, parameters);
             var actual = result.IsSuccess;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect.txt
@@ -71,9 +71,6 @@ Blank()
 >> Collect("", "")
 Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instead.|Error 12-14: Invalid argument type (Text). Expecting a Record value instead.|Error 12-14: Invalid argument type. Cannot use Text values in this context.|Error 0-15: The function 'Collect' has some invalid arguments.
 
->> Collect(If(false,Blank()),r2)
-Errors: Error 8-25: The function 'Collect' has some invalid arguments.
-
 >> Collect(t1,{Price:200}).Price
 Errors: Error 11-22: The specified column 'Price' does not exist.|Error 0-23: The function 'Collect' has some invalid arguments.|Error 23-29: Name isn't valid. 'Price' isn't recognized.
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
@@ -77,9 +77,6 @@ Table({x:1,y:2},Blank())
 >> Last(ForAll([true,false], If(ThisRecord.Value, {x:1,y:2}, Blank()))).x
 Blank()
 
->> ForAll([1], If(false, {a:1}, {b:2}))
-Table({})
-
 >> ForAll([1,2,Blank()], If(IsBlank(ThisRecord), 999, ThisRecord.Value + 1))
 Table({Value:2},{Value:3},{Value:1})
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll_V1Compat.txt
@@ -1,0 +1,4 @@
+#SETUP: PowerFxV1CompatibilityRules
+
+>> ForAll([1], If(false, {a:1}, {b:2}))
+Table({a:Blank()})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll_V1CompatDisabled.txt
@@ -1,0 +1,4 @@
+#SETUP: disable:PowerFxV1CompatibilityRules
+
+>> ForAll([1], If(false, {a:1}, {b:2}))
+Table({})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
@@ -55,12 +55,6 @@ Blank()
 >> If(1/0 = 7, 2, 3)
 Error({Kind:ErrorKind.Div0})
 
->> If(false, {x:1, y:1}, {x:2, z:2})
-{x:2}
-
->> If(true, {x:1, y:1}, {x:2, z:2})
-{x:1}
-
 // Demos expression that generates Void value.
 >> If(true, {a:1}, "test")
 If(true, {test:1}, "Mismatched args (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_V1Compat.txt
@@ -1,0 +1,13 @@
+#SETUP: PowerFxV1CompatibilityRules
+
+>> If(1>0, {a:1}, {b:2})
+{a:1}
+
+>> If(1<0, {a:1}, {b:2})
+{a:Blank()}
+
+>> If(false, {x:1, y:1}, {x:2, z:2})
+{x:2,y:Blank()}
+
+>> If(true, {x:1, y:1}, {x:2, z:2})
+{x:1,y:1}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_V1CompatDisabled.txt
@@ -1,0 +1,13 @@
+#SETUP: disable:PowerFxV1CompatibilityRules
+
+>> If(1>0, {a:1}, {b:2})
+{}
+
+>> If(1<0, {a:1}, {b:2})
+{}
+
+>> If(false, {x:1, y:1}, {x:2, z:2})
+{x:2}
+
+>> If(true, {x:1, y:1}, {x:2, z:2})
+{x:1}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -154,13 +154,7 @@ Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 0-51: The fun
 >> Patch(Foo, Bar, {DisplayNameField2:"jupter"})
 Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 11-14: Name isn't valid. 'Bar' isn't recognized.|Error 0-45: The function 'Patch' has some invalid arguments.
 
->> Patch([1,2], {Value:1}, If(false, {x:1, Value:2}, {Value:11, z:2}))
-{Value:11}
-
->> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  {Value:11})
-{Value:11}
-
->> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  If(false, {x:1, Value:2}, {Value:11, z:2}))
+>> Patch([1,2], {Value:1},  {Value:11})
 {Value:11}
 
 >> Patch(Table({Value:1}, If(false, {x:1, Value:2}, {Value:2, z:2}), {Value:3}), {Value:2}, {Value:11})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1Compat.txt
@@ -17,3 +17,12 @@
     {Properties:{Moon:{Name:"Phobos"}}},
     {Planet:"Jupter"})
 #SKIP: awaiting https://github.com/microsoft/Power-Fx/issues/1383
+
+>> Patch([1,2], {Value:1}, If(false, {x:1, Value:2}, {Value:11, z:2}))
+Errors: Error 24-66: The specified column 'x' does not exist.|Error 0-67: The function 'Patch' has some invalid arguments.
+
+>> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  {Value:11})
+Errors: Error 13-54: The specified column 'x' does not exist.|Error 0-68: The function 'Patch' has some invalid arguments.
+
+>> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  If(false, {x:1, Value:2}, {Value:11, z:2}))
+Errors: Error 13-54: The specified column 'x' does not exist.|Error 57-99: The specified column 'x' does not exist.|Error 0-100: The function 'Patch' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1CompatDisabled.txt
@@ -18,3 +18,11 @@ Errors: Error 151-176: Invalid argument type. Expecting a Record value, but of a
     {Planet:"Jupter"})
 Errors: Error 258-293: Invalid argument type. Expecting a Record value, but of a different schema.|Error 258-293: Missing column. Your formula is missing a column 'Color' with a type of 'Text'.|Error 0-318: The function 'Patch' has some invalid arguments.
 
+>> Patch([1,2], {Value:1}, If(false, {x:1, Value:2}, {Value:11, z:2}))
+{Value:11}
+
+>> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  {Value:11})
+{Value:11}
+
+>> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  If(false, {x:1, Value:2}, {Value:11, z:2}))
+{Value:11}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With.txt
@@ -13,10 +13,6 @@ Blank()
 >> With(First(First(LastN(ForAll(Table({Value:1}, {Value:0}, {Value:2}), Table({a: 1/ThisRecord.Value})), 2)).Value), a * a)
 Error(Table({Kind:ErrorKind.Div0},{Kind:ErrorKind.Div0}))
 
-// since If uses the interaction of types, If(false, {x:1}, {z:2}) => {} hence the below is {}
->> With({y:1}, If(false, {x:1}, {z:2}))
-{}
-
 // void values are allowed in With function's argument.
 >> With({y:1}, If(true, {a:1}, "test"))
 If(true, {test:1}, "Mismatched args (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_V1Compat.txt
@@ -1,0 +1,5 @@
+#SETUP: PowerFxV1CompatibilityRules
+
+// since If uses the first type on PFxV1 rules, If(false, {x:1}, {z:2}) => {x:Blank()}
+>> With({y:1}, If(false, {x:1}, {z:2}))
+{x:Blank()}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_V1CompatDisabled.txt
@@ -1,0 +1,5 @@
+#SETUP: disable:PowerFxV1CompatibilityRules
+
+// since If uses the interaction of types, If(false, {x:1}, {z:2}) => {} hence the below is {}
+>> With({y:1}, If(false, {x:1}, {z:2}))
+{}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
@@ -68,4 +68,4 @@ Blank()
 Errors: Error 13-15: Invalid argument type (Text). Expecting a Table value instead.|Error 17-19: Invalid argument type (Text). Expecting a Record value instead.|Error 17-19: Invalid argument type. Cannot use Text values in this context.|Error 0-20: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(If(false,Blank()),r1)
-Errors: Error 13-30: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 31-33: The specified column 'a' does not exist.|Error 0-34: The function 'ClearCollect' has some invalid arguments.


### PR DESCRIPTION
Currently the If function uses an intersection rule for the arguments - `If(varBool, {a:1}, {b:2})` returns an empty record since there are no common properties in the two records. With the PowerFxV1 rules, we are changing it to follow the "first-type rule" that is used in other functions, so the type of that expression would be `![a:n]` with the new feature.

Addresses #1497 