### PR TITLE
Fxing expression formatting/pretty print bug with reserved keywords

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -1766,12 +1766,17 @@ namespace Microsoft.PowerFx.Core.Parser
             }
         }
 
-        public static string Format(string text, Flags? flags = null)
+        /// <summary>
+        /// Formats/Pretty Print the given expression to more a readable form.
+        /// </summary>
+        /// <param name="text">Expression Text to format.</param>
+        /// <param name="flags">Optional flags to customize the behavior of underlying lexer and parser. By default, Expression Chaining is enabled.</param>
+        /// <returns>Formatted Expression.</returns>
+        public static string Format(string text, Flags flags = Flags.EnableExpressionChaining)
         {
-            flags = flags ?? Flags.EnableExpressionChaining;
             var result = ParseScript(
                 text,
-                flags: flags.Value);
+                flags: flags);
 
             // Can't pretty print a script with errors.
             if (result.HasError)

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -1766,11 +1766,12 @@ namespace Microsoft.PowerFx.Core.Parser
             }
         }
 
-        public static string Format(string text)
+        public static string Format(string text, Flags? flags = null)
         {
+            flags = flags ?? Flags.EnableExpressionChaining;
             var result = ParseScript(
                 text,
-                flags: Flags.EnableExpressionChaining);
+                flags: flags.Value);
 
             // Can't pretty print a script with errors.
             if (result.HasError)

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -1767,11 +1767,11 @@ namespace Microsoft.PowerFx.Core.Parser
         }
 
         /// <summary>
-        /// Formats/Pretty Print the given expression to more a readable form.
+        /// Formats/Pretty Print the given expression text to more a readable form.
         /// </summary>
-        /// <param name="text">Expression Text to format.</param>
-        /// <param name="flags">Optional flags to customize the behavior of underlying lexer and parser. By default, Expression Chaining is enabled.</param>
-        /// <returns>Formatted Expression.</returns>
+        /// <param name="text">Expression text to format.</param>
+        /// <param name="flags">Optional flags to customize the behavior of underlying lexer and parser. By default, expression chaining is enabled.</param>
+        /// <returns>Formatted expression text.</returns>
         public static string Format(string text, Flags flags = Flags.EnableExpressionChaining)
         {
             var result = ParseScript(

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
@@ -199,7 +199,6 @@ namespace Microsoft.PowerFx.Tests
             // Asssert
             Assert.NotNull(result);
             Assert.Equal(expectedFormattedExpr, result);
-            var t = TexlLexer.InvariantLexer.RemoveWhiteSpace(result);
 
             // Act: Ensure idempotence
             result = Format(result, flags);


### PR DESCRIPTION
Earlier this week, Customer reached out to us about a bug when trying to format the expression like "Set(Children; true)" in the formula bar. "Children" is not a reserved keyword and unless the disabled reserved keyword flag is not set when invoking Lexer, "Children" gets identified as an ErrorToken. This causes errors in the AST and we don't format when there are errors and just return the same expression.

To solve this, we need to pass in a Flags.DisabledReservedKeyword flag to the parser and ultimately lexer when invoking them before the pretty printing. There was no ability to pass in custom flags so I extended the "Format" function (which is an entry point for pretty printing) with an optional argument to allow passing custom flags. These changes would be later consumed in Canvas Apps Backend (Would be passing in Flags.DisabledReservedKeyword | Flags.EnableExpressionChaining to Format in Canvas Apps Backend)

@gregli-msft Could you take a look at this and see if this is the right way to solve it