### PR TITLE
Adding the very small part of logic behind hiding tokens I forgot to migrate in PR #1420

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Tokenization.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Tokenization.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense
                 TokenType type = MapBindKindToTokenType(firstName.Kind);
 
                 // Try to set the canHide flag if the FirstName type is Enum
-                var canHide = allowTokenHiding && CanHideLeftHandSideOfDottedName(firstName, binding);
+                var canHide = allowTokenHiding && (type == TokenType.Enum && CanHideLeftHandSideOfDottedName(firstName, binding));
 
                 // If the first name can be hidden, Create and Add a token for the dot.
                 if (canHide && expression.Length > span.Lim && (TexlLexer.PunctuatorDot + TexlLexer.PunctuatorBang).IndexOf(expression.Substring(span.Lim, 1), StringComparison.Ordinal) >= 0)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Tokenization.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/Tokenization.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerFx.Core.Texl.Intellisense
                 TokenType type = MapBindKindToTokenType(firstName.Kind);
 
                 // Try to set the canHide flag if the FirstName type is Enum
-                var canHide = allowTokenHiding && (type == TokenType.Enum && CanHideLeftHandSideOfDottedName(firstName, binding));
+                var canHide = allowTokenHiding && type == TokenType.Enum && CanHideLeftHandSideOfDottedName(firstName, binding);
 
                 // If the first name can be hidden, Create and Add a token for the dot.
                 if (canHide && expression.Length > span.Lim && (TexlLexer.PunctuatorDot + TexlLexer.PunctuatorBang).IndexOf(expression.Substring(span.Lim, 1), StringComparison.Ordinal) >= 0)


### PR DESCRIPTION
The support for semantic tokenization was added in PR https://github.com/microsoft/Power-Fx/pull/1420. I migrated the logic behind tokenization in old formula bar from Canvas App backend to PowerFx. In doing so, i forgot to bring over a very tiny part but important for old formula bar of the logic that computes whether first name tokens can be hidden or not.