### PR TITLE
Make the Switch function follow the first-type rule

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
@@ -12,6 +13,7 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
+using static Microsoft.PowerFx.Syntax.PrettyPrintVisitor;
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
@@ -57,6 +59,115 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return index >= 1;
         }
 
+        internal static bool TryDetermineReturnTypePowerFxV1CompatRules(
+            List<(TexlNode node, DType type)> possibleResults,
+            IErrorContainer errors, 
+            ref Dictionary<TexlNode, DType> nodeToCoercedTypeMap,
+            out DType returnType)
+        {
+            returnType = null;
+            var type = possibleResults[0].type;
+            var fArgsValid = true;
+
+            foreach (var (argNode, argType) in possibleResults)
+            {
+                if (argType.IsVoid)
+                {
+                    type = DType.Void;
+                }
+                else if (argType.IsError)
+                {
+                    errors.EnsureError(argNode, TexlStrings.ErrTypeError);
+                    fArgsValid = false;
+                }
+                else if (type.Kind == DKind.ObjNull)
+                {
+                    // Anything goes with null
+                    type = argType;
+                }
+                else if (argType.Kind == DKind.ObjNull)
+                {
+                    // ObjNull can be accepted by the current type
+                }
+                else if (DType.TryUnionWithCoerce(
+                         type,
+                         argType,
+                         usePowerFxV1CompatibilityRules: true,
+                         coerceToLeftTypeOnly: true,
+                         out var unionType,
+                         out var coercionNeeded))
+                {
+                    type = unionType;
+                    if (coercionNeeded)
+                    {
+                        CollectionUtils.Add(ref nodeToCoercedTypeMap, argNode, type);
+                    }
+                }
+                else
+                {
+                    // If types are incompatible, result is Void
+                    type = DType.Void;
+                }
+            }
+
+            returnType = type;
+            return fArgsValid;
+        }
+
+        internal static bool TryDetermineReturnTypePowerFxV1CompatRulesDisabled(
+            List<(TexlNode node, DType type)> possibleResults,
+            IErrorContainer errors,
+            ref Dictionary<TexlNode, DType> nodeToCoercedTypeMap,
+            out DType returnType)
+        {
+            returnType = null;
+            var type = DType.Unknown;
+            var fArgsValid = true;
+
+            foreach (var (nodeArg, typeArg) in possibleResults)
+            {
+                var typeSuper = DType.Supertype(
+                    type,
+                    typeArg,
+                    useLegacyDateTimeAccepts: false,
+                    usePowerFxV1CompatibilityRules: false);
+
+                if (!typeSuper.IsError)
+                {
+                    type = typeSuper;
+                }
+                else if (typeArg.IsVoid)
+                {
+                    type = DType.Void;
+                }
+                else if (typeArg.IsError)
+                {
+                    errors.EnsureError(nodeArg, TexlStrings.ErrTypeError);
+                    fArgsValid = false;
+                }
+                else if (!type.IsError)
+                {
+                    if (typeArg.CoercesTo(type, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: false))
+                    {
+                        CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
+                    }
+                    else
+                    {
+                        // If the types are incompatible, the result type is void.
+                        type = DType.Void;
+                    }
+                }
+                else if (typeArg.Kind != DKind.Unknown)
+                {
+                    type = typeArg;
+                    fArgsValid = false;
+                }
+            }
+
+            returnType = type;
+            return fArgsValid;
+        }
+
         public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(context);
@@ -84,93 +195,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var type = context.Features.PowerFxV1CompatibilityRules ? argTypes[1] : ReturnType;
 
-            // For pre-PowerFxV1, compute the result type by joining the types of all non-predicate args.
-            // For PowerFxV1 compat rules, validate that all non-predicate args can be coerced to the first one
+            var possibleResults = new List<(TexlNode node, DType type)>();
             for (var i = 1; i < count;)
             {
-                var nodeArg = args[i];
-                var typeArg = argTypes[i];
-
-                if (context.Features.PowerFxV1CompatibilityRules)
-                {
-                    if (typeArg.IsVoid)
-                    {
-                        type = DType.Void;
-                    }
-                    else if (typeArg.IsError)
-                    {
-                        errors.EnsureError(args[i], TexlStrings.ErrTypeError);
-                        fArgsValid = false;
-                    }
-                    else if (type.Kind == DKind.ObjNull)
-                    {
-                        // Anything goes with null
-                        type = typeArg;
-                    }
-                    else if (typeArg.Kind == DKind.ObjNull)
-                    {
-                        // ObjNull can be accepted by the current type
-                    }
-                    else if (DType.TryUnionWithCoerce(
-                             type,
-                             typeArg,
-                             usePowerFxV1CompatibilityRules: true,
-                             coerceToLeftTypeOnly: true,
-                             out var unionType,
-                             out var coercionNeeded))
-                    {
-                        type = unionType;
-                        if (coercionNeeded)
-                        {
-                            CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
-                        }
-                    }
-                    else
-                    {
-                        // If types are incompatible, result is Void
-                        type = DType.Void;
-                    }
-                }
-                else
-                {
-                    // Legacy logic
-                    var typeSuper = DType.Supertype(
-                        type,
-                        typeArg,
-                        useLegacyDateTimeAccepts: false,
-                        usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules);
-
-                    if (!typeSuper.IsError)
-                    {
-                        type = typeSuper;
-                    }
-                    else if (typeArg.IsVoid)
-                    {
-                        type = DType.Void;
-                    }
-                    else if (typeArg.IsError)
-                    {
-                        errors.EnsureError(args[i], TexlStrings.ErrTypeError);
-                        fArgsValid = false;
-                    }
-                    else if (!type.IsError)
-                    {
-                        if (typeArg.CoercesTo(type, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
-                        {
-                            CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
-                        }
-                        else
-                        {
-                            // If the types are incompatible, the result type is void.
-                            type = DType.Void;
-                        }
-                    }
-                    else if (typeArg.Kind != DKind.Unknown)
-                    {
-                        type = typeArg;
-                        fArgsValid = false;
-                    }
-                }
+                possibleResults.Add((args[i], argTypes[i]));
 
                 // If there are an odd number of args, the last arg also participates.
                 i += 2;
@@ -180,9 +208,25 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
             }
 
+            // For pre-PowerFxV1, compute the result type by joining the types of all non-predicate args.
+            // For PowerFxV1 compat rules, validate that all non-predicate args can be coerced to the first one
+            if (context.Features.PowerFxV1CompatibilityRules)
+            {
+                if (!TryDetermineReturnTypePowerFxV1CompatRules(possibleResults, errors, ref nodeToCoercedTypeMap, out type))
+                {
+                    fArgsValid = false;
+                }
+            }
+            else
+            {
+                if (!TryDetermineReturnTypePowerFxV1CompatRulesDisabled(possibleResults, errors, ref nodeToCoercedTypeMap, out type))
+                {
+                    fArgsValid = false;
+                }
+            }
+
             // Update the return type based on the specified invocation args.
             returnType = type;
-
             return fArgsValid;
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
@@ -115,53 +115,32 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             // Compute the result type by joining the types of all non-predicate args.
             Contracts.Assert(type == DType.Unknown);
+
+            var possibleResults = new List<(TexlNode node, DType type)>();
             for (var i = 2; i < count;)
             {
-                var nodeArg = args[i];
-                var typeArg = argTypes[i];
-
-                var typeSuper = DType.Supertype(
-                    type,
-                    typeArg,
-                    useLegacyDateTimeAccepts: false,
-                    usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules);
-
-                if (!typeSuper.IsError)
-                {
-                    type = typeSuper;
-                }
-                else if (typeArg.IsVoid)
-                {
-                    type = DType.Void;
-                }
-                else if (typeArg.IsError)
-                {
-                    errors.EnsureError(args[i], TexlStrings.ErrTypeError);
-                    fArgsValid = false;
-                }
-                else if (!type.IsError)
-                {
-                    if (typeArg.CoercesTo(type, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
-                    {
-                        CollectionUtils.Add(ref nodeToCoercedTypeMap, nodeArg, type);
-                    }
-                    else
-                    {
-                        // If the types are incompatible, the result type is void.
-                        type = DType.Void;
-                    }
-                }
-                else if (typeArg.Kind != DKind.Unknown)
-                {
-                    type = typeArg;
-                    fArgsValid = false;
-                }
+                possibleResults.Add((args[i], argTypes[i]));
 
                 // If there are an odd number of args, the last arg also participates.
                 i += 2;
                 if (i == count)
                 {
                     i--;
+                }
+            }
+
+            if (context.Features.PowerFxV1CompatibilityRules)
+            {
+                if (!IfFunction.TryDetermineReturnTypePowerFxV1CompatRules(possibleResults, errors, ref nodeToCoercedTypeMap, out type))
+                {
+                    fArgsValid = false;
+                }
+            }
+            else
+            {
+                if (!IfFunction.TryDetermineReturnTypePowerFxV1CompatRulesDisabled(possibleResults, errors, ref nodeToCoercedTypeMap, out type))
+                {
+                    fArgsValid = false;
                 }
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch_V1Compat.txt
@@ -7,3 +7,16 @@ Date(2001,4,1)
 //Time-DateTime
 >> Switch("Case1","Case2",Time(6,30,30),"Case1",DateTimeValue("4/1/2001 10:00:00"))
 Time(10,0,0,0)
+
+// Records - first type wins
+>> Switch(0, 0, {a:1,b:true}, 1, {b:"false",c:"hello"})
+{a:1,b:true,c:Blank()}
+
+>> Switch(1, 0, {a:1,b:true}, 1, {b:"false",c:"hello"})
+{a:Blank(),b:false,c:"hello"}
+
+>> Switch(0, 0, {x:1, y:2}, {y:3, z:4})
+{x:1,y:2,z:Blank()}
+
+>> Switch(1, 0, {x:1, y:2}, {y:3, z:4})
+{x:Blank(),y:3,z:4}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch_V1CompatDisabled.txt
@@ -1,9 +1,22 @@
-﻿#SETUP: PowerFxV1CompatibilityRules
+﻿#SETUP: disable:PowerFxV1CompatibilityRules
 
 //Date-DateTime
 >> Switch("Case1","Case2",Date(2000,1,4),"Case1",DateTimeValue("4/1/2001 10:00:00"))
-Date(2001,4,1)
+DateTime(2001,4,1,10,0,0,0)
 
 //Time-DateTime
 >> Switch("Case1","Case2",Time(6,30,30),"Case1",DateTimeValue("4/1/2001 10:00:00"))
-Time(10,0,0,0)
+DateTime(2001,4,1,10,0,0,0)
+
+// Records - intersection rule
+>> Switch(0, 0, {a:1,b:true}, 1, {b:"false",c:"hello"})
+{}
+
+>> Switch(1, 0, {a:1,b:true}, 1, {b:"false",c:"hello"})
+{}
+
+>> Switch(0, 0, {x:1, y:2}, {y:3, z:4})
+{y:2}
+
+>> Switch(1, 0, {x:1, y:2}, {y:3, z:4})
+{y:3}


### PR DESCRIPTION
Currently the Switch function uses an intersection rule for the arguments - Switch(var, 1, {a:1}, {b:2}) returns an empty record since there are no common properties in the two records. With the PowerFxV1 rules, we are changing it to follow the "union with first-type rule" that is used in other functions, so the type of that expression would be ![a:n] with the new feature.

This is similar to #1507 which did the change for the If function.