### PR TITLE
Make data source FirstNameNodes also mutable

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4554,9 +4554,10 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // Propagate mutability if supported by the function
-                var firstChildNode = node.Args.ChildNodes[0];
-                if (func.PropagatesMutability && node.Args.Count > 0 && _txb.IsMutable(firstChildNode))
+                if (func.PropagatesMutability && node.Args.Count > 0 && _txb.IsMutable(node.Args.ChildNodes[0]))
                 {
+                    var firstChildNode = node.Args.ChildNodes[0];
+
                     // Propagate mutability if it is *not* a connected data source
                     var mutable = true;
                     if (firstChildNode is FirstNameNode first &&

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2807,6 +2807,13 @@ namespace Microsoft.PowerFx.Core.Binding
                     var nameSymbol = lookupInfo.Data as NameSymbol;
                     _txb.SetMutable(node, nameSymbol?.IsMutable ?? false);
                 }
+                else if (lookupInfo.Kind == BindKind.Data)
+                {
+                    if (lookupInfo.Data is IExternalCdsDataSource or IExternalTabularDataSource)
+                    {
+                        _txb.SetMutable(node, true);
+                    }
+                }
 
                 Contracts.Assert(lookupInfo.Kind != BindKind.LambdaField);
                 Contracts.Assert(lookupInfo.Kind != BindKind.LambdaFullRecord);
@@ -4547,9 +4554,19 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // Propagate mutability if supported by the function
-                if (func.PropagatesMutability && node.Args.Count > 0 && _txb.IsMutable(node.Args.ChildNodes[0]))
+                var firstChildNode = node.Args.ChildNodes[0];
+                if (func.PropagatesMutability && node.Args.Count > 0 && _txb.IsMutable(firstChildNode))
                 {
-                    _txb.SetMutable(node, true);
+                    // Propagate mutability if it is *not* a connected data source
+                    var mutable = true;
+                    if (firstChildNode is FirstNameNode first &&
+                        _nameResolver?.Lookup(first.Ident.Name, out var lookupInfo) == true &&
+                        lookupInfo.Kind == BindKind.Data)
+                    {
+                        mutable = false;
+                    }
+
+                    _txb.SetMutable(node, mutable);
                 }
 
                 // Invalid datasources always result in error

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BinderTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BinderTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("First(tbl)")]
         [InlineData("Last(tbl)")]
         [InlineData("Index(tbl, 3)")]
+        [InlineData("MyDataSource")]
         public void TestMutableNodes(string expression)
         {
             var config = new PowerFxConfig();
@@ -57,6 +58,11 @@ namespace Microsoft.PowerFx.Core.Tests
                 "tbl",
                 TableType.Empty().Add("Value", FormulaType.Number),
                 mutable: true);
+            var schema = DType.CreateTable(
+                new TypedName(DType.Guid, new DName("ID")),
+                new TypedName(DType.Number, new DName("Value")));
+            config.SymbolTable.AddEntity(new TestDataSource("MyDataSource", schema));
+
             var engine = new Engine(config);
             var checkResult = engine.Check(expression);
             Assert.True(checkResult.IsSuccess);
@@ -72,6 +78,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Filter(tbl, Value > 10)")]
         [InlineData("FirstN(tbl, 2)")]
         [InlineData("LastN(tbl, 2)")]
+        [InlineData("First(MyDataSource)")]
         public void TestImmutableNodes(string expression)
         {
             var config = new PowerFxConfig();
@@ -85,6 +92,11 @@ namespace Microsoft.PowerFx.Core.Tests
                 "tbl",
                 TableType.Empty().Add("Value", FormulaType.Number),
                 mutable: true);
+            var schema = DType.CreateTable(
+                new TypedName(DType.Guid, new DName("ID")),
+                new TypedName(DType.Number, new DName("Value")));
+            config.SymbolTable.AddEntity(new TestDataSource("MyDataSource", schema));
+
             var engine = new Engine(config);
             var checkResult = engine.Check(expression);
             Assert.True(checkResult.IsSuccess);


### PR DESCRIPTION
A previous change to tag nodes for mutability didn't take account of connected data source nodes. This updates it.