### PR TITLE
Allow Void expressions to be used within ForAll

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ForAll.cs
@@ -46,7 +46,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fArgsValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            nodeToCoercedTypeMap = null;
+            var fArgsValid = CheckType(context, args[0], argTypes[0], ParamTypes[0], errors, ref nodeToCoercedTypeMap);
 
             if (argTypes[1].IsRecord)
             {
@@ -55,6 +56,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             else if (argTypes[1].IsPrimitive || argTypes[1].IsTable || argTypes[1].IsUntypedObject)
             {
                 returnType = DType.CreateTable(new TypedName(argTypes[1], ColumnName_Value));
+            }
+            else if (argTypes[1].IsVoid)
+            {
+                returnType = argTypes[1];
             }
             else
             {
@@ -104,7 +109,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            var fArgsValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            nodeToCoercedTypeMap = null;
+            var fArgsValid = CheckType(context, args[0], argTypes[0], ParamTypes[0], errors, ref nodeToCoercedTypeMap);
 
             if (argTypes[1].IsRecord)
             {
@@ -113,6 +119,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             else if (argTypes[1].IsPrimitive || argTypes[1].IsTable || argTypes[1].IsUntypedObject)
             {
                 returnType = DType.CreateTable(new TypedName(argTypes[1], ColumnName_Value));
+            }
+            else if (argTypes[1].IsVoid)
+            {
+                returnType = argTypes[1];
             }
             else
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2487,6 +2487,11 @@ namespace Microsoft.PowerFx.Functions
                 return ErrorValue.Combine(irContext, errorRows);
             }
 
+            if (irContext.ResultType is Types.Void)
+            {
+                return new VoidValue(irContext);
+            }
+
             return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows.ToArray(), forceSingleColumn: false));
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -557,6 +557,11 @@ namespace Microsoft.PowerFx.Functions
                 return ErrorValue.Combine(irContext, errorRows);
             }
 
+            if (irContext.ResultType is Types.Void)
+            {
+                return new VoidValue(irContext);
+            }
+
             return new InMemoryTableValue(irContext, StandardTableNodeRecords(irContext, rows.ToArray(), forceSingleColumn: false));
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ForAll.txt
@@ -89,3 +89,23 @@ Table({Value:true})
 >> ForAll([Blank()],IsBlank(ThisRecord))
 Table({Value:false})
 
+// ************ ForAll and Void expressions ****************
+
+>> ForAll([1,2], If(Value = 1, Value * 2, {Result: Value}))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+>> ForAll([1,2,3] As p, Switch(p.Value, 1, {a:1}, 2, [{a:2}], 3, "Hello"))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+>> ForAll(ParseJSON("[1,2]"), If(Value(ThisRecord) = 1, Value(ThisRecord) * 2, {Result: Value(ThisRecord)}))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+>> ForAll(ParseJSON("[1,2,3]"), Switch(Value(ThisRecord), 1, {a:1}, 2, [{a:2}], 3, "Hello"))
+If(true, {test:1}, "Mismatched args (result of the expression can't be used).")
+
+// Errors are returned
+>> ForAll([1,2], If(Value = 1, Sqrt(-Value), {Result: Value}))
+Error({Kind:ErrorKind.Numeric})
+
+>> ForAll(ParseJSON("[""1"",""a""]"), If(Text(ThisRecord) = "1", Value(ThisRecord) * 2, Value(ThisRecord)))
+Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -589,7 +589,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Hour(If(1 < 0, [1], 2))", "n", false)]
 
         // ForAll([1,2,3], V)
-        [InlineData("ForAll([1,2,3], If(1 < 0, [1], 2))", "e", false)]
+        [InlineData("ForAll([1,2,3], If(1 < 0, [1], 2))", "-", true)]
         public void TexlFunctionTypeSemanticsIfWithArgumentCoercion(string expression, string expectedType, bool checkSuccess)
         {
             var symbol = new SymbolTable();


### PR DESCRIPTION
If a ForAll expression is used within a context where its result is not needed, then it should be able to use void expressions, like in the example below. This change allows it, making the entire result of the ForAll expression a void result.

    ForAll(
        Sequence(4),
        If(
            Mod(Value, 2) = 1,
            Patch( table, Index(table, Value), { IsOdd: true } ),  // this returns a record, incompatible with tables
            Collect( table, { Value: Value, IsOdd: false }, { Value: Value + 1, IsOdd: true }   // this returns a table
        )
    )