### PR TITLE
Update to use IReadOnlyList/ConcurrentDictionary for thread safety

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/Tokens/ErrorToken.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/Tokens/ErrorToken.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
@@ -19,7 +20,7 @@ namespace Microsoft.PowerFx.Syntax
         public ErrorResourceKey? DetailErrorKey { get; }
 
         // Args for ErrorResourceKey("UnexpectedCharacterToken")'s format string used in UnexpectedCharacterTokenError/LexError inside Lexer.cs.
-        internal object[] ResourceKeyFormatStringArgs { get; }
+        internal IReadOnlyList<object> ResourceKeyFormatStringArgs { get; }
 
         internal ErrorToken(Span span)
             : this(span, null)

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -1046,12 +1046,12 @@ namespace Microsoft.PowerFx.Core.Parser
                 case TokKind.Error:
                     var errorToken = _curs.TokMove().As<ErrorToken>();
                     var args = errorToken.ResourceKeyFormatStringArgs;
-                    if (args == null || args.Length == 0)
+                    if (args == null || args.Count == 0)
                     {
                         return CreateError(errorToken, errorToken.DetailErrorKey ?? TexlStrings.ErrBadToken);
                     }
 
-                    return CreateError(errorToken, errorToken.DetailErrorKey ?? TexlStrings.ErrBadToken, args);
+                    return CreateError(errorToken, errorToken.DetailErrorKey ?? TexlStrings.ErrBadToken, args.ToArray());
 
                 case TokKind.Comment:
                     Contracts.Assert(false, "A stray comment was found");

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -37,6 +37,7 @@ namespace Microsoft.PowerFx
         }
 
         // SymbolTable is conceptually constant. 
+        [ThreadSafeProtectedByLock("Interlocked.Increment")]
         private readonly VersionHash _constant = VersionHash.New();
 
         internal override VersionHash VersionHash => _constant;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/VersionHash.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/VersionHash.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.Threading;
 
@@ -14,14 +15,20 @@ namespace Microsoft.PowerFx
     [DebuggerDisplay("Version:{_value}")]
     internal struct VersionHash
     {
+        [ThreadSafeProtectedByLock("Interlocked.Increment")]
         private int _value;
+
+        [ThreadSafeProtectedByLock("Interlocked.Increment")]
+        private static int _hashStarter;
+
+        public static bool operator ==(VersionHash a, VersionHash b) => a._value == b._value;
+
+        public static bool operator !=(VersionHash a, VersionHash b) => a._value != b._value;
 
         private VersionHash(int value)
         {
             _value = value;
         }
-
-        private static int _hashStarter;
 
         public static VersionHash New()
         {
@@ -38,7 +45,7 @@ namespace Microsoft.PowerFx
         /// </summary>
         public void Inc()
         {
-            _value++;
+            Interlocked.Increment(ref _value);
         }
 
         public VersionHash Combine(VersionHash other)
@@ -50,10 +57,6 @@ namespace Microsoft.PowerFx
         {
             return (a * -1521134295) + b;
         }
-
-        public static bool operator ==(VersionHash a, VersionHash b) => a._value == b._value;
-
-        public static bool operator !=(VersionHash a, VersionHash b) => a._value != b._value;
 
         public override bool Equals(object obj)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/ErrorNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/ErrorNode.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
@@ -18,7 +19,7 @@ namespace Microsoft.PowerFx.Syntax
         /// </summary>
         public string Message { get; }
 
-        internal readonly object[] Args;
+        internal readonly IReadOnlyList<object> Args;
 
         internal ErrorNode(ref int idNext, Token primaryToken, string msg)
             : base(ref idNext, primaryToken, new SourceList(primaryToken))

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/RecordNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/RecordNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
@@ -17,8 +18,8 @@ namespace Microsoft.PowerFx.Syntax
     /// </summary>
     public sealed class RecordNode : VariadicBase
     {
-        internal readonly Token[] Commas;
-        internal readonly Token[] Colons;
+        internal readonly IReadOnlyList<Token> Commas;
+        internal readonly IReadOnlyList<Token> Colons;
 
         /// <summary>
         /// The record identifier names (i.e., field names).
@@ -71,7 +72,7 @@ namespace Microsoft.PowerFx.Syntax
                 newIdentifiers[x] = Ids[x].Clone(ts);
             }
 
-            return new RecordNode(ref idNext, Token.Clone(ts), SourceList.Clone(ts, newNodes), newIdentifiers, children, Clone(Commas, ts), Clone(Colons, ts), CurlyClose.Clone(ts), SourceRestriction?.Clone(ref idNext, ts));
+            return new RecordNode(ref idNext, Token.Clone(ts), SourceList.Clone(ts, newNodes), newIdentifiers, children, Clone(Commas.ToArray(), ts), Clone(Colons.ToArray(), ts), CurlyClose.Clone(ts), SourceRestriction?.Clone(ref idNext, ts));
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TableNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TableNode.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerFx.Syntax
     /// </summary>
     public sealed class TableNode : VariadicBase
     {
-        internal readonly Token[] Commas;
+        internal readonly IReadOnlyList<Token> Commas;
 
         // BracketClose can be null.
         internal readonly Token BracketClose;
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Syntax
                 newNodes.Add(Children[i], children[i]);
             }
 
-            return new TableNode(ref idNext, Token.Clone(ts), SourceList.Clone(ts, newNodes), children, Clone(Commas, ts), BracketClose.Clone(ts));
+            return new TableNode(ref idNext, Token.Clone(ts), SourceList.Clone(ts, newNodes), children, Clone(Commas.ToArray(), ts), BracketClose.Clone(ts));
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/VariadicOpNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/VariadicOpNode.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerFx.Syntax
         /// </summary>
         public VariadicOp Op { get; }
         
-        internal readonly Token[] OpTokens;
+        internal readonly IReadOnlyList<Token> OpTokens;
 
         // Assumes ownership of the 'children' and 'opTokens' array.
         internal VariadicOpNode(ref int idNext, VariadicOp op, TexlNode[] children, Token[] opTokens, SourceList sourceList)
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Syntax
                 newNodes.Add(Children[i], children[i]);
             }
 
-            return new VariadicOpNode(ref idNext, Op, children, Clone(OpTokens, ts), SourceList.Clone(ts, newNodes));
+            return new VariadicOpNode(ref idNext, Op, children, Clone(OpTokens.ToArray(), ts), SourceList.Clone(ts, newNodes));
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/FindNodeVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/FindNodeVisitor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerFx.Syntax
             Contracts.AssertValue(node);
             Contracts.Assert(node.Children.Length > 0);
 
-            var numTokens = CollectionUtils.Size(node.OpTokens);
+            var numTokens = CollectionUtils.Size(node.OpTokens.ToArray());
 
             Contracts.Assert(node.Children.Length == numTokens + 1 || node.Children.Length == numTokens);
 
@@ -227,7 +227,7 @@ namespace Microsoft.PowerFx.Syntax
             }
 
             // Cursor is between the open and closed curly.
-            var length = CollectionUtils.Size(node.Commas);
+            var length = CollectionUtils.Size(node.Commas.ToArray());
 
             for (var i = 0; i < length; i++)
             {
@@ -267,7 +267,7 @@ namespace Microsoft.PowerFx.Syntax
             }
 
             // Cursor is between the open and closed bracket.
-            for (var i = 0; i < node.Commas.Length; i++)
+            for (var i = 0; i < node.Commas.Count; i++)
             {
                 // Cursor position is inside ith child.
                 if (_cursorPosition <= node.Commas[i].Span.Lim)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolValues.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Types;
@@ -13,18 +14,19 @@ namespace Microsoft.PowerFx
     /// Will lazily create a symbol table. 
     /// To match to an existing symbol table, call <see cref="SymbolExtensions.CreateValues(ReadOnlySymbolTable, ReadOnlySymbolValues[])"/>.
     /// </summary>
+    [ThreadSafeImmutable]
     public class SymbolValues : ReadOnlySymbolValues
     {
         // Map of name Slots --> Values. 
         // Index by Slot.SlotIndex. This could be optimized to be a dense array. 
-        private readonly Dictionary<int, Tuple<ISymbolSlot, FormulaValue>> _symbolValues = new Dictionary<int, Tuple<ISymbolSlot, FormulaValue>>();
+        private readonly ConcurrentDictionary<int, Tuple<ISymbolSlot, FormulaValue>> _symbolValues = new ConcurrentDictionary<int, Tuple<ISymbolSlot, FormulaValue>>();
 
         private readonly ReadOnlySymbolTable _symTable;
 
         /// <summary>
         /// Register an event to invoke when <see cref="Set(ISymbolSlot, FormulaValue)"/> is called.
         /// </summary>
-        public event Action<ISymbolSlot, FormulaValue> OnUpdate;
+        public readonly Action<ISymbolSlot, FormulaValue> OnUpdate;
 
         // Table will be inferred from the values we add. 
         // Take debugName as a parameter so that we can pass it to SymbolTable that we create.
@@ -34,12 +36,14 @@ namespace Microsoft.PowerFx
         }
 
         // Values for an existing table.
-        public SymbolValues(SymbolTable table)
+        public SymbolValues(SymbolTable table, Action<ISymbolSlot, FormulaValue> onUpdateAction = null)
             : base(table)
         {
             _symTable = table ?? throw new ArgumentNullException(nameof(table));
 
             DebugName = table.DebugName;
+
+            OnUpdate = onUpdateAction;
         }
 
         // Limit which kinds of SymbolTables this handles.
@@ -74,17 +78,13 @@ namespace Microsoft.PowerFx
         {
             ValidateSlot(slot);
 
-            if (value == null)
-            {
-                _symbolValues.Remove(slot.SlotIndex);
-            }
-            else
+            _symbolValues[slot.SlotIndex] = Tuple.Create(slot, value);
+
+            if (value != null)
             {
                 _symTable.ValidateAccepts(slot, value.Type);
-                _symbolValues[slot.SlotIndex] = Tuple.Create(slot, value);
+                OnUpdate?.Invoke(slot, value);
             }
-
-            OnUpdate?.Invoke(slot, value);
         }
 
         public override FormulaValue Get(ISymbolSlot slot)
@@ -93,7 +93,7 @@ namespace Microsoft.PowerFx
 
             if (_symbolValues.TryGetValue(slot.SlotIndex, out var value))
             {
-                if (!value.Item1.IsDisposed())
+                if (value.Item2 != null && !value.Item1.IsDisposed())
                 {
                     return value.Item2;
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -42,8 +42,7 @@ namespace Microsoft.PowerFx
             : base(powerFxConfig)
         {
             _symbolTable = new SymbolTable { DebugName = "Globals" };
-            _symbolValues = new SymbolValues(_symbolTable);
-            _symbolValues.OnUpdate += OnSymbolValuesOnUpdate;
+            _symbolValues = new SymbolValues(_symbolTable, OnSymbolValuesOnUpdate);
 
             base.EngineSymbols = _symbolTable;
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/LexerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/LexerTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(TokKind.Ident, tokens[2].Kind);
             Assert.Equal(TokKind.Comma, tokens[3].Kind);
             Assert.Equal(TokKind.Error, tokens[4].Kind);
-            Assert.Equal(2, (tokens[4] as ErrorToken).ResourceKeyFormatStringArgs.Length);
+            Assert.Equal(2, (tokens[4] as ErrorToken).ResourceKeyFormatStringArgs.Count);
             Assert.Equal((tokens[4] as ErrorToken).DetailErrorKey.Value, TexlStrings.UnexpectedCharacterToken);
             Assert.Equal(TokKind.BracketOpen, tokens[5].Kind);
             Assert.Equal(TokKind.BracketClose, tokens[6].Kind);
@@ -148,7 +148,7 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.NotNull(tokens);
             Assert.Equal(9, tokens.Count);
             Assert.Equal(TokKind.Error, tokens[0].Kind);
-            Assert.Equal(2, (tokens[0] as ErrorToken).ResourceKeyFormatStringArgs.Length);
+            Assert.Equal(2, (tokens[0] as ErrorToken).ResourceKeyFormatStringArgs.Count);
             Assert.Equal((tokens[0] as ErrorToken).DetailErrorKey.Value, TexlStrings.UnexpectedCharacterToken);
         }
 


### PR DESCRIPTION
Fix bug 1, 2, 3, 4, 5, 6, 7, 8 in issue: https://github.com/microsoft/Power-Fx/issues/1535.
Update array to IReadOnlyList.
Update dictionary to ConcurrentDictionary.
Use thread safe Interlocked.Increment to increase int value.