### PR TITLE
Fix crash when CurrentUICulture is Invariant

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -99,6 +99,12 @@ namespace Microsoft.PowerFx.Core.Localization
             {
                 // $$$ Don't use CurrentUICulture
                 locale = CultureInfo.CurrentUICulture.Name;
+
+                if (string.IsNullOrEmpty(locale))
+                {
+                    locale = "en-US";
+                }
+
                 Contracts.CheckNonEmpty(locale, "locale");
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ResourceValidationTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Microsoft.PowerFx.Tests
 {
     public class ResourceValidationTests : PowerFxTest
-    {       
+    {
         [Fact]
         public void ResourceLoadsOnlyRequiredLocales()
         {
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx.Tests
             string frContent = frERContent.GetSingleValue(ErrorResource.ShortMessageTag);
 
             Assert.NotEqual(usContent, frContent);
-        }        
+        }
 
         [Fact]
         public void TestErrorResourceImport()
@@ -88,6 +88,32 @@ namespace Microsoft.PowerFx.Tests
                         "Missing parameter description. Please add the following to Resources: " + "About" + function.LocaleInvariantName + "_" + paramName);
                 }
             }
+        }
+
+        [Fact]
+        public void InvariantCultureForResourceImportTest()
+        {            
+            // $$$ Don't use CurrentUICulture
+            CultureInfo.CurrentUICulture = CultureInfo.CreateSpecificCulture("en-US");
+            var enUsERContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken);
+            var enUsBasicContent = StringResources.Get("AboutAbs");
+
+            // $$$ Don't use CurrentUICulture
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            var invariantContent = StringResources.GetErrorResource(TexlStrings.ErrBadToken);
+            var invariantBasicContent = StringResources.Get("AboutAbs");
+
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            Assert.True(assemblies.Where(x => x.FullName.Contains("Culture=neutral")).Any());
+
+            // Strings in invariantculture are the same as en-US culture
+            // Not validating content directly, since it might change
+            Assert.Equal(enUsBasicContent, invariantBasicContent);
+
+            string usContent = enUsERContent.GetSingleValue(ErrorResource.ShortMessageTag);
+            string invContent = invariantContent.GetSingleValue(ErrorResource.ShortMessageTag);
+
+            Assert.Equal(usContent, invContent);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
@@ -453,6 +453,14 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             RunOnIsolatedThread(_doNotUseCulture, MultiCulture1ThreadProc);
         }
 
+        [Fact]
+        private void MultiCultureWithCurrentUICulture()
+        {
+            // $$$ Don't use CurrentUICulture
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            RunOnIsolatedThread(_doNotUseCulture, MultiCulture1ThreadProc);
+        }
+
         // Test Parse and errors 
         private void MultiCulture1ThreadProc(CultureInfo culture)
         {


### PR DESCRIPTION
Fix issue: https://github.com/microsoft/Power-Fx/issues/1553
CultureInfo.CurrentUICulture.Name is empty (make locale empty) when CurrentUICulture is set to invariant. This makes TryGetErrorResource throw exception for empty locale. 
This PR fix to set "en-US" default when CultureInfo.CurrentUICulture.Name is empty (invariant case).