### PR TITLE
Move expansion of Canvas-Specific control type into INameResolver from IExternalControl

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControl.cs
@@ -26,8 +26,6 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         bool IsCommandComponentInstance { get; }
 
-        IExternalControlType GetControlDType(bool calculateAugmentedExpandoType, bool isDataLimited);
-
         bool IsDescendentOf(IExternalControl controlInfo);
 
         IExternalRule GetRule(string propertyInvariantName);

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3415,7 +3415,11 @@ namespace Microsoft.PowerFx.Core.Binding
                             // If visiting an expando type property of control type variable, we cannot calculate the type here because
                             // The LHS associated ControlInfo is App/Component.
                             // e.g. Set(controlVariable1, DropDown1), Label1.Text = controlVariable1.Selected.Value.
-                            leftType = (DType)controlInfo.GetControlDType(calculateAugmentedExpandoType: true, isDataLimited: false);
+                            if (!_nameResolver.LookupExpandedControlType(controlInfo, out leftType))
+                            {
+                                SetDottedNameError(node, TexlStrings.ErrInvalidName, property.InvariantName);
+                                return;
+                            }
                         }
 
                         if (!leftType.ToRecord().TryGetType(property.InvariantName, out typeRhs))

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/INameResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/INameResolver.cs
@@ -67,9 +67,9 @@ namespace Microsoft.PowerFx.Core.Binding
         bool LookupParent(out NameLookupInfo lookupInfo);
 
         /// <summary>
-        /// In Canvas specifically, this is used to retrieve the full, derived, type
-        /// of a control object where the output schema may be dependent on a control inputs and heirarchy. 
-        /// All Non-Canvas hosts should not implement this method.
+        /// In Power Apps specifically, this is used to retrieve the full, derived, type
+        /// of a control object where the output schema may be dependent on a control inputs and hierarchy. 
+        /// All Non-Power Apps hosts should not implement this method.
         /// </summary>
         /// <param name="control">The control to get the full type of.</param>
         /// <param name="controlType">output: the expanded control type.</param>

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/INameResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/INameResolver.cs
@@ -66,6 +66,15 @@ namespace Microsoft.PowerFx.Core.Binding
         // Looks up the parent control for the current context.
         bool LookupParent(out NameLookupInfo lookupInfo);
 
+        /// <summary>
+        /// In Canvas specifically, this is used to retrieve the full, derived, type
+        /// of a control object where the output schema may be dependent on a control inputs and heirarchy. 
+        /// All Non-Canvas hosts should not implement this method.
+        /// </summary>
+        /// <param name="control">The control to get the full type of.</param>
+        /// <param name="controlType">output: the expanded control type.</param>
+        bool LookupExpandedControlType(IExternalControl control, out DType controlType);
+
         // Looks up the current control for the current context.
         bool LookupSelf(out NameLookupInfo lookupInfo);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
@@ -221,6 +221,11 @@ namespace Microsoft.PowerFx.Core.Functions
             {
                 return _globalNameResolver.TryLookupEnum(name, out lookupInfo);
             }
+
+            public bool LookupExpandedControlType(IExternalControl control, out DType controlType)
+            {
+                return _globalNameResolver.LookupExpandedControlType(control, out controlType);
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -7,10 +7,12 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.App;
+using Microsoft.PowerFx.Core.App.Controls;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
@@ -388,6 +390,11 @@ namespace Microsoft.PowerFx
             dataControlName = default;
             lookupInfo = default;
             return false;
+        }
+
+        bool INameResolver.LookupExpandedControlType(IExternalControl control, out DType controlType)
+        {
+            throw new NotImplementedException();
         }
         #endregion
     }


### PR DESCRIPTION
This change is a breaking-internals change, but it allows for safer testing of ongoing analysis improvements. It should have no impact on non-canvas hosts, other than up taking a new member, if they directly implement INameResolver, and IIRC, they should be using ReadOnlySymbolTable instead of directly using INameResolver. 