### PR TITLE
Update Text_Format.txt file

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -378,6 +378,13 @@ namespace Microsoft.PowerFx.Functions
             var formatString = textFormatArgs.FormatArg;
             result = null;
 
+            // There is a difference between Windows 10 and 11 for French locale
+            // We fix the thousand separator here to be consistent 
+            if (culture.Name == "fr-FR" && culture.NumberFormat.NumberGroupSeparator == "\uC2A0")
+            {
+                culture.NumberFormat.NumberGroupSeparator = "\uE280AF";
+            }
+
             Contract.Assert(StringValue.AllowedListConvertToString.Contains(value.Type));
 
             switch (value)
@@ -395,12 +402,7 @@ namespace Microsoft.PowerFx.Functions
                     }
                     else
                     {
-                        result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture));
-
-                        if (formatString == "#,##0.00")
-                        {
-                            result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture) + $" [{culture.Name}]");
-                        }
+                        result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture));                       
                     }
 
                     break;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
@@ -380,7 +379,7 @@ namespace Microsoft.PowerFx.Functions
 
             // There is a difference between Windows 10 and 11 for French locale
             // We fix the thousand separator here to be consistent 
-            if (culture.Name == "fr-FR" && culture.NumberFormat.NumberGroupSeparator == "\u00A0")
+            if (culture.Name.Equals("fr-FR", StringComparison.OrdinalIgnoreCase) && culture.NumberFormat.NumberGroupSeparator == "\u00A0")
             {
                 culture.NumberFormat.NumberGroupSeparator = "\u202F";
             }
@@ -402,7 +401,7 @@ namespace Microsoft.PowerFx.Functions
                     }
                     else
                     {
-                        result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture));                       
+                        result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture));
                     }
 
                     break;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -380,9 +380,9 @@ namespace Microsoft.PowerFx.Functions
 
             // There is a difference between Windows 10 and 11 for French locale
             // We fix the thousand separator here to be consistent 
-            if (culture.Name == "fr-FR" && culture.NumberFormat.NumberGroupSeparator == "\uC2A0")
+            if (culture.Name == "fr-FR" && culture.NumberFormat.NumberGroupSeparator == "\u00A0")
             {
-                culture.NumberFormat.NumberGroupSeparator = "\uE280AF";
+                culture.NumberFormat.NumberGroupSeparator = "\u202F";
             }
 
             Contract.Assert(StringValue.AllowedListConvertToString.Contains(value.Type));

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -396,6 +396,11 @@ namespace Microsoft.PowerFx.Functions
                     else
                     {
                         result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture));
+
+                        if (formatString == "#,##0.00")
+                        {
+                            result = new StringValue(irContext, num.Value.ToString(formatString ?? "g", culture) + $" [{culture.Name}]");
+                        }
                     }
 
                     break;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -652,7 +652,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 "1,234.57"
 
 >> Text(1234.5678, "[$-pt-BR]#.##0,00", "fr-FR")
-"1 234,57"
+"1 234,57"
 
 >> Text(1234.5678, "[$-en-US]#,##0.00", "pt-BR")
 "1.234,57"
@@ -672,7 +672,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 "12,345.68"
 
 >> Text(12345.6789, $"[$-fr-FR]#{ParseJSON("""\u202F""")}##0.00", "fr-FR")
-"12 345,68"
+"12 345,68"
 
 >> Text(1234.5678, "[$-en-US]", "en-US")
 "1234.5678"
@@ -684,7 +684,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 "1234.5678"
 
 >> Text(1234.5678, "# ##0,00", "fr-FR")
-"1 234,57"
+"1 234,57"
 
 >> Text(1234.5678, "[$-  fr-FR  ]    # ##0,00   ", "vi-VI")
 "1.234,57"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Core.Tests
@@ -221,7 +219,7 @@ namespace Microsoft.PowerFx.Core.Tests
                             // Compiler errors result in exceptions
                             return (TestResult.Pass, null);
                         }
-                        else if (NumberIsFloat && expected.StartsWith("Errors:") && 
+                        else if (NumberIsFloat && expected.StartsWith("Errors:") &&
                                  actualStr.Contains(Regex.Replace(expected, "(?<!Number,)(\\s|'|\\()Decimal(\\s|'|,|\\.|\\))", "$1Number$2")))
                         {
                             // Compiler errors result in exceptions
@@ -313,7 +311,7 @@ namespace Microsoft.PowerFx.Core.Tests
                     // strict compare binary decimal values after being parsed (for printing differences)
                     else if (originalResult is DecimalValue dec && decimal.Parse(expected, System.Globalization.NumberStyles.Float) == dec.Value)
                     {
-                            return (TestResult.Pass, null);
+                        return (TestResult.Pass, null);
                     }
                 }
 
@@ -331,7 +329,7 @@ namespace Microsoft.PowerFx.Core.Tests
                     {
                         return (TestResult.Pass, null);
                     }
-                }                
+                }
 
                 return (TestResult.Fail, $"\r\n  Expected: {expected}\r\n  Actual  : {actualStr}");
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -330,9 +331,9 @@ namespace Microsoft.PowerFx.Core.Tests
                     {
                         return (TestResult.Pass, null);
                     }
-                }
+                }                
 
-                return (TestResult.Fail, $"\r\n  Expected: {expected}\r\n  Actual  : {actualStr}");
+                return (TestResult.Fail, $"\r\n  Expected: {expected} [{BitConverter.ToString(Encoding.UTF8.GetBytes(expected))}] \r\n  Actual  : {actualStr} [{BitConverter.ToString(Encoding.UTF8.GetBytes(actualStr))}]");
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/BaseRunner.cs
@@ -333,7 +333,7 @@ namespace Microsoft.PowerFx.Core.Tests
                     }
                 }                
 
-                return (TestResult.Fail, $"\r\n  Expected: {expected} [{BitConverter.ToString(Encoding.UTF8.GetBytes(expected))}] \r\n  Actual  : {actualStr} [{BitConverter.ToString(Encoding.UTF8.GetBytes(actualStr))}]");
+                return (TestResult.Fail, $"\r\n  Expected: {expected}\r\n  Actual  : {actualStr}");
             }
         }
 


### PR DESCRIPTION
Fixing TXT file for tests that are impacting French locale
Fixed an issue with Windows 10 / 11 being inconsistent for the thousand separator