### PR TITLE
Allow better mutation controls. 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2805,7 +2805,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 if (lookupInfo.Kind == BindKind.PowerFxResolvedObject)
                 {
                     var nameSymbol = lookupInfo.Data as NameSymbol;
-                    _txb.SetMutable(node, nameSymbol?.IsMutable ?? false);
+                    _txb.SetMutable(node, nameSymbol?.Props.CanMutate ?? false);
                 }
                 else if (lookupInfo.Kind == BindKind.Data)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -102,7 +102,14 @@ namespace Microsoft.PowerFx
             // We only want to add these once. 
             var slotIndex = _slots.Alloc();
 
-            var data = new NameSymbol(logical, mutable: false)
+            // $$$ Take this as top-level param
+            var props = new SymbolProperties
+            {
+                 CanMutate = true,
+                 CanSet = false
+            };
+
+            var data = new NameSymbol(logical, props)
             {
                 Owner = this,
                 SlotIndex = slotIndex

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -101,8 +101,7 @@ namespace Microsoft.PowerFx
             // This is crticial that we're under lock.
             // We only want to add these once. 
             var slotIndex = _slots.Alloc();
-
-            // $$$ Take this as top-level param
+                        
             var props = new SymbolProperties
             {
                  CanMutate = true,

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/NameSymbol.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/NameSymbol.cs
@@ -24,14 +24,14 @@ namespace Microsoft.PowerFx
     [DebuggerDisplay("{Name} ({Owner.DebugName}:{SlotIndex})")]
     internal class NameSymbol : ISymbolSlot
     {
-        public NameSymbol(string name, bool mutable)
+        public NameSymbol(string name, SymbolProperties props)
         {
             Name = name;
-            IsMutable = mutable;
+            Props = props ?? throw new ArgumentNullException(nameof(props));
         }
 
-        public NameSymbol(DName name, bool mutable)
-            : this(name.Value, mutable)
+        public NameSymbol(DName name, SymbolProperties props)
+            : this(name.Value, props)
         {
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.PowerFx
         /// <summary>
         /// Can this variable be passed to Set(). If not, then this is a binding failure. 
         /// </summary>
-        public bool IsMutable { get; private set; }
+        public SymbolProperties Props { get; private set; }
 
         public ReadOnlySymbolTable Owner { get; set; }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolProperties.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolProperties.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.PowerFx.Core;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Binding.BindInfo;
+using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Types.Enums;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{    
+    public class SymbolProperties
+    {
+        // Can this symbol be reassigned with a Set() function. 
+        public bool CanSet { get; init; }
+
+        // Can this symbol be passed to Collect, Patch() for mutation 
+        // This only applies to symbols of a tabular type. 
+        public bool CanMutate { get; init; }
+
+        // Is Copyable?
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -78,8 +78,7 @@ namespace Microsoft.PowerFx
             return _variables.TryGetValue(lookupName, out symbol);
         }
 
-        // $$$ too many callers...
-        // [Obsolete("Use overload with SymbolProperties")]
+        // Exists for binary backcompat.
         public ISymbolSlot AddVariable(string name, FormulaType type, bool mutable = false, string displayName = null)
         {
             var props = new SymbolProperties

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -11,6 +11,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Texl.Builtins;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
@@ -77,6 +78,18 @@ namespace Microsoft.PowerFx
             return _variables.TryGetValue(lookupName, out symbol);
         }
 
+        // $$$ too many callers...
+        // [Obsolete("Use overload with SymbolProperties")]
+        public ISymbolSlot AddVariable(string name, FormulaType type, bool mutable = false, string displayName = null)
+        {
+            var props = new SymbolProperties
+            {
+                CanSet = mutable,
+                CanMutate = mutable
+            };
+            return AddVariable(name, type, props, displayName);
+        }
+
         /// <summary>
         /// Provide variable for binding only.
         /// Value must be provided at runtime.
@@ -84,10 +97,25 @@ namespace Microsoft.PowerFx
         /// </summary>
         /// <param name="name"></param>
         /// <param name="type"></param>
-        /// <param name="mutable"></param>
+        /// <param name="props"></param>
         /// <param name="displayName"></param>
-        public ISymbolSlot AddVariable(string name, FormulaType type, bool mutable = false, string displayName = null)
+        public ISymbolSlot AddVariable(string name, FormulaType type, SymbolProperties props, string displayName = null)
         {
+            if (props == null)
+            {
+                // Default.
+                props = new SymbolProperties();
+            }
+
+            /*
+            if (props.CanMutate)
+            {
+                if (type is not TableType)
+                {
+                    throw new InvalidOperationException($"Only TableTypes are mutable");
+                }
+            }*/
+
             using var guard = _guard.Enter(); // Region is single threaded.
 
             Inc();
@@ -110,7 +138,7 @@ namespace Microsoft.PowerFx
             }
 
             var slotIndex = _slots.Alloc();
-            var data = new NameSymbol(name, mutable)
+            var data = new NameSymbol(name, props)
             {
                 Owner = this,
                 SlotIndex = slotIndex

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -107,15 +107,6 @@ namespace Microsoft.PowerFx
                 props = new SymbolProperties();
             }
 
-            /*
-            if (props.CanMutate)
-            {
-                if (type is not TableType)
-                {
-                    throw new InvalidOperationException($"Only TableTypes are mutable");
-                }
-            }*/
-
             using var guard = _guard.Enter(); // Region is single threaded.
 
             Inc();

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTableOverRecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTableOverRecordType.cs
@@ -37,7 +37,11 @@ namespace Microsoft.PowerFx
 
             if (_allowThisRecord)
             {
-                var data = new NameSymbol(TexlBinding.ThisRecordDefaultName, mutable: false)
+                var data = new NameSymbol(TexlBinding.ThisRecordDefaultName, new SymbolProperties
+                {
+                     CanMutate = false,
+                     CanSet = false
+                })
                 {
                     Owner = this,
                     SlotIndex = int.MaxValue
@@ -174,7 +178,11 @@ namespace Microsoft.PowerFx
                     // Slot is based on map count, so whole operation needs to be under single lock. 
                     var slotIdx = _map.Count;
 
-                    data = new NameSymbol(logicalName, _mutable)
+                    data = new NameSymbol(logicalName, new SymbolProperties
+                    {
+                        CanSet = _mutable,
+                        CanMutate = false
+                    })
                     {
                         Owner = this,
                         SlotIndex = slotIdx

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
@@ -69,7 +69,7 @@ namespace Microsoft.PowerFx.Interpreter
             if (firstName != null)
             {
                 var info = binding.GetInfo(firstName);
-                if (info.Data is NameSymbol nameSymbol && nameSymbol.IsMutable)
+                if (info.Data is NameSymbol nameSymbol && nameSymbol.Props.CanSet)
                 {
                     // We have a variable. type check
                     var arg1 = argTypes[1];

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -48,6 +48,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.PowerFxConfig",
                 "Microsoft.PowerFx.ReadOnlySymbolTable",
                 "Microsoft.PowerFx.SymbolTable",
+                "Microsoft.PowerFx.SymbolProperties",
 
                 // Lexer                
                 "Microsoft.PowerFx.Syntax.BinaryOp",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -877,7 +877,7 @@ namespace Microsoft.PowerFx.Tests
             optionSet.TryGetValue(new DName("option_1"), out var option1);
 
             var symbol = new SymbolTable();
-            var option1Solt = symbol.AddVariable("Option1", FormulaType.OptionSetValue);
+            var option1Solt = symbol.AddVariable("Option1", FormulaType.OptionSetValue, null);
             var symValues = new SymbolValues(symbol);
             symValues.Set(option1Solt, option1);
 
@@ -1108,7 +1108,7 @@ namespace Microsoft.PowerFx.Tests
         public async Task ExecutingWithRemovedVarFails()
         {
             var symTable = new SymbolTable();
-            var slot = symTable.AddVariable("x", FormulaType.Number);
+            var slot = symTable.AddVariable("x", FormulaType.Number, null);
 
             var engine = new RecalcEngine();
             var result = engine.Check("x+1", symbolTable: symTable);
@@ -1122,7 +1122,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(11.0, result1.ToObject());
 
             // Adding a variable is ok. 
-            var slotY = symTable.AddVariable("y", FormulaType.Number);
+            var slotY = symTable.AddVariable("y", FormulaType.Number, null);
             result1 = await eval.EvalAsync(CancellationToken.None, symValues).ConfigureAwait(false);
             Assert.Equal(11.0, result1.ToObject());
 
@@ -1132,7 +1132,7 @@ namespace Microsoft.PowerFx.Tests
 
             // Even re-adding with same type still fails. 
             // (somebody could have re-added with a different type)
-            var slot2 = symTable.AddVariable("x", FormulaType.Number);
+            var slot2 = symTable.AddVariable("x", FormulaType.Number, null);
             symValues.Set(slot2, FormulaValue.New(20));
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await eval.EvalAsync(CancellationToken.None, symValues).ConfigureAwait(false)).ConfigureAwait(false);
@@ -1191,7 +1191,7 @@ namespace Microsoft.PowerFx.Tests
                 new NamedValue("Field2", FormulaValue.New("_field2")));
 
             var globals = new SymbolTable();
-            var slot = globals.AddVariable("Task", FormulaType.String);
+            var slot = globals.AddVariable("Task", FormulaType.String, null);
             
             var rowScope = ReadOnlySymbolTable.NewFromRecord(record.Type, allowThisRecord: true);
 


### PR DESCRIPTION
Before, Set() and Collect()  were both tied ot a single IsMutable concept. 
Need to decouple to allow scenarios like:

Set(Accounts, ....)  // Fail
Collect(Accounts, ... ) // Succeed
Set(ThisRecord.field1, ...) // succeed

Collect([1,2,3,4], ..) // fail
Set([1,2,3,4], ..) // fail

Set(namedFormula1, ...); // fail 

Set(x, [1,2,3,4], ..) // Succeed
Collect(x, {5}) // Succeed



