### PR TITLE
Fix 1594

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
@@ -73,11 +73,21 @@ namespace Microsoft.PowerFx
             {
                 for (var i = 0; i < args.Length; i++)
                 {
-                    DType curType = argTypes[i];
+                    DType curType = argTypes[i]; // caller
+                    DType paramType = this.ParamTypes[i]; // callsite 
 
-                    if ((curType.IsRecord || curType.IsTable) && !curType.CheckAggregateNames(this.ParamTypes[i], args[i], errors, SupportCoercionForArg(i), context.Features.PowerFxV1CompatibilityRules))
+                    if (curType.IsRecord || curType.IsTable)
                     {
-                        return false;
+                        // If param type is an empty record, then don't enforce. 
+                        if (paramType.ChildCount == 0)
+                        {
+                            continue;
+                        }
+
+                        if (!curType.CheckAggregateNames(paramType, args[i], errors, SupportCoercionForArg(i), context.Features.PowerFxV1CompatibilityRules))
+                        {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
@@ -298,24 +298,28 @@ namespace Microsoft.PowerFx
             {
                 bool isValid = false;
 
-                if (retType.IsRecord || retType.IsTable)
+                if (formulaResultType.IsRecord || formulaResultType.IsTable)
                 {
                     isValid = true;
 
-                    // Check if all names in formulaResultType exist in retType
-                    foreach (var typedName in formulaResultType.GetNames(DPath.Root))
+                    // if retType is an empty record, then don't enforce.
+                    if (retType.ChildCount != 0)
                     {
-                        if (!retType.TryGetType(typedName.Name, out DType dsNameType))
+                        // Check if all names in formulaResultType exist in retType
+                        foreach (var typedName in formulaResultType.GetNames(DPath.Root))
+                        {
+                            if (!retType.TryGetType(typedName.Name, out DType dsNameType))
+                            {
+                                isValid = false;
+                                continue;
+                            }
+                        }
+
+                        // Check if formulaResultType can coerce to retType
+                        if (isValid && !formulaResultType.CoercesTo(retType, aggregateCoercion: false, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: true))
                         {
                             isValid = false;
-                            continue;
                         }
-                    }
-
-                    // Check if formulaResultType can coerce to retType
-                    if (isValid && !formulaResultType.CoercesTo(retType, aggregateCoercion: false, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: true))
-                    {
-                        isValid = false;
                     }
                 }
 


### PR DESCRIPTION
Tactical fix #1594 . 

Need to let Dataver
All the dataverse custom functions are also failing to bind on new Fx builds due to #1490.   

Eg, consider a custom function like:

"XSendEmailFromTemplate(GUID(\"88000000-0000-0000-0000-000000000001\"),First(Entity1s),First(Entity1s),[\"valid@contoso.com\"])"

 Before, for arguments that took Dataverse records, they'd specify empty record value.  

: base("XSendEmailFromTemplate", FormulaType.Guid , FormulaType.Guid, RecordType.Empty(), RecordType.Empty(), TableType.Empty())

But with 1490, passing a dataverse record to an empty record is a mismatch (extra fields). 
But we still need some way to allow dataverse records. So allow empty records to accept any type. Need to find a stronger enforcement.  
