### PR TITLE
Backwards compat shims for Dataverse

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/IUserInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/IUserInfo.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerFx
+{
+    // Backwards compat shim 
+    [Obsolete("Use UserInfo")]
+    public interface IUserInfo
+    {
+        string FullName { get; }
+
+        string Email { get; }
+
+        string Id { get; }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
@@ -73,21 +73,11 @@ namespace Microsoft.PowerFx
             {
                 for (var i = 0; i < args.Length; i++)
                 {
-                    DType curType = argTypes[i]; // caller
-                    DType paramType = this.ParamTypes[i]; // callsite 
+                    DType curType = argTypes[i];
 
-                    if (curType.IsRecord || curType.IsTable)
+                    if ((curType.IsRecord || curType.IsTable) && !curType.CheckAggregateNames(this.ParamTypes[i], args[i], errors, SupportCoercionForArg(i), context.Features.PowerFxV1CompatibilityRules))
                     {
-                        // If param type is an empty record, then don't enforce. 
-                        if (paramType.ChildCount == 0)
-                        {
-                            continue;
-                        }
-
-                        if (!curType.CheckAggregateNames(paramType, args[i], errors, SupportCoercionForArg(i), context.Features.PowerFxV1CompatibilityRules))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
@@ -73,11 +73,21 @@ namespace Microsoft.PowerFx
             {
                 for (var i = 0; i < args.Length; i++)
                 {
-                    DType curType = argTypes[i];
+                    DType curType = argTypes[i]; // caller
+                    DType paramType = this.ParamTypes[i]; // callsite 
 
-                    if ((curType.IsRecord || curType.IsTable) && !curType.CheckAggregateNames(this.ParamTypes[i], args[i], errors, SupportCoercionForArg(i), context.Features.PowerFxV1CompatibilityRules))
+                    if (curType.IsRecord || curType.IsTable)
                     {
-                        return false;
+                        // If param type is an empty record, then don't enforce. 
+                        if (paramType.ChildCount == 0)
+                        {
+                            continue;
+                        }
+
+                        if (!curType.CheckAggregateNames(paramType, args[i], errors, SupportCoercionForArg(i), context.Features.PowerFxV1CompatibilityRules))
+                        {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolTableExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolTableExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+    [Obsolete("Remove this")]
+    public static class SymbolTableExtensions
+    {
+        /// <summary>
+        /// Adds a UserInfo object schema.
+        /// Actual object is added in Runtime config service provider.
+        /// </summary>
+        public static void AddUserInfoObject(this SymbolTable symbolTable)
+        {
+            var userInfoType = RecordType.Empty()
+                .Add("FullName", FormulaType.String)
+                .Add("Email", FormulaType.String)
+                .Add("Id", FormulaType.String);
+
+            symbolTable.AddHostObject("User", userInfoType, GetUserInfoObject);
+        }
+
+        private static FormulaValue GetUserInfoObject(IServiceProvider serviceProvider)
+        {
+            var userInfo = (IUserInfo)serviceProvider.GetService(typeof(IUserInfo)) ?? throw new InvalidOperationException("UserInfo object was not added to service");
+
+            RecordValue userRecord = FormulaValue.NewRecordFromFields(
+                new NamedValue("FullName", FormulaValue.New(userInfo.FullName ?? string.Empty)),
+                new NamedValue("Email", FormulaValue.New(userInfo.Email ?? string.Empty)),
+                new NamedValue("Id", FormulaValue.New(userInfo.Id ?? string.Empty)));
+
+            return userRecord;
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -177,7 +177,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Utils.DName",
                 "Microsoft.PowerFx.Core.Utils.DPath",
                 "Microsoft.PowerFx.Core.Utils.ICheckable",                
-                "Microsoft.PowerFx.UserInfo"                
+                "Microsoft.PowerFx.UserInfo",
+                "Microsoft.PowerFx.IUserInfo" // Deprecated, remove. 
             };
 
             var sb = new StringBuilder();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -64,6 +64,7 @@ namespace Microsoft.PowerFx.Tests
                 $"{ns}.Interpreter.{nameof(CustomFunctionErrorException)}",
                 $"{ns}.Interpreter.UDF.{nameof(DefineFunctionsResult)}",
                 $"{ns}.{nameof(TypeCoercionProvider)}",
+                "Microsoft.PowerFx.SymbolTableExtensions", // Deprecated, remove. 
 
                 // Services for functions. 
                 $"{ns}.Functions.IRandomService"


### PR DESCRIPTION
Fix #1592 

We should be able to revert this change after DV moves off the old surface. 

