### PR TITLE
Allow constant nodes (not only constant string expressions) to be used in IsMatch

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsMatch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsMatch.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Binding;
@@ -10,7 +9,6 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
-using static Microsoft.PowerFx.Syntax.PrettyPrintVisitor;
 
 #pragma warning disable SA1649 // File name should match first type name
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsMatch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsMatch.cs
@@ -10,6 +10,7 @@ using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
+using static Microsoft.PowerFx.Syntax.PrettyPrintVisitor;
 
 #pragma warning disable SA1649 // File name should match first type name
 
@@ -41,19 +42,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.IsMatchArg1, TexlStrings.IsMatchArg2, TexlStrings.IsMatchArg3 };
         }
 
-        public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        public override void CheckSemantics(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors)
         {
-            bool fValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);            
-
-            TexlNode regExNode = args[1];
-            
-            if ((argTypes[1].Kind != DKind.String && argTypes[1].Kind != DKind.OptionSetValue) || !BinderUtils.TryGetConstantValue(context, regExNode, out var nodeValue))                
+            if ((argTypes[1].Kind != DKind.String && argTypes[1].Kind != DKind.OptionSetValue) || !binding.IsConstant(args[1]))
             {
-                errors.EnsureError(regExNode, TexlStrings.ErrVariableRegEx);
-                return false;
+                errors.EnsureError(args[1], TexlStrings.ErrVariableRegEx);
             }
-
-            return fValid;
         }
 
         public override bool HasSuggestionsForParam(int index)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsMatch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsMatch.txt
@@ -139,3 +139,6 @@ false
 
 >> IsMatch("""Hello world""", Char(34) & "Hello",  MatchOptions.Contains)
 true
+
+>> IsMatch("Hello 123 world", $"Hello {Sqrt(1)}{Sqrt(4)}{Sqrt(9)} world")
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsMatch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IsMatch.txt
@@ -136,3 +136,6 @@ true
 
 >> IsMatch("(44) 123-4567", "^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$")
 false
+
+>> IsMatch("""Hello world""", Char(34) & "Hello",  MatchOptions.Contains)
+true


### PR DESCRIPTION
This was the previous behavior - we should revert to what we had before. Since IsMatch doesn't need to know the value of the regular expressions at compile-time (unlike Match[All], which need it to determine the output schema), the constant check can be less strict.