### PR TITLE
Component Function property - Block access to all DottedNameNode

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3361,12 +3361,15 @@ namespace Microsoft.PowerFx.Core.Binding
                         return;
                     }
 
-                    bool isComponentDataProperty = template.IsComponent &&
+                    bool isBindingPropertyFunctionPropertyOrParameter = (_txb.Property?.IsScopeVariable ?? false) || (_txb.Property?.IsScopedProperty ?? false);
+                    bool isReferencedPropertyDataProperty = !property.IsScopedProperty && !property.IsScopeVariable && property.PropertyCategory == PropertyRuleCategory.Data;
+                    bool isFunctionPropertyReferencingDataProperty = template.IsComponent &&
                         (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
-                        !property.IsScopedProperty && !property.IsScopeVariable && property.PropertyCategory == PropertyRuleCategory.Data;
-                    if (isComponentDataProperty)
+                        isBindingPropertyFunctionPropertyOrParameter &&
+                        isReferencedPropertyDataProperty;
+                    if (isFunctionPropertyReferencingDataProperty)
                     {
-                        SetDottedNameError(node, TexlStrings.ErrInvalidPropertyReference);
+                        SetDottedNameError(node, TexlStrings.ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess);
                         return;
                     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3361,6 +3361,15 @@ namespace Microsoft.PowerFx.Core.Binding
                         return;
                     }
 
+                    bool isComponentDataProperty = template.IsComponent &&
+                        (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
+                        !property.IsScopedProperty && !property.IsScopeVariable && property.PropertyCategory == PropertyRuleCategory.Data;
+                    if (isComponentDataProperty)
+                    {
+                        SetDottedNameError(node, TexlStrings.ErrInvalidPropertyReference);
+                        return;
+                    }
+
                     // We block the property access usage for datasource of the command component.
                     if (template.IsCommandComponent &&
                         _txb._glue.IsPrimaryCommandComponentProperty(property))

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3361,6 +3361,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         return;
                     }
 
+                    // Binding function property and its parameters should not allow DottedNameNode
                     bool isBindingPropertyFunctionPropertyOrParameter = template.IsComponent &&
                         (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
                         _txb.Property?.PropertyCategory == PropertyRuleCategory.Data &&

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3361,12 +3361,10 @@ namespace Microsoft.PowerFx.Core.Binding
                         return;
                     }
 
-                    bool isBindingPropertyFunctionPropertyOrParameter = (_txb.Property?.IsScopeVariable ?? false) || (_txb.Property?.IsScopedProperty ?? false);
-                    bool isReferencedPropertyDataProperty = !property.IsScopedProperty && !property.IsScopeVariable && property.PropertyCategory == PropertyRuleCategory.Data;
-                    bool isFunctionPropertyReferencingDataProperty = template.IsComponent &&
+                    bool isBindingPropertyFunctionPropertyOrParameter = template.IsComponent &&
                         (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
-                        isBindingPropertyFunctionPropertyOrParameter;
-                    if (isFunctionPropertyReferencingDataProperty)
+                        ((_txb.Property?.IsScopeVariable ?? false) || (_txb.Property?.IsScopedProperty ?? false));
+                    if (isBindingPropertyFunctionPropertyOrParameter)
                     {
                         SetDottedNameError(node, TexlStrings.ErrUnSupportedComponentFunctionPropertyReferenceNonFunctionPropertyAccess);
                         return;

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3363,6 +3363,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                     bool isBindingPropertyFunctionPropertyOrParameter = template.IsComponent &&
                         (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
+                        _txb.Property?.PropertyCategory == PropertyRuleCategory.Data &&
                         ((_txb.Property?.IsScopeVariable ?? false) || (_txb.Property?.IsScopedProperty ?? false));
                     if (isBindingPropertyFunctionPropertyOrParameter)
                     {

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3365,11 +3365,10 @@ namespace Microsoft.PowerFx.Core.Binding
                     bool isReferencedPropertyDataProperty = !property.IsScopedProperty && !property.IsScopeVariable && property.PropertyCategory == PropertyRuleCategory.Data;
                     bool isFunctionPropertyReferencingDataProperty = template.IsComponent &&
                         (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
-                        isBindingPropertyFunctionPropertyOrParameter &&
-                        isReferencedPropertyDataProperty;
+                        isBindingPropertyFunctionPropertyOrParameter;
                     if (isFunctionPropertyReferencingDataProperty)
                     {
-                        SetDottedNameError(node, TexlStrings.ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess);
+                        SetDottedNameError(node, TexlStrings.ErrUnSupportedComponentFunctionPropertyReferenceNonFunctionPropertyAccess);
                         return;
                     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -529,6 +529,7 @@ namespace Microsoft.PowerFx.Core.Localization
         // Any new additions here should be of type ErrorResourceKey and contain the value of the resource key.
         public static ErrorResourceKey ErrUnSupportedComponentBehaviorInvocation = new ErrorResourceKey("ErrUnSupportedComponentBehaviorInvocation");
         public static ErrorResourceKey ErrUnSupportedComponentDataPropertyAccess = new ErrorResourceKey("ErrUnSupportedComponentDataPropertyAccess");
+        public static ErrorResourceKey ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess = new ErrorResourceKey("ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess");
         public static ErrorResourceKey ErrOperandExpected = new ErrorResourceKey("ErrOperandExpected");
         public static ErrorResourceKey ErrBadToken = new ErrorResourceKey("ErrBadToken");
         public static ErrorResourceKey UnexpectedCharacterToken = new ErrorResourceKey("UnexpectedCharacterToken");

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -529,7 +529,7 @@ namespace Microsoft.PowerFx.Core.Localization
         // Any new additions here should be of type ErrorResourceKey and contain the value of the resource key.
         public static ErrorResourceKey ErrUnSupportedComponentBehaviorInvocation = new ErrorResourceKey("ErrUnSupportedComponentBehaviorInvocation");
         public static ErrorResourceKey ErrUnSupportedComponentDataPropertyAccess = new ErrorResourceKey("ErrUnSupportedComponentDataPropertyAccess");
-        public static ErrorResourceKey ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess = new ErrorResourceKey("ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess");
+        public static ErrorResourceKey ErrUnSupportedComponentFunctionPropertyReferenceNonFunctionPropertyAccess = new ErrorResourceKey("ErrUnSupportedComponentFunctionPropertyReferenceNonFunctionPropertyAccess");
         public static ErrorResourceKey ErrOperandExpected = new ErrorResourceKey("ErrOperandExpected");
         public static ErrorResourceKey ErrBadToken = new ErrorResourceKey("ErrBadToken");
         public static ErrorResourceKey UnexpectedCharacterToken = new ErrorResourceKey("UnexpectedCharacterToken");

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1742,7 +1742,11 @@
     <comment>Error Message.</comment>
   </data>
   <data name="ErrUnSupportedComponentDataPropertyAccess" xml:space="preserve">
-    <value>Component custom data property with parameters can only be accessed from within a component or from component output properties.</value>
+    <value>Component function property or parameter can only be accessed from within a component or from component output properties.</value>
+    <comment>Error Message.</comment>
+  </data>
+  <data name="ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess" xml:space="preserve">
+    <value>Component function property or parameter cannot access data property.</value>
     <comment>Error Message.</comment>
   </data>
   <data name="ErrBadArity" xml:space="preserve">

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1745,8 +1745,8 @@
     <value>Component function property or parameter can only be accessed from within a component or from component output properties.</value>
     <comment>Error Message.</comment>
   </data>
-  <data name="ErrUnSupportedComponentFunctionPropertyReferenceDataPropertyAccess" xml:space="preserve">
-    <value>Component function property or parameter cannot access data property.</value>
+  <data name="ErrUnSupportedComponentFunctionPropertyReferenceNonFunctionPropertyAccess" xml:space="preserve">
+    <value>Component function property or parameter can only reference other function properties.</value>
     <comment>Error Message.</comment>
   </data>
   <data name="ErrBadArity" xml:space="preserve">


### PR DESCRIPTION
In order to support function to function reference, we need to allow component control to be returned as a lookupInfo. This, however, also allows reference to all properties of the component. Since we only want function to function reference, we need to restrict all DottedNameNode in the binder.