### PR TITLE
Connector swagger parser improvements

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ArgumentMapper.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ArgumentMapper.cs
@@ -81,6 +81,11 @@ namespace Microsoft.PowerFx.Connectors
             {
                 bool hiddenRequired = false;
 
+                if (param == null)
+                {
+                    throw new PowerFxConnectorException("OpenApiParameters cannot be null, this swagger file is probably containing errors");
+                }
+
                 if (param.IsInternal())
                 {
                     if (param.Required && param.Schema.Default != null)
@@ -99,7 +104,7 @@ namespace Microsoft.PowerFx.Connectors
                 ConnectorParameterType cpt = param.Schema.ToFormulaType(numberIsFloat: numberIsFloat);
                 cpt.SetProperties(param.Name, param.Required);
 
-                ConnectorDynamicValue connectorDynamicValue = GetDynamicValue(param);
+                ConnectorDynamicValue connectorDynamicValue = GetDynamicValue(param, numberIsFloat);
                 string summary = GetSummary(param);
                 bool explicitInput = GetExplicitInput(param);
 
@@ -154,7 +159,7 @@ namespace Microsoft.PowerFx.Connectors
                     if (!string.IsNullOrEmpty(contentType) && mediaType != null)
                     {
                         OpenApiSchema schema = mediaType.Schema;
-                        ConnectorDynamicSchema connectorDynamicSchema = GetDynamicSchema(schema);
+                        ConnectorDynamicSchema connectorDynamicSchema = GetDynamicSchema(schema, numberIsFloat);
 
                         ContentType = contentType;
                         ReferenceId = schema?.Reference?.Id;
@@ -407,7 +412,7 @@ namespace Microsoft.PowerFx.Connectors
             return param.Extensions != null && param.Extensions.TryGetValue("x-ms-explicit-input", out IOpenApiExtension ext) && ext is OpenApiBoolean apiBool ? apiBool.Value : false;            
         }
 
-        private static ConnectorDynamicValue GetDynamicValue(IOpenApiExtensible param)
+        private static ConnectorDynamicValue GetDynamicValue(IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
             if (param.Extensions != null && param.Extensions.TryGetValue("x-ms-dynamic-values", out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
@@ -423,39 +428,11 @@ namespace Microsoft.PowerFx.Connectors
                 if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)
                 {
                     if (apiObj.TryGetValue("parameters", out IOpenApiAny op_prms) && op_prms is OpenApiObject opPrms)
-                    {
-                        Dictionary<string, string> dvParams = new ();
-
-                        foreach (KeyValuePair<string, IOpenApiAny> prm in opPrms)
-                        {
-                            // dynamic parameter
-                            if (prm.Value is OpenApiObject prmStr)
-                            {
-                                if (prmStr.Count != 1)
-                                {
-                                    throw new NotImplementedException($"Not expecting more than one parameter string per parameter");
-                                }
-
-                                if (prmStr.First().Value is OpenApiString prmStr2)
-                                {
-                                    dvParams.Add(prm.Key, prmStr2.Value);
-                                }
-                                else
-                                {
-                                    throw new NotImplementedException($"Unsupported OpenApi inner type {prmStr.First().Value.GetType().FullName}");
-                                }
-                            }
-                            else
-                            {
-                                // We do not support static parameters for now
-                                throw new NotImplementedException($"Unsupported static param with OpenApi type {prm.Value.GetType().FullName}");
-                            }
-                        }
-
+                    {                        
                         ConnectorDynamicValue cdv = new ()
                         {
                             OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
-                            ParameterMap = dvParams
+                            ParameterMap = GetOpenApiObject(opPrms, numberIsFloat)
                         };
 
                         if (apiObj.TryGetValue("value-title", out IOpenApiAny op_valtitle) && op_valtitle is OpenApiString opValTitle)
@@ -491,7 +468,24 @@ namespace Microsoft.PowerFx.Connectors
             return null;
         }
 
-        private static ConnectorDynamicSchema GetDynamicSchema(IOpenApiExtensible param)
+        private static Dictionary<string, string> GetOpenApiObject(OpenApiObject opPrms, bool numberIsFloat)
+        {
+            Dictionary<string, string> dvParams = new ();
+
+            foreach (KeyValuePair<string, IOpenApiAny> prm in opPrms)
+            {                
+                if (!OpenApiExtensions.TryGetOpenApiValue(prm.Value, out FormulaValue fv, numberIsFloat))
+                {
+                    throw new NotImplementedException($"Unsupported param with OpenApi type {prm.Value.GetType().FullName}, key = {prm.Key}");
+                }
+
+                dvParams.Add(prm.Key, System.Text.Json.JsonSerializer.Serialize(fv.ToObject()));
+            }
+
+            return dvParams;
+        }
+
+        private static ConnectorDynamicSchema GetDynamicSchema(IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
             if (param.Extensions != null && param.Extensions.TryGetValue("x-ms-dynamic-schema", out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
@@ -500,39 +494,11 @@ namespace Microsoft.PowerFx.Connectors
                 if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)
                 {
                     if (apiObj.TryGetValue("parameters", out IOpenApiAny op_prms) && op_prms is OpenApiObject opPrms)
-                    {
-                        Dictionary<string, string> dvParams = new ();
-
-                        foreach (KeyValuePair<string, IOpenApiAny> prm in opPrms)
-                        {
-                            // dynamic parameter
-                            if (prm.Value is OpenApiObject prmStr)
-                            {
-                                if (prmStr.Count != 1)
-                                {
-                                    throw new NotImplementedException($"Not expecting more than one parameter string per parameter");
-                                }
-
-                                if (prmStr.First().Value is OpenApiString prmStr2)
-                                {
-                                    dvParams.Add(prm.Key, prmStr2.Value);
-                                }
-                                else
-                                {
-                                    throw new NotImplementedException($"Unsupported OpenApi inner type {prmStr.First().Value.GetType().FullName}");
-                                }
-                            }
-                            else
-                            {
-                                // We do not support static parameters for now
-                                throw new NotImplementedException($"Unsupported static param with OpenApi type {prm.Value.GetType().FullName}");
-                            }
-                        }
-
+                    {                       
                         ConnectorDynamicSchema cds = new ()
                         {
                             OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
-                            ParameterMap = dvParams
+                            ParameterMap = GetOpenApiObject(opPrms, numberIsFloat)
                         };
 
                         if (apiObj.TryGetValue("value-path", out IOpenApiAny op_valpath) && op_valpath is OpenApiString opValPath)

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -271,7 +271,6 @@ namespace Microsoft.PowerFx.Connectors
 
                     switch (schema.Format)
                     {                        
-
                         case "date":
                         case "date-time":
                         case "date-no-tz":

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -3,13 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
-using System.Net.NetworkInformation;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
@@ -75,11 +77,16 @@ namespace Microsoft.PowerFx.Connectors
                         if (item is OpenApiObject obj)
                         {
                             // has keys, "value", and "displayName"
-                            if (obj.TryGetValue("value", out var value2))
+                            if (obj.TryGetValue("value", out IOpenApiAny value2))
                             {
                                 if (value2 is OpenApiString str)
                                 {
                                     list.Add(str.Value);
+                                    continue;
+                                }
+                                else if (value2 is OpenApiInteger i)
+                                {
+                                    list.Add(i.Value.ToString(CultureInfo.InvariantCulture));
                                     continue;
                                 }
                             }
@@ -106,9 +113,9 @@ namespace Microsoft.PowerFx.Connectors
 
         public static bool TryGetDefaultValue(this OpenApiSchema schema, FormulaType formulaType, out FormulaValue defaultValue, bool numberIsFloat = false)
         {
-            var x = schema.Default;
+            IOpenApiAny openApiDefaultValue = schema.Default;
 
-            if (x == null)
+            if (openApiDefaultValue == null)
             {
                 if (formulaType is RecordType rt && schema.Properties != null)
                 {
@@ -137,37 +144,97 @@ namespace Microsoft.PowerFx.Connectors
                 defaultValue = null;
                 return false;
             }
+            
+            return TryGetOpenApiValue(openApiDefaultValue, out defaultValue, numberIsFloat);
+        }
 
-            if (x is OpenApiString str)
+        internal static bool TryGetOpenApiValue(IOpenApiAny openApiAny, out FormulaValue formulaValue, bool numberIsFloat = false)
+        {
+            if (openApiAny is OpenApiString str)
             {
-                defaultValue = FormulaValue.New(str.Value); // StringValue
-                return true;
+                formulaValue = FormulaValue.New(str.Value);
+            }
+            else if (openApiAny is OpenApiInteger intVal)
+            {
+                formulaValue = numberIsFloat ? FormulaValue.New(intVal.Value) : FormulaValue.New((decimal)intVal.Value);
+            }
+            else if (openApiAny is OpenApiDouble dbl)
+            {
+                formulaValue = numberIsFloat ? FormulaValue.New(dbl.Value) : FormulaValue.New((decimal)dbl.Value);
+            }
+            else if (openApiAny is OpenApiLong lng)
+            {
+                formulaValue = numberIsFloat ? FormulaValue.New(lng.Value) : FormulaValue.New((decimal)lng.Value);
+            }
+            else if (openApiAny is OpenApiBoolean b)
+            {
+                formulaValue = FormulaValue.New(b.Value);
+            }
+            else if (openApiAny is OpenApiFloat flt)
+            {
+                formulaValue = numberIsFloat ? FormulaValue.New(flt.Value) : FormulaValue.New((decimal)flt.Value);
+            }
+            else if (openApiAny is OpenApiByte by)
+            {
+                // OpenApi library uses Convert.FromBase64String
+                formulaValue = FormulaValue.New(Convert.ToBase64String(by.Value));
+            }
+            else if (openApiAny is OpenApiDateTime dt)
+            {
+                // A string like "2022-11-18" is interpreted as a DateTimeOffset
+                // https://github.com/microsoft/OpenAPI.NET/issues/533
+                throw new PowerFxConnectorException($"Unsupported OpenApiDateTime {dt.Value}");
+            }
+            else if (openApiAny is OpenApiPassword pw)
+            {
+                formulaValue = FormulaValue.New(pw.Value);
+            }
+            else if (openApiAny is OpenApiNull)
+            {
+                formulaValue = FormulaValue.NewBlank();
+            }
+            else if (openApiAny is OpenApiArray arr)
+            {                
+                List<FormulaValue> lst = new List<FormulaValue>();
+
+                foreach (IOpenApiAny element in arr)
+                {
+                    bool ba = TryGetOpenApiValue(element, out FormulaValue fv, numberIsFloat);
+                    if (!ba)
+                    {
+                        formulaValue = null;
+                        return false;
+                    }
+
+                    lst.Add(fv);
+                }
+
+                RecordType recordType = RecordType.Empty().Add(TableValue.ValueName, FormulaType.String);
+                IRContext irContext = IRContext.NotInSource(recordType);
+                IEnumerable<InMemoryRecordValue> recordValues = lst.Select(item => new InMemoryRecordValue(irContext, new NamedValue[] { new NamedValue(TableValue.ValueName, item) }));
+
+                formulaValue = FormulaValue.NewTable(recordType, recordValues);
+            }
+            else if (openApiAny is OpenApiObject o)
+            {
+                Dictionary<string, FormulaValue> dvParams = new ();
+
+                foreach (KeyValuePair<string, IOpenApiAny> kvp in o)
+                {                    
+                    if (TryGetOpenApiValue(kvp.Value, out FormulaValue fv, numberIsFloat))
+                    {
+                        dvParams[kvp.Key] = fv;
+                    }
+                }
+
+                formulaValue = FormulaValue.NewRecordFromFields(dvParams.Select(dvp => new NamedValue(dvp.Key, dvp.Value)));
+            }
+            else
+            { 
+                throw new NotImplementedException($"Unknown default value type {openApiAny.GetType().FullName}");
             }
 
-            if (x is OpenApiInteger intVal)
-            {
-                defaultValue = numberIsFloat
-                    ? FormulaValue.New(intVal.Value) // NumberValue
-                    : FormulaValue.New((decimal)intVal.Value); // DecimalValue
-
-                return true;
-            }
-
-            if (x is OpenApiDouble dbl)
-            {
-                defaultValue = numberIsFloat
-                    ? FormulaValue.New(dbl.Value) // NumberValue
-                    : FormulaValue.New((decimal)dbl.Value); // DecimalValue
-                return true;
-            }
-
-            if (x is OpenApiBoolean b)
-            {
-                defaultValue = FormulaValue.New(b.Value); // BooleanValue
-                return true;
-            }
-
-            throw new NotImplementedException($"Unknown default value type {x.GetType().FullName}");
+            return true;
         }
 
         public static bool HasDefaultValue(this OpenApiParameter param)
@@ -203,15 +270,7 @@ namespace Microsoft.PowerFx.Connectors
                     // Anyhow, we'll have schema.Enum content in ConnertorType
 
                     switch (schema.Format)
-                    {
-                        case null:
-                        case "uuid":
-                        case "mquery": // For SQL Server Power Query language
-                        case "email":
-                        case "uri":
-                        case "byte": // Base64 encoded string
-                        case "html":
-                            return new ConnectorParameterType(schema, FormulaType.String);
+                    {                        
 
                         case "date":
                         case "date-time":
@@ -225,8 +284,19 @@ namespace Microsoft.PowerFx.Connectors
                         case "binary":
                             return new ConnectorParameterType(schema, FormulaType.String);
 
+                        case "enum":                            
+                            if (schema.Enum.All(e => e is OpenApiString))
+                            {                                
+                                OptionSet os = new OptionSet("enum", schema.Enum.Select(e => new DName((e as OpenApiString).Value)).ToDictionary(k => k, e => e).ToImmutableDictionary());
+                                return new ConnectorParameterType(schema, os.FormulaType);                            
+                            }
+                            else
+                            {
+                                throw new NotImplementedException($"Unsupported enum type {schema.Enum.GetType().Name}");
+                            }
+
                         default:
-                            throw new NotImplementedException($"Unsupported type of string {schema.Format}");
+                            return new ConnectorParameterType(schema, FormulaType.String);
                     }
 
                 // OpenAPI spec: Format could be float, double, or not specified.
@@ -237,15 +307,18 @@ namespace Microsoft.PowerFx.Connectors
                     {
                         case "float":
                         case "double":
-                            return numberIsFloat
-                                ? new ConnectorParameterType(schema, FormulaType.Number)
-                                : new ConnectorParameterType(schema, FormulaType.Decimal);
+                        case "integer":
+                        case "byte":
+                        case "number":
+                        case "int32":
+                            return numberIsFloat ? new ConnectorParameterType(schema, FormulaType.Number) : new ConnectorParameterType(schema, FormulaType.Decimal);
 
                         case null:
+                        case "decimal":
                             return new ConnectorParameterType(schema, FormulaType.Decimal);
 
                         default:
-                            throw new NotImplementedException("Unsupported type of number");
+                            throw new NotImplementedException($"Unsupported type of number: {schema.Format}");
                     }
 
                 // Always a boolean (Format not used)                
@@ -257,12 +330,13 @@ namespace Microsoft.PowerFx.Connectors
                     {
                         case null:
                         case "int32":
-                            return numberIsFloat
-                                ? new ConnectorParameterType(schema, FormulaType.Number)
-                                : new ConnectorParameterType(schema, FormulaType.Decimal);
+                            return numberIsFloat ? new ConnectorParameterType(schema, FormulaType.Number) : new ConnectorParameterType(schema, FormulaType.Decimal);
 
                         case "int64":
                             return new ConnectorParameterType(schema, FormulaType.Decimal);
+
+                        case "unixtime":
+                            return new ConnectorParameterType(schema, FormulaType.DateTime);
 
                         default:
                             throw new NotImplementedException("Unsupported type of integer");
@@ -287,16 +361,17 @@ namespace Microsoft.PowerFx.Connectors
                     chain.Push(innerA);
                     ConnectorParameterType cpt = schema.Items.ToFormulaType(chain, level + 1, numberIsFloat: numberIsFloat);
                     cpt.SetProperties("Array", true);
-                    chain.Pop();
-
-                    if (cpt.HiddenRecordType != null)
-                    {
-                        throw new NotImplementedException("Unexpected value for array items");
-                    }
+                    chain.Pop();                    
 
                     if (cpt.Type is RecordType r)
                     {
                         return new ConnectorParameterType(schema, r.ToTable(), cpt.ConnectorType);
+                    }
+                    else if (cpt.Type is TableType t)
+                    {                        
+                        // Array of array 
+                        TableType tt = new TableType(TableType.Empty().Add(TableValue.ValueName, t)._type);
+                        return new ConnectorParameterType(schema, tt, cpt.ConnectorType);
                     }
                     else if (cpt.Type is not AggregateType)
                     {
@@ -385,9 +460,7 @@ namespace Microsoft.PowerFx.Connectors
 
         private static string GetUniqueIdentifier(this OpenApiSchema schema)
         {
-            return schema.Reference != null
-                ? "R:" + schema.Reference.Id
-                : "T:" + schema.Type;
+            return schema.Reference != null ? "R:" + schema.Reference.Id : "T:" + schema.Type;
         }
 
         public static HttpMethod ToHttpMethod(this OperationType key)
@@ -448,11 +521,12 @@ namespace Microsoft.PowerFx.Connectors
             // Headers are case insensitive.
             foreach (var kv3 in response.Content)
             {
-                var mediaType = kv3.Key;
-                var openApiMediaType = kv3.Value;
+                string mediaType = kv3.Key.Split(';')[0];
+                OpenApiMediaType openApiMediaType = kv3.Value;
 
                 if (string.Equals(mediaType, ContentType_ApplicationJson, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(mediaType, ContentType_TextPlain, StringComparison.OrdinalIgnoreCase))
+                    string.Equals(mediaType, ContentType_TextPlain, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(mediaType, ContentType_Any, StringComparison.OrdinalIgnoreCase))
                 {
                     if (openApiMediaType.Schema == null)
                     {
@@ -463,17 +537,12 @@ namespace Microsoft.PowerFx.Connectors
                     ConnectorParameterType connectorParameterType = openApiMediaType.Schema.ToFormulaType(numberIsFloat: numberIsFloat);
                     connectorParameterType.SetProperties("response", true);
 
-                    if (connectorParameterType.HiddenRecordType != null)
-                    {
-                        throw new NotImplementedException($"Unexpected value mediatype schema {mediaType}");
-                    }
-
                     return connectorParameterType;
                 }               
             }
 
             // Returns something, but not json. 
-            throw new InvalidOperationException($"Unsupported return type - must have {ContentType_ApplicationJson} or {ContentType_TextPlain}");
+            throw new InvalidOperationException($"Unsupported return type - found {string.Join(", ", response.Content.Select(kv4 => kv4.Key))}");
         }
 
         // Keep these constants all lower case
@@ -481,6 +550,7 @@ namespace Microsoft.PowerFx.Connectors
         public const string ContentType_XWwwFormUrlEncoded = "application/x-www-form-urlencoded";
         public const string ContentType_ApplicationJson = "application/json";
         public const string ContentType_TextPlain = "text/plain";
+        public const string ContentType_Any = "*/*";
 
         private static readonly IReadOnlyList<string> _knownContentTypes = new string[]
         {

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerFx.Connectors
                             return new ConnectorParameterType(schema, FormulaType.DateTime);
 
                         default:
-                            throw new NotImplementedException("Unsupported type of integer");
+                            throw new NotImplementedException($"Unsupported type of integer: {schema.Format}");
                     }
 
                 case "array":
@@ -454,7 +454,7 @@ namespace Microsoft.PowerFx.Connectors
 
                 default:
 
-                    throw new NotImplementedException($"{schema.Type}");
+                    throw new NotImplementedException($"Unsupported schema type {schema.Type}");
             }
         }
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/PowerFxConnectorException.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/PowerFxConnectorException.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    [Serializable]
+    public class PowerFxConnectorException : Exception
+    {
+        public PowerFxConnectorException()
+        {
+        }
+
+        public PowerFxConnectorException(string message) 
+            : base(message)
+        {
+        }
+
+        public PowerFxConnectorException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+
+        protected PowerFxConnectorException(SerializationInfo info, StreamingContext context) 
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/Helpers/Helpers.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/Helpers/Helpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.IO;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
 using Xunit;
@@ -41,7 +42,13 @@ namespace Microsoft.PowerFx.Tests
         {
             using (var stream = GetStream(name))
             {
-                var doc = new OpenApiStreamReader().Read(stream, out var diag);
+                var doc = new OpenApiStreamReader().Read(stream, out OpenApiDiagnostic diag);
+
+                if ((doc == null || doc.Paths == null || doc.Paths.Count == 0) && diag != null && diag.Errors.Count > 0)
+                { 
+                    throw new InvalidDataException($"Unable to parse Swagger file: {string.Join(", ", diag.Errors.Select(err => err.Message))}");
+                }
+
                 return doc;
             }
         }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/InternalTesting.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/InternalTesting.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
     public class InternalTesting
     {
         // This test is only meant for internal testing
-        [Fact] //Skip = "Need files from AAPT-connector and PowerPlatformConnectors projects")]
+        [Fact(Skip = "Need files from AAPT-connector and PowerPlatformConnectors projects")]
         public void TestAllConnectors()
         {
             int i = 0;
@@ -61,7 +61,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
         [Fact(Skip = "Need files from AAPT-connector and PowerPlatformConnectors projects")]
         public void TestConnector1()
         {
-            string swaggerFile = @"c:\data\PowerPlatformConnectors\independent-publisher-connectors\Updown\apiDefinition.swagger.json";
+            string swaggerFile = @"c:\data\AAPT-connectors\src\Connectors\FirstParty\microsoftspatialservices\Connector\apiDefinition.swagger.json";
             OpenApiDocument doc = Helpers.ReadSwagger(swaggerFile);
             IEnumerable<ConnectorFunction> functions = OpenApiParser.GetFunctions(doc);
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/InternalTesting.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/InternalTesting.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
     public class InternalTesting
     {
         // This test is only meant for internal testing
-        [Fact(Skip = "Need files from AAPT-connector and PowerPlatformConnectors projects")]
+        [Fact] //Skip = "Need files from AAPT-connector and PowerPlatformConnectors projects")]
         public void TestAllConnectors()
         {
             int i = 0;
@@ -24,7 +24,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             string srcFolder = @"c:\data";
 
             // Store results for analysis
-            using StreamWriter writer = new StreamWriter(outFolder, append: false);
+            using StreamWriter writer = new StreamWriter(Path.Combine(outFolder, "Analysis.txt"), append: false);
 
             foreach (string swaggerFile in Directory.EnumerateFiles(@$"{srcFolder}\AAPT-connectors\src", "apidefinition*swagger*json", new EnumerationOptions() { RecurseSubdirectories = true })
                                     .Union(Directory.EnumerateFiles(@$"{srcFolder}\PowerPlatformConnectors", "apidefinition*swagger*json", new EnumerationOptions() { RecurseSubdirectories = true })))
@@ -56,6 +56,19 @@ namespace Microsoft.PowerFx.Connectors.Tests
             }
 
             writer.WriteLine($"Total: {i} - Exceptions: {j}");
+        }
+
+        [Fact(Skip = "Need files from AAPT-connector and PowerPlatformConnectors projects")]
+        public void TestConnector1()
+        {
+            string swaggerFile = @"c:\data\PowerPlatformConnectors\independent-publisher-connectors\Updown\apiDefinition.swagger.json";
+            OpenApiDocument doc = Helpers.ReadSwagger(swaggerFile);
+            IEnumerable<ConnectorFunction> functions = OpenApiParser.GetFunctions(doc);
+
+            var config = new PowerFxConfig();
+            using var client = new PowerPlatformConnectorClient("firstrelease-001.azure-apim.net", "839eace6-59ab-4243-97ec-a5b8fcc104e4", "72c42ee1b3c7403c8e73aa9c02a7fbcc", () => "Some JWT token") { SessionId = "ce55fe97-6e74-4f56-b8cf-529e275b253f" };
+            
+            config.AddService("Connector", doc, client);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PublicSurfaceTests.cs
@@ -40,7 +40,8 @@ namespace Microsoft.PowerFx.Connector.Tests
               "Microsoft.PowerFx.Connectors.ConnectorParameterWithSuggestions",
               "Microsoft.PowerFx.Connectors.ConnectorParameters",
               "Microsoft.PowerFx.Connectors.ConnectorParameterType",
-              "Microsoft.PowerFx.Connectors.ConnectorType"
+              "Microsoft.PowerFx.Connectors.ConnectorType",
+              "Microsoft.PowerFx.Connectors.PowerFxConnectorException"
             };
 
             var sb = new StringBuilder();


### PR DESCRIPTION
Out of 2515 swagger files: from 678 unsupported files to only 124 where
14 parse errors (duplicate keys or malformed format)
73 unsupported content types (octect-stream, pdf, text, csv, xml, zip, mp3, jpeg...)
14 unsupported parameter format (file)
2 deviation from swagger specification: enum integer (enums are in description field)
1 unsupport OpenApi version
6 duplicated parameters (2 params with same name in different locations)
2 malformatted swagger files
12 OpenApi nuget bug (version string taken for a date)

+
Better handling of unsupported swagger files (detection, error messages...)
Better support for numberIsFloat flag
Refactoring of dynamic intellisense (consolidation of code)
Better support of enums
Better support for option sets
Better support of string and integer formats
Code cleanup
