### PR TITLE
Add new ECS flag to negate recent changes to function property

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
@@ -22,6 +22,8 @@ namespace Microsoft.PowerFx.Core.App
         bool IsDynamicSchemaEnabled { get; }
 
         bool IsEnhancedComponentFunctionPropertyEnabled { get; }
+
+        bool IsComponentFunctionPropertyDataflowEnabled { get; }
     }
 
     internal sealed class DefaultEnabledFeatures : IExternalEnabledFeatures
@@ -37,5 +39,7 @@ namespace Microsoft.PowerFx.Core.App
         public bool IsDynamicSchemaEnabled => true;
 
         public bool IsEnhancedComponentFunctionPropertyEnabled => true;
+
+        public bool IsComponentFunctionPropertyDataflowEnabled => true;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3373,6 +3373,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // Binding function property and its parameters should not allow DottedNameNode
                     bool isBindingPropertyFunctionPropertyOrParameter = template.IsComponent &&
                         (_txb.Document?.Properties?.EnabledFeatures?.IsEnhancedComponentFunctionPropertyEnabled ?? false) &&
+                        !(_txb.Document?.Properties?.EnabledFeatures?.IsComponentFunctionPropertyDataflowEnabled ?? false) &&
                         _txb.Property?.PropertyCategory == PropertyRuleCategory.Data &&
                         ((_txb.Property?.IsScopeVariable ?? false) || (_txb.Property?.IsScopedProperty ?? false));
                     if (isBindingPropertyFunctionPropertyOrParameter)


### PR DESCRIPTION
To prepare for future work that would fix dataflow issue with component funciton property. We need to use an ECS to control rollout and rollback of this fix.