### PR TITLE
Filter function limited to two args

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -636,6 +636,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrDataSourceCannotBeRefreshed = new ErrorResourceKey("ErrDataSourceCannotBeRefreshed");
         public static ErrorResourceKey ErrNeedAgg = new ErrorResourceKey("ErrNeedAgg");
         public static ErrorResourceKey ErrFilterFunctionBahaviorAsPredicate = new ErrorResourceKey("ErrFilterFunctionBahaviorAsPredicate");
+        public static ErrorResourceKey ErrFilterFunction_OnlyTwoArgs = new ErrorResourceKey("ErrFilterFunction_OnlyTwoArgs");
 
         public static ErrorResourceKey ErrInvalidRegEx = new ErrorResourceKey("ErrInvalidRegEx");
         public static ErrorResourceKey ErrVariableRegEx = new ErrorResourceKey("ErrVariableRegEx");

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
@@ -58,6 +58,16 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var fArgsValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
 
+            // Only a small percentage of makers use the multi-argument version of Filter in Canvas.
+            // The C# interpreter never supported it.  Blocking this and pushing makers to the more readable
+            // use of "And" to tie multiple predicates together, consistent with LookUp, and freeing up the 
+            // third argument to perform an efficient projection as is also done for LookUp.
+            if (args.Length > 2 && context.Features.PowerFxV1CompatibilityRules)
+            {
+                errors.EnsureError(DocumentErrorSeverity.Severe, args[2], TexlStrings.ErrFilterFunction_OnlyTwoArgs);
+                fArgsValid = false;
+            }
+
             // The first Texl function arg determines the cursor type, the scope type for the lambda params, and the return type.
             fArgsValid &= ScopeInfo.CheckInput(context.Features, args[0], argTypes[0], errors, out var typeScope);
 

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -5302,4 +5302,8 @@
     <value>Filter functions don't allow behavior functions as predicates.</value>
     <comment>When a filter function (like LookUp) contains a function as predicate that will trigger a side effect.</comment>
   </data>
+  <data name="ErrFilterFunction_OnlyTwoArgs" xml:space="preserve">
+    <value>Use the And operator to combine multiple predicates into the second argument of Filter.</value>
+    <comment>Limiting the Filter funciton to just two arguments, like the LookUp function, allowing us to add a third argument later also like LookUp.</comment>
+  </data>
 </root>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -5303,7 +5303,7 @@
     <comment>When a filter function (like LookUp) contains a function as predicate that will trigger a side effect.</comment>
   </data>
   <data name="ErrFilterFunction_OnlyTwoArgs" xml:space="preserve">
-    <value>Use the And operator to combine multiple predicates into the second argument of Filter.</value>
+    <value>Use the And operator to combine multiple predicates into the second argument.</value>
     <comment>{Locked=And} Limiting the Filter funciton to just two arguments, like the LookUp function, allowing us to add a third argument later also like LookUp.</comment>
   </data>
 </root>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -5304,6 +5304,6 @@
   </data>
   <data name="ErrFilterFunction_OnlyTwoArgs" xml:space="preserve">
     <value>Use the And operator to combine multiple predicates into the second argument of Filter.</value>
-    <comment>Limiting the Filter funciton to just two arguments, like the LookUp function, allowing us to add a third argument later also like LookUp.</comment>
+    <comment>{Locked=And} Limiting the Filter funciton to just two arguments, like the LookUp function, allowing us to add a third argument later also like LookUp.</comment>
   </data>
 </root>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterLookUp_TwoArg_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterLookUp_TwoArg_V1Compat.txt
@@ -5,10 +5,10 @@ Table({Value:2},{Value:3})
 
 // Allowed in Canvas today, but disallowed in Power Fx 1.0, use And instead (see next test)
 >> Filter([1,2,3], Value > 1, Value > 2)
-Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument of Filter.|Error 0-37: The function 'Filter' has some invalid arguments.
+Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument.|Error 0-37: The function 'Filter' has some invalid arguments.
 
 >> Filter([1,2,3], Value > 1, Value > 2, Value > 3)
-Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument of Filter.|Error 0-48: The function 'Filter' has some invalid arguments.
+Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument.|Error 0-48: The function 'Filter' has some invalid arguments.
 
 >> Filter([1,2,3], Value > 1 And Value > 2)
 Table({Value:3})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterLookUp_TwoArg_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterLookUp_TwoArg_V1Compat.txt
@@ -1,0 +1,34 @@
+#SETUP: PowerFxV1CompatibilityRules
+
+>> Filter([1,2,3], Value > 1)
+Table({Value:2},{Value:3})
+
+// Allowed in Canvas today, but disallowed in Power Fx 1.0, use And instead (see next test)
+>> Filter([1,2,3], Value > 1, Value > 2)
+Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument of Filter.|Error 0-37: The function 'Filter' has some invalid arguments.
+
+>> Filter([1,2,3], Value > 1, Value > 2, Value > 3)
+Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument of Filter.|Error 0-48: The function 'Filter' has some invalid arguments.
+
+>> Filter([1,2,3], Value > 1 And Value > 2)
+Table({Value:3})
+
+>> Filter([1,2,3], Value > 1 And Value > 2 And Value > 3)
+Table()
+
+>> LookUp([1,2,3], Value > 1)
+{Value:2}
+
+// The second argument in this case is a projection, and since 2 is not greater than 2, it returns false.  
+// Again, And is the answer to combine predicates, as in the next test.
+>> LookUp([1,2,3], Value > 1, Value > 2)
+false
+
+>> LookUp([1,2,3], Value > 1, Value > 2, Value > 3)
+Errors: Error 0-48: Invalid number of arguments: received 4, expected 2-3.|Error 38-43: Name isn't valid. 'Value' isn't recognized.
+
+>> LookUp([1,2,3], Value > 1 And Value > 2)
+{Value:3}
+
+>> LookUp([1,2,3], Value > 1 And Value > 2 And Value > 3)
+Blank()


### PR DESCRIPTION
Addressing https://github.com/microsoft/Power-Fx/issues/1514.  

Advantages:
- This brings Filter and LookUp into alignment.  
- Using And to combine predicates is easier to understand and read than knowing that extra arguments are And'd together.
- Limiting to two arguments allows us to add a reduction argument like LookUp has.  Which enables us to push shaping of the result up the stack more easily when making a network call.

For C# clients, the Filter function was already effectively limited to two args because the interpreter couldn't handle it (a bug), so no change there.  

For Canvas, this is a breaking Power Fx 1.0 change (under Power FxV1CompatibiltyRules flag) that we'll need to manage later, but only ~13% of filter calls use the three or more argument form.  A back compat converter should be possible.