### PR TITLE
Implement Abstract DelegationHintProvider

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/DelegationWarningProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/DelegationWarningProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerFx.Core.Binding
+{
+    /// <summary>
+    /// An abstract class that may be implemented and used during binding to provide
+    /// warnings for specific delegation scenarios.  Visitation / provider methods are called
+    /// with a container pertaining to the formula that is being bound.
+    /// </summary>
+    internal abstract class DelegationHintProvider
+    {
+        public virtual bool TryGetWarning(BinaryOpNode node, out ErrorResourceKey? warningText)
+        {
+            warningText = null;
+            return false;
+        }
+        
+        public virtual bool TryGetWarning(CallNode node, TexlFunction function, out ErrorResourceKey? warningText)
+        {
+            warningText = null;
+            return false;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DelegationValidationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/DelegationValidationStrategy.cs
@@ -400,6 +400,11 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             }
 
             var callInfo = binding.GetInfo(node);
+            if (binding.DelegationHintProvider?.TryGetWarning(node, callInfo?.Function, out var warning) ?? false)
+            {
+                SuggestDelegationHint(node, binding, warning, new object[] { callInfo?.Function.Name });
+            }
+
             if (callInfo?.Function != null && ((TexlFunction)callInfo.Function).IsRowScopedServerDelegatable(node, binding, metadata))
             {
                 return true;

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -310,6 +310,11 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
                 return false;
             }
 
+            if (binding.DelegationHintProvider?.TryGetWarning(binaryOpNode, out var warning) ?? false)
+            {
+                SuggestDelegationHint(node, binding, warning, new object[] { binaryOpNode.Op.ToString() });
+            }
+
             var leftType = binding.GetType(binaryOpNode.Left);
             var rightType = binding.GetType(binaryOpNode.Right);
             if ((leftType.IsPolymorphic && rightType.IsRecord) || (leftType.IsRecord && rightType.IsPolymorphic))


### PR DESCRIPTION
In the upcoming months there are plans to add multiple warnings which pertain exclusively to Canvas into Power Fx.  While we decide on a strategy for allowing Canvas to extend the warning capabilities provided by the Binder, I am proposing the creation of a new data structure that extends the allows consumers to add custom delegation hints by providing an abstract class which implements virtual methods and invokes them during delegation warning visitation on an instance provided baller the caller on TexlBinding.Run.

Currently, the data structure implements two virtuals, one to visit callndoes and one to visit binary op nodes.  This decision was a consequence of the needs of [this PR](https://github.com/microsoft/Power-Fx/pull/1627) is reaching an imminent deadline.  The call node visitor needs extra information from the binder, which is curious, and while writing this I believe we may want to simply do a second visitation over some rules in Canvas rather than extending the binder.  However, this data structure gives us a means of keeping the new offline-profile delegation warning implementations out of the open source while we develop a long term plan that is most extensible for our users.