### PR TITLE
Update untyped blanks to be treated as scalar when it's possible to be a table or scalar

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4288,21 +4288,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 // Check for matching arities.
                 var carg = node.Args.Count;
-                var isFirstArgumentBlankOnStatisticalFunctionFavorScalar =
-                    _txb.Features.PowerFxV1CompatibilityRules &&
-                    carg == 2 &&
-                    node.Args.Children[0] is CallNode callNode &&
-                    callNode.Head.Name.Value == "Blank" &&
-                    callNode.Head.Namespace == DPath.Root &&
-                    numOverloads == 2 &&
-                    (
-                        maybeFunc == BuiltinFunctionsCore.MaxT ||
-                        maybeFunc == BuiltinFunctionsCore.MinT ||
-                        maybeFunc == BuiltinFunctionsCore.AverageT ||
-                        maybeFunc == BuiltinFunctionsCore.SumT ||
-                        maybeFunc == BuiltinFunctionsCore.VarPT ||
-                        maybeFunc == BuiltinFunctionsCore.StdevPT);
-                if (isFirstArgumentBlankOnStatisticalFunctionFavorScalar || carg < maybeFunc.MinArity || carg > maybeFunc.MaxArity)
+                if (carg < maybeFunc.MinArity || carg > maybeFunc.MaxArity)
                 {
                     var argCountVisited = 0;
                     if (numOverloads == 1)

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4288,7 +4288,21 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 // Check for matching arities.
                 var carg = node.Args.Count;
-                if (carg < maybeFunc.MinArity || carg > maybeFunc.MaxArity)
+                var isFirstArgumentBlankOnStatisticalFunctionFavorScalar =
+                    _txb.Features.PowerFxV1CompatibilityRules &&
+                    carg == 2 &&
+                    node.Args.Children[0] is CallNode callNode &&
+                    callNode.Head.Name.Value == "Blank" &&
+                    callNode.Head.Namespace == DPath.Root &&
+                    numOverloads == 2 &&
+                    (
+                        maybeFunc == BuiltinFunctionsCore.MaxT ||
+                        maybeFunc == BuiltinFunctionsCore.MinT ||
+                        maybeFunc == BuiltinFunctionsCore.AverageT ||
+                        maybeFunc == BuiltinFunctionsCore.SumT ||
+                        maybeFunc == BuiltinFunctionsCore.VarPT ||
+                        maybeFunc == BuiltinFunctionsCore.StdevPT);
+                if (isFirstArgumentBlankOnStatisticalFunctionFavorScalar || carg < maybeFunc.MinArity || carg > maybeFunc.MaxArity)
                 {
                     var argCountVisited = 0;
                     if (numOverloads == 1)

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -108,10 +108,21 @@ namespace Microsoft.PowerFx.Core.Functions
             }
             else if (_function.ParamTypes[0].IsTable)
             {
-                if (!typeScope.IsTable)
+                if (features.PowerFxV1CompatibilityRules)
                 {
-                    errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);
-                    fArgsValid = false;
+                    if (!typeScope.IsTableNonObjNull)
+                    {
+                        errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);
+                        fArgsValid = false;
+                    }
+                }
+                else
+                {
+                    if (!typeScope.IsTable)
+                    {
+                        errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);
+                        fArgsValid = false;
+                    }
                 }
 
                 // This assumes that the lambdas operate on the individual records

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -110,6 +110,7 @@ namespace Microsoft.PowerFx.Core.Functions
             {
                 if (features.PowerFxV1CompatibilityRules)
                 {
+                    // Untyped blank values should not be used to define the scope
                     if (!typeScope.IsTableNonObjNull)
                     {
                         errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -108,22 +108,13 @@ namespace Microsoft.PowerFx.Core.Functions
             }
             else if (_function.ParamTypes[0].IsTable)
             {
-                if (features.PowerFxV1CompatibilityRules)
+                var isBadArgumentType = features.PowerFxV1CompatibilityRules ?
+                    !typeScope.IsTableNonObjNull : // Untyped blank values should not be used to define the scope
+                    !typeScope.IsTable;
+                if (isBadArgumentType)
                 {
-                    // Untyped blank values should not be used to define the scope
-                    if (!typeScope.IsTableNonObjNull)
-                    {
-                        errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);
-                        fArgsValid = false;
-                    }
-                }
-                else
-                {
-                    if (!typeScope.IsTable)
-                    {
-                        errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);
-                        fArgsValid = false;
-                    }
+                    errors.Error(callNode, TexlStrings.ErrNeedTable_Func, _function.Name);
+                    fArgsValid = false;
                 }
 
                 // This assumes that the lambdas operate on the individual records

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct.txt
@@ -61,7 +61,7 @@ Table({Value:1},{Value:2},{Value:3})
 >> Distinct([3,2,1,3,3,3,3], Value)
 Table({Value:3},{Value:2},{Value:1})
 
->> Distinct(Blank(), true)
+>> Distinct(If(1<0,[1,2,3]), true)
 Blank()
 
 >> Distinct([1/0], Value)
@@ -73,7 +73,7 @@ Table()
 >> Sort(Distinct([{FirstName: "Harry"}, {FirstName: "Sally"}, {FirstName: "Harry"}, {FirstName: "Alice"}, {FirstName: "Sally"}], FirstName), Value)
 Table({Value:"Alice"},{Value:"Harry"},{Value:"Sally"})
 
->> Distinct(Error("error"), true)
+>> Distinct(If(1<0,[1,2,3],Error("error")), true)
 Error({Kind:ErrorKind.Custom})
 
 >> Distinct([{A: 1}, {A: 2}, {A: 3}, Error("error")], A)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct_V1Compat.txt
@@ -1,0 +1,9 @@
+﻿#SETUP: PowerFxV1CompatibilityRules
+
+// Untyped blanks are not allowed in the argument that defines the row scope
+>> Distinct(Blank(), true)
+Errors: Error 9-16: Invalid argument type.|Error 0-23: The function 'Distinct' has some invalid arguments.
+
+// Untyped blanks are not allowed in the argument that defines the row scope
+>> Distinct(Error("error"), true)
+Errors: Error 9-23: Invalid argument type.|Error 0-30: The function 'Distinct' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct_V1CompatDisabled.txt
@@ -1,0 +1,9 @@
+﻿#SETUP: disable:PowerFxV1CompatibilityRules
+
+// Legacy behavior: untyped blanks are allowed in the argument that defines the row scope
+>> Distinct(Blank(), true)
+Blank()
+
+// Legacy behavior: untyped blanks are allowed in the argument that defines the row scope
+>> Distinct(Error("error"), true)
+Error({Kind:ErrorKind.Custom})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions.txt
@@ -49,7 +49,7 @@ Table()
 Table()
 
 // Filter blank table
->> Filter(Blank(), Blank())
+>> Filter(If(1<0,[1,2,3]), Blank())
 Blank()
 
 >> Filter(Sort([-2, -1, 0, 1, 2], 1 / Value), 1/ThisRecord.Value >= 0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions_V1Compat.txt
@@ -1,0 +1,5 @@
+#SETUP: TableSyntaxDoesntWrapRecords,PowerFxV1CompatibilityRules
+
+// Untyped blanks are not allowed in the argument that defines the row scope
+>> Filter(Blank(), Blank())
+Errors: Error 7-14: Invalid argument type.|Error 0-24: The function 'Filter' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions_V1CompatDisabled.txt
@@ -1,0 +1,5 @@
+#SETUP: TableSyntaxDoesntWrapRecords,disable:PowerFxV1CompatibilityRules
+
+// Legacy behavior: untyped blanks are allowed in the argument that defines the row scope
+>> Filter(Blank(), Blank())
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
@@ -84,10 +84,10 @@ Error({Kind:ErrorKind.Div0})
 >> LookUp([1,2,3,4], Blank())
 Blank()
 
->> LookUp(Blank(), Blank())
+>> LookUp(If(1<0,[1,2,3]), Blank())
 Blank()
 
->> LookUp(Blank(), Blank(), "constant")
+>> LookUp(If(1<0,[1,2,3]), Blank(), "constant")
 Blank()
 
 >> LookUp([100, 200, 300], Value > 250, Power(100, Value))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup_V1Compat.txt
@@ -1,0 +1,10 @@
+﻿#SETUP: DisableMemChecks,TableSyntaxDoesntWrapRecords,PowerFxV1CompatibilityRules
+
+// Untyped blanks are not allowed in the argument that defines the row scope
+>> LookUp(Blank(), Blank())
+Errors: Error 7-14: Invalid argument type.|Error 0-24: The function 'LookUp' has some invalid arguments.
+
+
+// Untyped blanks are not allowed in the argument that defines the row scope
+>> LookUp(Blank(), Blank(), "constant")
+Errors: Error 7-14: Invalid argument type.|Error 0-36: The function 'LookUp' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup_V1CompatDisabled.txt
@@ -1,0 +1,9 @@
+﻿#SETUP: DisableMemChecks,TableSyntaxDoesntWrapRecords,disable:PowerFxV1CompatibilityRules
+
+// Legacy behavior: untyped blanks are allowed in the argument that defines the row scope
+>> LookUp(Blank(), Blank())
+Blank()
+
+// Legacy behavior: untyped blanks are allowed in the argument that defines the row scope
+>> LookUp(Blank(), Blank(), "constant")
+Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable.txt
@@ -80,8 +80,9 @@ Table({Value:Error({Kind:ErrorKind.Numeric})})
 >> Log(If(1<0,[1]),3)
 Blank()
 
+// Favor scalar over table
 >> Sum(Blank(),1)
-Blank()
+1
 
 >> Sum([4,5],Blank())
 Blank()
@@ -92,8 +93,9 @@ Blank()
 >> Sum(If(1<0,[1,2,3]),Blank())
 Blank()
 
+// Favor scalar over table
 >> Average(Blank(),1)
-Blank()
+1
 
 // one argument, single column table functions, will treat Blank() as a scalar
 >> Sin(Blank())

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable.txt
@@ -80,9 +80,6 @@ Table({Value:Error({Kind:ErrorKind.Numeric})})
 >> Log(If(1<0,[1]),3)
 Blank()
 
->> Sum(Blank(),1)
-Blank()
-
 >> Sum([4,5],Blank())
 Blank()
 
@@ -90,9 +87,6 @@ Blank()
 Blank()
 
 >> Sum(If(1<0,[1,2,3]),Blank())
-Blank()
-
->> Average(Blank(),1)
 Blank()
 
 // one argument, single column table functions, will treat Blank() as a scalar

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable.txt
@@ -80,9 +80,8 @@ Table({Value:Error({Kind:ErrorKind.Numeric})})
 >> Log(If(1<0,[1]),3)
 Blank()
 
-// Favor scalar over table
 >> Sum(Blank(),1)
-1
+Blank()
 
 >> Sum([4,5],Blank())
 Blank()
@@ -93,9 +92,8 @@ Blank()
 >> Sum(If(1<0,[1,2,3]),Blank())
 Blank()
 
-// Favor scalar over table
 >> Average(Blank(),1)
-1
+Blank()
 
 // one argument, single column table functions, will treat Blank() as a scalar
 >> Sin(Blank())

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable_V1Compat.txt
@@ -1,0 +1,34 @@
+#SETUP: PowerFxV1CompatibilityRules
+
+// Consider an untyped blank, such as the return type from Blank(), as an argument to a single column table enabled function.
+//
+// We favor treating these as a scalar blank, rather than a table blank.  Scalar is the simpler form and more likely
+// what the maker wanted.  This treatment is also consistent with Canvas.
+//
+// A typed Blank, such as returned from a database or If(1<0,"foo") is fine, it specifically an untyped Blank that is odd.
+//
+// In general, a function that takes a blank table argument will return a blank table.
+
+// Favor scalar over table
+>> Sum(Blank(),1)
+1
+
+// Favor scalar over table
+>> Average(Blank(),1)
+1
+
+// Favor scalar over table
+>> Min(Blank(),1)
+1
+
+// Favor scalar over table
+>> Max(Blank(),1)
+1
+
+// Favor scalar over table
+>> StdevP(Blank(),1)
+0
+
+// Favor scalar over table
+>> VarP(Blank(),1)
+0

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/UntypedBlankAsTable_V1CompatDisabled.txt
@@ -1,0 +1,34 @@
+#SETUP: disable:PowerFxV1CompatibilityRules
+
+// Consider an untyped blank, such as the return type from Blank(), as an argument to a single column table enabled function.
+//
+// We favor treating these as a scalar blank, rather than a table blank.  Scalar is the simpler form and more likely
+// what the maker wanted.  This treatment is also consistent with Canvas.
+//
+// A typed Blank, such as returned from a database or If(1<0,"foo") is fine, it specifically an untyped Blank that is odd.
+//
+// In general, a function that takes a blank table argument will return a blank table.
+
+// Legacy behavior: untyped blank treated as a table
+>> Sum(Blank(),1)
+Blank()
+
+// Legacy behavior: untyped blank treated as a table
+>> Average(Blank(),1)
+Blank()
+
+// Legacy behavior: untyped blank treated as a table
+>> Min(Blank(),1)
+Blank()
+
+// Legacy behavior: untyped blank treated as a table
+>> Max(Blank(),1)
+Blank()
+
+// Legacy behavior: untyped blank treated as a table
+>> StdevP(Blank(),1)
+Blank()
+
+// Legacy behavior: untyped blank treated as a table
+>> VarP(Blank(),1)
+Blank()


### PR DESCRIPTION
We updated all other functions to do that, but the statistical functions still behavior still favor the tabular overload: in `Min(Blank(), 1)` the blank value is interpreted as a table (and the operation returns `Blank()`), while there is an overload that takes numbers instead.