### PR TITLE
Added TypeLiteralNode

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/NodeKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/NodeKind.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerFx.Syntax
         DecLit,
 
         Error,
-        StrInterp
+        StrInterp,
+        TypeLiteral
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TypeLiteralNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TypeLiteralNode.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Syntax.SourceInformation;
+
+namespace Microsoft.PowerFx.Syntax
+{
+    // CallNode :: Type ( TypeLiteralNode )
+    // CallNode :: IsType ( Expr, TypeLiteralNode )
+    // CallNode :: AsType ( Expr, TypeLiteralNode )
+    // TypeLiteralNode will allow us to store information about a new kind of syntax, that being the Type Literal syntax, and manipulate it.
+    // TypeLiteral syntax needs to *only* work for these partial-compile time functions that evaluate the Type Literal syntax into some sort of 
+    // Representation so we can evaluate and compare it. We want to make sure that this Type Literal information isn't able to be
+    // Passed around in undesirable ways be users of PowerFx. A TypeLiteralNode allows us to strictly enforce requirements.
+
+    public sealed class TypeLiteralNode : TexlNode
+    {
+        internal TypeLiteralNode(ref int idNext, Token firstToken, SourceList sources)
+            : base(ref idNext, firstToken, sources)
+        {
+        }
+
+        internal override TexlNode Clone(ref int idNext, Span ts)
+        {
+            return new TypeLiteralNode(ref idNext, Token.Clone(ts).As<Token>(), this.SourceList.Clone(ts, new Dictionary<TexlNode, TexlNode>()));
+        }
+
+        /// <inheritdoc />
+        public override void Accept(TexlVisitor visitor)
+        {
+            Contracts.AssertValue(visitor);
+            visitor.Visit(this);
+        }
+
+        /// <inheritdoc />
+        public override TResult Accept<TResult, TContext>(TexlFunctionalVisitor<TResult, TContext> visitor, TContext context)
+        {
+            return visitor.Visit(this, context);
+        }
+
+        /// <inheritdoc />
+        public override NodeKind Kind => NodeKind.TypeLiteral;
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlFunctionalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlFunctionalVisitor.cs
@@ -11,6 +11,17 @@ namespace Microsoft.PowerFx.Syntax
     public abstract class TexlFunctionalVisitor<TResult, TContext>
     {
         /// <summary>
+        /// Visit <see cref="TypeLiteralNode"/> leaf node.
+        /// </summary>
+        /// <param name="node">The visited node.</param>
+        /// <param name="context">The context passed to the node.</param>
+        /// <returns>The node visit result.</returns>
+        public virtual TResult Visit(TypeLiteralNode node, TContext context)
+        {
+            throw new System.Exception("Not implemented");
+        }
+
+        /// <summary>
         /// Visit <see cref="ErrorNode" /> leaf node.
         /// </summary>
         /// <param name="node">The visited node.</param>

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlFunctionalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlFunctionalVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerFx.Syntax
         /// <returns>The node visit result.</returns>
         public virtual TResult Visit(TypeLiteralNode node, TContext context)
         {
-            throw new System.Exception("Not implemented");
+            throw new System.NotImplementedException();
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlVisitor.cs
@@ -9,6 +9,14 @@ namespace Microsoft.PowerFx.Syntax
     public abstract class TexlVisitor
     {
         /// <summary>
+        /// Visit <see cref="TypeLiteralNode"/> leaf node.
+        /// </summary>
+        /// <param name="node">The visited node.</param>
+        public virtual void Visit(TypeLiteralNode node)
+        {
+        }
+
+        /// <summary>
         /// Visit <see cref="ErrorNode" /> leaf node.
         /// </summary>
         /// <param name="node">The visited node.</param>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -91,6 +91,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Syntax.UnaryOpNode",
                 "Microsoft.PowerFx.Syntax.VariadicBase",
                 "Microsoft.PowerFx.Syntax.VariadicOpNode",
+                "Microsoft.PowerFx.Syntax.TypeLiteralNode",
                               
                 // Visitors
                 "Microsoft.PowerFx.Syntax.IdentityTexlVisitor",


### PR DESCRIPTION
This adds the TypeLiteralNode so we can use it for future functions `Type` and later possibly `IsType` and `AsType`