### PR TITLE
Lift Constant on Regex Parameter to IsMatch

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsMatch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsMatch.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override void CheckSemantics(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors)
         {
-            if ((argTypes[1].Kind != DKind.String && argTypes[1].Kind != DKind.OptionSetValue) || !binding.IsConstant(args[1]))
+            if (argTypes[1].Kind != DKind.String && argTypes[1].Kind != DKind.OptionSetValue)
             {
                 errors.EnsureError(args[1], TexlStrings.ErrVariableRegEx);
             }


### PR DESCRIPTION
The IsMatch function does not accept values that are not constants at runtime.  There is no reason for this to be the case.  Unlike Match, the contents of the regex value for IsMatch do not augment the return type for the function.  IsMatch always returns a true/false value.  This PR lifts the restriction.