### PR TITLE
Fix #1663 - warn that EnableRegExFunctions is still preview.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -44,6 +44,7 @@ namespace Microsoft.PowerFx
             symbolTable.AddFunction(new ClearCollectFunction());
         }
 
+        [Obsolete("RegEx is still in preview. Grammar may change.")]
         public static void EnableRegExFunctions(this PowerFxConfig config, TimeSpan regExTimeout = default, int regexCacheSize = -1)
         {
             RegexTypeCache regexTypeCache = new (regexCacheSize);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/PowerFxEvaluationTests.cs
@@ -31,8 +31,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         };
 
         private static (RecalcEngine engine, RecordValue parameters) RegExSetup(PowerFxConfig config, bool numberIsFloat)
-        {            
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
             config.EnableRegExFunctions(new TimeSpan(0, 0, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
             return (new RecalcEngine(config), null);
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RegExTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RegExTests.cs
@@ -6,13 +6,16 @@ using Xunit;
 
 namespace Microsoft.PowerFx.Interpreter.Tests
 {
+// Allow calling preview EnableRegExFunctions
+#pragma warning disable CS0618 // Type or member is obsolete
+
     public class RegExTests
     {
         [Fact]
         public void TestRegExNegativeTimeout()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {                
+            {
                 new PowerFxConfig().EnableRegExFunctions(TimeSpan.FromMilliseconds(-1));
             });            
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TexlTests.cs
@@ -150,7 +150,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var config = new PowerFxConfig(features);
             symbolTableActions?.Invoke(config.SymbolTable);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             config.EnableRegExFunctions(new TimeSpan(0, 0, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (optionSets != null)
             {
@@ -174,7 +176,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var config = new PowerFxConfig(features);
             symbolTableActions?.Invoke(config.SymbolTable);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             config.EnableRegExFunctions(new TimeSpan(0, 0, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var engine = new Engine(config);
             var opts = new ParserOptions() { NumberIsFloat = numberIsFloat };


### PR DESCRIPTION
Fix #1663 