### PR TITLE
Ensure that untyped blank is interpreted as a scalar for the 'in' operator

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -402,7 +402,7 @@ namespace Microsoft.PowerFx.Core.Binding
             {
                 // scalar in scalar: RHS must be a string (or coercible to string when LHS type is string). We'll allow coercion of LHS.
                 // This case deals with substring matches, e.g. 'FirstName in "Aldous Huxley"' or "123" in 123.
-                if (!typeRight.IsAggregate)
+                if (!typeRight.IsAggregate || (usePowerFxV1CompatibilityRules && typeRight.Kind == DKind.ObjNull))
                 {
                     if (!DType.String.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
                     {
@@ -435,7 +435,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // scalar in table: RHS must be a one column table. We'll allow coercion.
-                if (typeRight.IsTable)
+                if (typeRight.IsTableNonObjNull)
                 {
                     var names = typeRight.GetNames(DPath.Root);
                     if (names.Count() != 1)

--- a/src/libraries/Microsoft.PowerFx.Core/IR/BinaryOpMatrix.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/BinaryOpMatrix.cs
@@ -464,9 +464,9 @@ namespace Microsoft.PowerFx.Core.IR
 
         private static BinaryOpKind GetInOp(TexlBinding binding, BinaryOp parsedBinaryOp, DType leftType, DType rightType)
         {
-            if (!rightType.IsAggregate)
+            var usesPFxV1CompatRules = binding.Features.PowerFxV1CompatibilityRules;
+            if (!rightType.IsAggregate || (usesPFxV1CompatRules && rightType.Kind == DKind.ObjNull))
             {
-                var usesPFxV1CompatRules = binding.Features.PowerFxV1CompatibilityRules;
                 if ((DType.String.Accepts(rightType, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usesPFxV1CompatRules) && (DType.String.Accepts(leftType, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usesPFxV1CompatRules) || leftType.CoercesTo(DType.String, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: usesPFxV1CompatRules))) ||
                     (rightType.CoercesTo(DType.String, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: usesPFxV1CompatRules) && DType.String.Accepts(leftType, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usesPFxV1CompatRules)))
                 {
@@ -476,7 +476,7 @@ namespace Microsoft.PowerFx.Core.IR
                 return BinaryOpKind.Invalid;
             }
 
-            if (!leftType.IsAggregate)
+            if (!leftType.IsAggregate || (usesPFxV1CompatRules && leftType.Kind == DKind.ObjNull))
             {
                 if (rightType.IsTable)
                 {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar.txt
@@ -1,8 +1,6 @@
-﻿
-// In (Case insensitive), ExactIn (case sensitive)
+﻿// In (Case insensitive), ExactIn (case sensitive)
 // Scalar, Table forms. 
 // https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/operators#in-and-exactin-operators
-
 
 >> ("a" & 1/0) in "abc"
 Error({Kind:ErrorKind.Div0}) 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar_V1Compat.txt
@@ -1,0 +1,14 @@
+﻿#SETUP: PowerFxV1CompatibilityRules
+
+// In (Case insensitive), ExactIn (case sensitive)
+// Scalar, Table forms. 
+// https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/operators#in-and-exactin-operators
+
+>> "a" in Blank()
+false
+
+>> "" in Blank()
+true
+
+>> Blank() in Blank()
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar_V1CompatDisabled.txt
@@ -1,0 +1,14 @@
+﻿#SETUP: disable:PowerFxV1CompatibilityRules
+
+// In (Case insensitive), ExactIn (case sensitive)
+// Scalar, Table forms. 
+// https://docs.microsoft.com/en-us/powerapps/maker/canvas-apps/functions/operators#in-and-exactin-operators
+
+>> "a" in Blank()
+false
+
+>> "" in Blank()
+true
+
+>> Blank() in Blank()
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable.txt
@@ -40,13 +40,8 @@ true
 >> If(false,2,Blank()) in [1, Blank(), 2]
 true
 
-// Blank() on LHS is still false and treated liked record. 
->> Blank() in [1, Blank(), 2] 
-false
-
 >> 3 in [1, Blank(), 2]
 false
-
 
 >> 2 in Table({a:1}, {a:2}, {a:3})
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable_V1Compat.txt
@@ -1,0 +1,11 @@
+﻿#SETUP: PowerFxV1CompatibilityRules
+
+// "In" operator for Tables
+
+// When blank can be treated as a scalar or an aggregate, prefer scalar
+>> Blank() in [1, Blank(), 2] 
+true
+
+// When blank can be treated as a scalar or an aggregate, prefer scalar
+>> Blank() in Table({Value:1},Blank(),{Value:2})
+false

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable_V1CompatDisabled.txt
@@ -1,0 +1,11 @@
+﻿#SETUP: disable:PowerFxV1CompatibilityRules
+
+// "In" operator for Tables
+
+// Blank() on LHS is still false and treated liked record. 
+>> Blank() in [1, Blank(), 2]
+false
+
+// Blank() on LHS is still false and treated liked record.
+>> Blank() in Table({Value:1},Blank(),{Value:2})
+true

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/InScalarOverride.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/InScalarOverride.txt
@@ -1,6 +1,0 @@
-﻿#OVERRIDE: inScalar.txt
-
-// If Blank is on either side, operator is false. 
-// Use If() to coerce Blank to string. 
->> Blank() in Blank()
-Error({Kind:ErrorKind.Validation})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/InTableOverride.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/InTableOverride.txt
@@ -1,5 +1,0 @@
-﻿#OVERRIDE: inTable.txt
-
-// Blank() on LHS is still false and treated liked record. 
->> Blank() in [1, Blank(), 2] 
-Error({Kind:ErrorKind.Validation})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/inScalar_V1CompatDisabled_Overrides.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/inScalar_V1CompatDisabled_Overrides.txt
@@ -1,0 +1,13 @@
+﻿#OVERRIDE: inScalar_V1CompatDisabled.txt
+
+// Bug in pre-V1, fixed in V1
+>> "a" in Blank()
+#skip
+
+// Bug in pre-V1, fixed in V1
+>> "" in Blank()
+#skip
+
+// Bug in pre-V1, fixed in V1
+>> Blank() in Blank()
+#skip

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/inTable_V1CompatDisabled_Overrides.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterExpressionTestCases/inTable_V1CompatDisabled_Overrides.txt
@@ -1,0 +1,9 @@
+﻿#OVERRIDE: inTable_V1CompatDisabled.txt
+
+// Bug in pre-V1, fixed in V1
+>> Blank() in [1, Blank(), 2]
+#skip
+
+// Bug in pre-V1, fixed in V1
+>> Blank() in Table({Value:1},Blank(),{Value:2})
+#skip


### PR DESCRIPTION
Untyped blanks, when used in contexts where they can be interpreted as either a scalar or a complex type (record / table), should be interpreted as scalars. This wasn't working for the `in` operator, and this fixes it. Since this is technically a breaking change (although I can't see why someone would use that), the update is made under the PowerFxV1CompatibilityRules feature.