### PR TITLE
Add null check

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
@@ -111,8 +111,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     if (dataSourceInfo != null)
                     {
                         // Verify the view belongs to the same datasource
-                        var viewInfo = argTypes[i].ViewInfo.VerifyValue();
-                        if (viewInfo.RelatedEntityName != dataSourceInfo.Name)
+                        var viewInfo = argTypes[i].ViewInfo?.VerifyValue();
+                        if (viewInfo != null && viewInfo.RelatedEntityName != dataSourceInfo.Name)
                         {
                             errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrViewFromCurrentTableExpected, dataSourceInfo.Name);
                         }


### PR DESCRIPTION
A customer reported their app crashing when opening for editing.
The cause is a null reference exception was raised in the CheckSemantic of Filter function.We need to add null check for ViewInfo in Filter CheckSemantic

[Incident-409006522 Details - IcM (microsofticm.com)](https://portal.microsofticm.com/imp/v3/incidents/details/409006522/home)