### PR TITLE
Ensure that untyped blank is interpreted as scalar

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -398,7 +398,7 @@ namespace Microsoft.PowerFx.Core.Binding
             Contracts.Assert(!typeLeft.IsAggregate || typeLeft.IsTable || typeLeft.IsRecord);
             Contracts.Assert(!typeRight.IsAggregate || typeRight.IsTable || typeRight.IsRecord);
 
-            if (!typeLeft.IsAggregate)
+            if (!typeLeft.IsAggregate || (usePowerFxV1CompatibilityRules && typeLeft.Kind == DKind.ObjNull))
             {
                 // scalar in scalar: RHS must be a string (or coercible to string when LHS type is string). We'll allow coercion of LHS.
                 // This case deals with substring matches, e.g. 'FirstName in "Aldous Huxley"' or "123" in 123.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar_V1Compat.txt
@@ -7,8 +7,23 @@
 >> "a" in Blank()
 false
 
+>> "a" exactin Blank()
+false
+
 >> "" in Blank()
 true
 
+>> "" exactin Blank()
+true
+
 >> Blank() in Blank()
+true
+
+>> Blank() exactin Blank()
+true
+
+>> Blank() in "hello"
+true
+
+>> Blank() exactin "hello"
 true


### PR DESCRIPTION
We already fixed it in most places, but found one more. This fixes #1713 