### PR TITLE
Provide a delegation warning SortByColumns in an unsupported data source

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -246,6 +246,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 if (!TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.Sort, out var dataSource))
                 {
+                    SuggestDelegationHint(callNode, binding);
                     return false;
                 }
 


### PR DESCRIPTION
Previously, a complicated enough data source would not report a delegation warning.  Provide a warning in that scenario