### PR TITLE
Do not throw while serializing unsupported type in legacy serializer. Useful for Intellisense…

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeJsonConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeJsonConverter.cs
@@ -61,6 +61,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                 FormulaTypeSchema.ParamType.Record => GetAggregateType(schema.Fields, isTable: false),
                 FormulaTypeSchema.ParamType.Table => GetAggregateType(schema.Fields, isTable: true),
 
+                FormulaTypeSchema.ParamType.Unsupported => throw new NotImplementedException(),
                 FormulaTypeSchema.ParamType.OptionSetValue => throw new NotImplementedException(),
                 FormulaTypeSchema.ParamType.EntityRecord => throw new NotSupportedException(),
                 FormulaTypeSchema.ParamType.EntityTable => throw new NotSupportedException(),

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeSchema.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeSchema.cs
@@ -34,7 +34,8 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             Unknown,
             Error,
             Deferred,
-            Void
+            Void,
+            Unsupported,
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
@@ -88,7 +88,10 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                 Result = new FormulaTypeSchema() { Type = FormulaTypeSchema.ParamType.UntypedObject };
             }
 
-            public void Visit(UnsupportedType type) => throw new NotImplementedException();
+            public void Visit(UnsupportedType type)
+            {
+                Result = new FormulaTypeSchema() { Type = FormulaTypeSchema.ParamType.Unsupported };
+            }
 
             public void Visit(UnknownType type)
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -15,6 +15,7 @@ using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Core.Texl.Intellisense;
+using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Intellisense;
 using Microsoft.PowerFx.Interpreter.Tests.LanguageServiceProtocol;
 using Microsoft.PowerFx.LanguageServerProtocol;
@@ -1881,6 +1882,16 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             var result = await run.EvalAsync(CancellationToken.None).ConfigureAwait(false);
 
             Assert.Null(result.ToObject());
+        }
+
+        [Fact]
+        public void SerializeUnsupportedType()
+        {
+            var unsupportedType = FormulaType.Build(DType.Polymorphic);
+            var serialized = JsonSerializer.Serialize<FormulaType>(unsupportedType, _jsonSerializerOptions);
+            Assert.Equal("{\"Type\":\"Unsupported\"}", serialized);
+
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Deserialize<FormulaType>(serialized, _jsonSerializerOptions));
         }
 
         private EditorContextScope TestCreateEditorScope(string documentUri)


### PR DESCRIPTION
Fixes #1728 