### PR TITLE
Remove enhanced delegation external feature

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/IExternalEnabledFeatures.cs
@@ -11,8 +11,6 @@ namespace Microsoft.PowerFx.Core.App
     /// </summary>
     internal interface IExternalEnabledFeatures
     {
-        bool IsEnhancedDelegationEnabled { get; }
-
         bool IsProjectionMappingEnabled { get; }
 
         bool IsEnableRowScopeOneToNExpandEnabled { get; }
@@ -28,8 +26,6 @@ namespace Microsoft.PowerFx.Core.App
 
     internal sealed class DefaultEnabledFeatures : IExternalEnabledFeatures
     {
-        public bool IsEnhancedDelegationEnabled => true;
-
         public bool IsProjectionMappingEnabled => true;
 
         public bool IsEnableRowScopeOneToNExpandEnabled => true;

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -345,7 +345,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 resolver,
                 entityName: EntityName,
                 propertyName: Property?.InvariantName ?? string.Empty,
-                isEnhancedDelegationEnabled: Document?.Properties?.EnabledFeatures?.IsEnhancedDelegationEnabled ?? false,
                 allowsSideEffects: bindingConfig.AllowsSideEffects,
                 numberIsFloat: bindingConfig.NumberIsFloat);
         }
@@ -3850,7 +3849,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 var leftType = _txb.GetType(node.Left);
                 var rightType = _txb.GetType(node.Right);
 
-                var res = CheckBinaryOpCore(_txb.ErrorContainer, node, _txb.Features.PowerFxV1CompatibilityRules, leftType, rightType, _txb.Document != null && _txb.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled, _txb.BindingConfig.NumberIsFloat);
+                var res = CheckBinaryOpCore(_txb.ErrorContainer, node, _txb.Features.PowerFxV1CompatibilityRules, leftType, rightType, _txb.BindingConfig.NumberIsFloat);
 
                 foreach (var coercion in res.Coercions)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -376,7 +376,7 @@ namespace Microsoft.PowerFx.Core.Binding
         }
 
         // Performs type checking for the arguments passed to the membership "in"/"exactin" operators.
-        private static BinderCheckTypeResult CheckInArgTypesCore(IErrorContainer errorContainer, TexlNode left, TexlNode right, DType typeLeft, DType typeRight, bool isEnhancedDelegationEnabled, bool usePowerFxV1CompatibilityRules)
+        private static BinderCheckTypeResult CheckInArgTypesCore(IErrorContainer errorContainer, TexlNode left, TexlNode right, DType typeLeft, DType typeRight, bool usePowerFxV1CompatibilityRules)
         {
             Contracts.AssertValue(left);
             Contracts.AssertValue(right);
@@ -500,7 +500,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 return new BinderCheckTypeResult() { Coercions = coercions };
             }
 
-            if (isEnhancedDelegationEnabled && typeLeft.IsTable)
+            if (typeLeft.IsTable)
             {
                 // Table in table: RHS must be a single column table with a compatible schema. No coercion is allowed.
                 if (typeRight.IsTable)
@@ -1231,7 +1231,7 @@ namespace Microsoft.PowerFx.Core.Binding
         // REVIEW ragru: Introduce a TexlOperator abstract base plus various subclasses
         // for handling operators and their overloads. That will offload the burden of dealing with
         // operator special cases to the various operator classes.
-        public static BinderCheckTypeResult CheckBinaryOpCore(IErrorContainer errorContainer, BinaryOpNode node, bool usePowerFxV1CompatibilityRules, DType leftType, DType rightType, bool isEnhancedDelegationEnabled, bool numberIsFloat)
+        public static BinderCheckTypeResult CheckBinaryOpCore(IErrorContainer errorContainer, BinaryOpNode node, bool usePowerFxV1CompatibilityRules, DType leftType, DType rightType, bool numberIsFloat)
         {
             Contracts.AssertValue(node);
 
@@ -1295,7 +1295,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 case BinaryOp.In:
                 case BinaryOp.Exactin:
-                    var resIn = CheckInArgTypesCore(errorContainer, leftNode, rightNode, leftType, rightType, isEnhancedDelegationEnabled, usePowerFxV1CompatibilityRules);
+                    var resIn = CheckInArgTypesCore(errorContainer, leftNode, rightNode, leftType, rightType, usePowerFxV1CompatibilityRules);
                     return new BinderCheckTypeResult() { Node = node, NodeType = DType.Boolean, Coercions = resIn.Coercions };
 
                 default:

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/CheckTypesContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/CheckTypesContext.cs
@@ -18,19 +18,16 @@ namespace Microsoft.PowerFx.Core.Functions
 
         public string PropertyName { get; }
 
-        public bool IsEnhancedDelegationEnabled { get; }
-
         public bool AllowsSideEffects { get; }
 
         public bool NumberIsFloat { get; }
 
-        public CheckTypesContext(Features features, INameResolver nameResolver, string entityName, string propertyName, bool isEnhancedDelegationEnabled, bool allowsSideEffects, bool numberIsFloat)
+        public CheckTypesContext(Features features, INameResolver nameResolver, string entityName, string propertyName, bool allowsSideEffects, bool numberIsFloat)
         {
             Features = features;
             NameResolver = nameResolver;
             EntityName = entityName;
             PropertyName = propertyName;
-            IsEnhancedDelegationEnabled = isEnhancedDelegationEnabled;
             AllowsSideEffects = allowsSideEffects;
             NumberIsFloat = numberIsFloat;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/InOpDelegationStrategy.cs
@@ -79,12 +79,11 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
 
             var rightNodeType = binding.GetType(binaryOpNode.Right);
 
-            var hasEnhancedDelegation = binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled;
             var isColumn = rightNodeType?.IsColumn == true;
             var isDelegationSupportedByTable = metadata.IsDelegationSupportedByTable(DelegationCapability.CdsIn);
             var hasLeftFirstNameNodeOrIsFullRecordRowScopeAccessOrLookup = binaryOpNode.Left?.AsFirstName() != null || binding.IsFullRecordRowScopeAccess(binaryOpNode.Left) || (binaryOpNode.Left is DottedNameNode dottedField && binding.GetType(dottedField.Left).HasExpandInfo);
 
-            return hasEnhancedDelegation && isColumn && isDelegationSupportedByTable && hasLeftFirstNameNodeOrIsFullRecordRowScopeAccessOrLookup;
+            return isColumn && isDelegationSupportedByTable && hasLeftFirstNameNodeOrIsFullRecordRowScopeAccessOrLookup;
         }
 
         public bool CheckForFullyQualifiedFieldAccess(bool isRHSDelegableTable, BinaryOpNode binaryOpNode, TexlBinding binding, TexlNode node, ref DName columnName, ref FirstNameInfo info)
@@ -176,11 +175,10 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             }
 
             var nodeType = binding.GetType(column);
-            var hasEnhancedDelegation = binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled;
             var usePowerFxV1CompatibilityRules = binding.Features.PowerFxV1CompatibilityRules;
             return DType.String.Accepts(nodeType, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules) ||
                 nodeType.CoercesTo(DType.String, aggregateCoercion: true, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules) ||
-                (hasEnhancedDelegation && nodeType.IsMultiSelectOptionSet() && nodeType.IsTable);
+                (nodeType.IsMultiSelectOptionSet() && nodeType.IsTable);
         }
 
         public override bool IsOpSupportedByTable(OperationCapabilityMetadata metadata, TexlNode node, TexlBinding binding)
@@ -200,7 +198,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             var isRHSRecordScope = binding.IsFullRecordRowScopeAccess(_binaryOpNode.Right);
 
             // Check if this is a table delegation for CDS in operator
-            var isCdsInTableDelegation = binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled && metadata.IsDelegationSupportedByTable(DelegationCapability.CdsIn) &&
+            var isCdsInTableDelegation = metadata.IsDelegationSupportedByTable(DelegationCapability.CdsIn) &&
                 /* Left node can be first name, row scope lambda or a lookup column */
                 (_binaryOpNode.Left.Kind == NodeKind.FirstName || binding.IsFullRecordRowScopeAccess(_binaryOpNode.Left) || (_binaryOpNode.Left.Kind == NodeKind.DottedName && binding.GetType((_binaryOpNode.Left as DottedNameNode).Left).HasExpandInfo)) &&
                 /* Right has to be a single column table */

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationStrategies/OpDelegationStrategy.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationStrategies
             // Set(Names, ["Foo", Bar"]); Filter(Accounts, 'Account Name' in Names) - Using variable of type table
             // ClearCollect(Names, Accounts); Filter(Accounts, 'Account Name' in Names.'Account Name') - using column from collection.
             // This won't be delegated if the AllowAsyncDelegation- Filter(Accounts, 'Account Name' in Accounts.'Account Name') as Accounts.'Account Name' is async.
-            if (isRHSNode && binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled
+            if (isRHSNode
                 && opDelStrategy is BinaryOpDelegationStrategy { Op: BinaryOp.In }
                 && !binding.IsRowScope(node)
                 && binding.GetType(node).IsTable 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 var tableDsInfo = tableArgType.AssociatedDataSources.Single();
 
-                if (context.IsEnhancedDelegationEnabled && (tableDsInfo is IExternalCdsDataSource) && argTypes[0].HasPolymorphicInfo)
+                if ((tableDsInfo is IExternalCdsDataSource) && argTypes[0].HasPolymorphicInfo)
                 {
                     var expandInfo = argTypes[0].PolymorphicInfo.TryGetExpandInfo(tableDsInfo.TableMetadata.Name);
                     if (expandInfo != null)
@@ -106,7 +106,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsRowScopedServerDelegatable(CallNode callNode, TexlBinding binding, OperationCapabilityMetadata metadata)
         {
-            return binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled && metadata.IsDelegationSupportedByTable(DelegationCapability.AsType);
+            return metadata.IsDelegationSupportedByTable(DelegationCapability.AsType);
         }
 
         protected override bool RequiresPagedDataForParamCore(TexlNode[] args, int paramIndex, TexlBinding binding)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountIf.cs
@@ -102,8 +102,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             IExternalDataSource dataSource = null;
 
-            // We ensure Document is available because some tests run with a null Document.
-            if ((binding.Document != null && !binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled) || !TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource))
+            if (!TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource))
             {
                 if (dataSource != null && dataSource.IsDelegatable)
                 {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountRows.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/CountRows.cs
@@ -76,10 +76,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             preferredFunctionDelegationCapability = FunctionDelegationCapability;
 
-            // We ensure Document is available because some tests run with a null Document.
-            if ((binding.Document != null
-                && binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled)
-                && TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource)
+            if (TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource)
                 && !ExpressionContainsView(callNode, binding))
             {
                 // Check that target table is not an expanded entity (1-N/N-N relationships)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Filter.cs
@@ -153,8 +153,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             FilterOpMetadata metadata = null;
             if (TryGetEntityMetadata(callNode, binding, out IDelegationMetadata delegationMetadata))
             {
-                if (!binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled ||
-                    !TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
+                if (!TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
                 {
                     SuggestDelegationHint(callNode, binding);
                     return false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -83,8 +83,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             FilterOpMetadata metadata = null;
             if (TryGetEntityMetadata(callNode, binding, out IDelegationMetadata delegationMetadata))
             {
-                if (!binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled ||
-                    !TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
+                if (!TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
                 {
                     SuggestDelegationHint(callNode, binding);
                     return false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Sort.cs
@@ -150,8 +150,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             SortOpMetadata metadata = null;
             if (TryGetEntityMetadata(callNode, binding, out IDelegationMetadata delegationMetadata))
             {
-                if (!binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled ||
-                    !TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
+                if (!TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
                 {
                     SuggestDelegationHint(callNode, binding);
                     return false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -233,8 +233,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             SortOpMetadata metadata = null;
             if (TryGetEntityMetadata(callNode, binding, out IDelegationMetadata delegationMetadata))
             {
-                if (!binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled ||
-                    !TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
+                if (!TryGetValidDataSourceForDelegation(callNode, binding, DelegationCapability.ArrayLookup, out _))
                 {
                     SuggestDelegationHint(callNode, binding);
                     return false;

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestUtils.cs
@@ -282,7 +282,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
             {
                 IExternalDataSource dataSource = null;
 
-                if ((binding.Document != null && !binding.Document.Properties.EnabledFeatures.IsEnhancedDelegationEnabled) || !TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource))
+                if (!TryGetValidDataSourceForDelegation(callNode, binding, FunctionDelegationCapability, out dataSource))
                 {
                     if (dataSource != null && !dataSource.IsDelegatable)
                     {


### PR DESCRIPTION
Enhanced delegation has been out and enabled by default for a long time now. Considering it's enabled in around 87% of Power Apps and there is confidence in the feature, we're getting rid of it as a setting and just making it the default behavior.