### PR TITLE
Do not suggest deferred types in Collect(| Intellisense

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -534,6 +534,13 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
             {
                 bool suggestable = false;
                 var symbolType = symbol.Value.Type;
+
+                // Do not suggest deferred symbols.
+                if (symbolType.IsDeferred)
+                {
+                    continue;
+                }
+
                 if (argType.IsAggregate && argType.ChildCount != 0)
                 {
                     suggestable = argType.Kind == symbolType.Kind &&
@@ -541,7 +548,7 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
                 }
                 else
                 {
-                    suggestable = (function.SupportCoercionForArg(argIndex) || argType.IsAggregate)
+                    suggestable = (function.SupportCoercionForArg(argIndex) || argType.IsAggregate) 
                     ? symbolType.CoercesTo(argType, aggregateCoercion: false, isTopLevelCoercion: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules)
                     : symbolType == argType;
                 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -217,6 +217,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             config.SymbolTable.AddVariable("table1", tableType1, displayName: "Table1");
             config.SymbolTable.AddVariable("table2", tableType2);
 
+            // Do not suggest Deferred.
+            config.SymbolTable.AddVariable("deferred", FormulaType.Deferred);
+
             config.SymbolTable.AddVariable("record1", tableType1.ToRecord());
             config.SymbolTable.AddVariable("record2", tableType2.ToRecord());
 


### PR DESCRIPTION
-While Suggesting Collect(| do not suggest deferred type, since we only want to suggest Table Types and even though Deferred Type is coercable to Table Types, it has no real meaning in this case.
-This also helps with not suggesting row scope symbols since they are also deferred types.