### PR TITLE
Add Contextual Suggestion for Binary Op

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -583,12 +583,20 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
 
             foreach (var symbol in symbols)
             {
+                var symbolType = symbol.Value.Type;
+
+                // Do not suggest deferred symbols.
+                if (symbolType.IsDeferred)
+                {
+                    continue;
+                }
+
                 var errors = new ErrorContainer();
-                BinderUtils.CheckBinaryOpCore(errors, binaryOp, usePowerFxV1CompatibilityRules, nonErrorNodeType, symbol.Value.Type, true);
+                BinderUtils.CheckBinaryOpCore(errors, binaryOp, usePowerFxV1CompatibilityRules, nonErrorNodeType, symbolType, true);
 
                 if (!errors.HasErrors())
                 {
-                    IntellisenseHelper.AddSuggestion(this, symbol, SuggestionKind.Global, SuggestionIconKind.Other, symbol.Value.Type, requiresSuggestionEscaping: true);
+                    IntellisenseHelper.AddSuggestion(this, symbol, SuggestionKind.Global, SuggestionIconKind.Other, symbolType, requiresSuggestionEscaping: true);
                 }
             }
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -185,6 +185,12 @@ namespace Microsoft.PowerFx.Intellisense
             return _addSuggestionHelper.AddSuggestion(intellisenseData, suggestion, suggestionKind, iconKind, type, requiresSuggestionEscaping, sortPriority);
         }
 
+        internal static bool AddSuggestion(IntellisenseData.IntellisenseData intellisenseData, KeyValuePair<string,  NameLookupInfo> suggestion, SuggestionKind suggestionKind, SuggestionIconKind iconKind, DType type, bool requiresSuggestionEscaping, uint sortPriority = 0)
+        {
+            var suggestionText = suggestion.Value.DisplayName != default ? suggestion.Value.DisplayName : suggestion.Key;
+            return AddSuggestion(intellisenseData, suggestionText, suggestionKind, iconKind, type, requiresSuggestionEscaping, sortPriority);
+        }
+
         internal static void AddSuggestionsForMatches(IntellisenseData.IntellisenseData intellisenseData, IEnumerable<string> possibilities, SuggestionKind kind, SuggestionIconKind iconKind, bool requiresSuggestionEscaping, uint sortPriority = 0)
         {
             Contracts.AssertValue(intellisenseData);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Option|", "OptionSet", "OtherOptionSet", "TopOptionSetField")]
         [InlineData("Opt|", "OptionSet", "OtherOptionSet", "TopOptionSetField")]
         [InlineData("Opti|on", "OptionSet", "OtherOptionSet", "TopOptionSetField")]
-        [InlineData("TopOptionSetField <> |")]
+        [InlineData("TopOptionSetField <> |", "TopOptionSetField", "XXX")]
         [InlineData("TopOptionSetField <> Opt|", "OptionSet", "TopOptionSetField", "OtherOptionSet")]
         public void TestSuggestOptionSets(string expression, params string[] expectedSuggestions)
         {
@@ -207,6 +207,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         // No suggestion if function is not in binder.
         [InlineData("InvalidFunction(|")]
+
+        // Binary Op Suggestions.
+        [InlineData("1 = |", "num")]
+        [InlineData("1 + |", "num", "str")]
         public void TestArgSuggestion(string expression, params string[] expectedSuggestions)
         {
             var config = SuggestTests.Default;


### PR DESCRIPTION
-Adds contextual suggestions for Binary Op node.
Today 
`Num = |` doesn't suggest global number types.

This PR will suggest global types depending on left hand side of type for binary op nodes.