### PR TITLE
fix stackoverflow from 1789

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/JsonRpc/ObsoleteTypeSerializer/FormulaTypeToSchemaConverter.cs
@@ -146,6 +146,13 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             private Dictionary<string, FormulaTypeSchema> GetChildren(AggregateType type)
             {
                 var fields = new Dictionary<string, FormulaTypeSchema>(StringComparer.Ordinal);
+
+                if (type.TableSymbolName != null)
+                {
+                    // Doesn't support cycles. Just terminate. 
+                    return fields;
+                }
+
                 foreach (var child in type.GetFieldTypes())
                 {
                     child.Type.Visit(this);


### PR DESCRIPTION
Fix #1789 

This only happens when front end &getExpressionType=true

We don't even need type information for dataverse types. Just short circuit and return empty. 
