### PR TITLE
Enable field suggestion for custom functions.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -156,6 +156,8 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if the function uses an input's column names to inform Intellisense's suggestions.
         public virtual bool CanSuggestInputColumns => false;
 
+        public virtual bool IsInputColumnSuggestionArg0 => false;
+
         // Return true if the function expects a screen's context variables to be suggested within a record argument.
         public virtual bool CanSuggestContextVariables => false;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -156,7 +156,26 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if the function uses an input's column names to inform Intellisense's suggestions.
         public virtual bool CanSuggestInputColumns => false;
 
-        public virtual bool IsInputColumnSuggestionArg0 => false;
+        /// <summary>
+        /// If this returns false, the Intellisense will use Arg[0] type to suggest the type of the argument.
+        /// e.g. Collect(), Remove(), etc.
+        /// </summary>
+        /// <param name="argIndex"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public virtual bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            var maxArgIndex = (ParamTypes?.Count() ?? 0) - 1;
+
+            if (argIndex >= 0 && argIndex <= maxArgIndex)
+            {
+                type = ParamTypes.ElementAt(argIndex);
+                return true;
+            }
+
+            type = default;
+            return false;
+        }
 
         // Return true if the function expects a screen's context variables to be suggested within a record argument.
         public virtual bool CanSuggestContextVariables => false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -24,6 +24,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool CanSuggestInputColumns => true;
 
+        public override bool IsInputColumnSuggestionArg0 => true;
+
         public override bool IsSelfContained => true;
 
         public ErrorFunction()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Error.cs
@@ -24,9 +24,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool CanSuggestInputColumns => true;
 
-        public override bool IsInputColumnSuggestionArg0 => true;
-
         public override bool IsSelfContained => true;
+
+        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            type = default;
+            return false;
+        }
 
         public ErrorFunction()
             : base("Error", TexlStrings.AboutError, FunctionCategories.Logical, DType.ObjNull, 0, 1, 1)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -7,11 +7,15 @@ using System.Linq;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.Texl.Intellisense;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Types;
+using static Microsoft.PowerFx.Intellisense.Intellisense;
+using CallNode = Microsoft.PowerFx.Syntax.CallNode;
 
 namespace Microsoft.PowerFx.Intellisense.IntellisenseData
 {
@@ -529,11 +533,15 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
 
             var maxArgIndex = (function?.ParamTypes?.Count() ?? 0) - 1;
 
-            var argType = maxArgIndex >= argIndex
-                ? function.ParamTypes.ElementAt(argIndex)
-                : DType.Unknown;
-
             var symbols = globalResolver.GlobalSymbols;
+
+            var parentCallNode = IntellisenseHelper.GetNearestCallNode(CurNode);
+            var argType = FunctionRecordNameSuggestionHandler.GetAggregateType(function, parentCallNode, this);
+
+            if (CurNode?.Parent?.Kind == NodeKind.Record)
+            {
+                FunctionRecordNameSuggestionHandler.AddSuggestionForAggregateAndParentRecord(CurNode, argType, this);
+            }
 
             var usePowerFxV1CompatibilityRules = this.Binding.Features.PowerFxV1CompatibilityRules;
             foreach (var symbol in symbols)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -668,7 +668,7 @@ namespace Microsoft.PowerFx.Intellisense
             return false;
         }
 
-        private static CallNode GetNearestCallNode(TexlNode node)
+        internal static CallNode GetNearestCallNode(TexlNode node)
         {
             Contracts.AssertValue(node);
             var parent = node;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/FunctionRecordNameSuggestionHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/FunctionRecordNameSuggestionHandler.cs
@@ -102,8 +102,22 @@ namespace Microsoft.PowerFx.Intellisense
                 {
                     return type;
                 }
+                else if (func.IsInputColumnSuggestionArg0)
+                {
+                    return intellisenseData.Binding.GetType(callNode.Args.Children[0]);
+                }
+                else
+                {
+                    var argIndex = intellisenseData.ArgIndex;
+                    var maxArgIndex = (func?.ParamTypes?.Count() ?? 0) - 1;
 
-                return intellisenseData.Binding.GetType(callNode.Args.Children[0]);
+                    if (argIndex <= maxArgIndex)
+                    {
+                        return func.ParamTypes.ElementAt(argIndex);
+                    }
+                }
+
+                return DType.Error;
             }
 
             private static bool TryGetParentRecordNode(TexlNode node, out RecordNode recordNode)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
@@ -34,6 +34,8 @@ namespace Microsoft.PowerFx
 
         private readonly bool _isBehavior;
 
+        public override bool CanSuggestInputColumns => true;
+
         public CustomTexlFunction(string name, FunctionCategories functionCategory, FormulaType returnType, string[] argNames, params FormulaType[] paramTypes)
             : this(name, functionCategory, returnType._type, argNames, Array.ConvertAll(paramTypes, x => x._type))
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -42,6 +42,8 @@ namespace Microsoft.PowerFx.Interpreter
 
         public override bool CanSuggestInputColumns => true;
 
+        public override bool IsInputColumnSuggestionArg0 => true;
+
         public override bool ArgMatchesDatasourceType(int argNum)
         {
             return argNum >= 1;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
@@ -42,7 +43,16 @@ namespace Microsoft.PowerFx.Interpreter
 
         public override bool CanSuggestInputColumns => true;
 
-        public override bool IsInputColumnSuggestionArg0 => true;
+        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            if (argIndex == 1)
+            {
+                type = default;
+                return false;
+            }
+
+            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
+        }
 
         public override bool ArgMatchesDatasourceType(int argNum)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -25,6 +25,8 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool CanSuggestInputColumns => true;
 
+        public override bool IsInputColumnSuggestionArg0 => true;
+
         public override bool ArgMatchesDatasourceType(int argNum)
         {
             return argNum >= 1;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -25,7 +25,16 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool CanSuggestInputColumns => true;
 
-        public override bool IsInputColumnSuggestionArg0 => true;
+        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            if (argIndex == 1)
+            {
+                type = default;
+                return false;
+            }
+
+            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
+        }
 
         public override bool ArgMatchesDatasourceType(int argNum)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -25,16 +25,7 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool CanSuggestInputColumns => true;
 
-        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
-        {
-            if (argIndex == 1)
-            {
-                type = default;
-                return false;
-            }
-
-            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
-        }
+        public override bool ManipulatesCollections => true;
 
         public override bool ArgMatchesDatasourceType(int argNum)
         {
@@ -137,6 +128,17 @@ namespace Microsoft.PowerFx.Functions
         public override bool IsSelfContained => false;
 
         public override bool MutatesArg0 => true;
+
+        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            if (argIndex == 1 || argIndex == 2)
+            {
+                type = default;
+                return false;
+            }
+
+            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
+        }
 
         public override bool IsLazyEvalParam(int index)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -28,16 +28,7 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool CanSuggestInputColumns => true;
 
-        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
-        {
-            if (argIndex == 1)
-            {
-                type = default;
-                return false;
-            }
-
-            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
-        }
+        public override bool ManipulatesCollections => true;
 
         public override bool ArgMatchesDatasourceType(int argNum)
         {
@@ -85,6 +76,17 @@ namespace Microsoft.PowerFx.Functions
     internal class RemoveFunction : RemoveFunctionBase, IAsyncTexlFunction
     {
         public override bool IsSelfContained => false;
+
+        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            if (argIndex == 1)
+            {
+                type = default;
+                return false;
+            }
+
+            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
+        }
 
         public RemoveFunction()
         : base("Remove", AboutRemove, FunctionCategories.Table | FunctionCategories.Behavior, DType.Unknown, 0, 2, int.MaxValue, DType.EmptyTable, DType.EmptyRecord)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -28,6 +28,8 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool CanSuggestInputColumns => true;
 
+        public override bool IsInputColumnSuggestionArg0 => true;
+
         public override bool ArgMatchesDatasourceType(int argNum)
         {
             return argNum >= 1;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -28,7 +28,16 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool CanSuggestInputColumns => true;
 
-        public override bool IsInputColumnSuggestionArg0 => true;
+        public override bool TryGetTypeForArgSuggestionAt(int argIndex, out DType type)
+        {
+            if (argIndex == 1)
+            {
+                type = default;
+                return false;
+            }
+
+            return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
+        }
 
         public override bool ArgMatchesDatasourceType(int argNum)
         {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -251,6 +251,26 @@ namespace Microsoft.PowerFx.Tests
         }
 
         // Must have "Function" suffix. 
+        internal class TestRecordInputCustomFunction : ReflectionFunction
+        {
+            public TestRecordInputCustomFunction()
+                : base(
+                      "RecordInputTest",
+                      FormulaType.Number,
+                      RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)),
+                      FormulaType.String,
+                      RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)).Add(new NamedFormulaType("name", FormulaType.String)))
+            {
+            }
+
+            // Must have "Execute" method. 
+            public static NumberValue Execute(NumberValue number, RecordValue record1, StringValue str, RecordValue record2)
+            {
+                return FormulaValue.New(1);
+            }
+        }
+
+        // Must have "Function" suffix. 
         private class TestInvalidRecordCustomFunction : ReflectionFunction
         {
             public TestInvalidRecordCustomFunction()

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -253,13 +253,15 @@ namespace Microsoft.PowerFx.Tests
         // Must have "Function" suffix. 
         internal class TestRecordInputCustomFunction : ReflectionFunction
         {
-            private static FormulaType Arg1 => RecordType.Empty().Add(new NamedFormulaType("field1", FormulaType.Number));
+            private static RecordType Arg1 => RecordType.Empty().Add(new NamedFormulaType("field1", FormulaType.Number));
 
             private static FormulaType Arg2 => FormulaType.String;
             
-            private static FormulaType Arg3 => RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)).Add(new NamedFormulaType("name", FormulaType.String));
+            private static RecordType Arg3 => RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)).Add(new NamedFormulaType("name", FormulaType.String));
 
-            private static FormulaType Arg4 => RecordType.Empty().Add(new NamedFormulaType("nested", Arg1)).Add("nested2", Arg3);
+            private static RecordType Arg4 => RecordType.Empty().Add(new NamedFormulaType("nested", Arg1)).Add("nested2", Arg3);
+
+            private static TableType Arg5 => Arg4.ToTable();
 
             public TestRecordInputCustomFunction()
                 : base(
@@ -268,7 +270,8 @@ namespace Microsoft.PowerFx.Tests
                       Arg1,
                       Arg2,
                       Arg3,
-                      Arg4)
+                      Arg4,
+                      Arg5)
             {
             }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -253,13 +253,22 @@ namespace Microsoft.PowerFx.Tests
         // Must have "Function" suffix. 
         internal class TestRecordInputCustomFunction : ReflectionFunction
         {
+            private static FormulaType Arg1 => RecordType.Empty().Add(new NamedFormulaType("field1", FormulaType.Number));
+
+            private static FormulaType Arg2 => FormulaType.String;
+            
+            private static FormulaType Arg3 => RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)).Add(new NamedFormulaType("name", FormulaType.String));
+
+            private static FormulaType Arg4 => RecordType.Empty().Add(new NamedFormulaType("nested", Arg1)).Add("nested2", Arg3);
+
             public TestRecordInputCustomFunction()
                 : base(
                       "RecordInputTest",
                       FormulaType.Number,
-                      RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)),
-                      FormulaType.String,
-                      RecordType.Empty().Add(new NamedFormulaType("id", FormulaType.Number)).Add(new NamedFormulaType("name", FormulaType.String)))
+                      Arg1,
+                      Arg2,
+                      Arg3,
+                      Arg4)
             {
             }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/CustomFunctions.cs
@@ -263,6 +263,8 @@ namespace Microsoft.PowerFx.Tests
 
             private static TableType Arg5 => Arg4.ToTable();
 
+            private static FormulaType Arg6 => RecordType.Empty().Add(new NamedFormulaType("topNested", Arg4));
+
             public TestRecordInputCustomFunction()
                 : base(
                       "RecordInputTest",
@@ -271,12 +273,13 @@ namespace Microsoft.PowerFx.Tests
                       Arg2,
                       Arg3,
                       Arg4,
-                      Arg5)
+                      Arg5,
+                      Arg6)
             {
             }
 
             // Must have "Execute" method. 
-            public static NumberValue Execute(NumberValue number, RecordValue record1, StringValue str, RecordValue record2)
+            public static NumberValue Execute(NumberValue number, RecordValue record1, StringValue str, RecordValue record2, TableValue table, RecordValue record)
             {
                 return FormulaValue.New(1);
             }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -192,9 +192,15 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         [Theory]
         [InlineData("Collect(|", "Entity1", "Entity2", "Table1", "table2")]
+        [InlineData("Patch(|", "Entity1", "Entity2", "Table1", "table2")]
+        [InlineData("Remove(|", "Entity1", "Entity2", "Table1", "table2")]
 
         // doesn't suggest Irrelevant global variables if type1 is non empty aggregate.
         [InlineData("Collect(table2,|", "record2")]
+        [InlineData("Patch(table2,|", "record2")]
+        [InlineData("Patch(table2, record2, |", "record2")]
+        [InlineData("Remove(table2, |", "record2")]
+
         [InlineData("Collect(|, record1", "Entity1", "Entity2", "Table1", "table2")]
         [InlineData("Sum(|", "num", "str")]
         [InlineData("Text(|", "num", "str")]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -192,7 +192,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         [Theory]
         [InlineData("Collect(|", "Entity1", "Entity2", "Table1", "table2")]
-        [InlineData("Collect(t1,|", "record1", "record2")]
+
+        // doesn't suggest Irrelevant global variables if type1 is non empty aggregate.
+        [InlineData("Collect(table2,|", "record2")]
         [InlineData("Collect(|, record1", "Entity1", "Entity2", "Table1", "table2")]
         [InlineData("Sum(|", "num", "str")]
         [InlineData("Text(|", "num", "str")]
@@ -229,6 +231,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             config.SymbolTable.EnableMutationFunctions();
 
+            config.SymbolTable.AddHostObject("User", RecordType.Empty(), (sp) => RecordValue.NewRecordFromFields());
+            
             var tableType1 = TableType.Empty();
             config.SymbolTable.AddVariable("table1", tableType1, displayName: "Table1");
 
@@ -258,11 +262,43 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         [Theory]
 
-        [InlineData("RecordInputTest( {|", "field1:")]
-        [InlineData("RecordInputTest( {num : 1}, \"test\", {|", "id:", "name:")]
-        [InlineData("RecordInputTest( {num : 1}, \"test\", { id: 1, name: \"test\"}, {|", "nested:")]
-        [InlineData("RecordInputTest( {num : 1}, \"test\", { id: 1, name: \"test\"}, { nested:{|", "field1:")]
-        [InlineData("RecordInputTest( {num : 1}, \"test\", { id: 1, name: \"test\"}, { nested2:{|", "id:", "name:")]
+        // record fields.
+        [InlineData(
+            "RecordInputTest( {|",
+            "field1:")]
+        [InlineData(
+            "RecordInputTest( {field1 : 1}, \"test\", {|",
+            "id:", 
+            "name:")]
+        [InlineData(
+            "RecordInputTest( {field1 : 2}, \"test\", { id: 1, name: \"test\"}, {|", 
+            "nested:",
+            "nested2:")]
+
+        // nested record field.
+        [InlineData(
+            "RecordInputTest( {field1 : 3}, \"test\", { id: 1, name: \"test\"}, { nested:{|", 
+            "field1:")]
+        [InlineData(
+            "RecordInputTest( {field1 : 4}, \"test\", { id: 1, name: \"test\"}, { nested2:{|", 
+            "id:", 
+            "name:")]
+
+        // table type arg.
+        [InlineData(
+            "RecordInputTest( {field1 : 5}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [{|",
+            "nested:",
+            "nested2:")]
+
+        // table type arg with nested record field.
+        [InlineData(
+            "RecordInputTest( {field1 : 6}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [ { nested: |",
+            "field1:")]
+
+        [InlineData(
+            "RecordInputTest( {field1 : 7}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [ { nested2: |",
+            "id:",
+            "name:")]
         public void TestCustomFunctionSuggestion(string expression, params string[] expectedSuggestions)
         {
             var config = SuggestTests.Default;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -289,6 +289,19 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             "RecordInputTest( {field1 : 4}, \"test\", { id: 1, name: \"test\"}, { nested2:{|", 
             "id:", 
             "name:")]
+        [InlineData(
+            "RecordInputTest( {field1 : 3}, \"test\", { id: 1, name: \"test\"}, { nested:{ field1: 1}, nested2: {|",
+            "id:",
+            "name:")]
+
+        [InlineData(
+            "RecordInputTest({field1:1}, \"test\", {id:1,name:\"test\"}, {nested2:{id:1,name:\"test\"}},[{nested:{field1:1}}], {topNested:{nested2:{|",
+            "id:",
+            "name:")]
+
+        // No suggestion, if there is no curly brace open.
+        [InlineData(
+            "RecordInputTest( {field1 : 3}, \"test\", { id: 1, name: \"test\"}, { nested:{ field1: 1}, nested2: |")]
 
         // table type arg.
         [InlineData(
@@ -298,11 +311,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
         // table type arg with nested record field.
         [InlineData(
-            "RecordInputTest( {field1 : 6}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [ { nested: |",
+            "RecordInputTest( {field1 : 6}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [ { nested: {|",
             "field1:")]
 
         [InlineData(
-            "RecordInputTest( {field1 : 7}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [ { nested2: |",
+            "RecordInputTest( {field1 : 7}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [ { nested2: {|",
             "id:",
             "name:")]
         public void TestCustomFunctionSuggestion(string expression, params string[] expectedSuggestions)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -257,8 +257,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Theory]
-        [InlineData("RecordInputTest( {|", "id:")]
+
+        [InlineData("RecordInputTest( {|", "field1:")]
         [InlineData("RecordInputTest( {num : 1}, \"test\", {|", "id:", "name:")]
+        [InlineData("RecordInputTest( {num : 1}, \"test\", { id: 1, name: \"test\"}, {|", "nested:")]
+        [InlineData("RecordInputTest( {num : 1}, \"test\", { id: 1, name: \"test\"}, { nested:{|", "field1:")]
+        [InlineData("RecordInputTest( {num : 1}, \"test\", { id: 1, name: \"test\"}, { nested2:{|", "id:", "name:")]
         public void TestCustomFunctionSuggestion(string expression, params string[] expectedSuggestions)
         {
             var config = SuggestTests.Default;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -255,5 +255,21 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             Assert.Equal(expectedSuggestions, result.Suggestions.Select(suggestion => suggestion.DisplayText.Text).ToArray());
         }
+
+        [Theory]
+        [InlineData("RecordInputTest( {|", "id:")]
+        [InlineData("RecordInputTest( {num : 1}, \"test\", {|", "id:", "name:")]
+        public void TestCustomFunctionSuggestion(string expression, params string[] expectedSuggestions)
+        {
+            var config = SuggestTests.Default;
+
+            config.SymbolTable.EnableMutationFunctions();
+
+            // With Input record type param
+            config.AddFunction(new TestRecordInputCustomFunction());
+
+            var actualSuggestions = SuggestStrings(expression, config, null);
+            Assert.Equal(expectedSuggestions, actualSuggestions);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1787 
-If the custom function provided ParamType, now intellisense will suggest the corresponding columns. _including nested columns_, and columns inside a table type.
-Adds virtual `TryGetTypeForArgSuggestionAt(int argIndex, out DType type) ` to get Type intellisense will be used to match suggestions.
-Fixes Patch and Remove for suggestions.

NOTE: PA would need to override the `TryGetTypeForArgSuggestionAt()` for mutation functions definition in same way it's done here.