### PR TITLE
add clock service

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/SymbolExtensions.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx
@@ -32,6 +33,28 @@ namespace Microsoft.PowerFx
         public static void SetCulture(this RuntimeConfig symbols, CultureInfo culture)
         {
             symbols.AddService(culture ?? throw new ArgumentNullException(nameof(culture)));
+        }
+
+        /// <summary>
+        /// Set clock service for use with Today(), IsToday(), Now(). 
+        /// </summary>
+        /// <param name="symbols">SymbolValues where to set the CultureInfo.</param>
+        /// <param name="clock">service to provide current time.</param>
+        /// <exception cref="ArgumentNullException">When clock is null.</exception>
+        public static void SetClock(this RuntimeConfig symbols, IClockService clock)
+        {
+            symbols.AddService<IClockService>(clock ?? throw new ArgumentNullException(nameof(clock)));
+        }
+
+        /// <summary>
+        /// Set random service to override generating random numbers with Rand(), RandBetween().
+        /// </summary>
+        /// <param name="symbols">SymbolValues where to set the CultureInfo.</param>
+        /// <param name="random">servce to generate random numbers.</param>
+        /// <exception cref="ArgumentNullException">When random is null.</exception>
+        public static void SetRandom(this RuntimeConfig symbols, IRandomService random)
+        {
+            symbols.AddService<IRandomService>(random ?? throw new ArgumentNullException(nameof(random)));
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/IClockService.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/IClockService.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerFx.Functions
+{
+    /// <summary>
+    /// Service for any time function like Now() or Today().
+    /// </summary>
+    [ThreadSafeImmutable]
+    public interface IClockService
+    {
+        /// <summary>
+        /// Returns the current time, in UTC. 
+        /// </summary>
+        DateTime UtcNow { get; }
+    }
+
+    internal class DefaultClockService : IClockService
+    {
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -66,7 +66,8 @@ namespace Microsoft.PowerFx.Tests
                 $"{ns}.{nameof(TypeCoercionProvider)}",             
 
                 // Services for functions. 
-                $"{ns}.Functions.IRandomService"
+                $"{ns}.Functions.IRandomService",
+                $"{ns}.Functions.IClockService"
             };
 
             var sb = new StringBuilder();
@@ -1134,7 +1135,7 @@ namespace Microsoft.PowerFx.Tests
         {
             var engine = new RecalcEngine();
             var values = new RuntimeConfig();
-            values.AddService<IRandomService>(new TestRandService());
+            values.SetRandom(new TestRandService());
 
             // Rand 
             var result = engine.EvalAsync("Rand()", CancellationToken.None, runtimeConfig: values).Result;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/TimeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/TimeTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Core.Texl.Builtins;
+using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Types;
 using Xunit;
 
@@ -89,5 +91,33 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 Assert.True(false, "result was not a DateTimeValue");
             }
         }
+
+        public class TestClockService : IClockService
+        {
+            public DateTime UtcNow { get; set; } = new DateTime(2023, 6, 2, 3, 15, 7, DateTimeKind.Utc);
+        }
+
+        // Test Now/Today expressions.
+        // Use explicit clock service to set time and be fully deterministic. 
+        [Theory]
+        [InlineData("Today()", "6/1/2023 12:00:00 AM")]
+        [InlineData("Now()", "6/1/2023 8:15:07 PM")]
+        [InlineData("IsToday(Now())", "True")]
+        [InlineData("IsToday(Date(2023, 6,2))", "False")] // converts to local
+        [InlineData("IsToday(Date(2023, 6,1))", "True")]
+        [InlineData("Day(Now())", "1")]
+        [InlineData("TimeZoneOffset()", "420")]
+        public void TestWithClockService(string expr, string expectedResultStr)
+        {
+            RuntimeConfig rc = new RuntimeConfig();
+            rc.SetTimeZone(TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+            rc.SetClock(new TestClockService());
+                        
+            var result = _engine.EvalAsync(expr, default, runtimeConfig: rc).Result;
+
+            var actualResultStr = result.ToObject().ToString();
+
+            Assert.Equal(expectedResultStr, actualResultStr);
+        }        
     }
 }


### PR DESCRIPTION
Add an IClockService, similar to existing IRandomService. 
Call clock service instead of DateTime.UtcNow directly. This abstracts our direct dependency on the machine. It also allows the host to override, which can be very useful for deterministic testing Today(), IsToday(), Now() - especially around UTC , datetime boundaries. 
