### PR TITLE
Updates on x-ms-dynamic-* connector extensions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3" >
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>    

--- a/src/libraries/Microsoft.PowerFx.Connectors/ArgumentMapper.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ArgumentMapper.cs
@@ -49,16 +49,16 @@ namespace Microsoft.PowerFx.Connectors
         public readonly int ArityMax;
         public readonly OpenApiOperation Operation;
 
-        private readonly Dictionary<string, (FormulaValue, DType)> _parameterDefaultValues = new ();
+        private readonly Dictionary<string, (bool, FormulaValue, DType)> _parameterDefaultValues = new ();
         private readonly Dictionary<TypedName, List<string>> _parameterOptions = new ();
         #endregion // ServiceFunction args
 
         public bool HasBodyParameter => Operation.RequestBody != null;
 
         // numberIsFloat = numbers are stored as C# double when set to true, otherwise they are stored as C# decimal
-        public ArgumentMapper(IEnumerable<OpenApiParameter> parameters, OpenApiOperation operation, bool numberIsFloat = false)
-        {
-            OpenApiParameters = parameters.ToList();
+        public ArgumentMapper(OpenApiOperation operation, bool numberIsFloat = false)
+        {            
+            OpenApiParameters = operation.Parameters.ToList();
             OpenApiBodyParameters = new List<OpenApiParameter>();
             Operation = operation;
             ContentType = OpenApiExtensions.ContentType_ApplicationJson; // default
@@ -88,23 +88,25 @@ namespace Microsoft.PowerFx.Connectors
 
                 if (param.IsInternal())
                 {
-                    if (param.Required && param.Schema.Default != null)
+                    if (param.Required)
                     {
-                        // Ex: Api-Version (but not ConnectionId as it doesn't have a default value)
+                        if (param.Schema.Default == null)
+                        {
+                            // Ex: connectionId
+                            continue;
+                        }
+
+                        // Ex: Api-Version 
                         hiddenRequired = true;
-                    }
-                    else
-                    {
-                        // "Internal" params aren't shown in the signature.                     
-                        continue;
-                    }
+                    }                    
                 }
 
                 string name = param.Name;
                 ConnectorParameterType cpt = param.Schema.ToFormulaType(numberIsFloat: numberIsFloat);
-                cpt.SetProperties(param.Name, param.Required);
+                cpt.SetProperties(param);
 
                 ConnectorDynamicValue connectorDynamicValue = GetDynamicValue(param, numberIsFloat);
+                ConnectorDynamicList connectorDynamicList = GetDynamicList(param, numberIsFloat);
                 string summary = GetSummary(param);
                 bool explicitInput = GetExplicitInput(param);
 
@@ -117,23 +119,23 @@ namespace Microsoft.PowerFx.Connectors
 
                 if (param.Schema.TryGetDefaultValue(cpt.Type, out FormulaValue defaultValue, numberIsFloat: numberIsFloat))
                 {
-                    _parameterDefaultValues[name] = (defaultValue, cpt.Type._type);
+                    _parameterDefaultValues[name] = (cpt.ConnectorType.IsRequired, defaultValue, cpt.Type._type);
                 }
 
                 if (param.Required)
                 {
                     if (hiddenRequired)
                     {
-                        hiddenRequiredParams.Add(new ConnectorParameterInternal(param, cpt.Type, cpt.ConnectorType, summary, connectorDynamicValue, null));
+                        hiddenRequiredParams.Add(new ConnectorParameterInternal(param, cpt.Type, cpt.ConnectorType, summary, connectorDynamicValue, connectorDynamicList, null, null));
                     }
                     else
                     {
-                        requiredParams.Add(new ConnectorParameterInternal(param, cpt.Type, cpt.ConnectorType, summary, connectorDynamicValue, null));
+                        requiredParams.Add(new ConnectorParameterInternal(param, cpt.Type, cpt.ConnectorType, summary, connectorDynamicValue, connectorDynamicList, null, null));
                     }
                 }
                 else
                 {
-                    optionalParams.Add(new ConnectorParameterInternal(param, cpt.Type, cpt.ConnectorType, summary, connectorDynamicValue, null));
+                    optionalParams.Add(new ConnectorParameterInternal(param, cpt.Type, cpt.ConnectorType, summary, connectorDynamicValue, connectorDynamicList, null, null));
                 }
 
                 string[] options = param.GetOptions();
@@ -160,6 +162,7 @@ namespace Microsoft.PowerFx.Connectors
                     {
                         OpenApiSchema schema = mediaType.Schema;
                         ConnectorDynamicSchema connectorDynamicSchema = GetDynamicSchema(schema, numberIsFloat);
+                        ConnectorDynamicProperty connectorDynamicProperty = GetDynamicProperty(schema, numberIsFloat);
 
                         ContentType = contentType;
                         ReferenceId = schema?.Reference?.Id;
@@ -193,12 +196,12 @@ namespace Microsoft.PowerFx.Connectors
                                 OpenApiBodyParameters.Add(bodyParameter);
 
                                 ConnectorParameterType cpt = prop.Value.ToFormulaType(numberIsFloat: numberIsFloat);
-                                cpt.SetProperties(prop.Key, required);
-                                (hiddenRequired ? hiddenRequiredBodyParams : required ? requiredBodyParams : optionalBodyParams).Add(new KeyValuePair<string, ConnectorSchemaInternal>(prop.Key, new ConnectorSchemaInternal(prop.Value, cpt.Type, cpt.ConnectorType, summary, null, connectorDynamicSchema)));
+                                cpt.SetProperties(prop.Key, required, prop.Value.GetVisibility());
+                                (hiddenRequired ? hiddenRequiredBodyParams : required ? requiredBodyParams : optionalBodyParams).Add(new KeyValuePair<string, ConnectorSchemaInternal>(prop.Key, new ConnectorSchemaInternal(prop.Value, cpt.Type, cpt.ConnectorType, summary, null, null, connectorDynamicSchema, connectorDynamicProperty)));
 
                                 if (cpt.HiddenRecordType != null)
                                 {
-                                    hiddenRequiredBodyParams.Add(new KeyValuePair<string, ConnectorSchemaInternal>(prop.Key, new ConnectorSchemaInternal(prop.Value, cpt.HiddenRecordType, cpt.HiddenConnectorType, summary, null, connectorDynamicSchema)));
+                                    hiddenRequiredBodyParams.Add(new KeyValuePair<string, ConnectorSchemaInternal>(prop.Key, new ConnectorSchemaInternal(prop.Value, cpt.HiddenRecordType, cpt.HiddenConnectorType, summary, null, null, connectorDynamicSchema, connectorDynamicProperty)));
                                 }
                             }
                         }
@@ -209,8 +212,8 @@ namespace Microsoft.PowerFx.Connectors
 
                             OpenApiBodyParameters.Add(bodyParameter);
                             ConnectorParameterType cpt2 = schema.ToFormulaType(numberIsFloat: numberIsFloat);
-                            cpt2.SetProperties(bodyName, requestBody.Required);
-                            (requestBody.Required ? requiredParams : optionalParams).Add(new ConnectorParameterInternal(bodyParameter, cpt2.Type, cpt2.ConnectorType, summary, null, connectorDynamicSchema));
+                            cpt2.SetProperties(bodyName, requestBody.Required, schema.GetVisibility());
+                            (requestBody.Required ? requiredParams : optionalParams).Add(new ConnectorParameterInternal(bodyParameter, cpt2.Type, cpt2.ConnectorType, summary, null, null, connectorDynamicSchema, connectorDynamicProperty));
 
                             if (cpt2.HiddenRecordType != null)
                             {
@@ -226,7 +229,7 @@ namespace Microsoft.PowerFx.Connectors
                     bodyParameter = new OpenApiParameter() { Schema = new OpenApiSchema() { Type = "string" }, Name = bodyName, Description = "Body", Required = requestBody.Required };
 
                     OpenApiBodyParameters.Add(bodyParameter);
-                    (requestBody.Required ? requiredParams : optionalParams).Add(new ConnectorParameterInternal(bodyParameter, FormulaType.String, new ConnectorType(bodyParameter.Schema, FormulaType.String), summary, null, null));
+                    (requestBody.Required ? requiredParams : optionalParams).Add(new ConnectorParameterInternal(bodyParameter, FormulaType.String, new ConnectorType(bodyParameter.Schema, FormulaType.String), summary, null, null, null, null));
                 }
             }
 
@@ -257,7 +260,7 @@ namespace Microsoft.PowerFx.Connectors
                     while (requiredParamNames.Contains(newName));
     
                     TypedName newTypeName = new TypedName(opi.TypedName.Type, new DName(newName));
-                    opis2.Add(new ServiceFunctionParameterTemplate(opi.FormulaType, opi.ConnectorType, newTypeName, opi.Description, opi.Summary, opi.DefaultValue, opi.ConnectorDynamicValue, opi.ConnectorDynamicSchema));
+                    opis2.Add(new ServiceFunctionParameterTemplate(opi.FormulaType, opi.ConnectorType, newTypeName, opi.Description, opi.Summary, opi.DefaultValue, opi.ConnectorDynamicValue, opi.ConnectorDynamicList, opi.ConnectorDynamicSchema, opi.ConnectorDynamicProperty));
                 }
                 else
                 {
@@ -292,9 +295,12 @@ namespace Microsoft.PowerFx.Connectors
             Dictionary<string, FormulaValue> map = new (StringComparer.OrdinalIgnoreCase);
 
             // Seed with default values. This will get over written if provided. 
-            foreach (KeyValuePair<string, (FormulaValue, DType)> kv in _parameterDefaultValues)
+            foreach (KeyValuePair<string, (bool required, FormulaValue fValue, DType dType)> kv in _parameterDefaultValues)
             {
-                map[kv.Key] = kv.Value.Item1;
+                if (kv.Value.required)
+                {
+                    map[kv.Key] = kv.Value.fValue;
+                }
             }
 
             foreach (ServiceFunctionParameterTemplate param in HiddenRequiredParamInfo)
@@ -426,66 +432,75 @@ namespace Microsoft.PowerFx.Connectors
         {
             return param.Extensions != null && param.Extensions.TryGetValue("x-ms-url-encoding", out IOpenApiExtension ext) && ext is OpenApiString apiStr && apiStr.Value.Equals("double", StringComparison.OrdinalIgnoreCase);
         }
-
+        
         private static ConnectorDynamicValue GetDynamicValue(IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
             if (param.Extensions != null && param.Extensions.TryGetValue("x-ms-dynamic-values", out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
             {
-                // We don't support "capability" parameter which is present in Azure Blob storage swagger
-                // There is no "operationId" in this case and we don't manage this for now
-                if (apiObj.TryGetValue("capability", out IOpenApiAny cap))
-                {
-                    return null;
-                }
+                ConnectorDynamicValue cdv = new ();
 
+                // Mandatory openrationId for connectors, except when capibility or builtInOperation are defined
+                apiObj.WhenPresent("operationId", (opId) => cdv.OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId));
+                apiObj.WhenPresent("parameters", (opPrms) => cdv.ParameterMap = GetOpenApiObject(opPrms, numberIsFloat));
+                apiObj.WhenPresent("value-title", (opValTitle) => cdv.ValueTitle = opValTitle);
+                apiObj.WhenPresent("value-path", (opValPath) => cdv.ValuePath = opValPath);
+                apiObj.WhenPresent("value-collection", (opValCollection) => cdv.ValueCollection = opValCollection);
+                apiObj.WhenPresent("capability", (op_capStr) => cdv.Capability = op_capStr);
+                apiObj.WhenPresent("builtInOperation", (op_bioStr) => cdv.BuiltInOperation = op_bioStr);
+                
+                return cdv;
+            }
+
+            return null;
+        }
+
+        private static ConnectorDynamicList GetDynamicList(IOpenApiExtensible param, bool numberIsFloat)
+        {
+            // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
+            if (param.Extensions != null && param.Extensions.TryGetValue("x-ms-dynamic-list", out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
+            {                
                 // Mandatory openrationId for connectors
                 if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)
                 {
                     if (apiObj.TryGetValue("parameters", out IOpenApiAny op_prms) && op_prms is OpenApiObject opPrms)
-                    {                        
-                        ConnectorDynamicValue cdv = new ()
+                    {
+                        ConnectorDynamicList cdl = new ()
                         {
                             OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
                             ParameterMap = GetOpenApiObject(opPrms, numberIsFloat)
                         };
 
-                        if (apiObj.TryGetValue("value-title", out IOpenApiAny op_valtitle) && op_valtitle is OpenApiString opValTitle)
+                        if (apiObj.TryGetValue("itemTitlePath", out IOpenApiAny op_valtitle) && op_valtitle is OpenApiString opValTitle)
                         {
-                            cdv.ValueTitle = opValTitle.Value;
+                            cdl.ItemTitlePath = opValTitle.Value;
                         }
 
-                        if (apiObj.TryGetValue("value-path", out IOpenApiAny op_valpath) && op_valpath is OpenApiString opValPath)
+                        if (apiObj.TryGetValue("itemsPath", out IOpenApiAny op_valpath) && op_valpath is OpenApiString opValPath)
                         {
-                            cdv.ValuePath = opValPath.Value;
+                            cdl.ItemPath = opValPath.Value;
                         }
 
-                        if (apiObj.TryGetValue("value-collection", out IOpenApiAny op_valcoll) && op_valcoll is OpenApiString opValCollection)
+                        if (apiObj.TryGetValue("itemValuePath", out IOpenApiAny op_valcoll) && op_valcoll is OpenApiString opValCollection)
                         {
-                            cdv.ValueCollection = opValCollection.Value;
+                            cdl.ItemValuePath = opValCollection.Value;
                         }
 
-                        return cdv;
+                        return cdl;
                     }
                 }
                 else
-                {
-                    if (apiObj.TryGetValue("builtInOperation", out IOpenApiAny _))
-                    {
-                        // We don't support builtInOperation for now
-                        return null;
-                    }
-
-                    throw new NotImplementedException("Missing mandatory parameters operationId and parameters in x-ms-dynamic-values extension");
+                {                   
+                    throw new NotImplementedException("Missing mandatory parameters operationId and parameters in x-ms-dynamic-list extension");
                 }
             }
 
             return null;
         }
 
-        private static Dictionary<string, string> GetOpenApiObject(OpenApiObject opPrms, bool numberIsFloat)
+        private static Dictionary<string, IValue> GetOpenApiObject(OpenApiObject opPrms, bool numberIsFloat)
         {
-            Dictionary<string, string> dvParams = new ();
+            Dictionary<string, IValue> dvParams = new ();
 
             foreach (KeyValuePair<string, IOpenApiAny> prm in opPrms)
             {                
@@ -494,13 +509,42 @@ namespace Microsoft.PowerFx.Connectors
                     throw new NotImplementedException($"Unsupported param with OpenApi type {prm.Value.GetType().FullName}, key = {prm.Key}");
                 }
 
-                dvParams.Add(prm.Key, System.Text.Json.JsonSerializer.Serialize(fv.ToObject()));
+                if (fv is not RecordValue rv)
+                {
+                    dvParams.Add(prm.Key, new StaticValue() { Value = fv });
+                }                
+                else 
+                {
+                    FormulaValue staticValue = rv.GetField("value");
+
+                    if (staticValue is not BlankValue)
+                    {
+                        dvParams.Add(prm.Key, new StaticValue() { Value = staticValue });
+                        continue;
+                    }                    
+
+                    FormulaValue dynamicValue = rv.GetField("parameter");
+
+                    if (dynamicValue is BlankValue)
+                    {
+                        dynamicValue = rv.GetField("parameterReference");
+                    }
+
+                    if (dynamicValue is StringValue sv2)
+                    {
+                        dvParams.Add(prm.Key, new DynamicValue() { Reference = sv2.Value });
+                    }                    
+                    else
+                    {
+                        throw new Exception("Invalid dynamic value type for {prm.Value.GetType().FullName}, key = {prm.Key}");
+                    }
+                }               
             }
 
             return dvParams;
         }
 
-        private static ConnectorDynamicSchema GetDynamicSchema(IOpenApiExtensible param, bool numberIsFloat)
+        internal static ConnectorDynamicSchema GetDynamicSchema(IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
             if (param.Extensions != null && param.Extensions.TryGetValue("x-ms-dynamic-schema", out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
@@ -527,6 +571,39 @@ namespace Microsoft.PowerFx.Connectors
                 else
                 {
                     throw new NotImplementedException("Missing mandatory parameters operationId and parameters in x-ms-dynamic-schema extension");
+                }
+            }
+
+            return null;
+        }
+
+        internal static ConnectorDynamicProperty GetDynamicProperty(IOpenApiExtensible param, bool numberIsFloat)
+        {
+            // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
+            if (param.Extensions != null && param.Extensions.TryGetValue("x-ms-dynamic-properties", out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
+            {
+                // Mandatory openrationId for connectors
+                if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)
+                {
+                    if (apiObj.TryGetValue("parameters", out IOpenApiAny op_prms) && op_prms is OpenApiObject opPrms)
+                    {
+                        ConnectorDynamicProperty cdp = new ()
+                        {
+                            OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
+                            ParameterMap = GetOpenApiObject(opPrms, numberIsFloat)
+                        };
+
+                        if (apiObj.TryGetValue("itemValuePath", out IOpenApiAny op_valpath) && op_valpath is OpenApiString opValPath)
+                        {
+                            cdp.ItemValuePath = opValPath.Value;
+                        }
+
+                        return cdp;
+                    }
+                }
+                else
+                {
+                    throw new NotImplementedException("Missing mandatory parameters operationId and parameters in x-ms-dynamic-properties extension");
                 }
             }
 
@@ -563,8 +640,10 @@ namespace Microsoft.PowerFx.Connectors
                         internalParameter.OpenApiParameter.Description, 
                         internalParameter.Summary, 
                         defaultValue, 
-                        internalParameter.DynamicValue, 
-                        internalParameter.DynamicSchema);
+                        internalParameter.DynamicValue,
+                        internalParameter.DynamicList,
+                        internalParameter.DynamicSchema,
+                        internalParameter.DynamicProperty);
         }
 
         private static ServiceFunctionParameterTemplate Convert(KeyValuePair<string, ConnectorSchemaInternal> internalParameter, bool numberIsFloat)
@@ -581,8 +660,10 @@ namespace Microsoft.PowerFx.Connectors
                         "Body", 
                         internalParameter.Value.Summary, 
                         defaultValue, 
-                        internalParameter.Value.DynamicValue, 
-                        internalParameter.Value.DynamicSchema);
+                        internalParameter.Value.DynamicValue,
+                        internalParameter.Value.DynamicList,
+                        internalParameter.Value.DynamicSchema,
+                        internalParameter.Value.DynamicProperty);
         }
     }
 
@@ -590,8 +671,8 @@ namespace Microsoft.PowerFx.Connectors
     {
         public OpenApiParameter OpenApiParameter { get; }
 
-        public ConnectorParameterInternal(OpenApiParameter openApiParameter, FormulaType type, ConnectorType connectorType, string summary, ConnectorDynamicValue dynamicValue, ConnectorDynamicSchema dynamicSchema)
-            : base(openApiParameter.Schema, type, connectorType, summary, dynamicValue, dynamicSchema)
+        public ConnectorParameterInternal(OpenApiParameter openApiParameter, FormulaType type, ConnectorType connectorType, string summary, ConnectorDynamicValue dynamicValue, ConnectorDynamicList dynamicList, ConnectorDynamicSchema dynamicSchema, ConnectorDynamicProperty dynamicProperty)
+            : base(openApiParameter.Schema, type, connectorType, summary, dynamicValue, dynamicList, dynamicSchema, dynamicProperty)
         {
             OpenApiParameter = openApiParameter;
         }
@@ -611,20 +692,32 @@ namespace Microsoft.PowerFx.Connectors
         public ConnectorDynamicValue DynamicValue { get; }
 
         /// <summary>
+        /// "x-ms-dynamic-list".
+        /// </summary>
+        public ConnectorDynamicList DynamicList { get; }
+
+        /// <summary>
         /// "x-ms-dynamic-schema".
         /// </summary>
         public ConnectorDynamicSchema DynamicSchema { get; }
 
+        /// <summary>
+        /// "x-ms-dynamic-properties".
+        /// </summary>
+        public ConnectorDynamicProperty DynamicProperty { get; }
+
         public string Summary { get; }
 
-        public ConnectorSchemaInternal(OpenApiSchema schema, FormulaType type, ConnectorType connectorType, string summary, ConnectorDynamicValue dynamicValue, ConnectorDynamicSchema dynamicSchema)
+        public ConnectorSchemaInternal(OpenApiSchema schema, FormulaType type, ConnectorType connectorType, string summary, ConnectorDynamicValue dynamicValue, ConnectorDynamicList dynamicList, ConnectorDynamicSchema dynamicSchema, ConnectorDynamicProperty dynamicProperty)
         {
             Schema = schema;
             Type = type;
             ConnectorType = connectorType;
             Summary = summary;
             DynamicValue = dynamicValue;
-            DynamicSchema = dynamicSchema;            
+            DynamicList = dynamicList;
+            DynamicSchema = dynamicSchema;           
+            DynamicProperty = dynamicProperty;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConfigExtensions.cs
@@ -57,6 +57,7 @@ namespace Microsoft.PowerFx
                 throw new ArgumentNullException(nameof(openApiDocument));
             }
 
+            connectorSettings.Namespace = functionNamespace;
             List<ServiceFunction> functions = OpenApiParser.Parse(functionNamespace, openApiDocument, httpClient, connectorSettings);
             foreach (ServiceFunction function in functions)
             {
@@ -99,7 +100,7 @@ namespace Microsoft.PowerFx
                 throw new ArgumentNullException(nameof(function));
             }
 
-            config.AddFunction(function.GetServiceFunction(functionNamespace, httpClient, connectorSettings: connectorSettings));
+            config.AddFunction(function.GetServiceFunction(httpClient, connectorSettings));
         }
 
         public static void Add(this Dictionary<string, FormulaValue> map, string fieldName, FormulaValue value)

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicApi.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicApi.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
-using Microsoft.AppMagic.Authoring.Texl.Builtins;
+using System.Diagnostics;
+using Microsoft.PowerFx.Connectors;
+using Microsoft.PowerFx.Types;
 
 namespace Microsoft.AppMagic.Authoring.Texl.Builtins
 {
@@ -11,8 +13,26 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
         public string OperationId;
 
         // param name to be called, param name of current function
-        public Dictionary<string, string> ParameterMap;
+        public Dictionary<string, IValue> ParameterMap;
 
-        public ServiceFunction ServiceFunction;
+        //public ServiceFunction ServiceFunction;
+
+        public ConnectorFunction ConnectorFunction;
+    }
+
+    [DebuggerDisplay("Static: {Value}")]
+    internal class StaticValue : IValue
+    {
+        public FormulaValue Value;
+    }
+
+    [DebuggerDisplay("Dynamic: {Reference}")]
+    internal class DynamicValue : IValue
+    {
+        public string Reference;
+    }
+
+    internal interface IValue
+    {
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicList.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicList.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AppMagic.Authoring.Texl.Builtins;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    internal class ConnectorDynamicList : ConnectionDynamicApi
+    {
+        /// <summary>
+        /// "itemTitlePath" in "x-ms-dynamic-list".
+        /// </summary>
+        public string ItemTitlePath = null;
+
+        /// <summary>
+        /// "itemsPath" in "x-ms-dynamic-list".
+        /// </summary>
+        public string ItemPath = null;
+
+        /// <summary>
+        /// "itemValuePath" in "x-ms-dynamic-list".
+        /// </summary>
+        public string ItemValuePath = null;
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicProperty.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicProperty.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.AppMagic.Authoring.Texl.Builtins;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    internal class ConnectorDynamicProperty : ConnectionDynamicApi
+    {
+        /// <summary>
+        /// "itemValuePath" in "x-ms-dynamic-properties".
+        /// </summary>
+        public string ItemValuePath = null;
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorDynamicValue.cs
@@ -18,6 +18,18 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
         /// <summary>
         /// "value-collection" in "x-ms-dynamic-values".
         /// </summary>
-        public string ValueCollection = null;        
+        public string ValueCollection = null;
+
+        /// <summary>
+        /// "capability" in "x-ms-dynamic-values".
+        /// https://github.com/nk-gears/pa-custom-connector-filepicker/blob/main/README.md.
+        /// https://reenhanced.com/2021/power-automate-secrets-how-to-implement-a-custom-file-picker-undocumented/.
+        /// </summary>
+        public string Capability = null;
+
+        /// <summary>
+        /// "builtInOperation" in "x-ms-dynamic-values".
+        /// </summary>
+        public string BuiltInOperation = null;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Connectors
         /// <summary>
         /// Namespace of the function (not contained in swagger file).
         /// </summary>
-        public string Namespace { get; private set; }
+        public string Namespace => ConnectorSettings.Namespace;
 
         /// <summary>
         /// Defines if the function is supported or contains unsupported elements.
@@ -96,6 +96,18 @@ namespace Microsoft.PowerFx.Connectors
         internal OpenApiDocument Document { get; init; }
 
         /// <summary>
+        /// Dynamic schema extension on return type (response).
+        /// </summary>
+        internal ConnectorDynamicSchema DynamicReturnSchema => ReturnParameterType.DynamicReturnSchema;
+
+        /// <summary>
+        /// Dynamic schema extension on return type (response).
+        /// </summary>
+        internal ConnectorDynamicProperty DynamicReturnProperty => ReturnParameterType.DynamicReturnProperty;
+
+        internal ConnectorParameterType ReturnParameterType { get; init; }
+
+        /// <summary>
         /// Visibility defined as "x-ms-visibility" string content.
         /// </summary>
         public string Visibility => Operation.GetVisibility();
@@ -129,7 +141,7 @@ namespace Microsoft.PowerFx.Connectors
         /// <summary>
         /// Required parameters.
         /// </summary>
-        public ConnectorParameter[] RequiredParameters => _requiredParameters ??= ArgumentMapper.RequiredParamInfo.Select(sfpt => new ConnectorParameter(sfpt.TypedName.Name, sfpt.FormulaType, sfpt.ConnectorType, sfpt.Description, sfpt.Summary, sfpt.DefaultValue)).ToArray();
+        public ConnectorParameter[] RequiredParameters => _requiredParameters ??= ArgumentMapper.RequiredParamInfo.Select(sfpt => new ConnectorParameter(sfpt.TypedName.Name, sfpt.FormulaType, sfpt.ConnectorType, sfpt.Description, sfpt.Summary, sfpt.DefaultValue, sfpt.SupportsDynamicIntellisense)).ToArray();
 
         /// <summary>
         /// Hidden required parameters.
@@ -138,12 +150,12 @@ namespace Microsoft.PowerFx.Connectors
         /// - "x-ms-visibility" string set to "internal" 
         /// - has a default value.
         /// </summary>
-        internal ConnectorParameter[] HiddenRequiredParameters => _hiddenRequiredParameters ??= ArgumentMapper.HiddenRequiredParamInfo.Select(sfpt => new ConnectorParameter(sfpt.TypedName.Name, sfpt.FormulaType, sfpt.ConnectorType, sfpt.Description, sfpt.Summary, sfpt.DefaultValue)).ToArray();
+        internal ConnectorParameter[] HiddenRequiredParameters => _hiddenRequiredParameters ??= ArgumentMapper.HiddenRequiredParamInfo.Select(sfpt => new ConnectorParameter(sfpt.TypedName.Name, sfpt.FormulaType, sfpt.ConnectorType, sfpt.Description, sfpt.Summary, sfpt.DefaultValue, sfpt.SupportsDynamicIntellisense)).ToArray();
 
         /// <summary>
         /// Optional parameters.
         /// </summary>
-        public ConnectorParameter[] OptionalParameters => _optionalParameters ??= ArgumentMapper.OptionalParamInfo.Select(sfpt => new ConnectorParameter(sfpt.TypedName.Name, sfpt.FormulaType, sfpt.ConnectorType, sfpt.Description, sfpt.Summary, sfpt.DefaultValue)).ToArray();
+        public ConnectorParameter[] OptionalParameters => _optionalParameters ??= ArgumentMapper.OptionalParamInfo.Select(sfpt => new ConnectorParameter(sfpt.TypedName.Name, sfpt.FormulaType, sfpt.ConnectorType, sfpt.Description, sfpt.Summary, sfpt.DefaultValue, sfpt.SupportsDynamicIntellisense)).ToArray();
 
         /// <summary>
         /// Minimum number of arguments.
@@ -165,45 +177,14 @@ namespace Microsoft.PowerFx.Connectors
         /// <summary>
         /// ArgumentMapper class.
         /// </summary>
-        internal ArgumentMapper ArgumentMapper => _argumentMapper ??= new ArgumentMapper(Operation.Parameters, Operation, NumberIsFloat);
-
-        /// <summary>
-        /// True if the function has a service function.
-        /// </summary>
-        internal bool HasServiceFunction => _defaultServiceFunction != null;
+        internal ArgumentMapper ArgumentMapper => _argumentMapper ??= new ArgumentMapper(Operation, NumberIsFloat);
 
         private ArgumentMapper _argumentMapper;
         private ConnectorParameter[] _requiredParameters;
         private ConnectorParameter[] _hiddenRequiredParameters;
         private ConnectorParameter[] _optionalParameters;
-        internal readonly ServiceFunction _defaultServiceFunction;
 
-        public ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod)
-            : this(openApiOperation, isSupported, notSupportedReason, name, operationPath, httpMethod, null, null, false, new ConnectorSettings())
-        {
-        }
-
-        public ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod, string @namespace)
-            : this(openApiOperation, isSupported, notSupportedReason, name, operationPath, httpMethod, @namespace, null, false, new ConnectorSettings())
-        {
-        }
-
-        public ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod, string @namespace, HttpClient httpClient)
-            : this(openApiOperation, isSupported, notSupportedReason, name, operationPath, httpMethod, @namespace, httpClient, false, new ConnectorSettings())
-        {
-        }
-
-        public ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod, string @namespace, HttpClient httpClient, bool throwOnError)
-            : this(openApiOperation, isSupported, notSupportedReason, name, operationPath, httpMethod, @namespace, httpClient, throwOnError, new ConnectorSettings())
-        {
-        }
-
-        public ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod, string @namespace, HttpClient httpClient, bool throwOnError, bool numberIsFloat)
-            : this(openApiOperation, isSupported, notSupportedReason, name, operationPath, httpMethod, @namespace, httpClient, throwOnError, new ConnectorSettings() { NumberIsFloat = numberIsFloat })
-        {
-        }
-
-        public ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod, string @namespace, HttpClient httpClient, bool throwOnError, ConnectorSettings connectorSettings)
+        internal ConnectorFunction(OpenApiOperation openApiOperation, bool isSupported, string notSupportedReason, string name, string operationPath, HttpMethod httpMethod, ConnectorSettings connectorSettings)
         {
             Operation = openApiOperation ?? throw new ArgumentNullException(nameof(openApiOperation));
             Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -213,54 +194,41 @@ namespace Microsoft.PowerFx.Connectors
             IsSupported = isSupported;
             NotSupportedReason = notSupportedReason ?? (isSupported ? string.Empty : throw new ArgumentNullException(nameof(notSupportedReason)));
 
-            if (httpClient != null)
-            {
-                _defaultServiceFunction = GetServiceFunction(@namespace, httpClient, throwOnError: throwOnError, connectorSettings);
-            }
+            // validate return type
+            (ConnectorParameterType ct, string unsupportedReason) = openApiOperation.GetConnectorParameterReturnType(connectorSettings.NumberIsFloat);
+            ReturnParameterType = ct;
 
-            if (isSupported)
+            if (!string.IsNullOrEmpty(unsupportedReason))
             {
-                // validate return type
-                (ConnectorParameterType ct, string unsupportedReason) = openApiOperation.GetConnectorParameterReturnType(connectorSettings.NumberIsFloat);
-
-                if (!string.IsNullOrEmpty(unsupportedReason))
-                {
-                    IsSupported = false;
-                    NotSupportedReason = unsupportedReason;
-                }
+                IsSupported = false;
+                NotSupportedReason = unsupportedReason;
             }
         }
-                
-        public ConnectorParameters GetParameters(FormulaValue[] knownParameters)
-        {
-            return this.GetParameters(knownParameters, null);
-        }
 
-        public ConnectorParameters GetParameters(FormulaValue[] knownParameters, IServiceProvider services)
+        public ConnectorParameters GetParameters(FormulaValue[] knownParameters, IServiceProvider services, ConnectorSettings connectorSettings = null)
         {
             ConnectorParameterWithSuggestions[] parametersWithSuggestions = RequiredParameters.Select((rp, i) => i < ArityMax - 1
                                                                                                             ? new ConnectorParameterWithSuggestions(rp, i < knownParameters.Length ? knownParameters[i] : null)
                                                                                                             : new ConnectorParameterWithSuggestions(rp, knownParameters.Skip(ArityMax - 1).ToArray())).ToArray();
 
-            bool error = true;
+            connectorSettings ??= new ConnectorSettings();
+            RuntimeConnectorContext context = services?.GetService<RuntimeConnectorContext>();
+            ServiceFunction serviceFunction = GetServiceFunction(httpClient: context?.GetInvoker(Namespace), connectorSettings: connectorSettings);
 
-            if (HasServiceFunction)
+            int index = Math.Min(knownParameters.Length, serviceFunction.MaxArity - 1);
+            ConnectorSuggestions suggestions = serviceFunction.GetConnectorSuggestionsAsync(knownParameters, knownParameters.Length, services, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            bool error = suggestions == null || suggestions.Error != null;
+
+            if (!error)
             {
-                int index = Math.Min(knownParameters.Length, _defaultServiceFunction.MaxArity - 1);
-                ConnectorSuggestions suggestions = _defaultServiceFunction.GetConnectorSuggestionsAsync(knownParameters, knownParameters.Length, services, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
-
-                error = suggestions == null || suggestions.Error != null;
-
-                if (!error)
+                if (knownParameters.Length >= ArityMax - 1)
                 {
-                    if (knownParameters.Length >= ArityMax - 1)
-                    {
-                        parametersWithSuggestions[index].ParameterNames = suggestions.Suggestions.Select(s => s.DisplayName).ToArray();
-                        suggestions.Suggestions = suggestions.Suggestions.Skip(knownParameters.Length - ArityMax + 1).ToList();
-                    }
-
-                    parametersWithSuggestions[index].Suggestions = suggestions.Suggestions;
+                    parametersWithSuggestions[index].ParameterNames = suggestions.Suggestions.Select(s => s.DisplayName).ToArray();
+                    suggestions.Suggestions = suggestions.Suggestions.Skip(knownParameters.Length - ArityMax + 1).ToList();
                 }
+
+                parametersWithSuggestions[index].Suggestions = suggestions.Suggestions;
             }
 
             return new ConnectorParameters()
@@ -307,18 +275,17 @@ namespace Microsoft.PowerFx.Connectors
             return sb.ToString();
         }
 
-        internal ServiceFunction GetServiceFunction(string ns = null, HttpMessageInvoker httpClient = null, bool throwOnError = false, ConnectorSettings connectorSettings = null)
+        internal ServiceFunction GetServiceFunction(HttpMessageInvoker httpClient = null, ConnectorSettings connectorSettings = null)
         {
             ScopedHttpFunctionInvoker invoker = null;
-            string func_ns = string.IsNullOrEmpty(ns) ? "Internal_Function" : ns;
-            DPath functionNamespace = DPath.Root.Append(new DName(func_ns));
-            Namespace = func_ns;
             connectorSettings ??= new ConnectorSettings();
+            string func_ns = string.IsNullOrEmpty(connectorSettings.Namespace) ? "Internal_Function" : connectorSettings.Namespace;
+            DPath functionNamespace = DPath.Root.Append(new DName(func_ns));
 
             if (httpClient != null)
             {
-                var httpInvoker = new HttpFunctionInvoker(httpClient, HttpMethod, OpenApiParser.GetServer(Document, httpClient), OperationPath, ReturnType, ArgumentMapper, connectorSettings.Cache);
-                invoker = new ScopedHttpFunctionInvoker(DPath.Root.Append(DName.MakeValid(func_ns, out _)), Name, func_ns, httpInvoker, throwOnError);
+                var httpInvoker = new HttpFunctionInvoker(httpClient, HttpMethod, OpenApiParser.GetServer(Document, httpClient), OperationPath, ReturnType, ArgumentMapper, connectorSettings.Cache, connectorSettings.ReturnRawResult);
+                invoker = new ScopedHttpFunctionInvoker(DPath.Root.Append(DName.MakeValid(func_ns, out _)), Name, func_ns, httpInvoker, connectorSettings.ThrowOnError);
             }
 
             ServiceFunction serviceFunction = new ServiceFunction(
@@ -340,6 +307,7 @@ namespace Microsoft.PowerFx.Connectors
                 parameterOptions: new Dictionary<TypedName, List<string>>(),
                 optionalParamInfo: ArgumentMapper.OptionalParamInfo,
                 requiredParamInfo: ArgumentMapper.RequiredParamInfo,
+                returnTypeInfo: ReturnParameterType,
                 parameterDefaultValues: new Dictionary<string, Tuple<string, DType>>(StringComparer.Ordinal),
                 pageLink: PageLink,
                 isSupported: IsSupported,
@@ -359,19 +327,37 @@ namespace Microsoft.PowerFx.Connectors
         internal async Task<FormulaValue> InvokeAync(FormattingInfo context, HttpClient httpClient, FormulaValue[] values, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return await GetServiceFunction(null, httpClient).InvokeAsync(context, values, cancellationToken).ConfigureAwait(false);
-        }
-
-        public Task<FormulaValue> InvokeAync(IRuntimeConfig config, HttpClient httpClient, FormulaValue[] values, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return InvokeAync(config.ServiceProvider.GetFormattingInfo(), httpClient, values, cancellationToken);
-        }
+            return await GetServiceFunction(httpClient, ConnectorSettings).InvokeAsync(context, values, cancellationToken).ConfigureAwait(false);
+        }    
 
         public Task<FormulaValue> InvokeAync(HttpClient httpClient, FormulaValue[] values, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return InvokeAync(FormattingInfoHelper.CreateFormattingInfo(), httpClient, values, cancellationToken);
+        }
+
+        // For future implementation, we want to support the capability to run intellisense on optional parameters and need to use the parameter name to get the suggestions.
+        // An example is Office 365 Outlook connector, with GetEmails function, where folderPath is optional and defines x-ms-dynamic-values
+        // Also on SharePoint action SearchForUser (Resolve User)
+        //public async Task<ConnectorSuggestions> GetConnectorSuggestionsAsync(HttpClient httpClient, NamedFormulaType[] inputParams, string suggestedParamName, CancellationToken cancellationToken)
+
+        // This API only works on required paramaters and assumes we interrogate param number N+1 if N parameters are provided.
+        public async Task<ConnectorSuggestions> GetConnectorSuggestionsAsync(HttpClient httpClient, FormulaValue[] knownParameters, IServiceProvider services, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ConnectorSettings connectorSettings = ConnectorSettings.Clone(throwOnError: false);            
+
+            ServiceFunction serviceFunction = GetServiceFunction(httpClient, connectorSettings);
+            return await serviceFunction.GetConnectorSuggestionsAsync(knownParameters, knownParameters.Length, services, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<FormulaType> GetConnectorReturnSchemaAsync(HttpClient httpClient, FormulaValue[] knownParameters, IServiceProvider services, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ConnectorSettings connectorSettings = ConnectorSettings.Clone(throwOnError: false, returnRawResult: true);
+            
+            ServiceFunction serviceFunction = GetServiceFunction(httpClient, connectorSettings);
+            return await serviceFunction.GetConnectorReturnSchemaAsync(knownParameters, services, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -408,7 +394,12 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         public FormulaValue DefaultValue { get; }
 
-        public ConnectorParameter(string name, FormulaType type, ConnectorType connectorType, string description, string summary, FormulaValue defaultValue)
+        /// <summary>
+        /// Supports dynamic Intellisense.
+        /// </summary>
+        public bool SupportsDynamicIntellisense { get; }
+
+        public ConnectorParameter(string name, FormulaType type, ConnectorType connectorType, string description, string summary, FormulaValue defaultValue, bool supportsDynamicIntellisense)
         {
             Name = name;
             FormulaType = type;
@@ -416,6 +407,7 @@ namespace Microsoft.PowerFx.Connectors
             Description = description;
             Summary = summary;
             DefaultValue = defaultValue;
+            SupportsDynamicIntellisense = supportsDynamicIntellisense;
         }
     }
 
@@ -429,14 +421,8 @@ namespace Microsoft.PowerFx.Connectors
 
         public string[] ParameterNames { get; internal set; }
 
-        public ConnectorParameterWithSuggestions(string name, FormulaType type, ConnectorType connectorType, string description, string summary, FormulaValue defaultValue)
-            : base(name, type, connectorType, description, summary, defaultValue)
-        {
-            Suggestions = new List<ConnectorSuggestion>();
-        }
-
         public ConnectorParameterWithSuggestions(ConnectorParameter connectorParameter, FormulaValue value)
-            : base(connectorParameter.Name, connectorParameter.FormulaType, connectorParameter.ConnectorType, connectorParameter.Description, connectorParameter.Summary, connectorParameter.DefaultValue)
+            : base(connectorParameter.Name, connectorParameter.FormulaType, connectorParameter.ConnectorType, connectorParameter.Description, connectorParameter.Summary, connectorParameter.DefaultValue, connectorParameter.SupportsDynamicIntellisense)
         {
             Suggestions = new List<ConnectorSuggestion>();
             Value = value;
@@ -444,7 +430,7 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         public ConnectorParameterWithSuggestions(ConnectorParameter connectorParameter, FormulaValue[] values)
-            : base(connectorParameter.Name, connectorParameter.FormulaType, connectorParameter.ConnectorType, connectorParameter.Description, connectorParameter.Summary, connectorParameter.DefaultValue)
+            : base(connectorParameter.Name, connectorParameter.FormulaType, connectorParameter.ConnectorType, connectorParameter.Description, connectorParameter.Summary, connectorParameter.DefaultValue, connectorParameter.SupportsDynamicIntellisense)
         {
             Suggestions = new List<ConnectorSuggestion>();
             Value = null;

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorParameterType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorParameterType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Diagnostics;
+using Microsoft.AppMagic.Authoring.Texl.Builtins;
 using Microsoft.OpenApi.Models;
 using Microsoft.PowerFx.Types;
 
@@ -20,6 +21,12 @@ namespace Microsoft.PowerFx.Connectors
         public ConnectorType ConnectorType { get; }
 
         public ConnectorType HiddenConnectorType { get; }
+
+        public bool SupportsSuggestions => false;
+
+        internal ConnectorDynamicSchema DynamicReturnSchema { get; private set; }
+
+        internal ConnectorDynamicProperty DynamicReturnProperty { get; private set; }
 
         public ConnectorParameterType(OpenApiSchema schema, FormulaType type, RecordType hiddenRecordType)
             : this(type)
@@ -59,16 +66,29 @@ namespace Microsoft.PowerFx.Connectors
             HiddenConnectorType = new ConnectorType(schema, hiddenRecordType, hiddenFields);
         }
 
-        public void SetProperties(string name, bool isRequired)
+        internal void SetProperties(OpenApiParameter param)
         {
+            SetProperties(param.Name, param.Required, param.GetVisibility());
+        }
+
+        internal void SetProperties(string name, bool required, string visibility)
+        { 
             ConnectorType.Name = name;
-            ConnectorType.IsRequired = isRequired;
+            ConnectorType.IsRequired = required;
+            ConnectorType.SetVisibility(visibility);
 
             if (HiddenConnectorType != null)
             {
                 HiddenConnectorType.Name = name;
-                HiddenConnectorType.IsRequired = isRequired;
+                HiddenConnectorType.IsRequired = required;
+                HiddenConnectorType.SetVisibility(visibility);
             }
+        }
+
+        internal void SetDynamicReturnSchemaAndProperty(ConnectorDynamicSchema dynamicSchema, ConnectorDynamicProperty dynamicProperty)
+        {
+            DynamicReturnSchema = dynamicSchema;
+            DynamicReturnProperty = dynamicProperty;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorSettings.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.PowerFx.Connectors
 {
-    public class ConnectorSettings
+    public class ConnectorSettings 
     {
         public ICachingHttpClient Cache { get; set; } = null;
 
@@ -12,5 +12,25 @@ namespace Microsoft.PowerFx.Connectors
         public int MaxRows { get; set; } = 1000;
 
         public bool IgnoreUnknownExtensions { get; set; } = false;
+
+        public bool ThrowOnError { get; set; } = true;
+
+        public bool ReturnRawResult { get; set; } = false;
+
+        public string Namespace { get; set; } = null;
+
+        public ConnectorSettings Clone(bool? throwOnError = null, bool? returnRawResult = null)
+        {
+            return new ConnectorSettings()
+            {
+                Cache = Cache,
+                NumberIsFloat = NumberIsFloat,
+                MaxRows = MaxRows,
+                IgnoreUnknownExtensions = IgnoreUnknownExtensions,
+                ThrowOnError = throwOnError ?? ThrowOnError,
+                ReturnRawResult = returnRawResult ?? ReturnRawResult,
+                Namespace = Namespace
+            };
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorType.cs
@@ -5,12 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
-using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
 
@@ -53,6 +51,8 @@ namespace Microsoft.PowerFx.Connectors
         // Option Set, only defined when IsEnum is true and EnumValues is not empty
         public OptionSet OptionSet => GetOptionSet();
 
+        public Visibility Visibility { get; internal set; }
+
         public ConnectorType(OpenApiSchema schema, FormulaType formulaType)
         {
             FormulaType = formulaType;
@@ -77,6 +77,18 @@ namespace Microsoft.PowerFx.Connectors
 
             IsRequired = false;
             Name = null;
+            
+            SetVisibility(schema);
+        }
+
+        internal void SetVisibility(OpenApiSchema schema)
+        {
+            SetVisibility(schema.GetVisibility());
+        }
+
+        internal void SetVisibility(string visibility)
+        {
+            Visibility = visibility.ToVisibility();
         }
 
         private OptionSet GetOptionSet()

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using Microsoft.AppMagic.Authoring.Texl.Builtins;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -144,7 +145,7 @@ namespace Microsoft.PowerFx.Connectors
                 defaultValue = null;
                 return false;
             }
-            
+
             return TryGetOpenApiValue(openApiDefaultValue, out defaultValue, numberIsFloat);
         }
 
@@ -194,7 +195,7 @@ namespace Microsoft.PowerFx.Connectors
                 formulaValue = FormulaValue.NewBlank();
             }
             else if (openApiAny is OpenApiArray arr)
-            {                
+            {
                 List<FormulaValue> lst = new List<FormulaValue>();
 
                 foreach (IOpenApiAny element in arr)
@@ -220,7 +221,7 @@ namespace Microsoft.PowerFx.Connectors
                 Dictionary<string, FormulaValue> dvParams = new ();
 
                 foreach (KeyValuePair<string, IOpenApiAny> kvp in o)
-                {                    
+                {
                     if (TryGetOpenApiValue(kvp.Value, out FormulaValue fv, numberIsFloat))
                     {
                         dvParams[kvp.Key] = fv;
@@ -230,7 +231,7 @@ namespace Microsoft.PowerFx.Connectors
                 formulaValue = FormulaValue.NewRecordFromFields(dvParams.Select(dvp => new NamedValue(dvp.Key, dvp.Value)));
             }
             else
-            { 
+            {
                 throw new NotImplementedException($"Unknown default value type {openApiAny.GetType().FullName}");
             }
 
@@ -244,7 +245,28 @@ namespace Microsoft.PowerFx.Connectors
 
         // Internal parameters are not showen to the user. 
         // They can have a default value or be special cased by the infrastructure (like "connectionId").
-        public static bool IsInternal(this IOpenApiExtensible schema) => schema.Extensions.TryGetValue("x-ms-visibility", out var openApiExt) && openApiExt is OpenApiString openApiStr && openApiStr.Value == "internal";
+        public static bool IsInternal(this IOpenApiExtensible schema) => string.Equals(schema.GetVisibility(), "internal", StringComparison.OrdinalIgnoreCase);
+
+        internal static string GetVisibility(this IOpenApiExtensible schema) => schema.Extensions.TryGetValue("x-ms-visibility", out IOpenApiExtension openApiExt) && openApiExt is OpenApiString openApiStr ? openApiStr.Value : null;
+
+        internal static (bool IsPresent, string Value) GetString(this OpenApiObject apiObj, string str) => apiObj.TryGetValue(str, out IOpenApiAny openApiAny) && openApiAny is OpenApiString openApiStr ? (true, openApiStr.Value) : (false, null);
+
+        internal static void WhenPresent(this OpenApiObject apiObj, string propName, Action<string> action)
+        {     
+            var (isPresent, value) = apiObj.GetString(propName);
+            if (isPresent) 
+            { 
+                action(value); 
+            }
+        }
+
+        internal static void WhenPresent(this OpenApiObject apiObj, string str, Action<OpenApiObject> action)
+        {
+            if (apiObj.TryGetValue(str, out IOpenApiAny openApiAny) && openApiAny is OpenApiObject openApiObj)
+            {
+                action(openApiObj);
+            }
+        }
 
         // See https://swagger.io/docs/specification/data-models/data-types/
         // numberIsFloat = numbers are stored as C# double when set to true, otherwise they are stored as C# decimal
@@ -270,8 +292,8 @@ namespace Microsoft.PowerFx.Connectors
                     // Anyhow, we'll have schema.Enum content in ConnertorType
 
                     switch (schema.Format)
-                    {                        
-                        case "date":                            
+                    {
+                        case "date":
                         case "date-time":
                             return new ConnectorParameterType(schema, FormulaType.DateTime);
                         case "date-no-tz":
@@ -280,11 +302,11 @@ namespace Microsoft.PowerFx.Connectors
                         case "binary":
                             return new ConnectorParameterType(schema, FormulaType.String);
 
-                        case "enum":                            
+                        case "enum":
                             if (schema.Enum.All(e => e is OpenApiString))
-                            {                                
+                            {
                                 OptionSet os = new OptionSet("enum", schema.Enum.Select(e => new DName((e as OpenApiString).Value)).ToDictionary(k => k, e => e).ToImmutableDictionary());
-                                return new ConnectorParameterType(schema, os.FormulaType);                            
+                                return new ConnectorParameterType(schema, os.FormulaType);
                             }
                             else
                             {
@@ -331,7 +353,7 @@ namespace Microsoft.PowerFx.Connectors
 
                         case "int64":
                         case "unixtime":
-                            return new ConnectorParameterType(schema, FormulaType.Decimal);                                                    
+                            return new ConnectorParameterType(schema, FormulaType.Decimal);
 
                         default:
                             throw new NotImplementedException($"Unsupported type of integer: {schema.Format}");
@@ -355,15 +377,15 @@ namespace Microsoft.PowerFx.Connectors
 
                     chain.Push(innerA);
                     ConnectorParameterType cpt = schema.Items.ToFormulaType(chain, level + 1, numberIsFloat: numberIsFloat);
-                    cpt.SetProperties("Array", true);
-                    chain.Pop();                    
+                    cpt.SetProperties("Array", true, schema.Items.GetVisibility());
+                    chain.Pop();
 
                     if (cpt.Type is RecordType r)
                     {
                         return new ConnectorParameterType(schema, r.ToTable(), cpt.ConnectorType);
                     }
                     else if (cpt.Type is TableType t)
-                    {                        
+                    {
                         // Array of array 
                         TableType tt = new TableType(TableType.Empty().Add(TableValue.ValueName, t)._type);
                         return new ConnectorParameterType(schema, tt, cpt.ConnectorType);
@@ -422,8 +444,8 @@ namespace Microsoft.PowerFx.Connectors
                             }
 
                             chain.Push(innerO);
-                            ConnectorParameterType cpt2 = kv.Value.ToFormulaType(chain, level + 1, numberIsFloat: numberIsFloat);                            
-                            cpt2.SetProperties(propName, schema.Required.Contains(propName));
+                            ConnectorParameterType cpt2 = kv.Value.ToFormulaType(chain, level + 1, numberIsFloat: numberIsFloat);
+                            cpt2.SetProperties(propName, schema.Required.Contains(propName), kv.Value.GetVisibility());
                             chain.Pop();
 
                             if (cpt2.HiddenRecordType != null)
@@ -485,19 +507,9 @@ namespace Microsoft.PowerFx.Connectors
             return ct?.Type ?? new BlankType();
         }
 
-        public static string GetVisibility(this OpenApiOperation op)
-        {
-            return op.Extensions.TryGetValue("x-ms-visibility", out IOpenApiExtension openExt) && openExt is OpenApiString str ? str.Value : null;
-        }
-
-        public static bool IsInternal(this OpenApiOperation op)
-        {
-            return string.Equals(op.GetVisibility(), "internal", StringComparison.OrdinalIgnoreCase);
-        }
-
         public static bool GetRequiresUserConfirmation(this OpenApiOperation op)
-        { 
-            return op.Extensions.TryGetValue("x-ms-require-user-confirmation", out IOpenApiExtension openExt) && openExt is OpenApiBoolean b && b.Value;            
+        {
+            return op.Extensions.TryGetValue("x-ms-require-user-confirmation", out IOpenApiExtension openExt) && openExt is OpenApiBoolean b && b.Value;
         }
 
         internal static (ConnectorParameterType, string) GetConnectorParameterReturnType(this OpenApiOperation op, bool numberIsFloat)
@@ -536,11 +548,15 @@ namespace Microsoft.PowerFx.Connectors
                         return (new ConnectorParameterType(), null);
                     }
 
+                    ConnectorDynamicSchema connectorDynamicSchema = ArgumentMapper.GetDynamicSchema(openApiMediaType.Schema, numberIsFloat);
+                    ConnectorDynamicProperty connectorDynamicProperty = ArgumentMapper.GetDynamicProperty(openApiMediaType.Schema, numberIsFloat);
+
                     ConnectorParameterType connectorParameterType = openApiMediaType.Schema.ToFormulaType(numberIsFloat: numberIsFloat);
-                    connectorParameterType.SetProperties("response", true);
+                    connectorParameterType.SetProperties("response", true, openApiMediaType.GetVisibility());
+                    connectorParameterType.SetDynamicReturnSchemaAndProperty(connectorDynamicSchema, connectorDynamicProperty);
 
                     return (connectorParameterType, null);
-                }               
+                }
             }
 
             // Returns something, but not json. 
@@ -600,6 +616,15 @@ namespace Microsoft.PowerFx.Connectors
 
             // Cannot determine Content-Type
             return (null, null);
+        }
+
+        public static Visibility ToVisibility(this string visibility)
+        {
+            return string.IsNullOrEmpty(visibility)
+                ? Visibility.None
+                : Enum.TryParse(visibility, true, out Visibility vis)
+                ? vis
+                : Visibility.Unknown;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunction.cs
@@ -10,8 +10,11 @@ using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
 using Microsoft.PowerFx;
 using Microsoft.PowerFx.Connectors;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
@@ -45,7 +48,7 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
         private readonly Dictionary<string, Tuple<string, DType>> _parameterDefaultValues;
         private readonly WeakReference<IService> _parentService;
         private readonly string _actionName;
-        private readonly bool _numberIsFloat;
+        private bool _numberIsFloat => _connectorSettings.NumberIsFloat;
 
         // Name of the field storing the page page link
         private readonly string _pageLink;
@@ -65,8 +68,9 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
         private readonly string _notSupportedReason;
 
         // For functions supporting paging, this is the max number of items that will be returned, independently of the number of pages
-        private readonly int _maxRows;
+        private int _maxRows => _connectorSettings.MaxRows;
         internal readonly ServiceFunctionParameterTemplate[] _requiredParameters;
+        private ConnectorParameterType _returnTypeInfo;
 
         public IEnumerable<TypedName> OptionalParams => _optionalParamInfo.Values;
         public Dictionary<string, TypedName> OptionalParamInfo => _optionalParamInfo;
@@ -78,14 +82,16 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
         public bool IsInternal => _isInternal;
         public bool IsNotSupported => !_isSupported;
         public string NotSupportedReason => _notSupportedReason;
+        public ConnectorParameterType ReturnTypeInfo => _returnTypeInfo;
+        private ConnectorSettings _connectorSettings;
 
         // Provide as hook for execution. 
         public ScopedHttpFunctionInvoker _invoker { get; init; }
 
         public ServiceFunction(IService parentService, DPath theNamespace, string name, string localeSpecificName, string description, DType returnType, BigInteger maskLambdas, int arityMin, int arityMax, bool isBehaviorOnly,
             bool isAutoRefreshable, bool isDynamic, bool isCacheEnabled, int cacheTimeoutMs, bool isHidden, Dictionary<TypedName, List<string>> parameterOptions, ServiceFunctionParameterTemplate[] optionalParamInfo,
-            ServiceFunctionParameterTemplate[] requiredParamInfo, Dictionary<string, Tuple<string, DType>> parameterDefaultValues, string pageLink, bool isSupported, string notSupportedReason, bool isDeprecated, bool isInternal,
-            string actionName = "", ConnectorSettings connectorSettings = null, params DType[] paramTypes)
+            ServiceFunctionParameterTemplate[] requiredParamInfo, ConnectorParameterType returnTypeInfo, Dictionary<string, Tuple<string, DType>> parameterDefaultValues, string pageLink, bool isSupported, string notSupportedReason, 
+            bool isDeprecated, bool isInternal, string actionName = "", ConnectorSettings connectorSettings = null, params DType[] paramTypes)
             : base(theNamespace, name, localeSpecificName, (l) => description, FunctionCategories.REST, returnType, maskLambdas, arityMin, arityMax, paramTypes)
         {
             Contracts.AssertValueOrNull(parentService);
@@ -108,7 +114,7 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
 
             _optionalParamInfo = new Dictionary<string, TypedName>(optionalParamInfo.Length);
             _parameterDescriptionMap = new Dictionary<string, string>(optionalParamInfo.Length + requiredParamInfo.Length);
-            connectorSettings ??= new ConnectorSettings();
+            _connectorSettings = connectorSettings ??= new ConnectorSettings();
 
             foreach (var optionalParam in optionalParamInfo)
             {
@@ -143,14 +149,13 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
             _signatures.Add(_orderedRequiredParams);
             _parameterDefaultValues = parameterDefaultValues;
             _actionName = actionName;
-            _requiredParameters = requiredParamInfo;
-            _numberIsFloat = connectorSettings.NumberIsFloat;
+            _requiredParameters = requiredParamInfo;            
             _pageLink = pageLink;
             _isSupported = isSupported;
             _notSupportedReason = notSupportedReason;
             _isDeprecated = isDeprecated;
-            _isInternal = isInternal;
-            _maxRows = connectorSettings.MaxRows;
+            _isInternal = isInternal;            
+            _returnTypeInfo = returnTypeInfo;
 
             if (arityMax > arityMin)
             {
@@ -260,121 +265,268 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
             return fArgsValid;
         }
 
-        public override async Task<ConnectorSuggestions> GetConnectorSuggestionsAsync(FormulaValue[] knownParameters, int argPosition, IServiceProvider services, CancellationToken cts)
+        public async Task<FormulaType> GetConnectorReturnSchemaAsync(FormulaValue[] knownParameters, IServiceProvider services, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            var connectorCtx = services?.GetService<RuntimeConnectorContext>() ?? new RuntimeConnectorContext();
+
+            ConnectorDynamicSchema cds = ReturnTypeInfo.DynamicReturnSchema;
+            ConnectorDynamicProperty cdp = ReturnTypeInfo.DynamicReturnProperty;
+
+            if (cdp != null && !string.IsNullOrEmpty(cdp.ItemValuePath))
+            {
+                return await GetConnectorSuggestionsFromDynamicPropertyAsync(knownParameters, knownParameters.Length, connectorCtx, cdp, cancellationToken).ConfigureAwait(false);
+            }
+            else if (cds != null && !string.IsNullOrEmpty(cds.ValuePath))
+            {
+                return await GetConnectorSuggestionsFromDynamicSchemaAsync(knownParameters, knownParameters.Length, connectorCtx, cds, cancellationToken).ConfigureAwait(false);                
+            }
+
+            return null;
+        }
+
+        public override async Task<ConnectorSuggestions> GetConnectorSuggestionsAsync(FormulaValue[] knownParameters, int argPosition, IServiceProvider services, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             var connectorCtx = services?.GetService<RuntimeConnectorContext>() ?? new RuntimeConnectorContext();
 
             if (argPosition >= 0 && MaxArity > 0 && _requiredParameters.Length > MaxArity - 1)
             {
-                ConnectorDynamicValue cdv = _requiredParameters[Math.Min(argPosition, MaxArity - 1)].ConnectorDynamicValue;
+                ServiceFunctionParameterTemplate currentParam = _requiredParameters[Math.Min(argPosition, MaxArity - 1)];
 
-                if (cdv != null && cdv.ServiceFunction != null)
+                ConnectorDynamicList cdl = currentParam.ConnectorDynamicList;
+                ConnectorDynamicValue cdv = currentParam.ConnectorDynamicValue;
+                ConnectorDynamicSchema cds = currentParam.ConnectorDynamicSchema;
+                ConnectorDynamicProperty cdp = currentParam.ConnectorDynamicProperty;
+
+                if (cdl != null)
                 {
-                    FormulaValue result = await ConnectorDynamicCallAsync(cdv, knownParameters, connectorCtx, cts).ConfigureAwait(false);
-                    List<ConnectorSuggestion> suggestions = new List<ConnectorSuggestion>();
-
-                    if (result is ErrorValue ev)
-                    {
-                        return new ConnectorSuggestions(ev);
-                    }
-
-                    if (result is RecordValue rv)
-                    {
-                        if (!string.IsNullOrEmpty(cdv.ValuePath))
-                        {
-                            FormulaValue collection = rv.GetField(cdv.ValueCollection ?? "value");
-
-                            if (collection is TableValue tv)
-                            {
-                                foreach (DValue<RecordValue> row in tv.Rows)
-                                {
-                                    FormulaValue suggestion = row.Value.GetField(cdv.ValuePath);
-                                    string displayName = (row.Value.GetField(cdv.ValueTitle) as StringValue)?.Value;
-
-                                    suggestions.Add(new ConnectorSuggestion(suggestion, displayName));
-                                }
-                            }
-                            else
-                            {
-                                throw new NotImplementedException($"Expecting a TableValue and got {collection.GetType().FullName}");
-                            }
-                        }
-                        else
-                        {
-                            throw new NotImplementedException($"ValuePath is null");
-                        }
-                    }
-
-                    return new ConnectorSuggestions(suggestions);
+                    return await GetConnectorSuggestionsFromDynamicListAsync(knownParameters, connectorCtx, cdl, cancellationToken).ConfigureAwait(false);
                 }
 
-                ConnectorDynamicSchema cds = _requiredParameters[Math.Min(argPosition, MaxArity - 1)].ConnectorDynamicSchema;
-
-                if (cds != null && cds.ServiceFunction != null && !string.IsNullOrEmpty(cds.ValuePath))
+                if (cdv != null && string.IsNullOrEmpty(cdv.Capability))
                 {
-                    FormulaValue result = await ConnectorDynamicCallAsync(cds, knownParameters.Take(Math.Min(argPosition, MaxArity - 1)).ToArray(), connectorCtx, cts).ConfigureAwait(false);
-                    List<ConnectorSuggestion> suggestions = new List<ConnectorSuggestion>();
-
-                    if (result is ErrorValue ev)
-                    {
-                        return new ConnectorSuggestions(ev);
-                    }
-
-                    foreach (string vpPart in (cds.ValuePath + "/properties").Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
-                    {
-                        result = ((RecordValue)result).Fields.FirstOrDefault(f => f.Name.Equals(vpPart, StringComparison.OrdinalIgnoreCase)).Value;
-                    }
-
-                    foreach (NamedValue nv in ((RecordValue)result).Fields)
-                    {
-                        suggestions.Add(new ConnectorSuggestion(nv.Value, nv.Name));
-                    }
-
-                    return new ConnectorSuggestions(suggestions);
+                    return await GetConnectorSuggestionsFromDynamicValueAsync(knownParameters, connectorCtx, cdv, cancellationToken).ConfigureAwait(false);
                 }
 
-                // Neither dynamic value nor dynamic schema
+                FormulaType ft = null;
+
+                if (cdp != null && !string.IsNullOrEmpty(cdp.ItemValuePath))
+                {
+                    ft = await GetConnectorSuggestionsFromDynamicPropertyAsync(knownParameters, argPosition, connectorCtx, cdp, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (cds != null && !string.IsNullOrEmpty(cds.ValuePath))
+                {
+                    ft = await GetConnectorSuggestionsFromDynamicSchemaAsync(knownParameters, argPosition, connectorCtx, cds, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (ft != null && ft is RecordType rt)
+                {
+                    return new ConnectorSuggestions(rt.FieldNames.Select(fn => new ConnectorSuggestion(FormulaValue.NewBlank(rt.GetFieldType(fn)), fn)).ToList());
+                }
+
                 return null;
             }
 
             return null;
         }
 
-        private FormulaValue[] GetArguments(ConnectionDynamicApi dynamicApi, CallNode callNode)
+        private async Task<FormulaType> GetConnectorSuggestionsFromDynamicSchemaAsync(FormulaValue[] knownParameters, int argPosition, RuntimeConnectorContext connectorCtx, ConnectorDynamicSchema cds, CancellationToken cancellationToken)
         {
-            List<FormulaValue> arguments = new List<FormulaValue>();
+            cancellationToken.ThrowIfCancellationRequested();
+            FormulaValue[] newParameters = GetArguments(cds, knownParameters.Take(Math.Min(argPosition, MaxArity - 1)).ToArray());
+            FormulaValue result = await ConnectorDynamicCallAsync(cds, newParameters, connectorCtx, true, cancellationToken).ConfigureAwait(false);
+            List<ConnectorSuggestion> suggestions = new List<ConnectorSuggestion>();
 
-            foreach (ServiceFunctionParameterTemplate sfpt in dynamicApi.ServiceFunction._requiredParameters)
+            if (result is ErrorValue ev)
             {
-                string paramName = sfpt.TypedName.Name;
-                DType paramType = sfpt.TypedName.Type;
+                return ev.Type;
+            }
 
-                string currentFunctionParamName = dynamicApi.ParameterMap.FirstOrDefault(kvp => kvp.Value == paramName).Value;
-                int currentFunctionParamIndex = _requiredParameters.FindIndex(st => st.TypedName.Name == currentFunctionParamName);
-                TexlNode texlNode = callNode.Args.ChildNodes[currentFunctionParamIndex];
+            if (result is not StringValue sv)
+            {
+                return null;
+            }            
 
-                FormulaValue arg = texlNode switch
-                {
-                    StrLitNode str => FormulaValue.New(str.Value),
-                    NumLitNode num => FormulaValue.New(num.ActualNumValue),
-                    _ => null
-                };
+            JsonElement je = JsonDocument.Parse(sv.Value).RootElement;
 
-                if (arg == null)
+            foreach (string vpPart in (cds.ValuePath).Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                JsonProperty jp = je.EnumerateObject().FirstOrDefault(jp => vpPart.Equals(jp.Name, StringComparison.OrdinalIgnoreCase));
+
+                if (string.IsNullOrEmpty(jp.Name))
                 {
                     return null;
                 }
 
-                arguments.Add(arg);
+                je = jp.Value;                
+            }           
+
+            OpenApiSchema schema = new OpenApiStringReader().ReadFragment<OpenApiSchema>(je.ToString(), Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0, out OpenApiDiagnostic diag);
+            ConnectorParameterType cpt = schema.ToFormulaType();
+
+            return cpt.Type;
+        }
+
+        private async Task<FormulaType> GetConnectorSuggestionsFromDynamicPropertyAsync(FormulaValue[] knownParameters, int argPosition, RuntimeConnectorContext connectorCtx, ConnectorDynamicProperty cdp, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            FormulaValue[] newParameters = GetArguments(cdp, knownParameters.Take(Math.Min(argPosition, MaxArity - 1)).ToArray());
+            FormulaValue result = await ConnectorDynamicCallAsync(cdp, newParameters, connectorCtx, true, cancellationToken).ConfigureAwait(false);
+            List<ConnectorSuggestion> suggestions = new List<ConnectorSuggestion>();
+
+            if (result is ErrorValue ev)
+            {
+                return ev.Type;
+            }
+
+            if (result is not StringValue sv)
+            {
+                return null;
+            }
+
+            JsonElement je = JsonDocument.Parse(sv.Value).RootElement;
+
+            foreach (string vpPart in (cdp.ItemValuePath).Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                JsonProperty jp = je.EnumerateObject().FirstOrDefault(jp => vpPart.Equals(jp.Name, StringComparison.OrdinalIgnoreCase));
+
+                if (string.IsNullOrEmpty(jp.Name))
+                {
+                    return null;
+                }
+
+                je = jp.Value;
+            }
+
+            OpenApiSchema schema = new OpenApiStringReader().ReadFragment<OpenApiSchema>(je.ToString(), Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0, out OpenApiDiagnostic diag);
+            ConnectorParameterType cpt = schema.ToFormulaType();
+
+            return cpt.Type;
+        }
+
+        private async Task<ConnectorSuggestions> GetConnectorSuggestionsFromDynamicValueAsync(FormulaValue[] knownParameters, RuntimeConnectorContext connectorCtx, ConnectorDynamicValue cdv, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            FormulaValue[] newParameters = GetArguments(cdv, knownParameters);
+            FormulaValue result = await ConnectorDynamicCallAsync(cdv, newParameters, connectorCtx, false, cancellationToken).ConfigureAwait(false);
+            List<ConnectorSuggestion> suggestions = new List<ConnectorSuggestion>();
+
+            if (result is ErrorValue ev)
+            {
+                return new ConnectorSuggestions(ev);
+            }
+
+            if (result is RecordValue rv)
+            {
+                if (!string.IsNullOrEmpty(cdv.ValuePath))
+                {
+                    FormulaValue collection = rv.GetField(cdv.ValueCollection ?? "value");
+
+                    if (collection is TableValue tv)
+                    {
+                        foreach (DValue<RecordValue> row in tv.Rows)
+                        {
+                            FormulaValue suggestion = row.Value.GetField(cdv.ValuePath);
+                            string displayName = (row.Value.GetField(cdv.ValueTitle) as StringValue)?.Value;
+
+                            suggestions.Add(new ConnectorSuggestion(suggestion, displayName));
+                        }
+                    }
+                    else
+                    {
+                        throw new NotImplementedException($"[DynamicValue] Expecting a TableValue and got {collection.GetType().FullName}");
+                    }
+                }
+                else
+                {
+                    throw new NotImplementedException($"[DynamicValue] ValuePath is null");
+                }
+            }
+
+            return new ConnectorSuggestions(suggestions);
+        }
+
+        private async Task<ConnectorSuggestions> GetConnectorSuggestionsFromDynamicListAsync(FormulaValue[] knownParameters, RuntimeConnectorContext connectorCtx, ConnectorDynamicList cdl, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            FormulaValue[] newParameters = GetArguments(cdl, knownParameters);
+            FormulaValue result = await ConnectorDynamicCallAsync(cdl, newParameters, connectorCtx, false, cancellationToken).ConfigureAwait(false);
+            List<ConnectorSuggestion> suggestions = new List<ConnectorSuggestion>();
+
+            if (result is ErrorValue ev)
+            {
+                return new ConnectorSuggestions(ev);
+            }
+
+            if (result is RecordValue rv)
+            {
+                if (!string.IsNullOrEmpty(cdl.ItemValuePath))
+                {
+                    FormulaValue collection = rv.GetField(cdl.ItemValuePath);
+
+                    if (collection is TableValue tv)
+                    {
+                        foreach (DValue<RecordValue> row in tv.Rows)
+                        {
+                            FormulaValue suggestion = row.Value.GetField(cdl.ItemPath);
+                            string displayName = (row.Value.GetField(cdl.ItemTitlePath) as StringValue)?.Value;
+
+                            suggestions.Add(new ConnectorSuggestion(suggestion, displayName));
+                        }
+                    }
+                    else
+                    {
+                        throw new NotImplementedException($"[DynamicList] Expecting a TableValue and got {collection.GetType().FullName}");
+                    }
+                }
+                else
+                {
+                    throw new NotImplementedException($"[DynamicList] ItemValuePath is null");
+                }
+            }
+
+            return new ConnectorSuggestions(suggestions);
+        }
+
+        private FormulaValue[] GetArguments(ConnectionDynamicApi dynamicApi, FormulaValue[] knownParameters)
+        {
+            List<FormulaValue> arguments = new List<FormulaValue>();
+
+            foreach (ServiceFunctionParameterTemplate sfpt in dynamicApi.ConnectorFunction.GetServiceFunction(connectorSettings: _connectorSettings)._requiredParameters)
+            {
+                string paramName = sfpt.TypedName.Name;
+                DType paramType = sfpt.TypedName.Type;
+
+                StaticValue sValue = dynamicApi.ParameterMap.FirstOrDefault(kvp => kvp.Value is StaticValue && kvp.Key == paramName).Value as StaticValue;
+                if (sValue != null)
+                {
+                    arguments.Add(sValue.Value);
+                    continue;
+                }
+
+                KeyValuePair<string, IValue> dValue = dynamicApi.ParameterMap.FirstOrDefault(kvp => kvp.Value is DynamicValue dv && dv.Reference == paramName);
+                if (!string.IsNullOrEmpty(dValue.Key))
+                {
+                    int currentFunctionParamIndex = _requiredParameters.FindIndex(st => st.TypedName.Name == dValue.Key);
+
+                    if (currentFunctionParamIndex >= 0 && currentFunctionParamIndex < knownParameters.Length)
+                    {
+                        arguments.Add(knownParameters[currentFunctionParamIndex]);
+                    }
+                }
             }
 
             return arguments.ToArray();
         }
 
-        private async Task<FormulaValue> ConnectorDynamicCallAsync(ConnectionDynamicApi dynamicApi, FormulaValue[] arguments, RuntimeConnectorContext connectorCtx, CancellationToken cts)
+        private async Task<FormulaValue> ConnectorDynamicCallAsync(ConnectionDynamicApi dynamicApi, FormulaValue[] arguments, RuntimeConnectorContext connectorCtx, bool raw, CancellationToken cts)
         {
             cts.ThrowIfCancellationRequested();
-            return await dynamicApi.ServiceFunction.InvokeAsync(FormattingInfoHelper.CreateFormattingInfo(), arguments, connectorCtx, cts).ConfigureAwait(false);
+
+            ServiceFunction serviceFunction = dynamicApi.ConnectorFunction.GetServiceFunction(httpClient: connectorCtx?.GetInvoker(Namespace.Name) ?? _invoker.Invoker.HttpMessageInvoker, _connectorSettings.Clone(returnRawResult: raw));
+            return await serviceFunction.InvokeAsync(FormattingInfoHelper.CreateFormattingInfo(), arguments, connectorCtx, cts).ConfigureAwait(false);
         }
 
         // This method returns true if there are special suggestions for a particular parameter of the function.
@@ -473,7 +625,7 @@ namespace Microsoft.AppMagic.Authoring.Texl.Builtins
             cancellationToken.ThrowIfCancellationRequested();
 
             FormulaValue result = await (_invoker ?? throw new InvalidOperationException($"Function {Name} can't be invoked.")).InvokeAsync(context, args, connectorCtx, cancellationToken).ConfigureAwait(false);
-            result = await PostProcessResultAsync(result, cancellationToken).ConfigureAwait(false);
+            result = await PostProcessResultAsync(result, cancellationToken).ConfigureAwait(false);            
 
             return result;
         }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunctionParameterTemplate.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Shared/ServiceFunctionParameterTemplate.cs
@@ -18,7 +18,9 @@ namespace Microsoft.AppMagic.Authoring
         private readonly FormulaType _formulaType;
         private readonly ConnectorType _connectorType;
         private readonly ConnectorDynamicValue _dynamicValue;
+        private readonly ConnectorDynamicList _dynamicList;
         private readonly ConnectorDynamicSchema _dynamicSchema;
+        private readonly ConnectorDynamicProperty _dynamicProperty;
 
         public TypedName TypedName => _typedName;
 
@@ -33,10 +35,16 @@ namespace Microsoft.AppMagic.Authoring
         public FormulaValue DefaultValue => _defaultValue;
 
         public ConnectorDynamicValue ConnectorDynamicValue => _dynamicValue;
+
+        public ConnectorDynamicList ConnectorDynamicList => _dynamicList;
         
         public ConnectorDynamicSchema ConnectorDynamicSchema => _dynamicSchema;
+        
+        public ConnectorDynamicProperty ConnectorDynamicProperty => _dynamicProperty;
 
-        public ServiceFunctionParameterTemplate(FormulaType formulaType, ConnectorType connectorType, TypedName typedName, string description, string summary, FormulaValue defaultValue, ConnectorDynamicValue dynamicValue, ConnectorDynamicSchema dynamicSchema)
+        public bool SupportsDynamicIntellisense => (_dynamicValue != null && string.IsNullOrEmpty(_dynamicValue.Capability)) || _dynamicList != null || _dynamicSchema != null || _dynamicProperty != null;
+
+        public ServiceFunctionParameterTemplate(FormulaType formulaType, ConnectorType connectorType, TypedName typedName, string description, string summary, FormulaValue defaultValue, ConnectorDynamicValue dynamicValue, ConnectorDynamicList dynamicList, ConnectorDynamicSchema dynamicSchema, ConnectorDynamicProperty dynamicProperty)
         {
             Contracts.Assert(typedName.IsValid);
             Contracts.AssertValueOrNull(description);
@@ -49,7 +57,9 @@ namespace Microsoft.AppMagic.Authoring
             _summary = summary;
             _defaultValue = defaultValue;
             _dynamicValue = dynamicValue;
+            _dynamicList = dynamicList;
             _dynamicSchema = dynamicSchema;
+            _dynamicProperty = dynamicProperty;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Visibility.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Visibility.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerFx.Connectors
+{
+    /// <summary>
+    /// "x-ms-visibility" enum.
+    /// </summary>
+    public enum Visibility : int
+    {
+        // "x-ms-visibility" is not corresponding to any valid value (normally, only "important", "advanced" or "internal"
+        Unknown = -1,
+
+        // "x-ms-visibility" is not defined
+        None = 0,
+
+        // "x-ms-visibility" is "important"
+        Important,
+
+        // "x-ms-visibility" is "advanced"
+        Advanced,
+
+        // "x-ms-visibility" is "internal"
+        Internal
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -366,8 +366,10 @@ namespace Microsoft.PowerFx.Intellisense
                 FormulaValue[] parameters = callNode.Args.Children.Where(texlNode => NoErrorInTexlNode(texlNode))
                                                                   .Select(texlNode => texlNode switch
                 {
-                    StrLitNode strNode => FormulaValue.New(strNode.Value),
+                    BoolLitNode boolLitNode => FormulaValue.New(boolLitNode.Value),
+                    DecLitNode decNode => FormulaValue.New(decNode.ActualDecValue),
                     NumLitNode numNode => FormulaValue.New(numNode.ActualNumValue),
+                    StrLitNode strNode => FormulaValue.New(strNode.Value),
                     _ => null as FormulaValue
                 }).ToArray();
 
@@ -378,7 +380,7 @@ namespace Microsoft.PowerFx.Intellisense
                 }
 
                 // If connector function has some suggestions, let's add them here
-                var services = intellisenseData.Services;
+                var services = intellisenseData.Services;                
                 ConnectorSuggestions suggestions = info.Function.GetConnectorSuggestionsAsync(parameters, argPosition, services, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
 
                 if (suggestions != null && suggestions.Error == null && suggestions.Suggestions != null)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/IntellisenseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/IntellisenseTests.cs
@@ -33,6 +33,8 @@ namespace Microsoft.PowerFx.Connectors.Tests
         [InlineData(3, 4, @"SQL.ExecuteProcedureV2(""pfxdev-sql.database.windows.net"", ""connectortest"",", @"""[dbo].[sp_1]""|""[dbo].[sp_2]""")]
         [InlineData(3, 5, @"SQL.ExecuteProcedureV2(""default"", ""connectortest"",", @"""[dbo].[sp_1]""|""[dbo].[sp_2]""")]       // testing with "default" server
         [InlineData(3, 6, @"SQL.ExecuteProcedureV2(""default"", ""default"",", @"""[dbo].[sp_1]""|""[dbo].[sp_2]""")]             // testing with "default" server & database
+        // Using fake function
+        [InlineData(3, 4, @"SQL.ExecuteProcedureV2z(true, 17, ""connectortest"",", @"""[dbo].[sp_1]""|""[dbo].[sp_2]""")]
         public void ConnectorIntellisenseTest(int responseIndex, int queryIndex, string expression, string expectedSuggestions)
         {
             // These tests are exercising 'x-ms-dynamic-values' extension property
@@ -66,7 +68,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(checkResult, expression.Length);
 
             string list = string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text).OrderBy(x => x));
-            Assert.Equal(expectedSuggestions, list);
+            Assert.Equal(expectedSuggestions, list);            
             Assert.True((responseIndex == 0) ^ testConnector.SendAsyncCalled);
 
             string networkTrace = testConnector._log.ToString();
@@ -99,7 +101,7 @@ $@"POST https://tip1-shared-002.azure-apim.net/invoke
 "
             };
 
-            Assert.Equal(expectedNetwork.Replace("\r\n", "\n").Replace("\r", "\n"), networkTrace.Replace("\r\n", "\n").Replace("\r", "\n"));
+            Assert.Equal(expectedNetwork.Replace("\r\n", "\n").Replace("\r", "\n"), networkTrace.Replace("\r\n", "\n").Replace("\r", "\n"));            
         }
 
         [Theory]
@@ -212,12 +214,8 @@ $@"POST https://tip1-shared-002.azure-apim.net/invoke
             ctx._clients[cxNamespace] = client;
             BasicServiceProvider services = new BasicServiceProvider();
             services.AddService<RuntimeConnectorContext>(ctx);
-                        
-            IPowerFxScope scope = new EditorContextScope(
-                (expr) => engine.Check(expression, symbolTable: null))
-            {
-                Services = services
-            };
+
+            IPowerFxScope scope = new EditorContextScope((expr) => engine.Check(expression, symbolTable: null)) { Services = services };
             IIntellisenseResult suggestions = scope.Suggest(expression, expression.Length);
 
             string list = string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text).OrderBy(x => x));
@@ -240,7 +238,7 @@ $@"POST https://tip1-shared-002.azure-apim.net/invoke
             Assert.Equal(expectedNetwork.Replace("\r\n", "\n").Replace("\r", "\n"), networkTrace.Replace("\r\n", "\n").Replace("\r", "\n"));
         }
 
-        private class TestRuntimeConnectorContext : RuntimeConnectorContext
+        internal class TestRuntimeConnectorContext : RuntimeConnectorContext
         {
             public Dictionary<string, HttpMessageInvoker> _clients = new Dictionary<string, HttpMessageInvoker>();
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PublicSurfaceTests.cs
@@ -43,7 +43,8 @@ namespace Microsoft.PowerFx.Connector.Tests
               "Microsoft.PowerFx.Connectors.OpenApiParser",
               "Microsoft.PowerFx.Connectors.PowerFxConnectorException",
               "Microsoft.PowerFx.Connectors.PowerPlatformConnectorClient",
-              "Microsoft.PowerFx.Connectors.RuntimeConnectorContext"
+              "Microsoft.PowerFx.Connectors.RuntimeConnectorContext",
+              "Microsoft.PowerFx.Connectors.Visibility"
             };
 
             var sb = new StringBuilder();

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/Swagger/SQL Server.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/Swagger/SQL Server.json
@@ -12,7 +12,9 @@
     "__comments02": "     1. basePath is /apim/sql instead of / only",
     "__comments03": "",
     "__comments04": "     2. All paths are prefixed with /{connectionId}",
-    "__comments05": ""
+    "__comments05": "",
+    "__comments06": "     3. Added fake 'ExecuteProcedure_V2z' operation for testing",
+    "__comments07": ""
   },
   "host": "localhost:33069",
   "basePath": "/apim/sql",
@@ -1156,7 +1158,7 @@
             "x-ms-url-encoding": "double",
             "x-ms-dynamic-values": {
               "operationId": "GetDatabases",
-              "parameters": {                
+              "parameters": {
                 "server": {
                   "parameter": "server"
                 }
@@ -3030,6 +3032,141 @@
           "status": "Production",
           "family": "ExecuteProcedure",
           "revision": 2
+        }
+      }
+    },
+    "/{connectionId}/v2/datasets/pfxdev-sql.database.windows.net,{database}/procedures/{procedure}/{fake}": {
+      "post": {
+        "tags": [
+          "SqlProcedureV2z"
+        ],
+        "summary": "Execute stored procedure (V2z)",
+        "description": "This operation runs a stored procedure. *** This is an artificial function used for testing only. ***",
+        "operationId": "ExecuteProcedure_V2z",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "parameters": [
+          {
+            "name": "fakebool",
+            "in": "query",
+            "description": "Fake bool param",
+            "required": true,
+            "x-ms-summary": "Fake bool param",
+            "type": "boolean"            
+          },
+          {
+            "name": "fake",
+            "in": "path",
+            "description": "Fake param",
+            "required": true,
+            "x-ms-summary": "Fake param",
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "database",
+            "in": "path",
+            "description": "Database name",
+            "required": true,
+            "x-ms-summary": "Database name",
+            "x-ms-url-encoding": "double",
+            "x-ms-dynamic-values": {
+              "operationId": "GetDatabases",
+              "parameters": {
+                "server": "pfxdev-sql.database.windows.net"
+              },
+              "value-collection": "value",
+              "value-path": "Name",
+              "value-title": "DisplayName"
+            },
+            "type": "string"
+          },
+          {
+            "name": "procedure",
+            "in": "path",
+            "description": "Name of stored procedure",
+            "required": true,
+            "x-ms-summary": "Procedure name",
+            "x-ms-url-encoding": "double",
+            "x-ms-dynamic-values": {
+              "operationId": "GetProcedures_V2",
+              "parameters": {
+                "server": "pfxdev-sql.database.windows.net",
+                "database": {
+                  "parameter": "database"
+                }
+              },
+              "value-collection": "value",
+              "value-path": "Name",
+              "value-title": "DisplayName"
+            },
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Input parameters to the stored procedure",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Object"
+              },
+              "x-ms-dynamic-schema": {
+                "operationId": "GetProcedure_V2",
+                "parameters": {
+                  "server": "pfxdev-sql.database.windows.net",
+                  "database": {
+                    "parameter": "database"
+                  },
+                  "procedure": {
+                    "parameter": "procedure"
+                  }
+                },
+                "value-path": "Schema/InputParameters"
+              }
+            },
+            "x-ms-summary": "Parameters list"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/ProcedureResult"
+              },
+              "x-ms-dynamic-schema": {
+                "operationId": "GetProcedure_V2",
+                "parameters": {
+                  "server": "pfxdev-sql.database.windows.net",
+                  "database": {
+                    "parameter": "database"
+                  },
+                  "procedure": {
+                    "parameter": "procedure"
+                  }
+                },
+                "value-path": "schema/procedureresultschema"
+              }
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "important",
+        "x-ms-api-annotation": {
+          "status": "Production",
+          "family": "ExecuteProcedure",
+          "revision": 7
         }
       }
     },


### PR DESCRIPTION
- add management for x-ms-dynamic-list and x-ms-dynamic-properties connector extensions
- add support for x-ms-dynamic-schema/properties on return types
- rework x-ms-dynamic-schema/properties parsing & logic to return a FormulaType
- add support for static values in x-ms-dynamic-* extensions
- fix bug on functions with optional+internal parameters (parameter was missing)
- simplify ArgumentMapper constructor 
- remove all public ConnectorFunction constructors
- [API CHANGE] ConnectorFunction.GetParamters now need IServiceProvider (for HttpClient) [+ optional ConnectorSettings]
- [NEW API]* ConnectorFunction.GetConnectorSuggestionsAsync to get suggestions using x-ms-dynamic-* extensions
- [NEW API]* ConnectorFunction.GetConnectorReturnSchemaAsync to get a FormulaType out of x-ms-dynamic-schema/properties
* These new APIs are subject to future change as they do not address optional parameters yet
- new SupportsDynamicIntellisense prop on ConnectorParameter
- ConnectorSettings now supports Namespace, ThrowOnError and ReturnRawResult (will return connector results as StringValue)
- ConnectorType new property Visibility (linked to x-ms-visibility extension)
- [API CHANGE] OpenApiParser.GetFunctions static methods do not take an HttpClient anymore + throwOnError param moved to ConnectorSettings.
- (internal only) allow connector functions to return raw result