### PR TITLE
TexlFunction clean-up - removing DisabledFor[Commanding|DataComponent] virtuals

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -127,12 +127,6 @@ namespace Microsoft.PowerFx.Core.Functions
         // Returns true if the function is disabled for component.
         public virtual bool DisableForComponent => false;
 
-        // Returns true if the function is disabled for data component.
-        public virtual bool DisableForDataComponent => false;
-
-        // Returns true if the function is disabled for Commmanding
-        public virtual bool DisableForCommanding => false;
-
         // Returns true if the function will mutate the value of argument 0, as is the case with Patch, Collect, Remove, etc.
         public virtual bool MutatesArg0 => false;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Refresh.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Refresh.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsAsync => true;
 
-        public override bool DisableForDataComponent => true;
-
         public override Capabilities Capabilities => Capabilities.OutboundInternetAccess | Capabilities.EnterpriseAuthentication | Capabilities.PrivateNetworkAccess;
 
         public override bool SupportsParamCoercion => false;


### PR DESCRIPTION
Unused in Power Fx