### PR TITLE
Removed unused RequiresBindingContext virtual from TexlFunction

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -174,9 +174,6 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if this function can return a type with ExpandInfo.
         public virtual bool CanReturnExpandInfo => false;
 
-        // Return true if this function requires binding context info.
-        public virtual bool RequiresBindingContext => false;
-
         // Return true if this function can generate new data on its own without re-evaluating a rule.
         public virtual bool IsAutoRefreshable => false;
 


### PR DESCRIPTION
This virtual property is only used in Power Apps - no need to have it in Power Fx.