### PR TITLE
Do not suggest Deprecated Connector functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -331,6 +331,8 @@ namespace Microsoft.PowerFx.Core.Functions
         // If the function is in the global namespace, this.QualifiedName is the same as this.Name.
         public string QualifiedName => Namespace.IsRoot ? Name : Namespace.ToDottedSyntax() + TexlLexer.PunctuatorDot + TexlLexer.EscapeName(Name);
 
+        public bool IsDeprecatedOrInternalFunction => this is IHasUnsupportedFunctions sdf && (sdf.IsDeprecated || sdf.IsInternal);
+
         public TexlFunction(
             DPath theNamespace,
             string name,

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -728,6 +728,11 @@ namespace Microsoft.PowerFx.Intellisense
 #pragma warning disable CS0618 // Type or member is obsolete
             foreach (var function in intellisenseData.Binding.NameResolver.Functions.Functions)
             {
+                if (function.IsDeprecatedOrInternalFunction)
+                {
+                    continue;
+                }
+
                 var qualifiedName = function.QualifiedName;
                 var highlightStart = qualifiedName.IndexOf(intellisenseData.MatchingStr, StringComparison.OrdinalIgnoreCase);
                 var highlightEnd = intellisenseData.MatchingStr.Length;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/DottedNameNodeSuggestionHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SuggestionHandlers/DottedNameNodeSuggestionHandler.cs
@@ -177,7 +177,7 @@ namespace Microsoft.PowerFx.Intellisense
                 Contracts.AssertValid(firstNameInfo.Name);
 
                 var namespacePath = new DPath().Append(firstNameInfo.Name);
-                functions = binding.NameResolver.LookupFunctionsInNamespace(namespacePath).Where(f => f is not IHasUnsupportedFunctions sdf || (!sdf.IsDeprecated && !sdf.IsInternal));
+                functions = binding.NameResolver.LookupFunctionsInNamespace(namespacePath).Where(f => !f.IsDeprecatedOrInternalFunction);
 
                 return functions.Any();
             }


### PR DESCRIPTION
-If a path is deprecated or internal for Intellisense, do not suggest it.
-Dotted Name already was blocking it, FirstNameNode also blocks it now.