### PR TITLE
Create Cx build that avoids breaking change

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerFx.Connectors
             }
             else if (openApiAny is OpenApiInteger intVal)
             {
-                formulaValue = numberIsFloat ? FormulaValue.New(intVal.Value) : FormulaValue.New((decimal)intVal.Value);
+                formulaValue = numberIsFloat ? FormulaValue.New((float)intVal.Value) : FormulaValue.New((decimal)intVal.Value);
             }
             else if (openApiAny is OpenApiDouble dbl)
             {


### PR DESCRIPTION
#1813 made a breaking change to FormulaValue.New(int) . 
Create a Cx build that avoids the call to this method so that we don't hit binary breaks. 
