### PR TITLE
Update Coalesce function semantics to short circuit

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -557,6 +557,12 @@ namespace Microsoft.PowerFx.Core.Functions
         /// All lambda params are Lazy, but others may also be, including short-circuit booleans, conditionals, etc..
         /// </summary>
         /// <param name="index">Parameter index, 0-based.</param>
+        /// <param name="features">Engine features.</param>
+        public virtual bool IsLazyEvalParam(int index, Features features)
+        {
+            return IsLazyEvalParam(index);
+        }
+
         public virtual bool IsLazyEvalParam(int index)
         {
             Contracts.AssertIndexInclusive(index, MaxArity);

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -560,11 +560,6 @@ namespace Microsoft.PowerFx.Core.Functions
         /// <param name="features">Engine features.</param>
         public virtual bool IsLazyEvalParam(int index, Features features)
         {
-            return IsLazyEvalParam(index);
-        }
-
-        public virtual bool IsLazyEvalParam(int index)
-        {
             Contracts.AssertIndexInclusive(index, MaxArity);
 
             return IsLambdaParam(index);

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PowerFx.Core.IR
                         var nodeName = context.Binding.TryGetReplacedIdentName(identifierNode.Ident, out var newIdent) ? new DName(newIdent) : identifierNode.Ident.Name;
                         args.Add(new TextLiteralNode(argContext.GetIRContext(arg, DType.String), nodeName.Value));
                     }
-                    else if (func.IsLazyEvalParam(i))
+                    else if (func.IsLazyEvalParam(i, _features))
                     {
                         var child = arg.Accept(this, scope != null && func.ScopeInfo.AppliesToArgument(i) ? argContext.With(scope) : argContext);
                         args.Add(new LazyEvalNode(argContext.GetIRContext(arg), child));

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -67,6 +67,11 @@ namespace Microsoft.PowerFx
         internal bool SkipExpandableSetSemantics { get; set; }
 
         /// <summary>
+        /// Short circuit support in the Coalesce function: Coalesce(1,Collect()) will not run the Collect.
+        /// </summary>
+        internal bool CoalesceShortCircuit { get; set; }
+
+        /// <summary>
         /// This is specific for Cards team and it is a temporary feature.
         /// It will be soon deleted.
         /// </summary>
@@ -95,6 +100,7 @@ namespace Microsoft.PowerFx
             RestrictedIsEmptyArguments = true,
             FirstLastNRequiresSecondArguments = true,
             PowerFxV1CompatibilityRules = true,
+            CoalesceShortCircuit = true,
         };
 
         internal Features()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -47,7 +47,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsLazyEvalParam(int index, Features features)
         {
-            if (features.PowerFxV1CompatibilityRules)
+            if (features.CoalesceShortCircuit)
             {
                 return index > 0;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -45,6 +45,16 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
+        public override bool IsLazyEvalParam(int index, Features features)
+        {
+            if (features.PowerFxV1CompatibilityRules)
+            {
+                return index > 0;
+            }
+
+            return false;
+        }
+
         public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/If.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return base.GetSignatures(arity);
         }
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             return index >= 1;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Logical.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             _isAnd = isAnd;
         }
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             return index > 0;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Switch.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             yield return new[] { TexlStrings.SwitchExpression, TexlStrings.SwitchCaseExpr, TexlStrings.SwitchCaseArg, TexlStrings.SwitchDefaultReturn };
         }
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             return index > 0;
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerFx
             return _impl(serviceProvider, args, cancellationToken);
         }
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             return LamdaParamMask.TestBit(index);
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerFx.Interpreter
 
         public override bool MutatesArg0 => true;
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             // First argument to mutation functions is Lazy for datasources that are copy-on-write.
             // If there are any side effects in the arguments, we want those to have taken place before we make the copy.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/PatchFunction.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerFx.Functions
             return base.TryGetTypeForArgSuggestionAt(argIndex, out type);
         }
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             // First argument to mutation functions is Lazy for datasources that are copy-on-write.
             // If there are any side effects in the arguments, we want those to have taken place before we make the copy.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerFx.Functions
 
         public override bool MutatesArg0 => true;
 
-        public override bool IsLazyEvalParam(int index)
+        public override bool IsLazyEvalParam(int index, Features features)
         {
             // First argument to mutation functions is Lazy for datasources that are copy-on-write.
             // If there are any side effects in the arguments, we want those to have taken place before we make the copy.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 // If this method crashes, then we just get 0 tests. 
                 // The only way to communicate a failure from here back to the developer
                 // is to pass a "fake" test object that always fails and contains the error.
-                // In this ecase, this will be a bogus file name that won't load.
+                // In this case, this will be a bogus file name that won't load.
 
                 var item = $"ERROR: Test discovery failed with: {e}";
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestHelpers/TxtFileDataAttribute.cs
@@ -98,4 +98,58 @@ namespace Microsoft.PowerFx.Core.Tests
             return testDir;
         }
     }
+
+    /// <summary>
+    /// Simpler version of TxtFileDataAttribute (above) for the mutation tests.
+    /// The mutation tests need to run tests, one after another, retaining state - they are not independent.
+    /// This attribute just gathers together the directory of test files, rather than pulling the individual tests out of those files.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class ReplFileSimpleListAttribute : DataAttribute
+    {
+        private readonly string _filePath;
+
+        public ReplFileSimpleListAttribute(string filePath)
+        {
+            _filePath = filePath;
+        }
+
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            // This is run in a separate process. To debug, need to call Launch() and attach a debugger.
+            // System.Diagnostics.Debugger.Launch();
+
+            if (testMethod == null)
+            {
+                throw new ArgumentNullException(nameof(testMethod));
+            }
+
+            var list = new List<object[]>();
+
+            try
+            {
+                var path = TxtFileDataAttribute.GetDefaultTestDir(_filePath);
+                var dir = new DirectoryInfo(path);
+                var allFiles = dir.EnumerateFiles("*.txt");      // skip .md files
+
+                foreach (var file in allFiles)
+                {
+                    list.Add(new object[] { file.Name });
+                }
+            }
+            catch (Exception e)
+            {
+                // If this method crashes, then we just get 0 tests. 
+                // The only way to communicate a failure from here back to the developer
+                // is to pass a "fake" test object that always fails and contains the error.
+                // In this ecase, this will be a bogus file name that won't load.
+
+                var item = $"ERROR: Test discovery failed with: {e}";
+
+                list.Add(new object[] { item });
+            }
+
+            return list;
+        }
+    }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 #endif
 
         // Run cases in MutationScripts
-        //
+        //abcdefggegggg
         // Normal tests have each line as an independent test case. 
         // Whereas these are fed into a repl and each file maintains state.
         // 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -128,6 +128,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         // Whereas these are fed into a repl and each file maintains state.
         // 
         // These tests are run twice, as they are for the non-mutation tests, for both V1 and non-V1 compatibility.
+        // For Canvas, the important difference is the CoalesceShortCircuit feature, a part of PowerFxV1.
         [Theory]
         [ReplFileSimpleList("MutationScripts")]
         public void RunMutationTests_V1(string file)
@@ -143,10 +144,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             {
                 TableSyntaxDoesntWrapRecords = true,
                 ConsistentOneColumnTableResult = true,
-                PowerFxV1CompatibilityRules = true,
+                PowerFxV1CompatibilityRules = true,    // although not in Canvas today, mutation tests assume this semantic, which doesn't conflict with what is being tested
             };
 
-            RunMutationTestFile(file, features, "disable:CoalesceShortCircuit");
+            // disable:CoalesceShortCircuit will force the tests specifically for that behavior to be excluded from this run
+            // DecimalSupport allows tests that are written with Float and Decimal functions to operate; it is not itself a feature
+            RunMutationTestFile(file, features, "disable:CoalesceShortCircuit,TableSyntaxDoesntWrapRecords,ConsistentOneColumnTableResult,PowerFxV1CompatibilityRules,DecimalSupport");
         }
 
         private void RunMutationTestFile(string file, Features features, string setup)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -10,12 +11,20 @@ using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Interpreter.Tests.XUnitExtensions;
 using Microsoft.PowerFx.Types;
 using Xunit;
+using Xunit.Abstractions;
 using static Microsoft.PowerFx.Interpreter.Tests.ExpressionEvaluationTests;
 
 namespace Microsoft.PowerFx.Interpreter.Tests
 {
     public class FileExpressionEvaluationTests : PowerFxTest
     {
+        public readonly ITestOutputHelper Summary;
+
+        public FileExpressionEvaluationTests(ITestOutputHelper output)
+        {
+            Summary = output;
+        }
+
         // File expression tests are run multiple times for the different ways a host can use Power Fx.
         // 
         // 1. Features.PowerFxV1 without NumberIsFloat - the main way that most hosts will use Power Fx.
@@ -174,6 +183,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             if (result.Fail > 0)
             {
                 Assert.True(false, result.Output);
+            }
+            else
+            {
+                Summary.WriteLine(result.Output);
             }
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/FileExpressionEvaluationTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 #endif
 
         // Run cases in MutationScripts
-        //abcdefggegggg
+        //
         // Normal tests have each line as an independent test case. 
         // Whereas these are fed into a repl and each file maintains state.
         // 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/AndOr.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/AndOr.txt
@@ -7,28 +7,101 @@ Table({Value:false},{Value:true})
 >> false && Collect(t1, {Value:true}).Value;t1
 Table({Value:false},{Value:true})
 
+>> 0.00;t1
+Table({Value:false},{Value:true})
+
 >> false && Patch(t1, First(t1), {Value:true}).Value;t1
+Table({Value:false},{Value:true})
+
+>> 0.01;t1
 Table({Value:false},{Value:true})
 
 >> false && Remove(t1, First(t1));t1
 Table({Value:false},{Value:true})
 
+>> 0.02;t1
+Table({Value:false},{Value:true})
+
 >> false && Set(t1, [true,true]);t1
+Table({Value:false},{Value:true})
+
+>> 0.03;t1
+Table({Value:false},{Value:true})
+
+>> false And Collect(t1, {Value:true}).Value;t1
+Table({Value:false},{Value:true})
+
+>> 0.10;t1
+Table({Value:false},{Value:true})
+
+>> false And Patch(t1, First(t1), {Value:true}).Value;t1
+Table({Value:false},{Value:true})
+
+>> 0.11;t1
+Table({Value:false},{Value:true})
+
+>> false And Remove(t1, First(t1));t1
+Table({Value:false},{Value:true})
+
+>> 0.12;t1
+Table({Value:false},{Value:true})
+
+>> false And Set(t1, [true,true]);t1
+Table({Value:false},{Value:true})
+
+>> 0.13;t1
 Table({Value:false},{Value:true})
 
 >> And(false, Collect(t1, {Value:true}).Value);t1
 Table({Value:false},{Value:true})
 
+>> 0.14;t1
+Table({Value:false},{Value:true})
+
 >> And(false && Patch(t1, First(t1), {Value:true}).Value);t1
+Table({Value:false},{Value:true})
+
+>> 0.5;t1
 Table({Value:false},{Value:true})
 
 >> And(false && Remove(t1, First(t1)));t1
 Table({Value:false},{Value:true})
 
+>> 0.6;t1
+Table({Value:false},{Value:true})
+
 >> And(false && Set(t1, [true,true]));t1
 Table({Value:false},{Value:true})
 
-// OR
+>> 0.7;t1
+Table({Value:false},{Value:true})
+
+// OR with true, none of these should execute
+>> true || Collect(t1, {Value:true}).Value
+true
+
+>> -1;t1
+Table({Value:false},{Value:true})
+
+>> true || Patch(t1, First(t1), {Value:true}).Value
+true
+
+>> -2;t1
+Table({Value:false},{Value:true})
+
+>> true || IsBlank(Remove(t1, First(t1), "All"))
+true
+
+>> -3;t1
+Table({Value:false},{Value:true})
+
+>> true || Set(t1, [false, false])
+true
+
+>> -4;t1
+Table({Value:false},{Value:true})
+
+// OR with false, these should all execute
 >> false || Collect(t1, {Value:true}).Value
 true
 
@@ -48,6 +121,9 @@ true
 Table()
 
 >> false || Set(t1, [false, true]);t1
+Table({Value:false},{Value:true})
+
+>> 3.1;t1
 Table({Value:false},{Value:true})
 
 >> Or(false, Collect(t1, {Value:true}).Value)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Assert.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Assert.txt
@@ -1,0 +1,17 @@
+// This is a placeholder for when we add the Assert function, to ensure we test short circuit behavior.
+// Case to test how shortcut verification work along with behavior functions
+
+>> Set( t1, ["hello"] )
+Table({Value:"hello"})
+
+>> Assert( false, Collect( t1, {Value:"there"}).Value )
+#SKIP: not implemented yet
+
+>> 1;t1
+Table({Value:"hello"})
+
+>> Assert( true, Collect( t1, {Value:"there"}).Value )
+#SKIP: not implemented yet
+
+>> 2;t1
+#SKIP: not implemented yet, expected Table({Value:"hello"},{Value:"there"})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
@@ -1,4 +1,6 @@
-﻿>> Set(t1, Table({a:1},{a:2},{a:3}))
+﻿#SETUP: DecimalSupport
+
+>> Set(t1, Table({a:1},{a:2},{a:3}))
 Table({a:1},{a:2},{a:3})
 
 >> Set(r1, {a:99})
@@ -41,7 +43,13 @@ Errors: Error 0-30: Invalid number of arguments: received 3, expected 2.
 Errors: Error 17-20: Invalid argument type (Text). Expecting a Record value instead.|Error 17-20: Invalid argument type. Cannot use Text values in this context.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(t1, 1)
-Errors: Error 17-18: Invalid argument type (Number). Expecting a Record value instead.|Error 17-18: Invalid argument type. Cannot use Number values in this context.|Error 0-19: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-18: Invalid argument type (Decimal). Expecting a Record value instead.|Error 17-18: Invalid argument type. Cannot use Decimal values in this context.|Error 0-19: The function 'ClearCollect' has some invalid arguments.
+
+>> ClearCollect(t1, Float(1))
+Errors: Error 17-25: Invalid argument type (Number). Expecting a Record value instead.|Error 17-25: Invalid argument type. Cannot use Number values in this context.|Error 0-26: The function 'ClearCollect' has some invalid arguments.
+
+>> ClearCollect(t1, true)
+Errors: Error 17-21: Invalid argument type (Boolean). Expecting a Record value instead.|Error 17-21: Invalid argument type. Cannot use Boolean values in this context.|Error 0-22: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Table({name: "VC"}), {surname: "textInput1"})
 Errors: Error 34-57: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 13-32: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-58: The function 'ClearCollect' has some invalid arguments.
@@ -59,7 +67,10 @@ Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-19: The 
 Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-20: Name isn't valid. 'Bar' isn't recognized.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(1/0,Foo)
-Errors: Error 17-20: Name isn't valid. 'Foo' isn't recognized.|Error 14-15: Invalid argument type (Number). Expecting a Table value instead.|Error 14-15: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-20: Name isn't valid. 'Foo' isn't recognized.|Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 14-15: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
+
+>> ClearCollect(Float(1)/0,Foo)
+Errors: Error 24-27: Name isn't valid. 'Foo' isn't recognized.|Error 21-22: Invalid argument type (Number). Expecting a Table value instead.|Error 21-22: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-28: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Error({Kind:ErrorKind.Custom}), r1)
 Errors: Error 45-47: The specified column 'a' does not exist.|Error 13-43: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-48: The function 'ClearCollect' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce.txt
@@ -1,0 +1,44 @@
+// Cases to test how shortcut verification work along with behavior functions
+
+>> Set( t1, [1,2] )
+Table({Value:1},{Value:2})
+
+>> Coalesce(1,Collect(t1,{Value:3}).Value)
+1
+
+>> 1;t1
+Table({Value:1},{Value:2})
+
+>> Coalesce(1,Blank(),Collect(t1,{Value:3}).Value)
+1
+
+>> 1.1;t1
+Table({Value:1},{Value:2})
+
+>> Set( bn, If(1<0,1))
+Blank()
+
+>> Coalesce( bn, Collect(t1,{Value:3}).Value )
+3
+
+>> 2;t1
+Table({Value:1},{Value:2},{Value:3})
+
+>> Coalesce( bn, Collect(t1,{Value:4}).Value, Collect(t1,{Value:5}).Value )
+4
+
+>> 3;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4})
+
+>> Coalesce( bn, Blank(), Collect(t1,{Value:5}).Value )
+5
+
+>> 4;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> Coalesce( bn, Blank(), Collect(t1,{Value:6}).Value, Collect(t1,{Value:7}).Value )
+6
+
+>> 5;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6})
+

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce_CoalesceShortCircuit.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce_CoalesceShortCircuit.txt
@@ -1,3 +1,5 @@
+#SETUP: CoalesceShortCircuit
+
 // Cases to test how shortcut verification work along with behavior functions
 
 >> Set( t1, [1,2] )

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce_CoalesceShortCircuitDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce_CoalesceShortCircuitDisabled.txt
@@ -1,4 +1,4 @@
-#SETUP: disable:PowerFxV1CompatibilityRules
+#SETUP: disable:CoalesceShortCircuit
 
 // Cases to test how shortcut verification work along with behavior functions
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Coalesce_V1CompatDisabled.txt
@@ -1,0 +1,46 @@
+#SETUP: disable:PowerFxV1CompatibilityRules
+
+// Cases to test how shortcut verification work along with behavior functions
+
+>> Set( t1, [1,2] )
+Table({Value:1},{Value:2})
+
+>> Coalesce(1,Collect(t1,{Value:3}).Value)
+1
+
+>> 1;t1
+Table({Value:1},{Value:2},{Value:3})
+
+>> Coalesce(1,Blank(),Collect(t1,{Value:3.1}).Value)
+1
+
+>> 1.1;t1
+Table({Value:1},{Value:2},{Value:3},{Value:3.1})
+
+>> Set( bn, If(1<0,1))
+Blank()
+
+>> Coalesce( bn, Collect(t1,{Value:3.2}).Value )
+3.2
+
+>> 2;t1
+Table({Value:1},{Value:2},{Value:3},{Value:3.1},{Value:3.2})
+
+>> Coalesce( bn, Collect(t1,{Value:4}).Value, Collect(t1,{Value:5}).Value )
+4
+
+>> 3;t1
+Table({Value:1},{Value:2},{Value:3},{Value:3.1},{Value:3.2},{Value:4},{Value:5})
+
+>> Coalesce( bn, Blank(), Collect(t1,{Value:5.1}).Value )
+5.1
+
+>> 4;t1
+Table({Value:1},{Value:2},{Value:3},{Value:3.1},{Value:3.2},{Value:4},{Value:5},{Value:5.1})
+
+>> Coalesce( bn, Blank(), Collect(t1,{Value:6}).Value, Collect(t1,{Value:7}).Value )
+6
+
+>> 5;t1
+Table({Value:1},{Value:2},{Value:3},{Value:3.1},{Value:3.2},{Value:4},{Value:5},{Value:5.1},{Value:6},{Value:7})
+

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ForAllMutate.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ForAllMutate.txt
@@ -29,3 +29,78 @@ Table({Value:2},{Value:4},{Value:6},{Value:8},{Value:10})
      Concat(t, Value) & "," & Concat(t2, Value)
    )
 "12345,24681099"
+
+// short circuiting shouldn't execute any loops for a blank or empty table
+
+>> Set(t3,If(1<0,[1,2,3]))
+Blank()
+
+>> ForAll(t3,Patch(t3,ThisRecord,{Value:4}))
+Blank()
+
+>> 1;t3
+Blank()
+
+// interpretation of an empty table
+
+>> Set(t4,[1])
+Table({Value:1})
+
+>> Remove(t4,First(t4))
+Blank()
+
+>> 1;t4
+Table()
+
+// Should do nothing as t4 is empty
+>> ForAll(t4,Patch(t4,ThisRecord,{Value:4}))
+Table()
+
+>> 2;t4
+Table()
+
+>> Set(t5,[1])
+Table({Value:1})
+
+// ForAll shouldn't execute the collect, even once
+>> ForAll(t4,Collect(t5,{Value:9.1}))
+Table()
+
+// With shouldn't execute the collect, even once
+>> With(First(t4),Collect(t5,{Value:9.2}))
+Blank()
+
+// interpretation of one record
+
+>> 1;t5
+Table({Value:1})
+
+>> Collect(t4,{Value:1})
+{Value:1}
+
+// ForAll should execute the collect, exactly once
+>> ForAll(t4,Collect(t5,{Value:8.1}))
+Table({Value:8.1})
+
+// With shouldn execute the collect, exactly once
+>> With(First(t4),Collect(t5,{Value:8.2}))
+{Value:8.2}
+
+>> 2;t5
+Table({Value:1},{Value:8.1},{Value:8.2})
+
+// interpretation of a blank table
+
+>> Set( t4, Blank() )
+Blank()
+
+// ForAll shouldn't execute the collect, even once
+>> ForAll(t4,Collect(t5,{Value:7.1}))
+Blank()
+
+// With shouldn't execute the collect, even once
+>> With(First(t4),Collect(t5,{Value:7.2}))
+Blank()
+
+>> 3;t5
+Table({Value:1},{Value:8.1},{Value:8.2})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/If.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/If.txt
@@ -1,0 +1,46 @@
+// Cases to test how shortcut verification work along with behavior functions
+
+>> Set( t1, [1,2] )
+Table({Value:1},{Value:2})
+
+>> If(false,Collect(t1,{Value:3}).Value,2)
+2
+
+>> 1;t1
+Table({Value:1},{Value:2})
+
+>> If(true,3,Collect(t1,{Value:3}).Value)
+3
+
+>> 2;t1
+Table({Value:1},{Value:2})
+
+>> If(false,Collect(t1,{Value:3}).Value,false,Collect(t1,{Value:4}).Value,2)
+2
+
+>> 3;t1
+Table({Value:1},{Value:2})
+
+>> If(false,Collect(t1,{Value:3}).Value,true,2,Collect(t1,{Value:4}).Value,2)
+2
+
+>> 3.1;t1
+Table({Value:1},{Value:2})
+
+>> If(true,3,true,Collect(t1,{Value:3}).Value,Collect(t1,{Value:4}).Value)
+3
+
+>> 4;t1
+Table({Value:1},{Value:2})
+
+>> If(false,Collect(t1,{Value:3}).Value,false,Collect(t1,{Value:4}).Value,5)
+5
+
+>> 5;t1
+Table({Value:1},{Value:2})
+
+>> If(true,3,true,6,true,Collect(t1,{Value:3}).Value,Collect(t1,{Value:4}).Value)
+3
+
+>> 6;t1
+Table({Value:1},{Value:2})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/IfError.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/IfError.txt
@@ -1,0 +1,46 @@
+// Cases to test how shortcut verification work along with behavior functions
+
+>> Set( t1, [1,2] )
+Table({Value:1},{Value:2})
+
+>> IfError(1,Collect(t1,{Value:3}).Value)
+1
+
+>> 1;t1
+Table({Value:1},{Value:2})
+
+>> IfError(1/0,Collect(t1,{Value:3}).Value)
+3
+
+>> 2;t1
+Table({Value:1},{Value:2},{Value:3})
+
+>> IfError(1/0,Collect(t1,{Value:4}).Value,1/0,Collect(t1,{Value:5}).Value)
+4
+
+>> 3;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4})
+
+>> IfError(1/0,Collect(t1,{Value:5}).Value,1/0,Collect(t1,{Value:6}).Value,Collect(t1,{Value:7}).Value)
+5
+
+>> 4;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> IfError(1,Collect(t1,{Value:5}).Value,1/0,Collect(t1,{Value:6}).Value,Collect(t1,{Value:7}).Value)
+6
+
+>> 5;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6})
+
+>> IfError(1,Collect(t1,{Value:5}).Value,2,Collect(t1,{Value:6}).Value,Collect(t1,{Value:7}).Value)
+7
+
+>> 6;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6},{Value:7})
+
+>> IfError(1,Collect(t1,{Value:5}).Value,2,Collect(t1,{Value:6}).Value)
+2
+
+>> 7;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6},{Value:7})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Patch.txt
@@ -1,1 +1,100 @@
-﻿
+﻿#SETUP: DecimalSupport
+
+// basic mutations with blanks and coercions
+
+>> Set(y, [{d:1,t:"hi",b:true},{d:2,t:"bye",b:false},{d:3,t:"cycle",b:Blank()}] )
+Table({b:true,d:1,t:"hi"},{b:false,d:2,t:"bye"},{b:Blank(),d:3,t:"cycle"})
+
+>> 0;y
+Table({b:true,d:1,t:"hi"},{b:false,d:2,t:"bye"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, LookUp( y, d=2 ), {t:"back"})
+{b:false,d:2,t:"back"}
+
+>> 1;y
+Table({b:true,d:1,t:"hi"},{b:false,d:2,t:"back"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, First(y), {b:Blank()})
+{b:Blank(),d:1,t:"hi"}
+
+>> 2;y
+Table({b:Blank(),d:1,t:"hi"},{b:false,d:2,t:"back"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, LookUp(y, b=Blank()), {b:true})
+{b:true,d:1,t:"hi"}
+
+>> 3;y
+Table({b:true,d:1,t:"hi"},{b:false,d:2,t:"back"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, Index(y,2), {b:Blank(),d:12,t:"different"})
+{b:Blank(),d:12,t:"different"}
+
+>> 4;y
+Table({b:true,d:1,t:"hi"},{b:Blank(),d:12,t:"different"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, Index(y,2), {b:1,d:"23",t:DateTime(2002,2,2,2,2,2)})
+{b:true,d:23,t:"2/2/2002 2:02 AM"}
+
+>> 5;y
+Table({b:true,d:1,t:"hi"},{b:true,d:23,t:"2/2/2002 2:02 AM"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, Index(y,3), {b:"0",d:true,t:GUID("1d9ec9bf-3b8b-4ff3-bac4-c2a723a0f49c")} )
+#SKIP: waiting on https://github.com/microsoft/Power-Fx/issues/1834, expected compile time error
+
+// should not have been changedn from the previous patch
+>> 6;y
+Table({b:true,d:1,t:"hi"},{b:true,d:23,t:"2/2/2002 2:02 AM"},{b:Blank(),d:3,t:"cycle"})
+
+>> Patch( y, Index(y,3), {b:false,d:1/0,t:GUID("1d9ec9bf-3b8b-4ff3-bac4-c2a723a0f49d")} )
+#SKIP: waiting on https://github.com/microsoft/Power-Fx/issues/1835, expected {b:false,d:<Error: Invalid operation: division by zero.>,t:"1d9ec9bf-3b8b-4ff3-bac4-c2a723a0f49d"}
+
+>> 7;y
+#SKIP: waiting on https://github.com/microsoft/Power-Fx/issues/1835, expected table with {b:false,d:<Error: Invalid operation: division by zero.>,t:"1d9ec9bf-3b8b-4ff3-bac4-c2a723a0f49d"}
+
+// deep mutation with coercions
+
+>> Set(x, { v :1 , t: [1,2,3]})
+{t:Table({Value:1},{Value:2},{Value:3}),v:1}
+
+>> 0;x.t
+Table({Value:1},{Value:2},{Value:3})
+
+>> Patch(x.t, Index(x.t,2), { Value: 99})
+{Value:99}
+
+>> 1;x.t
+Table({Value:1},{Value:99},{Value:3})
+
+>> Patch(x.t, {Value:99}, {Value:88})
+{Value:88}
+
+>> 2;x.t
+Table({Value:1},{Value:88},{Value:3})
+
+// works in Canvas, with or without Defaults function, but does not work in C# Power Fx (yet)
+>> Patch(x.t, {}, {Value:77})
+Error({Kind:ErrorKind.NotFound})
+
+>> 3;x.t
+Table({Value:1},{Value:88},{Value:3})
+
+>> Patch(x.t, {Value:88}, {Value:"77"})
+{Value:77}
+
+>> 4;x.t
+Table({Value:1},{Value:77},{Value:3})
+
+>> Patch(x.t, {Value:77}, {Value:Float(66)})
+{Value:66}
+
+>> 5;x.t
+Table({Value:1},{Value:66},{Value:3})
+
+>> Patch(x.t, {Value:66}, {Value:false})
+{Value:0}
+
+>> 6;x.t
+Table({Value:1},{Value:0},{Value:3})
+
+
+

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Switch.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Switch.txt
@@ -1,35 +1,52 @@
 // Cases to test how shortcut verification work along with behavior functions
 
->> Set( t1, [1,2] )
-Table({Value:1},{Value:2})
+>> Set( t1, [0,1] )
+Table({Value:0},{Value:1})
 
->> Switch(2,1,Collect(t1,{Value:2}).Value,2,Collect(t1,{Value:3}).Value,3,Collect(t1,{Value:4}).Value)
+>> Switch(2,1,Collect(t1,{Value:1}).Value,2,Collect(t1,{Value:2}).Value,3,Collect(t1,{Value:3}).Value)
 2
 
 >> 1;t1
-Table({Value:1},{Value:2},{Value:3})
+Table({Value:0},{Value:1},{Value:2})
 
->> Switch(3,1,Collect(t1,{Value:2}).Value,2,Collect(t1,{Value:3}).Value,3,Collect(t1,{Value:4}).Value,Collect(t1,{Value:4}).Value)
-2
+>> Switch(3,
+    1,Collect(t1,{Value:1}).Value,
+    2,Collect(t1,{Value:2}).Value,
+    3,Collect(t1,{Value:3}).Value,
+    Collect(t1,{Value:4}).Value)
+3
 
 >> 2;t1
-Table({Value:1},{Value:2},{Value:3},{Value:4})
+Table({Value:0},{Value:1},{Value:2},{Value:3})
 
->> Switch(1,1,Collect(t1,{Value:5}).Value,2,Collect(t1,{Value:6}).Value,3,Collect(t1,{Value:7}).Value,Collect(t1,{Value:8}).Value)
-2
+>> Switch(1,
+    1,Collect(t1,{Value:4}).Value,
+    2,Collect(t1,{Value:6}).Value,
+    3,Collect(t1,{Value:7}).Value,
+    Collect(t1,{Value:8}).Value)
+4
 
 >> 3;t1
-Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+Table({Value:0},{Value:1},{Value:2},{Value:3},{Value:4})
 
->> Switch(2,Collect(t1,{Value:6}).Value,1,Collect(t1,{Value:3}).Value,2,3,Collect(t1,{Value:4}).Value)
-6
+>> Switch(6,
+    Collect(t1,{Value:5}).Value,1,
+    Collect(t1,{Value:6}).Value,12,
+    2,Collect(t1,{Value:7}).Value,
+    Collect(t1,{Value:8}).Value)
+12
 
 >> 4;t1
-Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6})
+Table({Value:0},{Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6})
 
->> Switch(8,Collect(t1,{Value:7}).Value,1,Collect(t1,{Value:8}).Value2,9,3,Collect(t1,{Value:4}).Value)
-9
+>> Switch(9,
+    Collect(t1,{Value:7}).Value,Collect(t1,{Value:20}).Value,
+    Collect(t1,{Value:8}).Value,2,
+    6,8,
+    Collect(t1,{Value:9}).Value,Collect(t1,{Value:10}).Value,
+    Collect(t1,{Value:30}).Value)
+10
 
 >> 5;t1
-Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6},{Value:7},{Value:8})
+Table({Value:0},{Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6},{Value:7},{Value:8},{Value:9},{Value:10})
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Switch.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Switch.txt
@@ -1,0 +1,35 @@
+// Cases to test how shortcut verification work along with behavior functions
+
+>> Set( t1, [1,2] )
+Table({Value:1},{Value:2})
+
+>> Switch(2,1,Collect(t1,{Value:2}).Value,2,Collect(t1,{Value:3}).Value,3,Collect(t1,{Value:4}).Value)
+2
+
+>> 1;t1
+Table({Value:1},{Value:2},{Value:3})
+
+>> Switch(3,1,Collect(t1,{Value:2}).Value,2,Collect(t1,{Value:3}).Value,3,Collect(t1,{Value:4}).Value,Collect(t1,{Value:4}).Value)
+2
+
+>> 2;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4})
+
+>> Switch(1,1,Collect(t1,{Value:5}).Value,2,Collect(t1,{Value:6}).Value,3,Collect(t1,{Value:7}).Value,Collect(t1,{Value:8}).Value)
+2
+
+>> 3;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5})
+
+>> Switch(2,Collect(t1,{Value:6}).Value,1,Collect(t1,{Value:3}).Value,2,3,Collect(t1,{Value:4}).Value)
+6
+
+>> 4;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6})
+
+>> Switch(8,Collect(t1,{Value:7}).Value,1,Collect(t1,{Value:8}).Value2,9,3,Collect(t1,{Value:4}).Value)
+9
+
+>> 5;t1
+Table({Value:1},{Value:2},{Value:3},{Value:4},{Value:5},{Value:6},{Value:7},{Value:8})
+


### PR DESCRIPTION
Fixes https://github.com/microsoft/Power-Fx/issues/1831 and https://github.com/microsoft/Power-Fx/issues/1066.  Added additional tests for short circuiting.  We also need to be careful not to break Canvas semantics before Power Fx 1.0 is adopted there.