### PR TITLE
Revert "Mark the Coalesce function as asynchronous to account for lazy evaluation"

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Coalesce.cs
@@ -12,6 +12,7 @@ using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
 
+#pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1649 // File name should match first type name
 
 namespace Microsoft.PowerFx.Core.Texl.Builtins
@@ -21,8 +22,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     internal sealed class CoalesceFunction : BuiltinFunction
     {
         public override bool IsSelfContained => true;
-
-        public override bool IsAsync => true;
 
         public CoalesceFunction()
             : base("Coalesce", TexlStrings.AboutCoalesce, FunctionCategories.Information, DType.Unknown, 0, 1, int.MaxValue)
@@ -216,4 +215,5 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
     }
 }
 
+#pragma warning restore SA1402 // File may only contain a single type
 #pragma warning restore SA1649 // File name should match first type name


### PR DESCRIPTION
Reverts microsoft/Power-Fx#1839

Power Apps doesn't need this change.