### PR TITLE
Draft: NamedFormula edit experience improvement

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Errors/IRuleError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/IRuleError.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 using Microsoft.AppMagic.Transport;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Errors
 {
     [TransportType(TransportKind.ByValue)]
     internal interface IRuleError : IDocumentError
     {
+        IRuleError Clone(Span span);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Errors/TexlError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/TexlError.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.Core.Errors
             Contracts.AssertValue(tok);
 
             Tok = tok;
-            TextSpan = new Span(tok.VerifyValue().Span.Min, tok.VerifyValue().Span.Lim);
+            TextSpan = new Span(tok.VerifyValue().Span.Min, tok.VerifyValue().Span.Lim, tok.VerifyValue().Span.Offset);
 
             _nameMapIDs = new List<string>();
         }
@@ -49,6 +49,11 @@ namespace Microsoft.PowerFx.Core.Errors
             TextSpan = node.GetTextSpan();
 
             _nameMapIDs = new List<string>();
+        }
+
+        IRuleError IRuleError.Clone(Span span)
+        {
+            return new TexlError(this.Tok.Clone(span), this.Severity, this.ErrorResourceKey, this.MessageArgs);
         }
 
         public void MarkSinkTypeError(DName name)

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Span.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Span.cs
@@ -18,6 +18,8 @@ namespace Microsoft.PowerFx.Syntax
     [ThreadSafeImmutable]
     public sealed class Span
     {
+        internal Span Offset { get; }
+
         /// <summary>
         /// Start index of this span.
         /// </summary>
@@ -28,13 +30,14 @@ namespace Microsoft.PowerFx.Syntax
         /// </summary>
         public int Lim { get; }
 
-        internal Span(int min, int lim)
+        internal Span(int min, int lim, Span offset = null)
         {
             Contracts.CheckParam(min >= 0, "min");
             Contracts.CheckParam(lim >= min, "lim");
 
             Min = min;
             Lim = lim;
+            Offset = offset;
         }
 
         internal Span(Span span)
@@ -44,6 +47,7 @@ namespace Microsoft.PowerFx.Syntax
 
             Min = span.Min;
             Lim = span.Lim;
+            Offset = span.Offset;
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseFormulasResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseFormulasResult.cs
@@ -11,8 +11,23 @@ using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Parser
 {
+    public sealed class NamedFormulaNode
+    {
+        public Span RelativeSpan { get; }
+
+        public TexlNode Node { get; }
+
+        public NamedFormulaNode(Span relativeSpan, TexlNode node)
+        {
+            RelativeSpan = relativeSpan;
+            Node = node;
+        }
+    }
+
     public class ParseFormulasResult
     {
+        public IEnumerable<KeyValuePair<IdentToken, NamedFormulaNode>> NamedFormulaNodes { get; }
+
         public IEnumerable<KeyValuePair<IdentToken, TexlNode>> NamedFormulas { get; }
 
         internal IEnumerable<TexlError> Errors { get; }
@@ -33,6 +48,20 @@ namespace Microsoft.PowerFx.Core.Parser
             }
 
             NamedFormulas = namedFormulas;
+        }
+
+        internal ParseFormulasResult(IEnumerable<KeyValuePair<IdentToken, TexlNode>> namedFormulas, IEnumerable<KeyValuePair<IdentToken, NamedFormulaNode>> namedFormulaNodes, List<TexlError> errors)
+        {
+            Contracts.AssertValue(namedFormulas);
+
+            if (errors?.Any() ?? false)
+            {
+                Errors = errors;
+                HasError = true;
+            }
+
+            NamedFormulas = namedFormulas;
+            NamedFormulaNodes = namedFormulaNodes;
         }
 
         [Obsolete("Use unified UDF parser")]

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Formula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Formula.cs
@@ -30,9 +30,11 @@ namespace Microsoft.PowerFx.Syntax
         // This may be null if the script hasn't yet been parsed.
         internal TexlNode ParseTree { get; private set; }
 
+        internal Span RelativeSpan { get; }
+
         internal List<CommentToken> Comments { get; private set; }
 
-        public Formula(string script, TexlNode tree, CultureInfo loc = null)
+        public Formula(string script, TexlNode tree, CultureInfo loc = null, Span relativeSpan = null)
         {
             Contracts.AssertValue(script);
             Contracts.AssertValueOrNull(loc);
@@ -40,6 +42,7 @@ namespace Microsoft.PowerFx.Syntax
             Script = script;
             ParseTree = tree;
             Loc = loc;
+            RelativeSpan = relativeSpan;
             AssertValid();
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/CallNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/CallNode.cs
@@ -146,7 +146,7 @@ namespace Microsoft.PowerFx.Syntax
                 return new Span(dotted.GetCompleteSpan().Min, ParenClose.Span.Lim);
             }
 
-            return new Span(Head.Token.Span.Min, ParenClose.Span.Lim);
+            return new Span(Head.Token.Span.Min, ParenClose.Span.Lim, Head.Token.Span.Offset);
         }
 
         /// <inheritdoc />
@@ -168,10 +168,10 @@ namespace Microsoft.PowerFx.Syntax
             DottedNameNode dotted;
             if (HeadNode != null && (dotted = HeadNode.AsDottedName()) != null)
             {
-                return new Span(dotted.GetCompleteSpan().Min, limit);
+                return new Span(dotted.GetCompleteSpan().Min, limit, dotted.GetCompleteSpan().Offset);
             }
 
-            return new Span(Head.Token.Span.Min, limit);
+            return new Span(Head.Token.Span.Min, limit, Head.Token.Span.Offset);
         }
 
         // Does the CallNode have an argument/expression that is async without side effects

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TexlNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TexlNode.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerFx.Syntax
         // TODO: Should we keep this internal?
         public virtual Span GetTextSpan()
         {
-            return new Span(Token.VerifyValue().Span.Min, Token.VerifyValue().Span.Lim);
+            return new Span(Token.VerifyValue().Span.Min, Token.VerifyValue().Span.Lim, Token.VerifyValue().Span.Offset);
         }
 
         // TODO: Comment - what are the differences between different spans defined here?

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitionResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitionResult.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Parser;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx
 {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -5,8 +5,10 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.PowerFx.Core.Glue;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Parser;
+using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Syntax;
 using Xunit;
 
@@ -840,10 +842,21 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("a = 10;; b = in'valid ;; c = 20", "c")]
-        [InlineData("a = 10;; b = in'valid ;; c = 20;; d = also(invalid;; e = 44;;", "e")]
+        [InlineData("A0 = Filter(Accounts, 'Account Name' = \"Ian One\");A1 = Filter(A, 'Account Name' = \"Ian One\");", "c")]
+
+        //[InlineData("a = 10;; b = in'valid ;; c = 20", "c")]
+        //[InlineData("a = 10;; b = in'valid ;; c = 20;; d = also(invalid;; e = 44;;", "e")]
         public void TestFormulaParseRestart2(string script, string key)
         {
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = false
+            };
+
+            var nameResolver = ReadOnlySymbolTable.NewDefault(BuiltinFunctionsCore._library);
+            var glue = new Glue2DocumentBinderGlue();
+            var userDefinitions = UserDefinitions.ProcessUserDefinitions(script, nameResolver, glue, null, parserOptions, out var userDefinitionResult);
+
             var formulasResult = TexlParser.ParseFormulasScript(script, new CultureInfo("fr-FR"));
             Assert.True(formulasResult.HasError);
 


### PR DESCRIPTION
This PR adds a base index in token span. This is needed so that when Formulas property rule changes, we don't need to rebind each and every named formula every time. We can only rebind the rules which are changed. Currently we need to do that as span for each named formula rule is not relative to named formula identifier token. This change adds the baseindex in each token which then can be used to report the span in whole formula rule.