### PR TITLE
Connector fix and API changes

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -222,12 +222,12 @@ namespace Microsoft.PowerFx.Connectors
         /// <summary>
         /// Dynamic schema extension on return type (response).
         /// </summary>
-        internal ConnectorDynamicSchema DynamicReturnSchema => EnsureConnectorFunction(ReturnParameterType?.DynamicReturnSchema, FunctionList);
+        internal ConnectorDynamicSchema DynamicReturnSchema => EnsureConnectorFunction(ReturnParameterType?.DynamicSchema, FunctionList);
 
         /// <summary>
         /// Dynamic schema extension on return type (response).
         /// </summary>
-        internal ConnectorDynamicProperty DynamicReturnProperty => EnsureConnectorFunction(ReturnParameterType?.DynamicReturnProperty, FunctionList);
+        internal ConnectorDynamicProperty DynamicReturnProperty => EnsureConnectorFunction(ReturnParameterType?.DynamicProperty, FunctionList);
 
         /// <summary>
         /// Return type when determined at runtime/by dynamic intellisense.
@@ -283,21 +283,21 @@ namespace Microsoft.PowerFx.Connectors
         /// Get connector function parameter suggestions.
         /// </summary>
         /// <param name="knownParameters">Known parameters.</param>
-        /// <param name="parameterName">Name of the parameter for which we need a set of suggestions.</param>
+        /// <param name="connectorParameter">Parameter for which we need a set of suggestions.</param>
         /// <param name="runtimeContext">Runtime connector context.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>ConnectorParameters class with suggestions.</returns>
-        public async Task<ConnectorParameters> GetParameterSuggestionsAsync(NamedValue[] knownParameters, string parameterName, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)
+        public async Task<ConnectorParameters> GetParameterSuggestionsAsync(NamedValue[] knownParameters, ConnectorParameter connectorParameter, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             List<ConnectorParameterWithSuggestions> parametersWithSuggestions = new List<ConnectorParameterWithSuggestions>();
-            ConnectorEnhancedSuggestions suggestions = GetConnectorSuggestionsAsync(knownParameters, parameterName, runtimeContext, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            ConnectorEnhancedSuggestions suggestions = GetConnectorSuggestionsAsync(knownParameters, connectorParameter, runtimeContext, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
 
             foreach (ConnectorParameter parameter in RequiredParameters.Union(OptionalParameters))
             {
                 NamedValue namedValue = knownParameters.FirstOrDefault(p => p.Name == parameter.Name);
-                ConnectorParameterWithSuggestions cpws = new ConnectorParameterWithSuggestions(parameter, namedValue?.Value, parameterName, suggestions, knownParameters);
+                ConnectorParameterWithSuggestions cpws = new ConnectorParameterWithSuggestions(parameter, namedValue?.Value, connectorParameter.Name, suggestions, knownParameters);
                 parametersWithSuggestions.Add(cpws);
             }
 
@@ -306,6 +306,57 @@ namespace Microsoft.PowerFx.Connectors
                 IsCompleted = suggestions != null && parametersWithSuggestions.All(p => !p.Suggestions.Any()),
                 ParametersWithSuggestions = parametersWithSuggestions.ToArray()
             };
+        }
+
+        /// <summary>
+        /// Dynamic intellisense (dynamic property/schema) on a given parameter.
+        /// </summary>
+        /// <param name="knownParameters">Known parameters.</param>
+        /// <param name="connectorParameter">Parameter for which we need the (dynamic) type.</param>
+        /// <param name="context">Connector context.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Formula Type determined by dynamic Intellisense.</returns>
+        public async Task<ConnectorType> GetConnectorTypeAsync(NamedValue[] knownParameters, ConnectorParameter connectorParameter, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await GetConnectorTypeAsync(knownParameters, connectorParameter.ConnectorType ?? ReturnParameterType, context, cancellationToken).ConfigureAwait(false);           
+        }
+
+        /// <summary>
+        /// Dynamic intellisense (dynamic property/schema) on a given connector type (coming from a parameter or returned from GetConnectorTypeAsync).
+        /// </summary>
+        /// <param name="knownParameters">Known parameters.</param>
+        /// <param name="connectorType">Connector type for which we need the (dynamic) type.</param>
+        /// <param name="context">Connector context.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Formula Type determined by dynamic Intellisense.</returns>
+        public async Task<ConnectorType> GetConnectorTypeAsync(NamedValue[] knownParameters, ConnectorType connectorType, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (connectorType.DynamicProperty != null && !string.IsNullOrEmpty(connectorType.DynamicProperty.ItemValuePath))
+            {
+                return await GetConnectorSuggestionsFromDynamicPropertyAsync(knownParameters, context, connectorType.DynamicProperty, cancellationToken).ConfigureAwait(false);
+            }
+            else if (connectorType.DynamicSchema != null && !string.IsNullOrEmpty(connectorType.DynamicSchema.ValuePath))
+            {
+                return await GetConnectorSuggestionsFromDynamicSchemaAsync(knownParameters, context, connectorType.DynamicSchema, cancellationToken).ConfigureAwait(false);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Dynamic intellisense on return value.
+        /// </summary>
+        /// <param name="knownParameters">Known parameters.</param>
+        /// <param name="context">Connector context.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Formula Type determined by dynamic Intellisense.</returns>
+        public async Task<ConnectorType> GetConnectorReturnTypeAsync(NamedValue[] knownParameters, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await GetConnectorTypeAsync(knownParameters, ReturnParameterType, context, cancellationToken).ConfigureAwait(false);            
         }
 
         /// <summary>
@@ -402,17 +453,15 @@ namespace Microsoft.PowerFx.Connectors
             result = await PostProcessResultAsync(result, context, invoker, cancellationToken).ConfigureAwait(false);
 
             return result;
-        }
+        }        
 
-        internal async Task<ConnectorEnhancedSuggestions> GetConnectorSuggestionsAsync(NamedValue[] knownParameters, string parameterName, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
+        internal async Task<ConnectorEnhancedSuggestions> GetConnectorSuggestionsAsync(NamedValue[] knownParameters, ConnectorParameter parameter, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            cancellationToken.ThrowIfCancellationRequested();            
 
-            ConnectorParameter currentParam = RequiredParameters.FirstOrDefault(p => string.Equals(p.Name, parameterName, StringComparison.OrdinalIgnoreCase)) ?? OptionalParameters.FirstOrDefault(p => string.Equals(p.Name, parameterName, StringComparison.OrdinalIgnoreCase));
-
-            if (currentParam != null)
+            if (parameter != null)
             {
-                ConnectorExtensions connectorExtensions = currentParam.ConnectorExtensions;
+                ConnectorExtensions connectorExtensions = parameter.ConnectorExtensions;
 
                 if (connectorExtensions.ConnectorDynamicList != null)
                 {
@@ -448,33 +497,7 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Dynamic intellisense on return value.
-        /// </summary>
-        /// <param name="knownParameters">Known parameters.</param>
-        /// <param name="context">Connector context.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>Formula Type determined by dynamic Intellisense.</returns>
-        public async Task<ConnectorType> GetConnectorReturnSchemaAsync(NamedValue[] knownParameters, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            ConnectorDynamicSchema cds = ReturnParameterType.DynamicReturnSchema;
-            ConnectorDynamicProperty cdp = ReturnParameterType.DynamicReturnProperty;
-
-            if (cdp != null && !string.IsNullOrEmpty(cdp.ItemValuePath))
-            {
-                return await GetConnectorSuggestionsFromDynamicPropertyAsync(knownParameters, context, cdp, cancellationToken).ConfigureAwait(false);
-            }
-            else if (cds != null && !string.IsNullOrEmpty(cds.ValuePath))
-            {
-                return await GetConnectorSuggestionsFromDynamicSchemaAsync(knownParameters, context, cds, cancellationToken).ConfigureAwait(false);
-            }
-
-            return null;
-        }
+        }       
 
         private static JsonElement ExtractFromJson(StringValue sv, string location)
         {
@@ -521,7 +544,7 @@ namespace Microsoft.PowerFx.Connectors
             JsonElement je = ExtractFromJson(sv, cds.ValuePath);
             OpenApiSchema schema = new OpenApiStringReader().ReadFragment<OpenApiSchema>(je.ToString(), Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0, out OpenApiDiagnostic diag);
 
-            return new ConnectorType(schema);
+            return new ConnectorType(schema, NumberIsFloat);
         }
 
         private async Task<ConnectorType> GetConnectorSuggestionsFromDynamicPropertyAsync(NamedValue[] knownParameters, BaseRuntimeConnectorContext context, ConnectorDynamicProperty cdp, CancellationToken cancellationToken)
@@ -544,7 +567,7 @@ namespace Microsoft.PowerFx.Connectors
             JsonElement je = ExtractFromJson(sv, cdp.ItemValuePath);
             OpenApiSchema schema = new OpenApiStringReader().ReadFragment<OpenApiSchema>(je.ToString(), Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0, out OpenApiDiagnostic diag);
 
-            return new ConnectorType(schema);
+            return new ConnectorType(schema, NumberIsFloat);
         }
 
         private async Task<ConnectorEnhancedSuggestions> GetConnectorSuggestionsFromDynamicValueAsync(NamedValue[] knownParameters, BaseRuntimeConnectorContext context, ConnectorDynamicValue cdv, CancellationToken cancellationToken)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Internal/ConnectorExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Internal/ConnectorExtensions.cs
@@ -14,11 +14,6 @@ namespace Microsoft.PowerFx.Connectors
         internal string Summary;
         internal bool ExplicitInput;
 
-        internal ConnectorExtensions(IOpenApiExtensible extension, bool numberIsFloat)
-            : this(extension, null, numberIsFloat)
-        {
-        }
-
         internal ConnectorExtensions(IOpenApiExtensible extension, IOpenApiExtensible body, bool numberIsFloat)
         {
             ConnectorDynamicValue = extension.GetDynamicValue(numberIsFloat);

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -520,8 +520,10 @@ namespace Microsoft.PowerFx.Connectors
 
         internal static (ConnectorType ConnectorType, string UnsupportedReason) GetConnectorReturnType(this OpenApiOperation openApiOperation, bool numberIsFloat)
         {
-            var responses = openApiOperation.Responses;
-            if (!responses.TryGetValue("200", out OpenApiResponse response))
+            OpenApiResponses responses = openApiOperation.Responses;
+            OpenApiResponse response = responses.FirstOrDefault(kvp => kvp.Key?.Length == 3 && kvp.Key.StartsWith("2", StringComparison.Ordinal)).Value;
+
+            if (response == null)
             {
                 // If no 200, but "default", use that. 
                 if (!responses.TryGetValue("default", out response))
@@ -539,10 +541,10 @@ namespace Microsoft.PowerFx.Connectors
 
             // Responses is a list by content-type. Find "application/json"
             // Headers are case insensitive.
-            foreach (var kv3 in response.Content)
+            foreach (KeyValuePair<string, OpenApiMediaType> contentKvp in response.Content)
             {
-                string mediaType = kv3.Key.Split(';')[0];
-                OpenApiMediaType openApiMediaType = kv3.Value;
+                string mediaType = contentKvp.Key.Split(';')[0];
+                OpenApiMediaType openApiMediaType = contentKvp.Value;
 
                 if (string.Equals(mediaType, ContentType_ApplicationJson, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(mediaType, ContentType_TextPlain, StringComparison.OrdinalIgnoreCase) ||

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -302,18 +302,18 @@ namespace Microsoft.PowerFx.Connectors
                     {
                         case "date":
                         case "date-time":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTime);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTime, numberIsFloat);
                         case "date-no-tz":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTimeNoTimeZone);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTimeNoTimeZone, numberIsFloat);
 
                         case "binary":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.String);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.String, numberIsFloat);
 
                         case "enum":
                             if (schema.Enum.All(e => e is OpenApiString))
                             {
                                 OptionSet os = new OptionSet("enum", schema.Enum.Select(e => new DName((e as OpenApiString).Value)).ToDictionary(k => k, e => e).ToImmutableDictionary());
-                                return new ConnectorType(schema, openApiParameter, os.FormulaType);
+                                return new ConnectorType(schema, openApiParameter, os.FormulaType, numberIsFloat);
                             }
                             else
                             {
@@ -321,7 +321,7 @@ namespace Microsoft.PowerFx.Connectors
                             }
 
                         default:
-                            return new ConnectorType(schema, openApiParameter, FormulaType.String);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.String, numberIsFloat);
                     }
 
                 // OpenAPI spec: Format could be float, double, or not specified.
@@ -336,19 +336,19 @@ namespace Microsoft.PowerFx.Connectors
                         case "byte":
                         case "number":
                         case "int32":
-                            return numberIsFloat ? new ConnectorType(schema, openApiParameter, FormulaType.Number) : new ConnectorType(schema, openApiParameter, FormulaType.Decimal);
+                            return numberIsFloat ? new ConnectorType(schema, openApiParameter, FormulaType.Number, numberIsFloat) : new ConnectorType(schema, openApiParameter, FormulaType.Decimal, numberIsFloat);
 
                         case null:
                         case "decimal":
                         case "currency":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.Decimal);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.Decimal, numberIsFloat);
 
                         default:
                             throw new NotImplementedException($"Unsupported type of number: {schema.Format}");
                     }
 
                 // Always a boolean (Format not used)                
-                case "boolean": return new ConnectorType(schema, openApiParameter, FormulaType.Boolean);
+                case "boolean": return new ConnectorType(schema, openApiParameter, FormulaType.Boolean, numberIsFloat);
 
                 // OpenAPI spec: Format could be <null>, int32, int64
                 case "integer":
@@ -357,11 +357,11 @@ namespace Microsoft.PowerFx.Connectors
                         case null:
                         case "integer":
                         case "int32":
-                            return numberIsFloat ? new ConnectorType(schema, openApiParameter, FormulaType.Number) : new ConnectorType(schema, openApiParameter, FormulaType.Decimal);
+                            return numberIsFloat ? new ConnectorType(schema, openApiParameter, FormulaType.Number, numberIsFloat) : new ConnectorType(schema, openApiParameter, FormulaType.Decimal, numberIsFloat);
 
                         case "int64":
                         case "unixtime":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.Decimal);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.Decimal, numberIsFloat);
 
                         default:
                             throw new NotImplementedException($"Unsupported type of integer: {schema.Format}");
@@ -371,7 +371,7 @@ namespace Microsoft.PowerFx.Connectors
                     if (schema.Items == null)
                     {
                         // Type of items in unknown
-                        return new ConnectorType(schema, openApiParameter, FormulaType.UntypedObject);
+                        return new ConnectorType(schema, openApiParameter, FormulaType.UntypedObject, numberIsFloat);
                     }
 
                     var innerA = GetUniqueIdentifier(schema.Items);
@@ -379,14 +379,14 @@ namespace Microsoft.PowerFx.Connectors
                     if (innerA.StartsWith("R:", StringComparison.Ordinal) && chain.Contains(innerA))
                     {
                         // Here, we have a circular reference and default to a string
-                        return new ConnectorType(schema, openApiParameter, FormulaType.String);
+                        return new ConnectorType(schema, openApiParameter, FormulaType.String, numberIsFloat);
                     }
 
                     // Inheritance/Polymorphism - Can't know the exact type
                     // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md
                     if (schema.Items.Discriminator != null)
                     {
-                        return new ConnectorType(schema, openApiParameter, FormulaType.UntypedObject);
+                        return new ConnectorType(schema, openApiParameter, FormulaType.UntypedObject, numberIsFloat);
                     }
 
                     chain.Push(innerA);                    
@@ -396,20 +396,20 @@ namespace Microsoft.PowerFx.Connectors
 
                     if (arrayType.FormulaType is RecordType connectorRecordType)
                     {
-                        return new ConnectorType(schema, openApiParameter, connectorRecordType.ToTable(), arrayType);
+                        return new ConnectorType(schema, openApiParameter, connectorRecordType.ToTable(), arrayType, numberIsFloat);
                     }
                     else if (arrayType.FormulaType is TableType tableType)
                     {
                         // Array of array 
                         TableType newTableType = new TableType(TableType.Empty().Add(TableValue.ValueName, tableType)._type);
-                        return new ConnectorType(schema, openApiParameter, newTableType, arrayType);
+                        return new ConnectorType(schema, openApiParameter, newTableType, arrayType, numberIsFloat);
                     }
                     else if (arrayType.FormulaType is not AggregateType)
                     {
                         // Primitives get marshalled as a SingleColumn table.
                         // Make sure this is consistent with invoker. 
                         var recordType3 = RecordType.Empty().Add(TableValue.ValueName, arrayType.FormulaType);
-                        return new ConnectorType(schema, openApiParameter, recordType3.ToTable(), arrayType);
+                        return new ConnectorType(schema, openApiParameter, recordType3.ToTable(), arrayType, numberIsFloat);
                     }
                     else
                     {
@@ -423,7 +423,7 @@ namespace Microsoft.PowerFx.Connectors
                     // Key is always a string, Value is in AdditionalProperties
                     if ((schema.AdditionalProperties != null && schema.AdditionalProperties.Properties.Any()) || schema.Discriminator != null)
                     {
-                        return new ConnectorType(schema, openApiParameter, FormulaType.UntypedObject);
+                        return new ConnectorType(schema, openApiParameter, FormulaType.UntypedObject, numberIsFloat);
                     }
                     else
                     {
@@ -432,7 +432,7 @@ namespace Microsoft.PowerFx.Connectors
                         List<ConnectorType> connectorTypes = new List<ConnectorType>();
                         List<ConnectorType> hiddenConnectorTypes = new List<ConnectorType>();
 
-                        foreach (var kv in schema.Properties)
+                        foreach (KeyValuePair<string, OpenApiSchema> kv in schema.Properties)
                         {
                             bool hiddenRequired = false;
 
@@ -454,7 +454,7 @@ namespace Microsoft.PowerFx.Connectors
                             if (innerO.StartsWith("R:", StringComparison.Ordinal) && chain.Contains(innerO))
                             {
                                 // Here, we have a circular reference and default to a string                                
-                                return new ConnectorType(schema, openApiParameter, FormulaType.String, hiddenRecordType);
+                                return new ConnectorType(schema, openApiParameter, FormulaType.String, hiddenRecordType, numberIsFloat);
                             }
 
                             chain.Push(innerO);
@@ -479,7 +479,7 @@ namespace Microsoft.PowerFx.Connectors
                             }
                         }
 
-                        return new ConnectorType(schema, openApiParameter, recordType, hiddenRecordType, connectorTypes.ToArray(), hiddenConnectorTypes.ToArray());
+                        return new ConnectorType(schema, openApiParameter, recordType, hiddenRecordType, connectorTypes.ToArray(), hiddenConnectorTypes.ToArray(), numberIsFloat);
                     }
 
                 default:
@@ -521,7 +521,7 @@ namespace Microsoft.PowerFx.Connectors
         internal static (ConnectorType ConnectorType, string UnsupportedReason) GetConnectorReturnType(this OpenApiOperation openApiOperation, bool numberIsFloat)
         {
             OpenApiResponses responses = openApiOperation.Responses;
-            OpenApiResponse response = responses.FirstOrDefault(kvp => kvp.Key?.Length == 3 && kvp.Key.StartsWith("2", StringComparison.Ordinal)).Value;
+            OpenApiResponse response = responses.Where(kvp => kvp.Key?.Length == 3 && kvp.Key.StartsWith("2", StringComparison.Ordinal)).OrderBy(kvp => kvp.Key).FirstOrDefault().Value;
 
             if (response == null)
             {
@@ -556,11 +556,7 @@ namespace Microsoft.PowerFx.Connectors
                         return (new ConnectorType(), null);
                     }
 
-                    ConnectorDynamicSchema connectorDynamicSchema = openApiMediaType.Schema.GetDynamicSchema(numberIsFloat);
-                    ConnectorDynamicProperty connectorDynamicProperty = openApiMediaType.Schema.GetDynamicProperty(numberIsFloat);
-
-                    ConnectorType connectorType = new OpenApiParameter() { Name = "response", Required = true, Schema = openApiMediaType.Schema, Extensions = openApiMediaType.Extensions }.ToConnectorType(numberIsFloat: numberIsFloat);
-                    connectorType.SetDynamicReturnSchemaAndProperty(connectorDynamicSchema, connectorDynamicProperty);
+                    ConnectorType connectorType = new OpenApiParameter() { Name = "response", Required = true, Schema = openApiMediaType.Schema, Extensions = openApiMediaType.Schema.Extensions }.ToConnectorType(numberIsFloat: numberIsFloat);
 
                     return (connectorType, null);
                 }
@@ -650,7 +646,7 @@ namespace Microsoft.PowerFx.Connectors
         internal static ConnectorDynamicValue GetDynamicValue(this IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
-            if (param.Extensions != null && param.Extensions.TryGetValue(XMsDynamicValues, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
+            if (param?.Extensions != null && param.Extensions.TryGetValue(XMsDynamicValues, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
             {
                 ConnectorDynamicValue cdv = new ();
 
@@ -672,7 +668,7 @@ namespace Microsoft.PowerFx.Connectors
         internal static ConnectorDynamicList GetDynamicList(this IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
-            if (param.Extensions != null && param.Extensions.TryGetValue(XMsDynamicList, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
+            if (param?.Extensions != null && param.Extensions.TryGetValue(XMsDynamicList, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
             {
                 // Mandatory openrationId for connectors
                 if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)
@@ -761,7 +757,7 @@ namespace Microsoft.PowerFx.Connectors
         internal static ConnectorDynamicSchema GetDynamicSchema(this IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
-            if (param.Extensions != null && param.Extensions.TryGetValue(XMsDynamicSchema, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
+            if (param?.Extensions != null && param.Extensions.TryGetValue(XMsDynamicSchema, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
             {
                 // Mandatory openrationId for connectors
                 if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)
@@ -794,7 +790,7 @@ namespace Microsoft.PowerFx.Connectors
         internal static ConnectorDynamicProperty GetDynamicProperty(this IOpenApiExtensible param, bool numberIsFloat)
         {
             // https://learn.microsoft.com/en-us/connectors/custom-connectors/openapi-extensions#use-dynamic-values
-            if (param.Extensions != null && param.Extensions.TryGetValue(XMsDynamicProperties, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
+            if (param?.Extensions != null && param.Extensions.TryGetValue(XMsDynamicProperties, out IOpenApiExtension ext) && ext is OpenApiObject apiObj)
             {
                 // Mandatory openrationId for connectors
                 if (apiObj.TryGetValue("operationId", out IOpenApiAny op_id) && op_id is OpenApiString opId)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
@@ -61,13 +61,13 @@ namespace Microsoft.PowerFx.Connectors
 
         internal RecordType HiddenRecordType { get; }
 
-        public bool SupportsSuggestions => DynamicReturnSchema != null || DynamicReturnProperty != null;
+        public bool SupportsSuggestions => DynamicSchema != null || DynamicProperty != null;
 
-        internal ConnectorDynamicSchema DynamicReturnSchema { get; private set; }
+        internal ConnectorDynamicSchema DynamicSchema { get; private set; }
 
-        internal ConnectorDynamicProperty DynamicReturnProperty { get; private set; }
+        internal ConnectorDynamicProperty DynamicProperty { get; private set; }
 
-        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, FormulaType formulaType)
+        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, FormulaType formulaType, bool numberIsFloat)
         {
             Name = openApiParameter?.Name;
             IsRequired = openApiParameter?.Required == true;
@@ -95,8 +95,11 @@ namespace Microsoft.PowerFx.Connectors
                 {
                     EnumValues = Array.Empty<FormulaValue>();
                     EnumDisplayNames = Array.Empty<string>();
-                }
+                }                                               
             }
+
+            DynamicSchema = openApiParameter.GetDynamicSchema(numberIsFloat);
+            DynamicProperty = openApiParameter.GetDynamicProperty(numberIsFloat);
         }
 
         internal ConnectorType()
@@ -104,42 +107,36 @@ namespace Microsoft.PowerFx.Connectors
             FormulaType = new BlankType();
         }
 
-        internal ConnectorType(OpenApiSchema schema)
-            : this(schema, null, new OpenApiParameter() { Schema = schema }.ToConnectorType())
+        internal ConnectorType(OpenApiSchema schema, bool numberIsFloat)
+            : this(schema, null, new OpenApiParameter() { Schema = schema }.ToConnectorType(), numberIsFloat)
         {
         }
 
-        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, ConnectorType connectorType)
-            : this(schema, openApiParameter, connectorType.FormulaType)
+        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, ConnectorType connectorType, bool numberIsFloat)
+            : this(schema, openApiParameter, connectorType.FormulaType, numberIsFloat)
         {
             Fields = connectorType.Fields;
         }
 
-        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, FormulaType formulaType, RecordType hiddenRecordType)
-            : this(schema, openApiParameter, formulaType)
+        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, FormulaType formulaType, RecordType hiddenRecordType, bool numberIsFloat)
+            : this(schema, openApiParameter, formulaType, numberIsFloat)
         {
             HiddenRecordType = hiddenRecordType;
         }
 
-        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, TableType tableType, ConnectorType tableConnectorType)
-            : this(schema, openApiParameter, tableType)
+        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, TableType tableType, ConnectorType tableConnectorType, bool numberIsFloat)
+            : this(schema, openApiParameter, tableType, numberIsFloat)
         {
             Fields = new ConnectorType[] { tableConnectorType };
             HiddenRecordType = null;
         }
 
-        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, RecordType recordType, RecordType hiddenRecordType, ConnectorType[] fields, ConnectorType[] hiddenFields)
-            : this(schema, openApiParameter, recordType)
+        internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, RecordType recordType, RecordType hiddenRecordType, ConnectorType[] fields, ConnectorType[] hiddenFields, bool numberIsFloat)
+            : this(schema, openApiParameter, recordType, numberIsFloat)
         {
             Fields = fields;
             HiddenFields = hiddenFields;
             HiddenRecordType = hiddenRecordType;
-        }
-
-        internal void SetDynamicReturnSchemaAndProperty(ConnectorDynamicSchema dynamicSchema, ConnectorDynamicProperty dynamicProperty)
-        {
-            DynamicReturnSchema = dynamicSchema;
-            DynamicReturnProperty = dynamicProperty;
         }
 
         private OptionSet GetOptionSet()

--- a/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             NamedValue[] namedValues = knownParameters.Select((kp, i) => new NamedValue(ConnectorFunction.RequiredParameters[i].Name, kp)).ToArray();
-            return (await ConnectorFunction.GetConnectorSuggestionsAsync(namedValues.ToArray(), ConnectorFunction.RequiredParameters[argPosition].Name, runtimeContext, cancellationToken).ConfigureAwait(false))?.ConnectorSuggestions;
+            return (await ConnectorFunction.GetConnectorSuggestionsAsync(namedValues.ToArray(), ConnectorFunction.RequiredParameters[argPosition], runtimeContext, cancellationToken).ConfigureAwait(false))?.ConnectorSuggestions;
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/ConnectorWizardTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/ConnectorWizardTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             // Get list of parameters for ExecuteProcedureV2 function, without knowing any parameter
             // Notice that GetParameters does NOT validate parameter types
-            ConnectorParameters parameters = await executeProcedureV2.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), "server", context, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters parameters = await executeProcedureV2.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), executeProcedureV2.RequiredParameters[0], context, CancellationToken.None).ConfigureAwait(false);
 
             // We'll always get 4 parameters and some fields are constant (see CheckParameters)
             CheckParameters(parameters.ParametersWithSuggestions);
@@ -75,7 +75,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Response 2.json");
 
             // With first parameter defined (and valid)
-            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")) }, "database", context, CancellationToken.None).ConfigureAwait(false);
+            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")) }, executeProcedureV2.RequiredParameters[1], context, CancellationToken.None).ConfigureAwait(false);
 
             CheckParameters(parameters.ParametersWithSuggestions);
 
@@ -88,7 +88,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Response 3.json");
 
             // With two parameters defined (and valid)
-            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")) }, "procedure", context, CancellationToken.None).ConfigureAwait(false);
+            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")) }, executeProcedureV2.RequiredParameters[2], context, CancellationToken.None).ConfigureAwait(false);
 
             CheckParameters(parameters.ParametersWithSuggestions);
 
@@ -102,7 +102,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Response2 2.json");
 
             // With three parameters defined (and valid)
-            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")), new NamedValue("procedure", FormulaValue.New(@"sp_2")) }, "parameters", context, CancellationToken.None).ConfigureAwait(false);
+            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")), new NamedValue("procedure", FormulaValue.New(@"sp_2")) }, executeProcedureV2.RequiredParameters[3], context, CancellationToken.None).ConfigureAwait(false);
 
             CheckParameters(parameters.ParametersWithSuggestions, true);
             (0..2).ForAll(i => Assert.Empty(parameters.ParametersWithSuggestions[i].Suggestions));
@@ -117,7 +117,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             // With 4 parameters defined (and valid)
             // p1 is not specified here
-            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")), new NamedValue("procedure", FormulaValue.New(@"sp_2")), new NamedValue("p1", FormulaValue.New(50)) }, "parameters", context, CancellationToken.None).ConfigureAwait(false);
+            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")), new NamedValue("procedure", FormulaValue.New(@"sp_2")), new NamedValue("p1", FormulaValue.New(50)) }, executeProcedureV2.RequiredParameters[3], context, CancellationToken.None).ConfigureAwait(false);
 
             CheckParameters(parameters.ParametersWithSuggestions, true);
             (0..2).ForAll(i => Assert.Empty(parameters.ParametersWithSuggestions[i].Suggestions));
@@ -131,7 +131,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Response2 2.json");
 
             // With 5 parameters defined (and valid)
-            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")), new NamedValue("procedure", FormulaValue.New(@"sp_2")), new NamedValue("p1", FormulaValue.New(50)), new NamedValue("p2", FormulaValue.New("abc")) }, "parameters", context, CancellationToken.None).ConfigureAwait(false);
+            parameters = await executeProcedureV2.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("server", FormulaValue.New(@"default")), new NamedValue("database", FormulaValue.New(@"default")), new NamedValue("procedure", FormulaValue.New(@"sp_2")), new NamedValue("p1", FormulaValue.New(50)), new NamedValue("p2", FormulaValue.New("abc")) }, executeProcedureV2.RequiredParameters[3], context, CancellationToken.None).ConfigureAwait(false);
 
             CheckParameters(parameters.ParametersWithSuggestions, true);
             (0..3).ForAll(i => Assert.Empty(parameters.ParametersWithSuggestions[i].Suggestions));
@@ -160,22 +160,22 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             OpenApiDocument apiDoc = testConnector._apiDocument;
             IEnumerable<ConnectorFunction> functions = OpenApiParser.GetFunctions("SQL", apiDoc); 
-            ConnectorFunction function = functions.First(cf => cf.Name == "ExecuteProcedureV2");
+            ConnectorFunction executeProcedureV2 = functions.First(cf => cf.Name == "ExecuteProcedureV2");
 
             BaseRuntimeConnectorContext context = new TestConnectorRuntimeContext("SQL", client, throwOnError: true);
 
             // Simulates an invalid token
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Error.json", System.Net.HttpStatusCode.BadRequest);
-            await Assert.ThrowsAsync<HttpRequestException>(async () => await function.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), "server", context, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await executeProcedureV2.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), executeProcedureV2.RequiredParameters[0], context, CancellationToken.None).ConfigureAwait(false)).ConfigureAwait(false);
 
             // now let's try with throwOnError false
             functions = OpenApiParser.GetFunctions("SQL", apiDoc);
-            function = functions.First(cf => cf.Name == "ExecuteProcedureV2");
+            executeProcedureV2 = functions.First(cf => cf.Name == "ExecuteProcedureV2");
 
             // Same invalid token
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Error.json", System.Net.HttpStatusCode.BadRequest);
             context = new TestConnectorRuntimeContext("SQL", client, throwOnError: false);
-            ConnectorParameters parameters = await function.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), "server", context, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters parameters = await executeProcedureV2.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), executeProcedureV2.RequiredParameters[0], context, CancellationToken.None).ConfigureAwait(false);
 
             CheckParameters(parameters.ParametersWithSuggestions);
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/DynamicTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/DynamicTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal("14|24", string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesStatic.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStatic.RequiredParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesStatic.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStatic.RequiredParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("14|24", string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal(string.Empty, string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesStaticOptional.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticOptional.OptionalParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesStaticOptional.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticOptional.OptionalParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("14|24", string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal("14|24", string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesStaticNoValueCollection.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticNoValueCollection.RequiredParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesStaticNoValueCollection.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticNoValueCollection.RequiredParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("14|24", string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal(string.Empty, string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesStaticInvalidValueCollection.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticInvalidValueCollection.RequiredParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesStaticInvalidValueCollection.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticInvalidValueCollection.RequiredParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(string.Empty, string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal(string.Empty, string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesStaticInvalidDisplayName.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticInvalidDisplayName.RequiredParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesStaticInvalidDisplayName.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticInvalidDisplayName.RequiredParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(string.Empty, string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal(string.Empty, string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesStaticInvalidValuePath.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticInvalidValuePath.RequiredParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesStaticInvalidValuePath.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesStaticInvalidValuePath.RequiredParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(string.Empty, string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal("15|25", string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(5)) }, getWithDynamicValuesDynamic.RequiredParameters[1].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(5)) }, getWithDynamicValuesDynamic.RequiredParameters[1], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("15|25", string.Join("|", cParameters.ParametersWithSuggestions[1].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -227,17 +227,23 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal("50|60", string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicValuesMultipleDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(5)), new NamedValue("j", FormulaValue.New(7)) }, getWithDynamicValuesMultipleDynamic.RequiredParameters[2].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicValuesMultipleDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(5)), new NamedValue("j", FormulaValue.New(7)) }, getWithDynamicValuesMultipleDynamic.RequiredParameters[2], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("50|60", string.Join("|", cParameters.ParametersWithSuggestions[2].Suggestions.Select(s => s.DisplayName)));
 
             // Missing parameter
-            cParameters = await getWithDynamicValuesMultipleDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(5)) }, getWithDynamicValuesMultipleDynamic.RequiredParameters[2].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            cParameters = await getWithDynamicValuesMultipleDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(5)) }, getWithDynamicValuesMultipleDynamic.RequiredParameters[2], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal(string.Empty, string.Join("|", cParameters.ParametersWithSuggestions[2].Suggestions.Select(s => s.DisplayName)));
 
-            cParameters = await getWithDynamicValuesMultipleDynamic.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesMultipleDynamic.OptionalParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal("Date|Index|Summary|SummaryEnum|TemperatureC|TemperatureF", string.Join("|", cParameters.ParametersWithSuggestions[3].Suggestions.Select(s => s.DisplayName)));
-            Assert.Equal("![Date:d, Index:w, Summary:s, SummaryEnum:w, TemperatureC:w, TemperatureF:w]", cParameters.ParametersWithSuggestions[3].FormulaType.ToStringWithDisplayNames());
+            cParameters = await getWithDynamicValuesMultipleDynamic.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicValuesMultipleDynamic.OptionalParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal("Database|Date|Index|Summary|SummaryEnum|TemperatureC|TemperatureF", string.Join("|", cParameters.ParametersWithSuggestions[3].Suggestions.Select(s => s.DisplayName)));
+            Assert.Equal("![Database:![], Date:d, Index:w, Summary:s, SummaryEnum:w, TemperatureC:w, TemperatureF:w]", cParameters.ParametersWithSuggestions[3].FormulaType.ToStringWithDisplayNames());
             Assert.Equal(Visibility.Important, cParameters.ParametersWithSuggestions[3].ConnectorType.Fields[4].Visibility);
+
+            ConnectorType cType = await getWithDynamicValuesMultipleDynamic.GetConnectorTypeAsync(Array.Empty<NamedValue>(), getWithDynamicValuesMultipleDynamic.OptionalParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal("![Database:![], Date:d, Index:w, Summary:s, SummaryEnum:w, TemperatureC:w, TemperatureF:w]", cType.FormulaType.ToStringWithDisplayNames());
+
+            cType = await getWithDynamicValuesMultipleDynamic.GetConnectorTypeAsync(Array.Empty<NamedValue>(), cType.Fields[5], connectorContext, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal("![Name:s, PrimaryKey:s]", cType.FormulaType.ToStringWithDisplayNames());
         }
 
         [SkippableFact]
@@ -256,7 +262,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal("13|23", string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicListStatic.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicListStatic.RequiredParameters[0].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicListStatic.GetParameterSuggestionsAsync(Array.Empty<NamedValue>(), getWithDynamicListStatic.RequiredParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("13|23", string.Join("|", cParameters.ParametersWithSuggestions[0].Suggestions.Select(s => s.DisplayName)));
         }
 
@@ -276,7 +282,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             IIntellisenseResult suggestions = engine.Suggest(result, expr.Length, services);
             Assert.Equal("16|26", string.Join("|", suggestions.Suggestions.Select(s => s.DisplayText.Text)));
 
-            ConnectorParameters cParameters = await getWithDynamicListDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(6)) }, getWithDynamicListDynamic.RequiredParameters[1].Name, connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters cParameters = await getWithDynamicListDynamic.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("i", FormulaValue.New(6)) }, getWithDynamicListDynamic.RequiredParameters[1], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("16|26", string.Join("|", cParameters.ParametersWithSuggestions[1].Suggestions.Select(s => s.DisplayName)));
         }
     }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/OpenApiParserTests.cs
@@ -674,8 +674,8 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 { 
                     new NamedValue("server", FormulaValue.New("pfxdev-sql.database.windows.net")),
                     new NamedValue("database", FormulaValue.New("connectortest"))
-                }, 
-                "procedure", 
+                },
+                executeProcedureV2.RequiredParameters[2], // procedure
                 context, 
                 CancellationToken.None).ConfigureAwait(false);
 
@@ -692,7 +692,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                     new NamedValue("database", FormulaValue.New("connectortest")),
                     new NamedValue("procedure", FormulaValue.New("sp_1"))
                 },
-                "parameters",
+                executeProcedureV2.RequiredParameters[3], // parameters
                 context,
                 CancellationToken.None).ConfigureAwait(false);
             
@@ -700,11 +700,11 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.NotNull(suggestions2);
             Assert.NotNull(suggestions2.Suggestions);
             Assert.Single(suggestions2.Suggestions);
-
+            
             Assert.True(executeProcedureV2.ReturnParameterType.SupportsSuggestions);
 
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Response2 1.json");
-            ConnectorType returnType = await executeProcedureV2.GetConnectorReturnSchemaAsync(
+            ConnectorType returnType = await executeProcedureV2.GetConnectorReturnTypeAsync(
                  new NamedValue[]
                 {
                     new NamedValue("server", FormulaValue.New("pfxdev-sql.database.windows.net")),
@@ -767,14 +767,31 @@ POST https://tip1002-002.azure-apihub.net/invoke
             ConnectorFunction createRecord = functions.First(f => f.Name == "CreateRecordWithOrganization");
 
             testConnector.SetResponseFromFile(@"Responses\Dataverse_Response_1.json");
-            ConnectorParameters parameters1 = await createRecord.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("organization", FormulaValue.New("https://org283e9949.crm10.dynamics.com")) }, "entityName", context, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters parameters1 = await createRecord.GetParameterSuggestionsAsync(
+                new NamedValue[] 
+                { 
+                    new NamedValue("organization", FormulaValue.New("https://org283e9949.crm10.dynamics.com")) 
+                },
+                createRecord.RequiredParameters[1], // entityName
+                context,
+                CancellationToken.None).ConfigureAwait(false);
+
             ConnectorParameterWithSuggestions suggestions1 = parameters1.ParametersWithSuggestions[1];
             Assert.Equal(651, suggestions1.Suggestions.Count);
             Assert.Equal("AAD Users", suggestions1.Suggestions[0].DisplayName);
             Assert.Equal("aadusers", ((StringValue)suggestions1.Suggestions[0].Suggestion).Value);
 
             testConnector.SetResponseFromFile(@"Responses\Dataverse_Response_2.json");
-            ConnectorParameters parameters2 = await createRecord.GetParameterSuggestionsAsync(new NamedValue[] { new NamedValue("organization", FormulaValue.New("https://org283e9949.crm10.dynamics.com")), new NamedValue("entityName", FormulaValue.New("accounts")) }, "item", context, CancellationToken.None).ConfigureAwait(false);
+            ConnectorParameters parameters2 = await createRecord.GetParameterSuggestionsAsync(
+                new NamedValue[] 
+                { 
+                    new NamedValue("organization", FormulaValue.New("https://org283e9949.crm10.dynamics.com")), 
+                    new NamedValue("entityName", FormulaValue.New("accounts")) 
+                },
+                createRecord.RequiredParameters[2], // item
+                context, 
+                CancellationToken.None).ConfigureAwait(false);
+
             ConnectorParameterWithSuggestions suggestions2 = parameters2.ParametersWithSuggestions[2];
             Assert.Equal(119, suggestions2.Suggestions.Count);
             Assert.Equal("accountcategorycode", suggestions2.Suggestions[0].DisplayName);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/Swagger/Teams.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/Swagger/Teams.json
@@ -1,0 +1,8138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0.4",
+    "title": "Microsoft Teams",
+    "description": "Microsoft Teams enables you to get all your content, tools and conversations in the Team workspace with Office 365.",
+    "x-ms-api-annotation": {
+      "status": "Production"
+    },
+    "contact": {
+      "name": "Microsoft"
+    }
+  },
+  "host": "graph.microsoft.com",
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1.0/me/calendars/{calendarid}/events": {
+      "post": {
+        "summary": "Create a Teams meeting",
+        "description": "Create a meeting with a link at the bottom of the invite to join the meeting online on Teams",
+        "operationId": "CreateTeamsMeeting",
+        "x-ms-visibility": "important",
+        "parameters": [
+          {
+            "name": "calendarid",
+            "in": "path",
+            "enum": [ "Birthdays", "Calendar", "United States holidays" ],
+            "x-ms-summary": "Calendar id",
+            "description": "Select a Value",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "item",
+            "in": "body",
+            "description": "Meeting to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewMeeting"
+            },
+            "x-ms-summary": "Item"
+          }
+        ],
+        "consumes": [ "application/json" ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "default",
+            "schema": {
+              "$ref": "#/definitions/NewMeetingRespone"
+            }
+          }
+        }
+      }
+    },
+    "/v1.0/me/outlook/supportedTimeZones": {
+      "get": {
+        "summary": "Get supported time zones",
+        "description": "This operation gets the list of time zones that are supported for the user, as configured on the user's mailbox server.",
+        "operationId": "GetSupportedTimeZones",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of one or more time zones.",
+                  "type": "array",
+                  "x-ms-summary": "Time zones List",
+                  "items": {
+                    "type": "object",
+                    "x-ms-summary": "Time zone",
+                    "description": "Represents a time zone entity",
+                    "properties": {
+                      "alias": {
+                        "description": "An identifier for the time zone.",
+                        "type": "string",
+                        "x-ms-summary": "Id",
+                        "x-ms-visibility": "important"
+                      },
+                      "displayName": {
+                        "description": "A display string that represents the time zone.",
+                        "type": "string",
+                        "x-ms-summary": "Name",
+                        "x-ms-visibility": "important"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "internal"
+      }
+    },
+    "/beta/me/joinedTeams": {
+      "get": {
+        "summary": "List teams",
+        "description": "This operation retrieves a list of all the Teams (Office 365 Groups) you are a member of.",
+        "operationId": "GetAllTeams",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of one or more Teams you are a part of.",
+                  "type": "array",
+                  "x-ms-summary": "Teams List",
+                  "items": {
+                    "type": "object",
+                    "x-ms-summary": "Team",
+                    "description": "Team Entity",
+                    "properties": {
+                      "description": {
+                        "description": "More information about the Team.",
+                        "type": "string",
+                        "x-ms-summary": "Description",
+                        "x-ms-visibility": "important"
+                      },
+                      "displayName": {
+                        "description": "Brief summary of the Team.",
+                        "type": "string",
+                        "x-ms-summary": "Name",
+                        "x-ms-visibility": "important"
+                      },
+                      "id": {
+                        "description": "Unique ID of the Team (O365 group).",
+                        "type": "string",
+                        "x-ms-summary": "Id",
+                        "x-ms-visibility": "advanced"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "advanced"
+      }
+    },
+    "/beta/me/teamwork": {
+      "get": {
+        "summary": "API to test connections",
+        "description": "This operation is a quick way to test connections.",
+        "operationId": "GetTeamwork",
+        "x-ms-visibility": "internal",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/beta/groups/{groupId}/channels": {
+      "get": {
+        "summary": "List channels",
+        "description": "This operation retrieves a list of all the channels for a specific Team.",
+        "operationId": "GetChannelsForGroup",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of one or more channels for a specific Team.",
+                  "type": "array",
+                  "x-ms-summary": "Channel List",
+                  "items": {
+                    "type": "object",
+                    "x-ms-summary": "Channel",
+                    "description": "Properties associated with a single channel.",
+                    "properties": {
+                      "description": {
+                        "description": "More information about the channel.",
+                        "type": "string",
+                        "x-ms-summary": "Description",
+                        "x-ms-visibility": "important"
+                      },
+                      "displayName": {
+                        "description": "Brief summary of the channel.",
+                        "type": "string",
+                        "x-ms-summary": "Name",
+                        "x-ms-visibility": "important"
+                      },
+                      "id": {
+                        "description": "Unique ID of the channel.",
+                        "type": "string",
+                        "x-ms-summary": "Id",
+                        "x-ms-visibility": "advanced"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "advanced"
+      },
+      "post": {
+        "summary": "Create a channel",
+        "description": "This operation is used to create a new channel for a specific Team.",
+        "x-ms-visibility": "advanced",
+        "operationId": "CreateChannel",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "displayName"
+              ],
+              "type": "object",
+              "properties": {
+                "description": {
+                  "description": "More information about the channel.",
+                  "type": "string",
+                  "x-ms-summary": "Description",
+                  "x-ms-visibility": "advanced"
+                },
+                "displayName": {
+                  "description": "Name of the channel.",
+                  "type": "string",
+                  "x-ms-summary": "Display Name",
+                  "x-ms-visibility": "important"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "default",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "description": {
+                  "description": "More information about the channel.",
+                  "type": "string",
+                  "x-ms-summary": "Description",
+                  "x-ms-visibility": "important"
+                },
+                "displayName": {
+                  "description": "Name of the channel.",
+                  "type": "string",
+                  "x-ms-summary": "Display Name",
+                  "x-ms-visibility": "important"
+                },
+                "id": {
+                  "description": "Unique ID of the channel.",
+                  "type": "string",
+                  "x-ms-summary": "Id",
+                  "x-ms-visibility": "advanced"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/flowbot/actions/listchats/chattypes/{chatType}/topic/{topic}/expandmembers/false": {
+      "get": {
+        "summary": "List chats",
+        "description": "This operation retrieves a list of recent chats.",
+        "operationId": "GetChats",
+        "parameters": [
+          {
+            "$ref": "#/parameters/chatType__in_path"
+          },
+          {
+            "$ref": "#/parameters/topic__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of one or more chats you are a part of.",
+                  "type": "array",
+                  "x-ms-summary": "Chats List",
+                  "items": {
+                    "type": "object",
+                    "x-ms-summary": "Chat",
+                    "description": "Chat Entity",
+                    "properties": {
+                      "topic": {
+                        "description": "The name of the chat.",
+                        "type": "string",
+                        "x-ms-summary": "Topic",
+                        "x-ms-visibility": "important"
+                      },
+                      "createdDateTime": {
+                        "description": "The date and time that the chat was created.",
+                        "type": "string",
+                        "x-ms-summary": "Created Date Time",
+                        "format": "date-time",
+                        "x-ms-visibility": "important"
+                      },
+                      "lastUpdatedDateTime": {
+                        "description": "The date and time that the chat was last updated.",
+                        "type": "string",
+                        "x-ms-summary": "Last Updated Date Time",
+                        "format": "date-time",
+                        "x-ms-visibility": "important"
+                      },
+                      "id": {
+                        "description": "Unique conversation ID of chat.",
+                        "type": "string",
+                        "x-ms-summary": "Conversation Id",
+                        "x-ms-visibility": "advanced"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/beta/teams/{groupId}/tags": {
+      "get": {
+        "summary": "List all tags for a team",
+        "description": "This operation retrieves a list of tags.",
+        "operationId": "GetTags",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get tags response",
+            "schema": {
+              "$ref": "#/definitions/GetTagsResponseSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a tag for a team",
+        "description": "This operation creates a tag.",
+        "operationId": "CreateTag",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "displayName",
+                "members"
+              ],
+              "type": "object",
+              "properties": {
+                "displayName": {
+                  "x-ms-summary": "Display Name",
+                  "description": "The display name for the tag.",
+                  "type": "string"
+                },
+                "members": {
+                  "x-ms-summary": "User IDs",
+                  "description": "List of users separated by semi-colons to add to the tag.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Create a tag response",
+            "schema": {
+              "$ref": "#/definitions/CreateTagResponseSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      }
+    },
+    "/beta/teams/{groupId}/tags/{tagId}/members": {
+      "post": {
+        "summary": "Add a member to a tag",
+        "description": "This operation adds a user to a tags.",
+        "operationId": "AddMemberToTag",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/tagId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "userId"
+              ],
+              "type": "object",
+              "properties": {
+                "userId": {
+                  "x-ms-summary": "User ID",
+                  "description": "The user ID of the member to add to the tag.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Add member to tag response",
+            "schema": {
+              "$ref": "#/definitions/AddMemberToTagResponseSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      },
+      "get": {
+        "summary": "List the members for a tag",
+        "description": "This operation lists the members for a tag.",
+        "operationId": "GetTagMembers",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/tagId__in_path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Get tag members response",
+            "schema": {
+              "$ref": "#/definitions/GetTagMembersResponseSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      }
+    },
+    "/beta/teams/{groupId}/tags/{tagId}/members/{tagMemberId}": {
+      "delete": {
+        "summary": "Delete a member from a tag",
+        "description": "This operation deletes a member from a tag.",
+        "operationId": "DeleteTagMember",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/tagId__in_path"
+          },
+          {
+            "name": "tagMemberId",
+            "in": "path",
+            "required": true,
+            "x-ms-summary": "Tag Member ID",
+            "description": "Add tag member Id",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete tag member succeeded"
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      }
+    },
+    "/flowbot/feednotification/poster/{poster}/notificationType/{notificationType}": {
+      "post": {
+        "summary": "Post a feed notification",
+        "description": "This operation posts a feed notification.",
+        "operationId": "PostFeedNotification",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterJustFlowbot__in_path"
+          },
+          {
+            "$ref": "#/parameters/notificationType__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Post feed notification request",
+            "description": "The post feed notification request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicPostFeedNotificationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Empty Response."
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/beta/teams/{groupId}/tags/{tagId}": {
+      "get": {
+        "summary": "Get an @mention token for a tag",
+        "description": "This operation creates a token that can be inserted into a message or adaptive card sent as a user inS a channel to @mention a tag.",
+        "operationId": "AtMentionTag",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/tagId__in_path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Get tags response",
+            "schema": {
+              "$ref": "#/definitions/AtMentionTagResponse"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a tag",
+        "description": "This operation deletes a tag.",
+        "operationId": "DeleteTag",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/tagId__in_path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete tag succeeded"
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      }
+    },
+    "/beta/teams/{groupId}/channels/{channelId}/messages": {
+      "post": {
+        "summary": "Post a message (V2)",
+        "description": "This operation is used to post a message to a channel in a specific Team.",
+        "x-ms-visibility": "important",
+        "operationId": "PostMessageToChannelV2",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "body"
+              ],
+              "type": "object",
+              "properties": {
+                "subject": {
+                  "description": "Subject of the message.",
+                  "type": "string",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Subject"
+                },
+                "body": {
+                  "description": "body",
+                  "required": [
+                    "content",
+                    "contentType"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "description": "Body of the message.",
+                      "type": "string",
+                      "x-ms-summary": "Message",
+                      "x-ms-visibility": "important"
+                    },
+                    "contentType": {
+                      "description": "Content type: html or text.",
+                      "type": "string",
+                      "x-ms-summary": "Type",
+                      "x-ms-visibility": "advanced",
+                      "default": "html",
+                      "enum": [
+                        "html",
+                        "text"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Empty Response."
+          }
+        },
+        "deprecated": true,
+        "x-ms-no-generic-test": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "family": "PostMessageToChannel",
+          "revision": 2
+        }
+      },
+      "get": {
+        "summary": "Get messages",
+        "description": "This operation is used to get messages from a channel in a specific Team.",
+        "x-ms-visibility": "important",
+        "operationId": "GetMessagesFromChannel",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetMessagesFromChannel_Response"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true,
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        }
+      }
+    },
+    "/beta/teams/messages/{messageId}/messageType/{threadType}": {
+      "post": {
+        "summary": "Get message details",
+        "description": "This operation gets details of a message in a chat or a channel.",
+        "x-ms-visibility": "important",
+        "operationId": "GetMessageDetails",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/messageId__in_path"
+          },
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Get message details request",
+            "description": "The get message details request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicGetMessageDetailsSchema"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Get message details response",
+            "schema": {
+              "$ref": "#/definitions/DynamicGetMessageDetailsResponseSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v1.0/teams/listmembers/threadType/{threadType}": {
+      "post": {
+        "summary": "List members",
+        "description": "This operation list members based on a threadtype (chat, channel, etc).",
+        "x-ms-visibility": "important",
+        "operationId": "ListMembers",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/listMembersThreadType__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "List members request",
+            "description": "The list members request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicListMembersSchema"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The list members response",
+            "schema": {
+              "$ref": "#/definitions/ListMembersResponseSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v3/beta/teams/{groupId}/channels/{channelId}/messages": {
+      "post": {
+        "summary": "Post a message (V3)",
+        "description": "This operation is used to post a message to a channel in a specific Team.",
+        "x-ms-visibility": "important",
+        "operationId": "PostMessageToChannelV3",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "body"
+              ],
+              "type": "object",
+              "properties": {
+                "subject": {
+                  "description": "Subject of the message.",
+                  "type": "string",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Subject"
+                },
+                "body": {
+                  "description": "body",
+                  "required": [
+                    "content",
+                    "contentType"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "description": "Body of the message.",
+                      "type": "string",
+                      "format": "html",
+                      "x-ms-summary": "Message",
+                      "x-ms-visibility": "important"
+                    },
+                    "contentType": {
+                      "description": "Content type: html or text.",
+                      "type": "string",
+                      "x-ms-summary": "Type",
+                      "x-ms-visibility": "internal",
+                      "default": "html",
+                      "enum": [
+                        "html",
+                        "text"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Message Id",
+            "schema": {
+              "$ref": "#/definitions/MessageId"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-no-generic-test": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "family": "PostMessageToChannel",
+          "revision": 3
+        }
+      }
+    },
+    "/beta/teams/{groupId}/channels/{channelId}/messages/{messageId}/replies": {
+      "post": {
+        "summary": "Post a reply to a message",
+        "description": "This operation is used to post a reply to a message in a channel in a specific Team.",
+        "x-ms-visibility": "important",
+        "operationId": "PostReplyToMessage",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "$ref": "#/parameters/messageId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "body"
+              ],
+              "type": "object",
+              "properties": {
+                "subject": {
+                  "description": "Subject of the message.",
+                  "type": "string",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Subject"
+                },
+                "body": {
+                  "description": "body",
+                  "required": [
+                    "content",
+                    "contentType"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "description": "Body of the message.",
+                      "type": "string",
+                      "x-ms-summary": "Reply",
+                      "x-ms-visibility": "important"
+                    },
+                    "contentType": {
+                      "description": "Content type: html or text.",
+                      "type": "string",
+                      "x-ms-summary": "Type",
+                      "x-ms-visibility": "advanced",
+                      "default": "html",
+                      "enum": [
+                        "html",
+                        "text"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Empty Response."
+          }
+        },
+        "deprecated": true,
+        "x-ms-no-generic-test": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "family": "PostReplyToMessage",
+          "revision": 1
+        }
+      }
+    },
+    "/v2/beta/teams/{groupId}/channels/{channelId}/messages/{messageId}/replies": {
+      "post": {
+        "summary": "Post a reply to a message (V2)",
+        "description": "This operation is used to post a reply to a message in a channel in a specific Team.",
+        "x-ms-visibility": "important",
+        "operationId": "PostReplyToMessageV2",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "$ref": "#/parameters/messageId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "body"
+              ],
+              "type": "object",
+              "properties": {
+                "subject": {
+                  "description": "Subject of the message.",
+                  "type": "string",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Subject"
+                },
+                "body": {
+                  "description": "body",
+                  "required": [
+                    "content",
+                    "contentType"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "description": "Body of the message.",
+                      "type": "string",
+                      "format": "html",
+                      "x-ms-summary": "Reply",
+                      "x-ms-visibility": "important"
+                    },
+                    "contentType": {
+                      "description": "Content type: html or text.",
+                      "type": "string",
+                      "x-ms-summary": "Type",
+                      "x-ms-visibility": "internal",
+                      "default": "html",
+                      "enum": [
+                        "html",
+                        "text"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Empty Response."
+          }
+        },
+        "deprecated": true,
+        "x-ms-no-generic-test": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "family": "PostReplyToMessage",
+          "revision": 2
+        }
+      }
+    },
+    "/trigger/beta/teams/{groupId}/channels/{channelId}/messages": {
+      "get": {
+        "summary": "When a new channel message is added",
+        "description": "This operation triggers when a new message is posted to a channel in a Team. Note that this trigger only fires when a root messages is added in the channel. Replies to an existing channel message will not result in the trigger event firing.",
+        "x-ms-visibility": "important",
+        "operationId": "OnNewChannelMessage",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "x-ms-summary": "Top",
+            "x-ms-test-value": "50",
+            "x-ms-visibility": "internal",
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OnNewChannelMessage_Response"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true,
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "x-ms-trigger": "batch",
+        "x-ms-trigger-hint": "To see it work now, add a message to the channel.",
+        "x-ms-dev-triggerType": "SimpleFilter",
+        "x-ms-dev-triggerDateFormat": "iso",
+        "x-ms-dev-triggerValueCollection": "value",
+        "x-ms-dev-triggerValuePath": "createdDateTime"
+      }
+    },
+    "/trigger/beta/teams/{groupId}/channels/{channelId}/messages_mentioningme": {
+      "get": {
+        "summary": "When I am mentioned in a channel message",
+        "description": "This operation triggers when a new message is added to a channel in a Team, that mentions the current user.",
+        "x-ms-visibility": "important",
+        "operationId": "OnNewChannelMessageMentioningMe",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "x-ms-summary": "Top",
+            "x-ms-test-value": "50",
+            "x-ms-visibility": "internal",
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OnNewChannelMessage_Response"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true,
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "x-ms-trigger": "batch",
+        "x-ms-trigger-hint": "To see it work now, add a message to the channel containing an @mention of yourself.",
+        "x-ms-dev-triggerType": "SimpleFilter",
+        "x-ms-dev-triggerDateFormat": "iso",
+        "x-ms-dev-triggerValueCollection": "value",
+        "x-ms-dev-triggerValuePath": "createdDateTime"
+      }
+    },
+    "/beta/subscriptions/atmentiontrigger/threadType/{threadType}": {
+      "post": {
+        "description": "Creates a webhook for @mentions in chats or channels.",
+        "summary": "When I'm @mentioned",
+        "operationId": "WebhookAtMentionTrigger",
+        "parameters": [
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          },
+          {
+            "name": "requestBody",
+            "in": "body",
+            "description": "This is the request body of the Webhook",
+            "schema": {
+              "$ref": "#/definitions/DynamicWebhookTriggerRequestSchema"
+            }
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "default response for a trigger subscription",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "To see it work, get @mentioned in one of the specified chats or channels."
+      },
+      "x-ms-notification-content": {
+        "description": "Details for Webhook",
+        "schema": {
+          "$ref": "#/definitions/DynamicAtMentionWebhookTriggerResponseSchema"
+        }
+      }
+    },
+    "/beta/subscriptions/chatmessagetrigger": {
+      "post": {
+        "description": "This operation triggers when a new message is posted in any chat the user is a part of.",
+        "summary": "When a new chat message is added",
+        "operationId": "WebhookChatMessageTrigger",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "ChatMessageSubscriptionRequest",
+            "x-ms-summary": "Chat Message subscription request",
+            "description": "The chat message subscription request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "notificationUrl": {
+                  "x-ms-visibility": "internal",
+                  "x-ms-notification-url": true,
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscription Created"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "To see it work, send a message in any chat."
+      },
+      "x-ms-notification-content": {
+        "description": "Details for Webhook",
+        "schema": {
+          "$ref": "#/definitions/ChatMessageWebhookResponseSchema"
+        }
+      }
+    },
+    "/beta/subscriptions/keywordtrigger/threadType/{threadType}": {
+      "post": {
+        "description": "Creates a webhook for keyword mentions in chats or channels.",
+        "summary": "When keywords are mentioned",
+        "operationId": "WebhookKeywordTrigger",
+        "parameters": [
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          },
+          {
+            "name": "$search",
+            "in": "query",
+            "required": true,
+            "x-ms-summary": "Keywords to search for",
+            "description": "A comma separated list of keywords to search for",
+            "x-ms-visibility": "important",
+            "type": "string"
+          },
+          {
+            "name": "requestBody",
+            "in": "body",
+            "description": "This is the request body of the Webhook",
+            "schema": {
+              "$ref": "#/definitions/DynamicWebhookTriggerRequestSchema"
+            }
+          }
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "default": {
+            "description": "default response for a trigger subscription",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "To see it work, use the keywords in one of the specified chats or channels."
+      },
+      "x-ms-notification-content": {
+        "description": "Details for Webhook",
+        "schema": {
+          "$ref": "#/definitions/DynamicKeywordWebhookTriggerResponseSchema"
+        }
+      }
+    },
+    "/beta/subscriptions/{subscriptionIds}": {
+      "delete": {
+        "summary": "Delete WebHook Subscription",
+        "x-ms-summary": "Delete WebHook Subscription",
+        "description": "Delete WebHook Subscription",
+        "operationId": "DeleteWebHookSubscription",
+        "parameters": [
+          {
+            "name": "subscriptionIds",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "default",
+            "schema": {}
+          }
+        },
+        "x-ms-visibility": "internal",
+        "x-ms-no-generic-test": true
+      },
+      "patch": {
+        "summary": "Update subscription",
+        "x-ms-summary": "Renew WebHook Subscription",
+        "description": "Renew a Microsoft Graph webhook subscription by updating its expiration time.",
+        "operationId": "RenewWebHookSubscription",
+        "parameters": [
+          {
+            "name": "subscriptionIds",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "expirationDateTime": {
+                  "type": "string",
+                  "description": "Specify the date and time, in UTC format, of when the Microsoft Graph webhook subscription expires. The maximum expiration time for security alerts is 43200 minutes (under 30 days).",
+                  "title": "Expiration date time",
+                  "x-ms-visibility": "important"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "default",
+            "schema": {}
+          }
+        },
+        "x-ms-visibility": "internal",
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/beta/groups/{groupId}/channels/{channelId}/chatThreads": {
+      "post": {
+        "summary": "Post a message",
+        "description": "This operation is used to post a message to a channel in a specific Team.",
+        "x-ms-visibility": "important",
+        "operationId": "PostMessageToChannel",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_path"
+          },
+          {
+            "$ref": "#/parameters/channelId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [
+                "rootMessage"
+              ],
+              "type": "object",
+              "properties": {
+                "rootMessage": {
+                  "description": "rootMessage",
+                  "required": [
+                    "body"
+                  ],
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "description": "body",
+                      "required": [
+                        "content",
+                        "contentType"
+                      ],
+                      "type": "object",
+                      "properties": {
+                        "content": {
+                          "description": "Body of the message.",
+                          "type": "string",
+                          "format": "html",
+                          "x-ms-summary": "Message",
+                          "x-ms-visibility": "important"
+                        },
+                        "contentType": {
+                          "format": "int32",
+                          "description": "0 for text or 1 for html.",
+                          "type": "integer",
+                          "x-ms-summary": "Type",
+                          "x-ms-visibility": "internal",
+                          "default": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Empty Response."
+          }
+        },
+        "deprecated": true,
+        "x-ms-no-generic-test": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "family": "PostMessageToChannel",
+          "revision": 1
+        }
+      }
+    },
+    "/flowbot/actions/notification/recipienttypes/user": {
+      "post": {
+        "operationId": "PostUserNotification",
+        "summary": "Post a message as the Flow bot to a user",
+        "description": "Easily automate the process of sending a message to someone in Teams.",
+        "parameters": [
+          {
+            "name": "PostNotificationRequest",
+            "x-ms-summary": "Post notification request",
+            "description": "The post notification request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicUserNotificationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscription Created"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/flowbot/actions/notification/recipienttypes/channel": {
+      "post": {
+        "operationId": "PostChannelNotification",
+        "summary": "Post a message as the Flow bot to a channel",
+        "description": "Easily automate the process of posting a message to a Teams channel.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_query"
+          },
+          {
+            "name": "PostNotificationRequest",
+            "x-ms-summary": "Post notification request",
+            "description": "The post notification request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicChannelNotificationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscription Created"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/flowbot/actions/adaptivecard/recipienttypes/user": {
+      "post": {
+        "operationId": "PostUserAdaptiveCard",
+        "summary": "Post your own adaptive card as the Flow bot to a user",
+        "description": "Add the JSON card definition to create a custom message for a Teams user. The message can contain images, graphs, text, and more.",
+        "parameters": [
+          {
+            "name": "PostAdaptiveCardRequest",
+            "x-ms-summary": "Post adaptive card request",
+            "description": "The post adaptive card request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicUserAdaptiveCardRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Adaptive Card Posted",
+            "schema": {
+              "$ref": "#/definitions/MessageId"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/flowbot/actions/adaptivecard/recipienttypes/channel": {
+      "post": {
+        "operationId": "PostChannelAdaptiveCard",
+        "summary": "Post your own adaptive card as the Flow bot to a channel",
+        "description": "Add the JSON card definition to create a custom post for a Teams channel. The post can contain images, graphs, text, and more.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_query"
+          },
+          {
+            "name": "PostAdaptiveCardRequest",
+            "x-ms-summary": "Post adaptive card request",
+            "description": "The post adaptive card request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicChannelAdaptiveCardRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Adaptive Card Posted",
+            "schema": {
+              "$ref": "#/definitions/MessageId"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/flowbot/actions/{actionType}/posters/{poster}/recipienttypes/{recipientType}/schema": {
+      "get": {
+        "operationId": "GetUnifiedActionSchema",
+        "summary": "Get unified action input metadata",
+        "description": "Get the schema information for unified actions",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/actionType__in_path"
+          },
+          {
+            "$ref": "#/parameters/poster__in_path"
+          },
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/UnifiedActionSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/{actionType}/posters/{poster}/recipienttypes/{recipientType}/response/schema": {
+      "get": {
+        "operationId": "GetPostToConversationResponseSchema",
+        "summary": "Get response schema",
+        "description": "Get the schema information for unified action responses",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/actionType__in_path"
+          },
+          {
+            "$ref": "#/parameters/poster__in_path"
+          },
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/DynamicResponseSchema"
+            }
+          }
+        }
+      }
+    },
+    "/flowbot/actions/adaptivecard/recipienttypes/{recipientType}/$metadata.json/inputs": {
+      "get": {
+        "operationId": "GetAdaptiveCardInputMetadata",
+        "summary": "Get adaptive card input metadata",
+        "description": "Get the schema information for adaptive card inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/notification/recipienttypes/{recipientType}/$metadata.json/inputs": {
+      "get": {
+        "operationId": "GetNotificationInputMetadata",
+        "summary": "Get notification input metadata",
+        "description": "Get the schema information for notification inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/messagewithoptions/recipienttypes/user/$subscriptions": {
+      "post": {
+        "operationId": "SubscribeUserMessageWithOptions",
+        "summary": "Post a choice of options as the Flow bot to a user",
+        "description": "Easily automate the process of sending a message to a Teams user that contains a set of options they must choose from before they respond.",
+        "x-ms-visibility": "important",
+        "parameters": [
+          {
+            "name": "UserMessageWithOptionsSubscriptionRequest",
+            "x-ms-summary": "User message with options subscription request",
+            "description": "The user message with options subscription request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicUserMessageWithOptionsSubscriptionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscription Created"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      },
+      "x-ms-notification-content": {
+        "description": "Details for the response with which a message with options subscription is completed and flows waiting on that subscription are resumed.",
+        "schema": {
+          "$ref": "#/definitions/DynamicUserMessageWithOptionsSubscriptionResult"
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/recipienttypes/user/$subscriptions": {
+      "post": {
+        "operationId": "SubscribeUserFlowContinuation",
+        "summary": "Post an Adaptive Card to a Teams user and wait for a response",
+        "description": "Easily automate the process of sending a message to a Teams user that contains actions to continue a waiting flow.",
+        "x-ms-visibility": "important",
+        "parameters": [
+          {
+            "name": "UserFlowContinuationSubscriptionRequest",
+            "x-ms-summary": "User flow continuation subscription request",
+            "description": "The user flow continuation subscription request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "notificationUrl": {
+                  "x-ms-visibility": "internal",
+                  "x-ms-notification-url": true,
+                  "type": "string"
+                },
+                "body": {
+                  "type": "object",
+                  "properties": {
+                    "updateMessage": {
+                      "description": "Message to be included in an update to the original card following response",
+                      "x-ms-summary": "Update message",
+                      "type": "string"
+                    },
+                    "shouldUpdateCard": {
+                      "description": "Whether or not to update the card following response",
+                      "x-ms-summary": "Should update card",
+                      "type": "boolean"
+                    },
+                    "recipient": {
+                      "x-ms-visibility": "important",
+                      "type": "object",
+                      "properties": {
+                        "to": {
+                          "description": "Add an email address",
+                          "x-ms-visibility": "important",
+                          "x-ms-summary": "Recipient",
+                          "x-ms-dynamic-values": {
+                            "builtInOperation": "AadGraph.GetUsers",
+                            "value-path": "mail",
+                            "value-title": "displayName"
+                          },
+                          "type": "string"
+                        },
+                        "summary": {
+                          "description": "The message summary",
+                          "x-ms-visibility": "advanced",
+                          "x-ms-summary": "Summary",
+                          "type": "string"
+                        },
+                        "isAlert": {
+                          "description": "If the message will be shown in the activity feed",
+                          "x-ms-visibility": "advanced",
+                          "x-ms-summary": "IsAlert",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "to"
+                      ]
+                    },
+                    "messageBody": {
+                      "x-ms-summary": "Message",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "recipient",
+                    "messageBody"
+                  ]
+                }
+              },
+              "required": [
+                "notificationUrl",
+                "body"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscription Created"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": true
+      },
+      "x-ms-notification-content": {
+        "description": "Details for the response with which a flow continuation subscription is completed and flows waiting on that subscription are resumed.",
+        "schema": {
+          "$ref": "#/definitions/DynamicUserFlowContinuationSubscriptionResult"
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/recipienttypes/channel/$subscriptions": {
+      "post": {
+        "operationId": "SubscribeChannelFlowContinuation",
+        "summary": "Post an Adaptive Card to a Teams channel and wait for a response",
+        "description": "Easily automate the process of sending a message to a Teams channel that contains actions to continue a waiting flow.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_query"
+          },
+          {
+            "name": "ChannelFlowContinuationSubscriptionRequest",
+            "x-ms-summary": "Channel flow continuation subscription request",
+            "description": "The channel flow continuation subscription request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "notificationUrl": {
+                  "x-ms-visibility": "internal",
+                  "x-ms-notification-url": true,
+                  "type": "string"
+                },
+                "body": {
+                  "type": "object",
+                  "properties": {
+                    "updateMessage": {
+                      "description": "Message to be included in an update to the original card following response",
+                      "x-ms-summary": "Update message",
+                      "type": "string"
+                    },
+                    "shouldUpdateCard": {
+                      "description": "Whether or not to update the card following response",
+                      "x-ms-summary": "Should update card",
+                      "type": "boolean"
+                    },
+                    "recipient": {
+                      "x-ms-visibility": "important",
+                      "type": "object",
+                      "properties": {
+                        "groupId": {
+                          "x-ms-visibility": "internal",
+                          "type": "string"
+                        },
+                        "channelId": {
+                          "description": "Add channel ID",
+                          "x-ms-visibility": "important",
+                          "x-ms-summary": "Channel",
+                          "x-ms-dynamic-values": {
+                            "value-path": "id",
+                            "value-title": "displayName",
+                            "operationId": "GetChannelsForGroup",
+                            "value-collection": "value",
+                            "parameters": {
+                              "groupId": {
+                                "parameter": "groupId"
+                              }
+                            }
+                          },
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "channelId"
+                      ]
+                    },
+                    "messageBody": {
+                      "x-ms-summary": "Message",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "recipient",
+                    "messageBody"
+                  ]
+                }
+              },
+              "required": [
+                "notificationUrl",
+                "body"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscription Created"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": true
+      },
+      "x-ms-notification-content": {
+        "description": "Details for the response with which a flow continuation subscription is completed and flows waiting on that subscription are resumed.",
+        "schema": {
+          "$ref": "#/definitions/DynamicChannelFlowContinuationSubscriptionResult"
+        }
+      }
+    },
+    "/flowbot/actions/messagewithoptions/recipienttypes/{recipientType}/$subscriptions/{subscriptionId}": {
+      "delete": {
+        "operationId": "UnsubscribeMessageWithOptions",
+        "summary": "Unsubscribe from a choice of options",
+        "description": "Unsubscribes from a message with options",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "ID of subscription to be deleted",
+            "required": true,
+            "x-ms-summary": "ID of subscription to be deleted",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription Deleted"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/recipienttypes/{recipientType}/$subscriptions/{subscriptionId}": {
+      "delete": {
+        "operationId": "UnsubscribeFlowContinuation",
+        "summary": "Unsubscribe from a flow continuation",
+        "description": "Unsubscribes from a flow continuation",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "ID of subscription to be deleted",
+            "required": true,
+            "x-ms-summary": "ID of subscription to be deleted",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription Deleted"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/messagewithoptions/recipienttypes/{recipientType}/$metadata.json/inputs": {
+      "get": {
+        "operationId": "GetMessageWithOptionsInputMetadata",
+        "summary": "Get message with options input metadata",
+        "description": "Get the schema information for the message with options inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/recipienttypes/{recipientType}/$metadata.json/inputs": {
+      "get": {
+        "operationId": "GetFlowContinuationInputMetadata",
+        "summary": "Get flow continuation input metadata",
+        "description": "Get the schema information for the flow continuation inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/messagewithoptions/recipienttypes/{recipientType}/$metadata.json/subscriptioninputs": {
+      "get": {
+        "operationId": "GetMessageWithOptionsSubscriptionInputMetadata",
+        "summary": "Get message with options subscription input metadata",
+        "description": "Get the schema information for the message with options subscription inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/recipienttypes/{recipientType}/$metadata.json/subscriptioninputs": {
+      "get": {
+        "operationId": "GetFlowContinuationSubscriptionInputMetadata",
+        "summary": "Get flow continuation subscription input metadata",
+        "description": "Get the schema information for the flow continuation subscription inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/messagewithoptions/recipienttypes/{recipientType}/$metadata.json/subscriptionoutputs": {
+      "get": {
+        "operationId": "GetMessageWithOptionsSubscriptionOutputMetadata",
+        "summary": "Get message with options subscription output metadata",
+        "description": "Get the schema information for the message with options subscription outputs.",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/recipienttypes/{recipientType}/$metadata.json/subscriptionoutputs": {
+      "post": {
+        "operationId": "GetFlowContinuationSubscriptionOutputMetadata",
+        "summary": "Get flow continuation subscription output metadata",
+        "description": "Get the schema information for the flow continuation subscription outputs.",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Channel flow continuation subscription request message body",
+            "description": "The channel flow continuation subscription request message body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "x-ms-summary": "Message",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/actions/flowcontinuation/posters/{poster}/recipienttypes/{recipientType}/$metadata.json/subscriptionoutputs": {
+      "post": {
+        "operationId": "GetFlowContinuationSubscriptionWithPosterOutputMetadata",
+        "summary": "Get flow continuation subscription output metadata",
+        "description": "Get the schema information for the flow continuation subscription outputs.",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterWithoutUser__in_path"
+          },
+          {
+            "$ref": "#/parameters/recipientType__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Channel flow continuation subscription request message body",
+            "description": "The channel flow continuation subscription request message body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "x-ms-summary": "Message",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ConnectorMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/triggers/selectedmessage/$metadata.json/selectedmessageoutputs": {
+      "post": {
+        "operationId": "GetSelectedMessageTriggerOutputsMetadata",
+        "summary": "Get selected message hybrid trigger output metadata",
+        "description": "Get the schema information for the selected message hybrid trigger outputs.",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "name": "body",
+            "x-ms-summary": "Adaptive card request message body",
+            "description": "The body for parsing the metadata of the trigger",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "x-ms-summary": "InputsAdaptiveCard",
+              "type": "string",
+              "default": "{}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/SelectedMessageTriggerMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/triggers/composemessage/$metadata.json/composemessageoutputs": {
+      "post": {
+        "operationId": "GetComposeMessageTriggerOutputsMetadata",
+        "summary": "Get compose message hybrid trigger output metadata",
+        "description": "Get the schema information for the compose message hybrid trigger outputs.",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "name": "body",
+            "x-ms-summary": "Adaptive card request message body",
+            "description": "The body for parsing the metadata of the trigger",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "x-ms-summary": "InputsAdaptiveCard",
+              "type": "string",
+              "default": "{}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ComposeMessageTriggerMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/triggers/cardresponse/$metadata.json/cardresponseoutputs": {
+      "post": {
+        "operationId": "GetCardResponseTriggerOutputsMetadata",
+        "summary": "Get compose message hybrid trigger output metadata",
+        "description": "Get the schema information for the compose message hybrid trigger outputs.",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "name": "body",
+            "x-ms-summary": "Adaptive card request message body",
+            "description": "The body for parsing the metadata of the trigger",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "x-ms-summary": "InputsAdaptiveCard",
+              "type": "string",
+              "default": "{}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/CardResponseTriggerMetadata"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Get a team",
+        "x-ms-summary": "Get team",
+        "description": "This operation returns details for a team using the team's unique ID.",
+        "operationId": "GetTeam",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetTeamResponse"
+            }
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/v1.0/users/{userId}": {
+      "get": {
+        "summary": "Get an @mention token for a user",
+        "description": "This operation creates a token that can be inserted into a message or adaptive card to @mention a user.",
+        "operationId": "AtMentionUser",
+        "produces": [
+          "application/json",
+          "text/json",
+          "application/xml",
+          "text/xml"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Specify a user principal or user ID to @mention",
+            "x-ms-summary": "User"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "$ref": "#/definitions/AtMentionUser_V1"
+            }
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/timeOffReasons": {
+      "get": {
+        "tags": [
+          "TimeOffReasons"
+        ],
+        "summary": "Shifts: List all Time Off reasons",
+        "x-ms-summary": "List Time Off Reasons",
+        "description": "This operation returns the list of time off reasons associated with a team.",
+        "operationId": "ListTimeOffReasons",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of Time Off reasons to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/GetTimeOffReasonsResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListTimeOffReasons"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/shifts": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all shifts",
+        "x-ms-summary": "List all team shifts",
+        "description": "This operation returns all shifts assigned to members of a team",
+        "operationId": "ListShifts",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "x-ms-summary": "From Start Time",
+            "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+            "required": false,
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "format": "date-time",
+            "x-ms-test-value": "2017-07-23T07:00:00Z"
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "x-ms-summary": "To End Time",
+            "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+            "required": false,
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "format": "date-time",
+            "x-ms-test-value": "2017-07-30T07:00:00Z"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of shifts to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of shifts in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "Shifts List",
+                  "items": {
+                    "$ref": "#/definitions/ShiftResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListShifts"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/shifts/{shiftId}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Get a shift",
+        "x-ms-summary": "Get Shift by ID",
+        "description": "This operation returns details for a shift using the shift's unique ID.",
+        "operationId": "GetShift",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "shiftId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Shift ID",
+            "description": "The unique ID of the shift.",
+            "x-ms-test-value": "SHFT_d45edcfe-7888-410c-8a7b-3dbf9e2e6d5b"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ShiftResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "GetShift"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Delete a shift",
+        "x-ms-summary": "Delete Shift by ID",
+        "description": "This operation deletes a shift using the shift's unique ID.",
+        "operationId": "DeleteShift",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "shiftId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Shift ID",
+            "description": "The unique ID of the shift.",
+            "x-ms-test-value": "SHFT_d45edcfe-7888-410c-8a7b-3dbf9e2e6d5b"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Shift Deleted"
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "DeleteShift"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/openShifts": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all Open Shifts",
+        "x-ms-summary": "List all team open shifts",
+        "description": "This operation returns all open shifts in a team",
+        "operationId": "ListOpenShifts",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "startTime",
+            "in": "query",
+            "x-ms-summary": "From Start Time",
+            "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+            "required": false,
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "format": "date-time",
+            "x-ms-test-value": "2017-07-23T07:00:00Z"
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "x-ms-summary": "To End Time",
+            "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+            "required": false,
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "format": "date-time",
+            "x-ms-test-value": "2017-07-30T07:00:00Z"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of open shifts to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of open shifts in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "Open Shifts List",
+                  "items": {
+                    "$ref": "#/definitions/OpenShiftResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListOpenShifts"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "operationId": "CreateOpenShift",
+        "summary": "Shifts: Create a new Open Shift",
+        "x-ms-summary": "Create a new open shift",
+        "description": "Create a new open shift in a schedule",
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "request",
+            "x-ms-summary": "Create Open Shift request",
+            "description": "The request to create an open shift",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EditOpenShiftRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OpenShiftResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "CreateOpenShift"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/openShifts/{openShiftId}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Get an open shift",
+        "x-ms-summary": "Get Open Shift by ID",
+        "description": "This operation returns details for an open shift.",
+        "operationId": "GetOpenShift",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "openShiftId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Open Shift ID",
+            "description": "The unique ID of the open shift.",
+            "x-ms-test-value": "OPNSHFT_577b75d2-a927-48c0-a5d1-dc984894e7b8"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OpenShiftResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "GetOpenShift"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Shifts"
+        ],
+        "operationId": "UpdateOpenShift",
+        "summary": "Shifts: Update an Open Shift",
+        "x-ms-summary": "Update an open shift",
+        "description": "Update an open shift in a schedule.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "openShiftId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Open Shift ID",
+            "description": "The unique ID of the open shift.",
+            "x-ms-test-value": "OPNSHFT_577b75d2-a927-48c0-a5d1-dc984894e7b8"
+          },
+          {
+            "name": "request",
+            "x-ms-summary": "Update Open Shift request",
+            "description": "The request to update an open shift",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EditOpenShiftRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/OpenShiftResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "UpdateOpenShift"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Delete an open shift",
+        "x-ms-summary": "Delete Open Shift by ID",
+        "description": "This operation deletes an open shift.",
+        "operationId": "DeleteOpenShift",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "openShiftId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Open Shift ID",
+            "description": "The unique ID of the open shift.",
+            "x-ms-test-value": "OPNSHFT_577b75d2-a927-48c0-a5d1-dc984894e7b8"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Open Shift Deleted"
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "DeleteOpenShift"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/schedulinggroups": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all scheduling groups",
+        "x-ms-summary": "List all scheduling groups",
+        "description": "This operation returns all scheduling groups in a schedule",
+        "operationId": "ListSchedulingGroups",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of entries to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of schedule groups in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "Scheduling Groups List",
+                  "items": {
+                    "$ref": "#/definitions/SchedulingGroupResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListSchedulingGroups"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/schedulinggroups/{schedulingGroupId}": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Get a scheduling group",
+        "x-ms-summary": "Get Scheduling Group by ID",
+        "description": "This operation returns details for a scheduling group using its unique ID.",
+        "operationId": "GetSchedulingGroup",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "schedulingGroupId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Scheduling Group ID",
+            "description": "The unique ID of the Scheduling Group.",
+            "x-ms-test-value": "TAG_f914d037-00a3-4ba4-b712-ef178cbea263"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SchedulingGroupResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "GetSchedulingGroup"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/timeOffRequests": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all Time Off requests",
+        "x-ms-summary": "Time Off Requests List",
+        "description": "This operation returns all time off requests in a schedule",
+        "operationId": "ListTimeOffRequests",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of requests to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Request state filter",
+            "required": false,
+            "x-ms-summary": "Request State",
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "declined"
+            ],
+            "x-ms-enum-values": [
+              {
+                "displayName": "Pending",
+                "value": "pending"
+              },
+              {
+                "displayName": "Approved",
+                "value": "approved"
+              },
+              {
+                "displayName": "Declined",
+                "value": "declined"
+              }
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of Time Off requests in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "TimeOff Requests List",
+                  "items": {
+                    "$ref": "#/definitions/TimeOffRequestResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListTimeOffRequests"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/timeOffRequests/{timeOffRequestId}/approve": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Approve a Time Off request",
+        "x-ms-summary": "Approve a time off request",
+        "description": "This operation allows managers to approve a time off request.",
+        "operationId": "TimeOffRequestApprove",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "timeOffRequestId",
+            "in": "path",
+            "x-ms-summary": "Time Off Request ID",
+            "description": "The unique ID of the time off request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Manager approves a time off request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Manager",
+                  "description": "A message from the manager to the sender/recipient when a request is accepted.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "TimeOffRequestApprove"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/timeOffRequests/{timeOffRequestId}/decline": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Decline a Time Off request",
+        "x-ms-summary": "Decline a time off request",
+        "description": "This operation allows managers to decline a time off request.",
+        "operationId": "TimeOffRequestDecline",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "timeOffRequestId",
+            "in": "path",
+            "x-ms-summary": "Time Off Request ID",
+            "description": "The unique ID of the time off request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Manager declines a time off request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Manager",
+                  "description": "A message from the manager to the sender/recipient when a request is declined.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "TimeOffRequestDecline"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/offerShiftRequests": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all Offer Shift requests",
+        "x-ms-summary": "Offer Shift Requests List",
+        "description": "This operation returns all offer shift requests in a schedule",
+        "operationId": "ListOfferShiftRequests",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of requests to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Request state filter",
+            "required": false,
+            "x-ms-summary": "Request State",
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "declined"
+            ],
+            "x-ms-enum-values": [
+              {
+                "displayName": "Pending",
+                "value": "pending"
+              },
+              {
+                "displayName": "Approved",
+                "value": "approved"
+              },
+              {
+                "displayName": "Declined",
+                "value": "declined"
+              }
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of Offer Shift requests in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "Offer Shift Requests List",
+                  "items": {
+                    "$ref": "#/definitions/OfferShiftRequestResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListOfferShiftRequests"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/offerShiftRequests/{offerShiftRequestId}/approve": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Approve an Offer Shift request",
+        "x-ms-summary": "Approve an offer shift request",
+        "description": "This operation allows recipients/managers to approve an offer shift request.",
+        "operationId": "OfferShiftRequestApprove",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "offerShiftRequestId",
+            "in": "path",
+            "x-ms-summary": "Offer Shift Request ID",
+            "description": "The unique ID of the offer shift request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Approve an offer shift request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Recipient/Manager",
+                  "description": "A message when a request is accepted.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "OfferShiftRequestApprove"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/offerShiftRequests/{offerShiftRequestId}/decline": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Decline an Offer Shift request",
+        "x-ms-summary": "Decline an offer shift request",
+        "description": "This operation allows users to decline an offer shift request.",
+        "operationId": "OfferShiftRequestDecline",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "offerShiftRequestId",
+            "in": "path",
+            "x-ms-summary": "Offer Shift Request ID",
+            "description": "The unique ID of the offer shift request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Recipient/Manager declines an offer shift request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Recipient/Manager",
+                  "description": "A message when a request is declined.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "OfferShiftRequestDecline"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/swapShiftsChangeRequests": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all Swap Shifts requests",
+        "x-ms-summary": "Swap Shifts Requests List",
+        "description": "This operation returns all swap shifts requests in a schedule",
+        "operationId": "ListSwapShiftsChangeRequests",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of requests to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Request state filter",
+            "required": false,
+            "x-ms-summary": "Request State",
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "declined"
+            ],
+            "x-ms-enum-values": [
+              {
+                "displayName": "Pending",
+                "value": "pending"
+              },
+              {
+                "displayName": "Approved",
+                "value": "approved"
+              },
+              {
+                "displayName": "Declined",
+                "value": "declined"
+              }
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of Swap Shifts Change Requests in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "Swap Shifts Change Requests List",
+                  "items": {
+                    "$ref": "#/definitions/SwapShiftsChangeRequestResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListSwapShiftsChangeRequests"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/swapShiftsChangeRequests/{swapShiftsChangeRequestId}/approve": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Approve a Swap Shifts request",
+        "x-ms-summary": "Approve a Swap Shifts request",
+        "description": "This operation allows a user to approve a Swap Shifts request.",
+        "operationId": "SwapShiftsChangeRequestApprove",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "swapShiftsChangeRequestId",
+            "in": "path",
+            "x-ms-summary": "Swap Shifts Change Request ID",
+            "description": "The unique ID of the request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Approve a swap shifts change request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Recipient/Manager",
+                  "description": "A message when a request is accepted.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "SwapShiftsChangeRequestApprove"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/swapShiftsChangeRequests/{swapShiftsChangeRequestId}/decline": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Decline a Swap Shifts request",
+        "x-ms-summary": "Decline a swap shifts request",
+        "description": "This operation allows users to decline a swap shifts request.",
+        "operationId": "SwapShiftsChangeRequestDecline",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "swapShiftsChangeRequestId",
+            "in": "path",
+            "x-ms-summary": "Swap Shifts Change Request ID",
+            "description": "The unique ID of the request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Decline a Swap Shifts change request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Recipient/Manager",
+                  "description": "A message when a request is declined.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "SwapShiftsChangeRequestDecline"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/openShiftChangeRequests": {
+      "get": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: List all Open Shift requests",
+        "x-ms-summary": "Open Shift Requests List",
+        "description": "This operation returns all open shift change requests in a schedule",
+        "operationId": "ListOpenShiftChangeRequests",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Total number of requests to retrieve",
+            "required": false,
+            "x-ms-summary": "Top Count",
+            "x-ms-visibility": "advanced",
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Request state filter",
+            "required": false,
+            "x-ms-summary": "Request State",
+            "x-ms-visibility": "advanced",
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "declined"
+            ],
+            "x-ms-enum-values": [
+              {
+                "displayName": "Pending",
+                "value": "pending"
+              },
+              {
+                "displayName": "Approved",
+                "value": "approved"
+              },
+              {
+                "displayName": "Declined",
+                "value": "declined"
+              }
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "@odata.context": {
+                  "type": "string",
+                  "x-ms-visibility": "internal"
+                },
+                "value": {
+                  "description": "List of Open Shift Change Requests in the schedule",
+                  "type": "array",
+                  "x-ms-summary": "Open Shift Change Requests List",
+                  "items": {
+                    "$ref": "#/definitions/OpenShiftChangeRequestResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "ListOpenShiftChangeRequests"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/openShiftChangeRequests/{openShiftChangeRequestId}/approve": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Approve an Open Shift request",
+        "x-ms-summary": "Approve an Open Shift request",
+        "description": "This operation allows managers to approve an Open Shift request.",
+        "operationId": "OpenShiftChangeRequestApprove",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "openShiftChangeRequestId",
+            "in": "path",
+            "x-ms-summary": "Open Shift Change Request ID",
+            "description": "The unique ID of the request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Manager approves an open shift change request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Manager",
+                  "description": "A message from the manager to the sender/recipient when a request is accepted.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "OpenShiftChangeRequestApprove"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule/openShiftChangeRequests/{openShiftChangeRequestId}/decline": {
+      "post": {
+        "tags": [
+          "Shifts"
+        ],
+        "summary": "Shifts: Decline an Open Shift request",
+        "x-ms-summary": "Decline an open shift request",
+        "description": "This operation allows managers to decline an open shift request.",
+        "operationId": "OpenShiftChangeRequestDecline",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "openShiftChangeRequestId",
+            "in": "path",
+            "x-ms-summary": "Open Shift Change Request ID",
+            "description": "The unique ID of the request",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "description": "Manager declines an Open Shift change request.",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "x-ms-summary": "Message From Manager",
+                  "description": "A message from the manager to the sender/recipient when a request is declined.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          }
+        },
+        "x-ms-no-generic-test": true,
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "OpenShiftChangeRequestDecline"
+          }
+        }
+      }
+    },
+    "/beta/teams/{teamId}/schedule": {
+      "get": {
+        "tags": [
+          "Schedules"
+        ],
+        "summary": "Shifts: Get a schedule's details",
+        "x-ms-summary": "Get Schedule details by ID",
+        "description": "This operation returns details of a schedule using the schedule's unique ID.",
+        "operationId": "GetSchedule",
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ScheduleResponse"
+            }
+          }
+        },
+        "deprecated": true,
+        "x-ms-api-annotation": {
+          "status": "Preview",
+          "replacement": {
+            "api": "Shifts",
+            "operationId": "GetSchedule"
+          }
+        }
+      }
+    },
+    "/hybridtriggers/onselectedmessage": {
+      "get": {
+        "tags": [
+          "TeamsMessageTrigger"
+        ],
+        "summary": "For a selected message",
+        "description": "For internal use with the on selected message hybrid trigger.",
+        "x-ms-visibility": "internal",
+        "operationId": "ForASelectedMessage",
+        "parameters": [
+          {
+            "name": "inputsAdaptiveCard",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "{}",
+            "x-ms-summary": "Inputs Adaptive Card"
+          },
+          {
+            "name": "taskModuleWidth",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog width (px)"
+          },
+          {
+            "name": "taskModuleHeight",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog height (px)"
+          }
+        ],
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "For internal use with the on selected message hybrid trigger."
+      },
+      "x-ms-notification-content": {
+        "description": "Tokens parsed out of the adaptive card given as an input by the user",
+        "schema": {
+          "$ref": "#/definitions/DynamicSelectedMessageTriggerResult"
+        }
+      }
+    },
+    "/hybridtriggers/onselectedmessagev2": {
+      "get": {
+        "tags": [
+          "TeamsMessageTriggerV2"
+        ],
+        "summary": "For a selected message (V2)",
+        "description": "For internal use with the on selected message hybrid trigger.",
+        "x-ms-visibility": "internal",
+        "operationId": "ForASelectedMessageV2",
+        "parameters": [
+          {
+            "name": "inputsAdaptiveCard",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "{}",
+            "x-ms-summary": "Inputs Adaptive Card"
+          },
+          {
+            "name": "taskModuleWidth",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog width (px)"
+          },
+          {
+            "name": "taskModuleHeight",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog height (px)"
+          }
+        ],
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "For internal use with the on selected message hybrid trigger."
+      },
+      "x-ms-notification-content": {
+        "description": "Tokens parsed out of the adaptive card given as an input by the user",
+        "schema": {
+          "$ref": "#/definitions/DynamicSelectedMessageTriggerResult"
+        }
+      }
+    },
+    "/hybridtriggers/oncomposemessage": {
+      "get": {
+        "tags": [
+          "TeamsComposeMessageTrigger"
+        ],
+        "summary": "From the compose box",
+        "description": "For internal use with the compose message hybrid trigger.",
+        "x-ms-visibility": "internal",
+        "operationId": "ComposeAMessage",
+        "parameters": [
+          {
+            "name": "inputsAdaptiveCard",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "{}",
+            "x-ms-summary": "Inputs Adaptive Card"
+          },
+          {
+            "name": "taskModuleWidth",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog width (px)"
+          },
+          {
+            "name": "taskModuleHeight",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog height (px)"
+          }
+        ],
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "For internal use with the compose message hybrid trigger."
+      },
+      "x-ms-notification-content": {
+        "description": "Tokens parsed out of the adaptive card given as an input by the user",
+        "schema": {
+          "$ref": "#/definitions/DynamicComposeMessageTriggerResult"
+        }
+      }
+    },
+    "/hybridtriggers/composeamessagev2": {
+      "get": {
+        "tags": [
+          "TeamsComposeMessageTriggerV2"
+        ],
+        "summary": "From the compose box (V2)",
+        "description": "For internal use with the compose message hybrid trigger.",
+        "x-ms-visibility": "internal",
+        "operationId": "ComposeAMessageV2",
+        "parameters": [
+          {
+            "name": "inputsAdaptiveCard",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "default": "{}",
+            "x-ms-summary": "Inputs Adaptive Card"
+          },
+          {
+            "name": "taskModuleWidth",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog width (px)"
+          },
+          {
+            "name": "taskModuleHeight",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "Dialog height (px)"
+          }
+        ],
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "For internal use with the compose message hybrid trigger."
+      },
+      "x-ms-notification-content": {
+        "description": "Tokens parsed out of the adaptive card given as an input by the user",
+        "schema": {
+          "$ref": "#/definitions/DynamicComposeMessageTriggerResult"
+        }
+      }
+    },
+    "/hybridtriggers/teamscardtrigger": {
+      "get": {
+        "tags": [
+          "TeamsCardResponseTrigger"
+        ],
+        "summary": "For adaptive card responses",
+        "description": "For internal use with the adaptive card response trigger.",
+        "x-ms-visibility": "internal",
+        "operationId": "TeamsCardTrigger",
+        "parameters": [
+          {
+            "name": "inputsAdaptiveCard",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "default": "{}",
+            "x-ms-summary": "Inputs Adaptive Card"
+          },
+          {
+            "name": "CardTypeId",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "x-ms-summary": "Card Type Id"
+          }
+        ],
+        "consumes": [],
+        "produces": [
+          "application/json",
+          "text/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {}
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        },
+        "deprecated": false,
+        "x-ms-trigger": "single",
+        "x-ms-trigger-hint": "For internal use with the adaptive card response hybrid trigger."
+      },
+      "x-ms-notification-content": {
+        "description": "Tokens parsed out of the adaptive card given as an input by the user",
+        "schema": {
+          "$ref": "#/definitions/DynamicCardResponseTriggerResult"
+        }
+      }
+    },
+    "/trigger/v1.0/groups/removal": {
+      "get": {
+        "summary": "When a new team member is removed",
+        "description": "This operation triggers when a member is removed from the given team.",
+        "operationId": "OnGroupMembershipRemoval",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_query"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "x-ms-summary": "Select",
+            "x-ms-test-value": "members",
+            "x-ms-visibility": "internal",
+            "type": "string",
+            "default": "members"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation Successful",
+            "schema": {
+              "$ref": "#/definitions/OnGroupMemberChange_Response"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "advanced",
+        "x-ms-test-value": "ee115782-220d-4acc-92c4-e261619d63cd",
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "x-ms-trigger": "batch",
+        "x-ms-trigger-hint": "To see it work now, remove a member from the team.",
+        "x-ms-dev-triggerType": "DeltaLink",
+        "x-ms-dev-triggerValueCollection": "value[0].members@delta",
+        "x-ms-dev-triggerValuePath": "@odata.deltaLink",
+        "x-ms-dev-queryfilterParamName": "$deltatoken"
+      }
+    },
+    "/trigger/v1.0/groups/delta": {
+      "get": {
+        "summary": "When a new team member is added",
+        "description": "This operation triggers when a member is added to the given team.",
+        "operationId": "OnGroupMembershipAdd",
+        "parameters": [
+          {
+            "$ref": "#/parameters/groupId__in_query"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "x-ms-summary": "Select",
+            "x-ms-test-value": "members",
+            "x-ms-visibility": "internal",
+            "type": "string",
+            "default": "members"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation Successful",
+            "schema": {
+              "$ref": "#/definitions/OnGroupMemberChange_Response"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-visibility": "advanced",
+        "x-ms-test-value": "ee115782-220d-4acc-92c4-e261619d63cd",
+        "x-ms-pageable": {
+          "nextLinkName": "@odata.nextLink"
+        },
+        "x-ms-trigger": "batch",
+        "x-ms-trigger-hint": "To see it work now, add a member to the team.",
+        "x-ms-dev-triggerType": "DeltaLink",
+        "x-ms-dev-triggerValueCollection": "value[0].members@delta",
+        "x-ms-dev-triggerValuePath": "@odata.deltaLink",
+        "x-ms-dev-queryfilterParamName": "$deltatoken"
+      }
+    },
+    "/beta/chats": {
+      "post": {
+        "summary": "Create a chat",
+        "description": "This operation creates a one on one or group chat",
+        "operationId": "CreateChat",
+        "x-ms-visibility": "important",
+        "parameters": [
+          {
+            "name": "item",
+            "in": "body",
+            "description": "Chat to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NewChat"
+            },
+            "x-ms-summary": "Item"
+          }
+        ],
+        "consumes": [ "application/json" ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "201": {
+            "description": "default",
+            "schema": {
+              "$ref": "#/definitions/NewChatResponse"
+            }
+          }
+        }
+      }
+    },
+    "/beta/teams": {
+      "post": {
+        "summary": "Create a team",
+        "description": "This operation a creates a new team.",
+        "x-ms-visibility": "important",
+        "operationId": "CreateATeam",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [ "displayName", "description" ],
+              "type": "object",
+              "properties": {
+                "displayName": {
+                  "description": "Name of the team",
+                  "type": "string",
+                  "x-ms-visibility": "important",
+                  "x-ms-summary": "Team Name"
+                },
+                "description": {
+                  "description": "Description of the team",
+                  "type": "string",
+                  "x-ms-visibility": "important",
+                  "x-ms-summary": "Description"
+                },
+                "visibility": {
+                  "description": "The visibility of the the team",
+                  "type": "string",
+                  "x-ms-summary": "Visibility",
+                  "x-ms-visibility": "advanced",
+                  "default": "Public",
+                  "enum": [ "Private", "Public" ]
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "default",
+            "schema": {
+              "$ref": "#/definitions/CreateATeamResponse"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/beta/teamsasyncresult": {
+      "get": {
+        "summary": "Get Teams async result",
+        "description": "This operation gets the result of an asynchronous operation within teams.",
+        "x-ms-visibility": "internal",
+        "operationId": "GetTeamsAsyncResult",
+        "produces": [ "application/json", "text/json" ],
+        "responses": {
+          "200": {
+            "description": "default",
+            "schema": {
+              "$ref": "#/definitions/CreateATeamResponse"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/beta/teams/{teamId}/members": {
+      "post": {
+        "summary": "Add a member to a team",
+        "description": "This operation adds a member to a team.",
+        "x-ms-visibility": "important",
+        "operationId": "AddMemberToTeam",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/teamId__in_path"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "required": [ "userId" ],
+              "type": "object",
+              "properties": {
+                "userId": {
+                  "description": "User principal name or AAD ID to add",
+                  "type": "string",
+                  "x-ms-visibility": "important",
+                  "x-ms-summary": "A user principal name or AAD ID to add to a team"
+                },
+                "owner": {
+                  "description": "The new member should be an owner",
+                  "type": "boolean",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Should the newly added user be an owner of the team"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "default"
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/beta/teams/conversation/message/poster/{poster}/location/{location}": {
+      "post": {
+        "summary": "Post message in a chat or channel",
+        "description": "This operation posts a message to a chat or a channel.",
+        "x-ms-visibility": "important",
+        "operationId": "PostMessageToConversation",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/poster__in_path"
+          },
+          {
+            "$ref": "#/parameters/location__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Post message request",
+            "description": "The post message request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicPostMessageRequest"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Post message response",
+            "schema": {
+              "$ref": "#/definitions/PostToConversationResponse"
+            }
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v1.0/teams/conversation/replyWithMessage/poster/{poster}/location/{location}": {
+      "post": {
+        "summary": "Reply with a message in a channel",
+        "description": "This operation replies with a message in a channel.",
+        "x-ms-visibility": "important",
+        "operationId": "ReplyWithMessageToConversation",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterWithoutPVA__in_path"
+          },
+          {
+            "$ref": "#/parameters/reply__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Reply message request",
+            "description": "The reply message request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicReplyMessageRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Reply message response",
+            "schema": {
+              "$ref": "#/definitions/PostToConversationResponse"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v1.0/teams/conversation/adaptivecard/poster/{poster}/location/{location}": {
+      "post": {
+        "summary": "Post card in a chat or channel",
+        "description": "This operation posts a card to a chat or a channel.",
+        "x-ms-visibility": "important",
+        "operationId": "PostCardToConversation",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterWithPowerApps__in_path"
+          },
+          {
+            "$ref": "#/parameters/location__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Post card request",
+            "description": "The post card request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicPostCardRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Post card response",
+            "schema": {
+              "$ref": "#/definitions/PostToConversationResponse"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v1.0/teams/conversation/gatherinput/poster/{poster}/location/{location}/$subscriptions": {
+      "post": {
+        "operationId": "PostCardAndWaitForResponse",
+        "summary": "Post adaptive card and wait for a response",
+        "description": "This operation posts an adaptive card to a chat or a channel and waits for a response.",
+        "x-ms-visibility": "important",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterWithoutUser__in_path"
+          },
+          {
+            "$ref": "#/parameters/location__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Flow continuation subscription request",
+            "description": "The flow continuation subscription request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "notificationUrl": {
+                  "x-ms-visibility": "internal",
+                  "x-ms-notification-url": true,
+                  "type": "string"
+                },
+                "body": {
+                  "type": "object",
+                  "properties": {
+                    "recipient": {
+                      "$ref": "#/definitions/DynamicPostCardAndWaitRequest"
+                    },
+                    "messageBody": {
+                      "x-ms-summary": "Message",
+                      "type": "string"
+                    },
+                    "updateMessage": {
+                      "description": "Message to show as an update in the original card following response",
+                      "default": "Thanks for your response!",
+                      "x-ms-summary": "Update message",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "recipient",
+                    "messageBody"
+                  ]
+                }
+              },
+              "required": [
+                "notificationUrl",
+                "body"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Post adaptive card response",
+            "schema": {
+              "$ref": "#/definitions/DynamicPostGatherInputToConversationResponse"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false
+      },
+      "x-ms-notification-content": {
+        "description": "Details for the response with which a flow continuation subscription is completed and flows waiting on that subscription are resumed.",
+        "schema": {
+          "$ref": "#/definitions/DynamicGatherInputSubscriptionResult"
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/whr": {
+      "post": {
+        "summary": "Proxy endpoint to validate subscriptions and forward notifications",
+        "description": "Proxy endpoint that receives notifications from the GraphAPI and validates subscriptions.",
+        "operationId": "WebhookResponse",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "OK"
+          }
+        },
+        "deprecated": false,
+        "security": [],
+        "x-ms-visibility": "internal",
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v1.0/teams/conversation/replyWithAdaptivecard/poster/{poster}/location/{location}": {
+      "post": {
+        "summary": "Reply with adaptive card in a channel",
+        "description": "This operation replies with an adaptive card to a channel.",
+        "x-ms-visibility": "important",
+        "operationId": "ReplyWithCardToConversation",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterWithoutPVA__in_path"
+          },
+          {
+            "$ref": "#/parameters/reply__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Reply adaptive card request",
+            "description": "The reply adaptive card request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicReplyCardRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Reply adaptive card response",
+            "schema": {
+              "$ref": "#/definitions/PostToConversationResponse"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/v1.0/teams/conversation/updateAdaptivecard/poster/{poster}/location/{location}": {
+      "post": {
+        "summary": "Update an adaptive card in a chat or channel",
+        "description": "This operation updates an existing adaptive card.",
+        "x-ms-visibility": "important",
+        "operationId": "UpdateCardInConversation",
+        "consumes": [ "application/json" ],
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterWithoutPVA__in_path"
+          },
+          {
+            "$ref": "#/parameters/update_location__in_path"
+          },
+          {
+            "name": "body",
+            "x-ms-summary": "Update adaptive card request",
+            "description": "The update adaptive card request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DynamicUpdateCardRequest"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Update adaptive card succeeded"
+          },
+          "201": {
+            "description": "Update adaptive card response",
+            "schema": {
+              "$ref": "#/definitions/PostToConversationResponse"
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        },
+        "deprecated": false,
+        "x-ms-no-generic-test": true
+      }
+    },
+    "/flowbot/getmessagedetailsinputschema/threadType/{threadType}": {
+      "get": {
+        "operationId": "GetMessageDetailsInputSchema",
+        "summary": "Get message details response schema",
+        "description": "Get the schema information for get message details response",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/GetMessageDetailsSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/getmessagedetailsresponseschema/threadType/{threadType}": {
+      "get": {
+        "operationId": "GetMessageDetailsResponseSchema",
+        "summary": "Get message details input metadata",
+        "description": "Get the schema information for message inputs",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/GetMessageDetailsSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/listmembersinputschema/threadType/{threadType}": {
+      "get": {
+        "operationId": "ListMembersInputSchema",
+        "summary": "List members input schema",
+        "description": "Get the schema information for list members input based on thread type",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/ListMembersSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/webhookTrigger/inputSchema/threadType/{threadType}": {
+      "get": {
+        "summary": "Input schema for webhook trigger",
+        "description": "Gets the input schema for webhook trigger",
+        "x-ms-visibility": "internal",
+        "operationId": "GetWebhookTriggerRequestSchema",
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/WebhookTriggerSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/webhookTrigger/triggerType/{triggerType}/responseSchema/threadType/{threadType}": {
+      "get": {
+        "summary": "Response schema for webhook trigger",
+        "description": "Gets the response schema for webhook trigger",
+        "x-ms-visibility": "internal",
+        "operationId": "GetWebhookTriggerResponseSchema",
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/triggerType__in_path"
+          },
+          {
+            "$ref": "#/parameters/threadType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/WebhookTriggerSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/flowbot/messageType/{messageType}/poster/{poster}": {
+      "get": {
+        "summary": "Conversation location for where to post",
+        "description": "Returns a list of locations to post a message or reply based on who the user is posting as",
+        "x-ms-visibility": "internal",
+        "operationId": "GetMessageLocations",
+        "produces": [ "application/json", "text/json" ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/messageType__in_path"
+          },
+          {
+            "$ref": "#/parameters/poster__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation is successful.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "locations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  },
+                  "description": "valid locations to post a message or reply, make verbose"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Operation Failed."
+          }
+        }
+      }
+    },
+    "/flowbot/getfeednotificationinputschema/poster/{poster}/notificationType/{notificationType}": {
+      "get": {
+        "operationId": "GetFeedNotificationInputSchema",
+        "summary": "Get feed notification input metadata",
+        "description": "Get the schema information for feed notification",
+        "x-ms-visibility": "internal",
+        "parameters": [
+          {
+            "$ref": "#/parameters/posterJustFlowbot__in_path"
+          },
+          {
+            "$ref": "#/parameters/notificationType__in_path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/PostFeedSchema"
+            }
+          },
+          "default": {
+            "description": "Operation Failed",
+            "schema": {}
+          }
+        }
+      }
+    },
+    "/teams/proxy/pva/bots": {
+      "get": {
+        "summary": "Gets all virtual agent chat bots",
+        "description": "Gets all virtual agent chat bots in current env",
+        "operationId": "GetVirtualAgentBots",
+        "x-ms-visibility": "internal",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/VirtualAgentBots"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Object": {
+      "type": "object",
+      "properties": {}
+    },
+    "ConnectorMetadata": {
+      "type": "object",
+      "properties": {
+        "metadatatype": {
+          "type": "string"
+        },
+        "activitytype": {
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "PostFeedSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "PostMessageSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "PostCardSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "PostCardAndWaitSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "UnifiedActionSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "GetMessageDetailsSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "ListMembersSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "GetTagsResponseSchema": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string",
+          "x-ms-visibility": "internal"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "Unique ID of the tag.",
+                "type": "string",
+                "x-ms-summary": "Id",
+                "x-ms-visibility": "important"
+              },
+              "teamId": {
+                "description": "The Team ID associated with the tag.",
+                "type": "string",
+                "x-ms-summary": "Team Id",
+                "x-ms-visibility": "important"
+              },
+              "displayName": {
+                "description": "The display name.",
+                "type": "string",
+                "x-ms-summary": "Name",
+                "x-ms-visibility": "important"
+              },
+              "memberCount": {
+                "description": "The member count.",
+                "type": "integer",
+                "x-ms-summary": "Member Count",
+                "x-ms-visibility": "important"
+              }
+            }
+          }
+        }
+      }
+    },
+    "GetTagMembersResponseSchema": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "Unique ID of the tag member.",
+                "type": "string",
+                "x-ms-summary": "Tag Member Id",
+                "x-ms-visibility": "important"
+              },
+              "tenantId": {
+                "description": "The tenant ID associated with the tag.",
+                "type": "string",
+                "x-ms-summary": "Tenant Id",
+                "x-ms-visibility": "important"
+              },
+              "displayName": {
+                "description": "The user display name.",
+                "type": "string",
+                "x-ms-summary": "User Display Name",
+                "x-ms-visibility": "important"
+              },
+              "userId": {
+                "description": "The user ID.",
+                "type": "string",
+                "x-ms-summary": "User Id",
+                "x-ms-visibility": "important"
+              }
+            }
+          }
+        }
+      }
+    },
+    "CreateTagResponseSchema": {
+      "description": "The created tag for a team.",
+      "x-ms-summary": "Tag",
+      "type": "object",
+      "properties": {
+        "@odata.type": {
+          "type": "string",
+          "x-ms-visibility": "internal"
+        },
+        "id": {
+          "description": "Unique ID of the tag.",
+          "type": "string",
+          "x-ms-summary": "Id",
+          "x-ms-visibility": "important"
+        },
+        "teamId": {
+          "description": "The Team ID associated with the tag.",
+          "type": "string",
+          "x-ms-summary": "Team Id",
+          "x-ms-visibility": "important"
+        },
+        "displayName": {
+          "description": "The display name.",
+          "type": "string",
+          "x-ms-summary": "Name",
+          "x-ms-visibility": "important"
+        },
+        "memberCount": {
+          "description": "The member count.",
+          "type": "integer",
+          "x-ms-summary": "Member Count",
+          "x-ms-visibility": "important"
+        }
+      }
+    },
+    "AddMemberToTagResponseSchema": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "description": "User ID of the member added to the tag.",
+          "type": "string",
+          "x-ms-summary": "Id",
+          "x-ms-visibility": "important"
+        }
+      }
+    },
+    "DynamicGetMessageDetailsSchema": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetMessageDetailsInputSchema",
+        "parameters": {
+          "threadType": {
+            "parameter": "threadType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicGetMessageDetailsResponseSchema": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetMessageDetailsResponseSchema",
+        "parameters": {
+          "threadType": {
+            "parameter": "threadType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicListMembersSchema": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "ListMembersInputSchema",
+        "parameters": {
+          "threadType": {
+            "parameter": "threadType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "ListMembersResponseSchema": {
+      "description": "List members response schema",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "List members response",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "displayName": {
+                "description": "Display Name of the member",
+                "type": "string",
+                "x-ms-summary": "displayName"
+              },
+              "email": {
+                "description": "Email Address of the member",
+                "type": "string",
+                "x-ms-summary": "email"
+              },
+              "id": {
+                "description": "ID of the member",
+                "type": "string",
+                "x-ms-summary": "ID"
+              },
+              "roles": {
+                "description": "List of roles of the member",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "x-ms-summary": "roles"
+              },
+              "tenantId": {
+                "description": "Tenant Id of the member",
+                "type": "string",
+                "x-ms-summary": "Tenant Id"
+              },
+              "userId": {
+                "description": "User Id of the member",
+                "type": "string",
+                "x-ms-summary": "User Id"
+              },
+              "visibleHistoryStartDateTime": {
+                "description": "The timestamp denoting how far back a conversation's history is shared with the conversation member.",
+                "type": "string",
+                "x-ms-summary": "Conversation Start Time"
+              }
+            }
+          },
+          "x-ms-summary": "List of members"
+        }
+      }
+    },
+    "DynamicUserNotificationRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetNotificationInputMetadata",
+        "parameters": {
+          "recipientType": "user"
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostConversationNotificationRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetNotificationInputMetadata",
+        "parameters": {
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicChannelNotificationRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetNotificationInputMetadata",
+        "parameters": {
+          "recipientType": "channel"
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostFeedNotificationRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetFeedNotificationInputSchema",
+        "parameters": {
+          "poster": {
+            "parameter": "poster"
+          },
+          "notificationType": {
+            "parameter": "notificationType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostMessageRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetUnifiedActionSchema",
+        "parameters": {
+          "actionType": "Message",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicReplyMessageRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetUnifiedActionSchema",
+        "parameters": {
+          "actionType": "ReplyWithMessage",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostCardRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetUnifiedActionSchema",
+        "parameters": {
+          "actionType": "UnifiedAdaptiveCard",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostCardAndWaitRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetUnifiedActionSchema",
+        "parameters": {
+          "actionType": "GatherInput",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicReplyCardRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetUnifiedActionSchema",
+        "parameters": {
+          "actionType": "ReplyWithAdaptiveCard",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicUpdateCardRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetUnifiedActionSchema",
+        "parameters": {
+          "actionType": "UpdateAdaptiveCard",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicUserAdaptiveCardRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetAdaptiveCardInputMetadata",
+        "parameters": {
+          "recipientType": "user"
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicChannelAdaptiveCardRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetAdaptiveCardInputMetadata",
+        "parameters": {
+          "recipientType": "channel"
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicUserMessageWithOptionsSubscriptionRequest": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetMessageWithOptionsSubscriptionInputMetadata",
+        "parameters": {
+          "recipientType": "user"
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicUserMessageWithOptionsSubscriptionResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetMessageWithOptionsSubscriptionOutputMetadata",
+        "parameters": {
+          "recipientType": "user"
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicSelectedMessageTriggerResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetSelectedMessageTriggerOutputsMetadata",
+        "parameters": {
+          "body": {
+            "parameter": "inputsAdaptiveCard"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicComposeMessageTriggerResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetComposeMessageTriggerOutputsMetadata",
+        "parameters": {
+          "body": {
+            "parameter": "inputsAdaptiveCard"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicCardResponseTriggerResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetCardResponseTriggerOutputsMetadata",
+        "parameters": {
+          "body": {
+            "parameter": "inputsAdaptiveCard"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "WebhookTriggerSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "ChatMessageWebhookResponseSchema": {
+      "description": "Message details",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Message details response",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "conversationId": {
+                "description": "Conversation Id",
+                "type": "string",
+                "x-ms-summary": "Conversation Id",
+                "x-ms-visibility": "advanced"
+              },
+              "messageId": {
+                "description": "Message ID",
+                "type": "string",
+                "x-ms-summary": "ID",
+                "x-ms-visibility": "advanced"
+              },
+              "linkToMessage": {
+                "description": "Message link",
+                "type": "string",
+                "x-ms-summary": "Link",
+                "x-ms-visibility": "advanced"
+              }
+            }
+          },
+          "x-ms-summary": "Message"
+        }
+      }
+    },
+    "DynamicWebhookTriggerRequestSchema": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetWebhookTriggerRequestSchema",
+        "parameters": {
+          "threadType": {
+            "parameter": "threadType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicKeywordWebhookTriggerResponseSchema": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetWebhookTriggerResponseSchema",
+        "parameters": {
+          "triggerType": "keyword",
+          "threadType": {
+            "parameter": "threadType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicAtMentionWebhookTriggerResponseSchema": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetWebhookTriggerResponseSchema",
+        "parameters": {
+          "triggerType": "atMention",
+          "threadType": {
+            "parameter": "threadType"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostToConversationResponse": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetPostToConversationResponseSchema",
+        "parameters": {
+          "actionType": "Message",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicPostGatherInputToConversationResponse": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetPostToConversationResponseSchema",
+        "parameters": {
+          "actionType": "GatherInput",
+          "poster": {
+            "parameter": "poster"
+          },
+          "recipientType": {
+            "parameter": "location"
+          }
+        },
+        "value-path": "schema"
+      }
+    },
+    "DynamicResponseSchema": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$ref": "#/definitions/Object"
+        }
+      }
+    },
+    "MessageId": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique Message Id",
+          "type": "string",
+          "x-ms-summary": "Message Id",
+          "x-ms-visibility": "advanced"
+        }
+      }
+    },
+    "DynamicUserFlowContinuationSubscriptionResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetFlowContinuationSubscriptionOutputMetadata",
+        "parameters": {
+          "recipientType": "user",
+          "body": {
+            "parameter": "body.messageBody"
+          }
+        },
+        "value-path": "schema"
+      },
+      "x-ms-dynamic-properties": {
+        "operationId": "GetFlowContinuationSubscriptionOutputMetadata",
+        "parameters": {
+          "recipientType": {
+            "value": "user"
+          },
+          "body": {
+            "parameterReference": "UserFlowContinuationSubscriptionRequest/body/messageBody"
+          }
+        },
+        "itemValuePath": "schema"
+      }
+    },
+    "DynamicChannelFlowContinuationSubscriptionResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetFlowContinuationSubscriptionOutputMetadata",
+        "parameters": {
+          "recipientType": "channel",
+          "body": {
+            "parameter": "body.messageBody"
+          }
+        },
+        "value-path": "schema"
+      },
+      "x-ms-dynamic-properties": {
+        "operationId": "GetFlowContinuationSubscriptionOutputMetadata",
+        "parameters": {
+          "recipientType": {
+            "value": "channel"
+          },
+          "body": {
+            "parameterReference": "ChannelFlowContinuationSubscriptionRequest/body/messageBody"
+          }
+        },
+        "itemValuePath": "schema"
+      }
+    },
+    "DynamicGatherInputSubscriptionResult": {
+      "type": "object",
+      "properties": {},
+      "x-ms-dynamic-schema": {
+        "operationId": "GetFlowContinuationSubscriptionWithPosterOutputMetadata",
+        "parameters": {
+          "recipientType": "user",
+          "poster": {
+            "parameter": "poster"
+          },
+          "body": {
+            "parameter": "body.messageBody"
+          }
+        },
+        "value-path": "schema"
+      },
+      "x-ms-dynamic-properties": {
+        "operationId": "GetFlowContinuationSubscriptionWithPosterOutputMetadata",
+        "parameters": {
+          "recipientType": {
+            "value": "user"
+          },
+          "poster": {
+            "parameterReference": "poster"
+          },
+          "body": {
+            "parameterReference": "body/body/messageBody"
+          }
+        },
+        "itemValuePath": "schema"
+      }
+    },
+    "GetMessagesFromChannel_Response": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "description": "@odata.context",
+          "type": "string",
+          "x-ms-summary": "@odata.context",
+          "x-ms-visibility": "advanced"
+        },
+        "@odata.count": {
+          "format": "int32",
+          "description": "@odata.count",
+          "type": "integer",
+          "x-ms-summary": "@odata.count",
+          "x-ms-visibility": "advanced"
+        },
+        "@odata.nextLink": {
+          "description": "@odata.nextLink",
+          "type": "string",
+          "x-ms-summary": "@odata.nextLink",
+          "x-ms-visibility": "advanced"
+        },
+        "value": {
+          "$ref": "#/definitions/OnNewChannelMessage_Response"
+        }
+      }
+    },
+    "OnGroupMemberChange_Response": {
+      "description": "value",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique id of the user.",
+            "type": "string",
+            "x-ms-visibility": "advanced",
+            "x-ms-summary": "User Id"
+          }
+        }
+      }
+    },
+    "OnNewChannelMessage_Response": {
+      "description": "List of one or more messages for a specific channel in a Team.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "x-ms-summary": "Message",
+        "description": "Properties associated with a single message.",
+        "properties": {
+          "attachments": {
+            "description": "attachments",
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "x-ms-summary": "attachments",
+            "x-ms-visibility": "advanced"
+          },
+          "body": {
+            "description": "Plaintext representation of the content of the message.",
+            "type": "object",
+            "properties": {
+              "content": {
+                "description": "content",
+                "type": "string",
+                "x-ms-summary": "content",
+                "x-ms-visibility": "advanced"
+              },
+              "contentType": {
+                "description": "contentType",
+                "type": "string",
+                "x-ms-summary": "contentType",
+                "x-ms-visibility": "advanced"
+              }
+            },
+            "x-ms-summary": "body",
+            "x-ms-visibility": "advanced"
+          },
+          "createdDateTime": {
+            "format": "date-time",
+            "description": "createdDateTime",
+            "type": "string",
+            "x-ms-summary": "createdDateTime",
+            "x-ms-visibility": "advanced"
+          },
+          "deleted": {
+            "description": "deleted",
+            "type": "boolean",
+            "x-ms-summary": "deleted",
+            "x-ms-visibility": "advanced"
+          },
+          "etag": {
+            "description": "etag",
+            "type": "string",
+            "x-ms-summary": "etag",
+            "x-ms-visibility": "advanced"
+          },
+          "from": {
+            "description": "from",
+            "type": "object",
+            "properties": {
+              "application": {
+                "description": "application",
+                "type": "object",
+                "x-ms-summary": "application",
+                "x-ms-visibility": "advanced"
+              },
+              "device": {
+                "description": "device",
+                "type": "string",
+                "x-ms-summary": "device",
+                "x-ms-visibility": "advanced"
+              },
+              "user": {
+                "description": "user",
+                "type": "object",
+                "properties": {
+                  "displayName": {
+                    "description": "displayName",
+                    "type": "string",
+                    "x-ms-summary": "displayName",
+                    "x-ms-visibility": "advanced"
+                  },
+                  "id": {
+                    "description": "ID",
+                    "type": "string",
+                    "x-ms-summary": "id",
+                    "x-ms-visibility": "advanced"
+                  },
+                  "identityProvider": {
+                    "description": "identityProvider",
+                    "type": "string",
+                    "x-ms-summary": "identityProvider",
+                    "x-ms-visibility": "advanced"
+                  }
+                },
+                "x-ms-summary": "user",
+                "x-ms-visibility": "advanced"
+              }
+            },
+            "x-ms-summary": "from",
+            "x-ms-visibility": "advanced"
+          },
+          "id": {
+            "description": "Unique ID of the message.",
+            "type": "string",
+            "x-ms-summary": "id",
+            "x-ms-visibility": "advanced"
+          },
+          "importance": {
+            "description": "importance",
+            "type": "string",
+            "x-ms-summary": "importance",
+            "x-ms-visibility": "advanced"
+          },
+          "lastModifiedDateTime": {
+            "description": "lastModifiedDateTime",
+            "type": "string",
+            "x-ms-summary": "lastModifiedDateTime",
+            "x-ms-visibility": "advanced"
+          },
+          "locale": {
+            "description": "locale",
+            "type": "string",
+            "x-ms-summary": "locale",
+            "x-ms-visibility": "advanced"
+          },
+          "mentions": {
+            "description": "mentions",
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "x-ms-summary": "mentions",
+            "x-ms-visibility": "advanced"
+          },
+          "messageType": {
+            "description": "messageType",
+            "type": "string",
+            "x-ms-summary": "messageType",
+            "x-ms-visibility": "advanced"
+          },
+          "reactions": {
+            "description": "reactions",
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "x-ms-summary": "reactions",
+            "x-ms-visibility": "advanced"
+          },
+          "replyToId": {
+            "description": "ID of the parent message of the thread",
+            "type": "string",
+            "x-ms-summary": "replyToId",
+            "x-ms-visibility": "advanced"
+          },
+          "subject": {
+            "description": "Message subject line. Optional.",
+            "type": "string",
+            "x-ms-summary": "subject",
+            "x-ms-visibility": "advanced"
+          },
+          "summary": {
+            "description": "Summary text of the message that could be used for push notifications and summary views or fall back views.",
+            "type": "string",
+            "x-ms-summary": "summary",
+            "x-ms-visibility": "advanced"
+          }
+        }
+      },
+      "x-ms-summary": "Message List",
+      "x-ms-visibility": "advanced"
+    },
+    "GetTeamResponse": {
+      "description": "Get team response",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "Team ID",
+          "description": "The unique ID of the team.",
+          "type": "string"
+        },
+        "displayName": {
+          "x-ms-summary": "Display Name",
+          "description": "The name of the team.",
+          "type": "string"
+        },
+        "description": {
+          "x-ms-summary": "Description of team",
+          "description": "The description of the Team.",
+          "type": "string"
+        },
+        "internalId": {
+          "x-ms-summary": "Internal Id",
+          "description": "The Internal Id of the Team.",
+          "type": "string"
+        },
+        "webUrl": {
+          "x-ms-summary": "Web Url of team",
+          "description": "The Web Url of the Team.",
+          "type": "string"
+        },
+        "isArchived": {
+          "x-ms-summary": "Is Archived",
+          "description": "Is Archived",
+          "type": "boolean"
+        },
+        "memberSettings": {
+          "$ref": "#/definitions/MemberSettings"
+        },
+        "guestSettings": {
+          "$ref": "#/definitions/GuestSettings"
+        },
+        "messagingSettings": {
+          "$ref": "#/definitions/MessagingSettings"
+        },
+        "funSettings": {
+          "$ref": "#/definitions/FunSettings"
+        },
+        "discoverySettings": {
+          "$ref": "#/definitions/DiscoverySettings"
+        }
+      }
+    },
+    "WebhookRequest": {
+      "type": "object",
+      "required": [
+        "notificationUrl"
+      ],
+      "properties": {
+        "notificationUrl": {
+          "type": "string",
+          "description": "Specify a well-formed URL of the endpoint that will receive notifications.",
+          "title": "Notification URL",
+          "x-ms-notification-url": true,
+          "x-ms-visibility": "internal"
+        }
+      }
+    },
+    "GetTimeOffReasonsResponse": {
+      "description": "The list of Time Off Reasons.",
+      "x-ms-summary": "List of time off reasons associated with a team",
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string",
+          "x-ms-visibility": "internal"
+        },
+        "value": {
+          "x-ms-summary": "Array containing time off reasons",
+          "description": "The list of time off reasons.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "x-ms-summary": "Single time off reason.",
+            "description": "Time off reason.",
+            "properties": {
+              "id": {
+                "x-ms-summary": "Time Off Reason ID",
+                "description": "The unique ID of the time off reason.",
+                "type": "string"
+              },
+              "createdDateTime": {
+                "x-ms-summary": "Created Time",
+                "format": "date-time",
+                "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+                "type": "string"
+              },
+              "lastModifiedDateTime": {
+                "x-ms-summary": "Modified Date Time",
+                "format": "date-time",
+                "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+                "type": "string"
+              },
+              "displayName": {
+                "x-ms-summary": "Display Name",
+                "description": "Display Name",
+                "type": "string"
+              },
+              "iconType": {
+                "x-ms-summary": "Icon Type",
+                "description": "Icon Type",
+                "type": "string"
+              },
+              "isActive": {
+                "x-ms-summary": "Is Active",
+                "description": "Is Active",
+                "type": "boolean"
+              },
+              "lastModifiedBy": {
+                "$ref": "#/definitions/LastModifiedBy"
+              }
+            }
+          }
+        }
+      }
+    },
+    "TimeOffRequestResponse": {
+      "x-ms-summary": "TimeOff Request",
+      "description": "TimeOff Request Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the TimeOff request.",
+          "type": "string"
+        },
+        "createdDateTime": {
+          "x-ms-summary": "Created Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "lastModifiedDateTime": {
+          "x-ms-summary": "Modified Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "assignedTo": {
+          "x-ms-summary": "Assigned To",
+          "description": "The person the request is assigned to: 'manager' or 'recipient'",
+          "type": "string"
+        },
+        "state": {
+          "x-ms-summary": "State",
+          "description": "'approved', 'pending' or 'declined'",
+          "type": "string"
+        },
+        "senderDateTime": {
+          "x-ms-summary": "Sender Time",
+          "format": "date-time",
+          "description": "Time when the request was sent",
+          "type": "string"
+        },
+        "senderMessage": {
+          "x-ms-summary": "Sender Message",
+          "description": "The message from the request sender",
+          "type": "string"
+        },
+        "senderUserId": {
+          "x-ms-summary": "Sender ID",
+          "description": "The ID of the user that sent the request",
+          "type": "string"
+        },
+        "managerActionDateTime": {
+          "x-ms-summary": "Manager Action Time",
+          "format": "date-time",
+          "description": "Time when the manager responded",
+          "type": "string"
+        },
+        "managerActionMessage": {
+          "x-ms-summary": "Manager Message",
+          "description": "The message from the manager",
+          "type": "string"
+        },
+        "managerUserId": {
+          "x-ms-summary": "Manager ID",
+          "description": "The ID of the manager that responded",
+          "type": "string"
+        },
+        "startDateTime": {
+          "x-ms-summary": "From Start Time",
+          "format": "date-time",
+          "description": "Start of time requested off",
+          "type": "string"
+        },
+        "endDateTime": {
+          "x-ms-summary": "To End Time",
+          "format": "date-time",
+          "description": "End of time requested off",
+          "type": "string"
+        },
+        "timeOffReasonId": {
+          "x-ms-summary": "TimeOff Reason ID",
+          "description": "The ID of the TimeOff Reason",
+          "type": "string"
+        }
+      }
+    },
+    "OfferShiftRequestResponse": {
+      "x-ms-summary": "Offer Shift Request",
+      "description": "Offer Shift Request Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the Offer Shift request.",
+          "type": "string"
+        },
+        "createdDateTime": {
+          "x-ms-summary": "Created Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "lastModifiedDateTime": {
+          "x-ms-summary": "Modified Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "assignedTo": {
+          "x-ms-summary": "Assigned To",
+          "description": "The person the request is assigned to: 'manager' or 'recipient'",
+          "type": "string"
+        },
+        "state": {
+          "x-ms-summary": "State",
+          "description": "'approved', 'pending' or 'declined'",
+          "type": "string"
+        },
+        "senderDateTime": {
+          "x-ms-summary": "Sender Time",
+          "format": "date-time",
+          "description": "Time when the request was sent",
+          "type": "string"
+        },
+        "senderMessage": {
+          "x-ms-summary": "Sender Message",
+          "description": "The message from the request sender",
+          "type": "string"
+        },
+        "senderUserId": {
+          "x-ms-summary": "Sender ID",
+          "description": "The ID of the user that sent the request",
+          "type": "string"
+        },
+        "senderShiftId": {
+          "x-ms-summary": "Sender Shift ID",
+          "description": "The ID of the shift from the sender",
+          "type": "string"
+        },
+        "recipientActionDateTime": {
+          "x-ms-summary": "Receiver Time",
+          "format": "date-time",
+          "description": "Time when the recipient responded",
+          "type": "string"
+        },
+        "recipientActionMessage": {
+          "x-ms-summary": "Recipient Message",
+          "description": "The message from the recipient",
+          "type": "string"
+        },
+        "recipientUserId": {
+          "x-ms-summary": "Recipient ID",
+          "description": "The ID of the recipient of the request",
+          "type": "string"
+        },
+        "managerActionDateTime": {
+          "x-ms-summary": "Manager Action Time",
+          "format": "date-time",
+          "description": "Time when the manager responded",
+          "type": "string"
+        },
+        "managerActionMessage": {
+          "x-ms-summary": "Manager Message",
+          "description": "The message from the manager",
+          "type": "string"
+        },
+        "managerUserId": {
+          "x-ms-summary": "Manager ID",
+          "description": "The ID of the manager that responded",
+          "type": "string"
+        }
+      }
+    },
+    "SwapShiftsChangeRequestResponse": {
+      "x-ms-summary": "Swap Shift Request",
+      "description": "Swap Shift Request Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the Swap Shift request.",
+          "type": "string"
+        },
+        "createdDateTime": {
+          "x-ms-summary": "Created Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "lastModifiedDateTime": {
+          "x-ms-summary": "Modified Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "assignedTo": {
+          "x-ms-summary": "Assigned To",
+          "description": "The person the request is assigned to: 'manager' or 'recipient'",
+          "type": "string"
+        },
+        "state": {
+          "x-ms-summary": "State",
+          "description": "'approved', 'pending' or 'declined'",
+          "type": "string"
+        },
+        "senderDateTime": {
+          "x-ms-summary": "Sender Time",
+          "format": "date-time",
+          "description": "Time when the request was sent",
+          "type": "string"
+        },
+        "senderMessage": {
+          "x-ms-summary": "Sender Message",
+          "description": "The message from the request sender",
+          "type": "string"
+        },
+        "senderUserId": {
+          "x-ms-summary": "Sender ID",
+          "description": "The ID of the user that sent the request",
+          "type": "string"
+        },
+        "senderShiftId": {
+          "x-ms-summary": "Sender Shift ID",
+          "description": "The ID of the shift from the sender",
+          "type": "string"
+        },
+        "recipientActionDateTime": {
+          "x-ms-summary": "Receiver Time",
+          "format": "date-time",
+          "description": "Time when the recipient responded",
+          "type": "string"
+        },
+        "recipientActionMessage": {
+          "x-ms-summary": "Recipient Message",
+          "description": "The message from the recipient",
+          "type": "string"
+        },
+        "recipientUserId": {
+          "x-ms-summary": "Recipient ID",
+          "description": "The ID of the recipient of the request",
+          "type": "string"
+        },
+        "recipientShiftId": {
+          "x-ms-summary": "Recipient Shift ID",
+          "description": "The ID of the shift from the recipient",
+          "type": "string"
+        },
+        "managerActionDateTime": {
+          "x-ms-summary": "Manager Action Time",
+          "format": "date-time",
+          "description": "Time when the manager responded",
+          "type": "string"
+        },
+        "managerActionMessage": {
+          "x-ms-summary": "Manager Message",
+          "description": "The message from the manager",
+          "type": "string"
+        },
+        "managerUserId": {
+          "x-ms-summary": "Manager ID",
+          "description": "The ID of the manager that responded",
+          "type": "string"
+        }
+      }
+    },
+    "OpenShiftChangeRequestResponse": {
+      "x-ms-summary": "Open Shift Change Request",
+      "description": "Open Shift Change Request Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the Open Shift Change request.",
+          "type": "string"
+        },
+        "createdDateTime": {
+          "x-ms-summary": "Created Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "lastModifiedDateTime": {
+          "x-ms-summary": "Modified Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "assignedTo": {
+          "x-ms-summary": "Assigned To",
+          "description": "The person the request is assigned to: 'manager' or 'recipient'",
+          "type": "string"
+        },
+        "state": {
+          "x-ms-summary": "State",
+          "description": "'approved', 'pending' or 'declined'",
+          "type": "string"
+        },
+        "senderDateTime": {
+          "x-ms-summary": "Sender Time",
+          "format": "date-time",
+          "description": "Time when the request was sent",
+          "type": "string"
+        },
+        "senderMessage": {
+          "x-ms-summary": "Sender Message",
+          "description": "The message from the request sender",
+          "type": "string"
+        },
+        "senderUserId": {
+          "x-ms-summary": "Sender ID",
+          "description": "The ID of the user that sent the request",
+          "type": "string"
+        },
+        "managerActionDateTime": {
+          "x-ms-summary": "Manager Action Time",
+          "format": "date-time",
+          "description": "Time when the manager responded",
+          "type": "string"
+        },
+        "managerActionMessage": {
+          "x-ms-summary": "Manager Message",
+          "description": "The message from the manager",
+          "type": "string"
+        },
+        "managerUserId": {
+          "x-ms-summary": "Manager ID",
+          "description": "The ID of the manager that responded",
+          "type": "string"
+        },
+        "openShiftId": {
+          "x-ms-summary": "Open Shift ID",
+          "description": "The ID of the open shift being requested",
+          "type": "string"
+        }
+      }
+    },
+    "EditOpenShiftRequest": {
+      "type": "object",
+      "properties": {
+        "schedulingGroupId": {
+          "x-ms-visibility": "important",
+          "description": "Scheduling Group ID",
+          "x-ms-summary": "Scheduling Group ID",
+          "type": "string",
+          "x-ms-dynamic-values": {
+            "value-path": "id",
+            "value-title": "displayName",
+            "operationId": "ListSchedulingGroups",
+            "value-collection": "value",
+            "parameters": {
+              "teamId": {
+                "parameter": "teamId"
+              }
+            }
+          }
+        },
+        "sharedOpenShift": {
+          "x-ms-visibility": "important",
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "x-ms-summary": "Display Name",
+              "description": "Display Name",
+              "x-ms-visibility": "advanced",
+              "type": "string"
+            },
+            "notes": {
+              "x-ms-summary": "Notes",
+              "description": "Notes",
+              "x-ms-visibility": "advanced",
+              "type": "string"
+            },
+            "startDateTime": {
+              "x-ms-summary": "From Start Time",
+              "x-ms-visibility": "important",
+              "format": "date-time",
+              "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+              "type": "string"
+            },
+            "endDateTime": {
+              "x-ms-summary": "To End Time",
+              "x-ms-visibility": "important",
+              "format": "date-time",
+              "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+              "type": "string"
+            },
+            "theme": {
+              "$ref": "#/definitions/ThemeEditor"
+            },
+            "openSlotCount": {
+              "x-ms-summary": "Open Slot Count",
+              "x-ms-visibility": "important",
+              "description": "Open Slot Count",
+              "type": "integer"
+            },
+            "activities": {
+              "$ref": "#/definitions/Activities"
+            }
+          },
+          "required": [
+            "startDateTime",
+            "endDateTime",
+            "openSlotCount"
+          ]
+        }
+      }
+    },
+    "OpenShiftResponse": {
+      "x-ms-summary": "Open Shift",
+      "description": "Open Shift Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the open shift.",
+          "type": "string"
+        },
+        "createdDateTime": {
+          "x-ms-summary": "Created Date Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "lastModifiedDateTime": {
+          "x-ms-summary": "Modified Date Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "schedulingGroupId": {
+          "x-ms-summary": "Scheduling Group ID",
+          "description": "Scheduling Group ID",
+          "type": "string"
+        },
+        "lastModifiedBy": {
+          "$ref": "#/definitions/LastModifiedBy"
+        },
+        "sharedOpenShift": {
+          "$ref": "#/definitions/SharedOpenShift"
+        },
+        "draftOpenShift": {
+          "$ref": "#/definitions/DraftOpenShift"
+        }
+      }
+    },
+    "SharedOpenShift": {
+      "x-ms-summary": "Shared Open Shift",
+      "description": "Shared version of the open shift",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "x-ms-summary": "Display Name",
+          "description": "Display Name",
+          "type": "string"
+        },
+        "notes": {
+          "x-ms-summary": "Notes",
+          "description": "Notes",
+          "type": "string"
+        },
+        "startDateTime": {
+          "x-ms-summary": "From Start Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "endDateTime": {
+          "x-ms-summary": "To End Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "theme": {
+          "x-ms-summary": "Theme",
+          "description": "Theme",
+          "type": "string"
+        },
+        "openSlotCount": {
+          "x-ms-summary": "Open Slot Count",
+          "description": "Open Slot Count",
+          "type": "integer"
+        },
+        "activities": {
+          "$ref": "#/definitions/Activities"
+        }
+      }
+    },
+    "DraftOpenShift": {
+      "x-ms-summary": "Draft Open Shift",
+      "description": "Preliminary version of the open shift",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "x-ms-summary": "Display Name",
+          "description": "Display Name",
+          "type": "string"
+        },
+        "notes": {
+          "x-ms-summary": "Notes",
+          "description": "Notes",
+          "type": "string"
+        },
+        "startDateTime": {
+          "x-ms-summary": "From Start Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "endDateTime": {
+          "x-ms-summary": "To End Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "theme": {
+          "x-ms-summary": "Theme",
+          "description": "Theme",
+          "type": "string"
+        },
+        "openSlotCount": {
+          "x-ms-summary": "Open Slot Count",
+          "description": "Open Slot Count",
+          "type": "integer"
+        },
+        "activities": {
+          "$ref": "#/definitions/Activities"
+        }
+      }
+    },
+    "ShiftResponse": {
+      "x-ms-summary": "Shift",
+      "description": "Shift Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the shift.",
+          "type": "string"
+        },
+        "createdDateTime": {
+          "x-ms-summary": "Created Date Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "lastModifiedDateTime": {
+          "x-ms-summary": "Modified Date Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "userId": {
+          "x-ms-summary": "Assigned To User ID",
+          "description": "Assigned To User ID",
+          "type": "string"
+        },
+        "schedulingGroupId": {
+          "x-ms-summary": "Scheduling Group ID",
+          "description": "Scheduling Group ID",
+          "type": "string"
+        },
+        "lastModifiedBy": {
+          "$ref": "#/definitions/LastModifiedBy"
+        },
+        "sharedShift": {
+          "$ref": "#/definitions/SharedShift"
+        },
+        "draftShift": {
+          "$ref": "#/definitions/DraftShift"
+        }
+      }
+    },
+    "SharedShift": {
+      "x-ms-summary": "Shared Shift",
+      "description": "Shared version of the shift",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "x-ms-summary": "Display Name",
+          "description": "Display Name",
+          "type": "string"
+        },
+        "notes": {
+          "x-ms-summary": "Notes",
+          "description": "Notes",
+          "type": "string"
+        },
+        "startDateTime": {
+          "x-ms-summary": "From Start Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "endDateTime": {
+          "x-ms-summary": "To End Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "theme": {
+          "x-ms-summary": "Theme",
+          "description": "Theme",
+          "type": "string"
+        },
+        "activities": {
+          "$ref": "#/definitions/Activities"
+        }
+      }
+    },
+    "DraftShift": {
+      "x-ms-summary": "Draft Shift",
+      "description": "Preliminary version of the shift",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "x-ms-summary": "Display Name",
+          "description": "Display Name",
+          "type": "string"
+        },
+        "notes": {
+          "x-ms-summary": "Notes",
+          "description": "Notes",
+          "type": "string"
+        },
+        "startDateTime": {
+          "x-ms-summary": "From Start Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "endDateTime": {
+          "x-ms-summary": "To End Time",
+          "format": "date-time",
+          "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+          "type": "string"
+        },
+        "theme": {
+          "x-ms-summary": "Theme",
+          "description": "Theme",
+          "type": "string"
+        },
+        "activities": {
+          "$ref": "#/definitions/Activities"
+        }
+      }
+    },
+    "ScheduleResponse": {
+      "description": "Schedule Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "Schedule ID",
+          "description": "The unique ID of the schedule.",
+          "type": "string"
+        },
+        "timeZone": {
+          "x-ms-summary": "Schedule Time Zone",
+          "description": "The Time Zone of the schedule.",
+          "type": "string"
+        },
+        "provisionStatus": {
+          "x-ms-summary": "Schedule Provision Status",
+          "description": "The Provision Status of the schedule.",
+          "type": "string"
+        },
+        "provisionStatusCode": {
+          "x-ms-summary": "Schedule Provision Status Code",
+          "description": "The Provision Status Code of the schedule.",
+          "type": "string"
+        }
+      }
+    },
+    "CreateATeamResponse": {
+      "type": "object",
+      "properties": {
+        "newTeamId": {
+          "description": "Team ID of the team that was just created",
+          "type": "string",
+          "x-ms-summary": "New Team ID"
+        }
+      }
+    },
+    "PostToConversationResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique Message Id",
+          "type": "string",
+          "x-ms-summary": "Message Id"
+        },
+        "messageLink": {
+          "description": "Link to the message",
+          "type": "string",
+          "x-ms-summary": "Message Link"
+        },
+        "conversationId": {
+          "description": "The conversation Id",
+          "type": "string",
+          "x-ms-summary": "Conversation Id"
+        }
+      }
+    },
+    "ThemeEditor": {
+      "x-ms-summary": "Theme",
+      "description": "Theme",
+      "x-ms-visibility": "advanced",
+      "type": "string",
+      "default": "white",
+      "enum": [
+        "white",
+        "blue",
+        "green",
+        "purple",
+        "pink",
+        "yellow",
+        "gray",
+        "darkblue",
+        "darkgreen",
+        "darkpurple",
+        "darkpink",
+        "darkyellow"
+      ],
+      "x-ms-enum-values": [
+        {
+          "displayName": "White",
+          "value": "white"
+        },
+        {
+          "displayName": "Blue",
+          "value": "blue"
+        },
+        {
+          "displayName": "Green",
+          "value": "green"
+        },
+        {
+          "displayName": "Purple",
+          "value": "purple"
+        },
+        {
+          "displayName": "Pink",
+          "value": "pink"
+        },
+        {
+          "displayName": "Yellow",
+          "value": "yellow"
+        },
+        {
+          "displayName": "Gray",
+          "value": "gray"
+        },
+        {
+          "displayName": "Dark Blue",
+          "value": "darkblue"
+        },
+        {
+          "displayName": "Dark Green",
+          "value": "darkgreen"
+        },
+        {
+          "displayName": "Dark Purple",
+          "value": "darkpurple"
+        },
+        {
+          "displayName": "Dark Pink",
+          "value": "darkpink"
+        },
+        {
+          "displayName": "Dark Yellow",
+          "value": "darkyellow"
+        }
+      ]
+    },
+    "Activities": {
+      "description": "Shift activities",
+      "type": "array",
+      "x-ms-visibility": "advanced",
+      "items": {
+        "description": "Shift activity",
+        "type": "object",
+        "x-ms-summary": "Activity",
+        "properties": {
+          "isPaid": {
+            "x-ms-summary": "Is Paid",
+            "description": "Is Paid",
+            "type": "boolean"
+          },
+          "startDateTime": {
+            "x-ms-summary": "From Start Time",
+            "format": "date-time",
+            "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+            "type": "string"
+          },
+          "endDateTime": {
+            "x-ms-summary": "To End Time",
+            "format": "date-time",
+            "description": "yyyy-MM-ddTHH:mm:ss.fffZ (UTC format)",
+            "type": "string"
+          },
+          "code": {
+            "x-ms-summary": "Code",
+            "description": "Code",
+            "type": "string"
+          },
+          "displayName": {
+            "x-ms-summary": "Display Name",
+            "description": "Display Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "startDateTime",
+          "endDateTime"
+        ]
+      }
+    },
+    "SchedulingGroupResponse": {
+      "x-ms-summary": "Scheduling Group",
+      "description": "Scheduling Group Entity",
+      "type": "object",
+      "properties": {
+        "id": {
+          "x-ms-summary": "ID",
+          "description": "The unique ID of the scheduling group.",
+          "type": "string"
+        },
+        "displayName": {
+          "x-ms-summary": "Display Name",
+          "description": "The display name for the scheduling group.",
+          "type": "string"
+        },
+        "isActive": {
+          "x-ms-summary": "Is Active",
+          "description": "Indicates whether the scheduling group can be used when creating new entities or updating existing ones.",
+          "type": "boolean"
+        },
+        "userIds": {
+          "x-ms-summary": "User IDs",
+          "description": "List of IDs of users in the scheduling group.",
+          "type": "array",
+          "items": {
+            "description": "The ID of a user in the scheduling group",
+            "type": "string",
+            "x-ms-summary": "User ID"
+          }
+        }
+      }
+    },
+    "AtMentionUser_V1": {
+      "description": "@mention Token",
+      "type": "object",
+      "properties": {
+        "atMention": {
+          "x-ms-summary": "@mention",
+          "description": "An @mention token for the user. This property can be inserted into messages and adaptive cards.",
+          "type": "string"
+        }
+      }
+    },
+    "AtMentionTagResponse": {
+      "description": "@mention token for a tag",
+      "type": "object",
+      "properties": {
+        "atMention": {
+          "x-ms-summary": "@mention tag",
+          "description": "A token for the tag to @mention. It can be inserted into messages and adaptive cards sent from a person.",
+          "type": "string"
+        }
+      }
+    },
+    "ChannelIdForTeam": {
+      "x-ms-dynamic-values": {
+        "operationId": "GetChannelsForGroup",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "groupId": {
+            "parameter": "groupId"
+          }
+        }
+      },
+      "x-ms-summary": "Channel",
+      "x-ms-test-value": "19:976f050cb80c4d57a2a5e28b8942e6ec@thread.skype",
+      "description": "Add channel ID",
+      "type": "string"
+    },
+    "ChannelIds": {
+      "description": "Channel IDs",
+      "type": "object",
+      "properties": {
+        "channel": {
+          "$ref": "#/definitions/ChannelIdForTeam"
+        }
+      },
+      "required": [
+        "channel"
+      ]
+    },
+    "ChatId": {
+      "x-ms-dynamic-values": {
+        "operationId": "GetChats",
+        "value-path": "id",
+        "value-title": "topic",
+        "value-collection": "value",
+        "parameters": {
+          "topic": "isDefined",
+          "chatType": "all"
+        }
+      },
+      "x-ms-summary": "Conversation Id",
+      "x-ms-test-value": "19:976f050cb80c4d57a2a5e28b8942e6ec@thread.skype",
+      "description": "Add Conversation ID",
+      "type": "string"
+    },
+    "NewChat": {
+      "description": "New chat event model",
+      "type": "object",
+      "required": [
+        "members"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "Enter title (displays in group chats, not 1:1 chats)",
+          "x-ms-summary": "Title",
+          "x-ms-visibility": "important"
+        },
+        "members": {
+          "description": "Enter user ID or email addresses, separated by semicolons",
+          "type": "string",
+          "x-ms-summary": "Members to add"
+        }
+      }
+    },
+    "NewChatResponse": {
+      "description": "Response for new chat that was created",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique conversation Id",
+          "type": "string",
+          "x-ms-summary": "Conversation Id"
+        }
+      }
+    },
+    "NewMeeting": {
+      "description": "New meeting event model",
+      "type": "object",
+      "required": [
+        "isOnlineMeeting",
+        "onlineMeetingProvider",
+        "subject",
+        "body",
+        "start",
+        "end",
+        "timeZone"
+      ],
+      "properties": {
+        "subject": {
+          "type": "string",
+          "description": "Event subject",
+          "x-ms-summary": "Subject",
+          "x-ms-visibility": "important"
+        },
+        "body": {
+          "description": "body",
+          "required": [
+            "content",
+            "contentType"
+          ],
+          "type": "object",
+          "properties": {
+            "content": {
+              "description": "Body of the message.",
+              "type": "string",
+              "x-ms-summary": "Message",
+              "x-ms-visibility": "important"
+            },
+            "contentType": {
+              "description": "Content type: html or text.",
+              "type": "string",
+              "x-ms-summary": "Type",
+              "x-ms-visibility": "internal",
+              "default": "html"
+            }
+          }
+        },
+        "timeZone": {
+          "description": "Time zone of the event",
+          "x-ms-summary": "Time zone",
+          "x-ms-visibility": "important",
+          "type": "string",
+          "x-ms-dynamic-values": {
+            "operationId": "GetSupportedTimeZones",
+            "value-path": "alias",
+            "value-title": "alias",
+            "value-collection": "value"
+          }
+        },
+        "start": {
+          "type": "object",
+          "required": [
+            "dateTime"
+          ],
+          "x-ms-visibility": "important",
+          "properties": {
+            "dateTime": {
+              "format": "date-no-tz",
+              "x-ms-visibility": "important",
+              "description": "Start time of the event (example: '2017-08-29T04:00:00')",
+              "type": "string",
+              "x-ms-summary": "Start time"
+            }
+          }
+        },
+        "end": {
+          "type": "object",
+          "required": [
+            "dateTime"
+          ],
+          "x-ms-visibility": "important",
+          "properties": {
+            "dateTime": {
+              "format": "date-no-tz",
+              "x-ms-visibility": "important",
+              "description": "End time of the event (example: '2017-08-29T05:00:00')",
+              "type": "string",
+              "x-ms-summary": "End time"
+            }
+          }
+        },
+        "requiredAttendees": {
+          "format": "email",
+          "description": "Required attendees for the event separated by semicolons",
+          "type": "string",
+          "x-ms-summary": "Required attendees",
+          "x-ms-dynamic-values": {
+            "builtInOperation": "AadGraph.GetUsers",
+            "parameters": {},
+            "value-path": "mail"
+          }
+        },
+        "optionalAttendees": {
+          "format": "email",
+          "description": "Optional attendees for the event separated by semicolons",
+          "type": "string",
+          "x-ms-summary": "Optional attendees",
+          "x-ms-dynamic-values": {
+            "builtInOperation": "AadGraph.GetUsers",
+            "parameters": {},
+            "value-path": "mail"
+          }
+        },
+        "location": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "Location",
+              "x-ms-summary": "Location",
+              "x-ms-visibility": "advanced"
+            }
+          },
+          "description": "Location"
+        },
+        "importance": {
+          "description": "The importance of the event: low, normal or high",
+          "type": "string",
+          "enum": [ "low", "normal", "high" ],
+          "x-ms-enum-values": [
+            {
+              "displayName": "Low",
+              "value": "low"
+            },
+            {
+              "displayName": "Normal",
+              "value": "normal"
+            },
+            {
+              "displayName": "High",
+              "value": "high"
+            }
+          ],
+          "x-ms-summary": "Importance",
+          "x-ms-visibility": "advanced"
+        },
+        "recurrence": {
+          "type": "object",
+          "description": "The recurrence pattern for the meeting",
+          "x-ms-visibility": "advanced",
+          "properties": {
+            "pattern": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Recurrence pattern",
+                  "description": "Pattern for the recurrence. Required when meeting is a recurrence",
+                  "enum": [
+                    "",
+                    "daily",
+                    "weekly",
+                    "relativeMonthly",
+                    "relativeYearly"
+                  ],
+                  "x-ms-enum-values": [
+                    {
+                      "displayName": "Daily",
+                      "value": "daily"
+                    },
+                    {
+                      "displayName": "Weekly",
+                      "value": "weekly"
+                    },
+                    {
+                      "displayName": "Monthly",
+                      "value": "relativeMonthly"
+                    }
+                  ]
+                },
+                "interval": {
+                  "format": "int32",
+                  "description": "Number of recurrences. Required when meeting is a recurrence",
+                  "type": "integer",
+                  "x-ms-summary": "Number of recurrences",
+                  "x-ms-visibility": "advanced"
+                },
+                "daysOfWeek": {
+                  "type": "array",
+                  "x-ms-summary": "Days of week",
+                  "description": "Comma separated days of weeks (example: 'Monday,Wednesday,Friday')",
+                  "items": {
+                    "type": "string",
+                    "x-ms-summary": "Recurrence Day(s) of week",
+                    "description": "Days of week (example: 'Monday'). Required when recurrence pattern is NOT daily"
+                  }
+                },
+                "index": {
+                  "type": "string",
+                  "x-ms-visibility": "advanced",
+                  "x-ms-summary": "Week Index",
+                  "description": "Specifies on which day of the week the event occurs. Default is first",
+                  "enum": [
+                    "",
+                    "first",
+                    "second",
+                    "third",
+                    "fourth",
+                    "last"
+                  ],
+                  "x-ms-enum-values": [
+                    {
+                      "displayName": "First",
+                      "value": "first"
+                    },
+                    {
+                      "displayName": "Second",
+                      "value": "second"
+                    },
+                    {
+                      "displayName": "Third",
+                      "value": "third"
+                    },
+                    {
+                      "displayName": "Fourth",
+                      "value": "fourth"
+                    },
+                    {
+                      "displayName": "Last",
+                      "value": "last"
+                    }
+                  ]
+                }
+              }
+            },
+            "range": {
+              "type": "object",
+              "description": "The recurrence pattern for the meeting",
+              "x-ms-visibility": "advanced",
+              "properties": {
+                "startDate": {
+                  "format": "date",
+                  "description": "Start Date of the recurrence, format YYYY-MM-DD. Required when meeting is a recurrence",
+                  "type": "string",
+                  "x-ms-summary": "Recurrence start date",
+                  "x-ms-visibility": "advanced"
+                },
+                "endDate": {
+                  "format": "date",
+                  "description": "End Date of the recurrence, format YYYY-MM-DD",
+                  "type": "string",
+                  "x-ms-summary": "Recurrence end date",
+                  "x-ms-visibility": "advanced"
+                }
+              }
+            }
+          }
+        },
+        "isAllDay": {
+          "description": "Set to true if the event lasts all day",
+          "type": "boolean",
+          "x-ms-summary": "Is all day event?",
+          "x-ms-visibility": "advanced"
+        },
+        "reminderMinutesBeforeStart": {
+          "description": "Time in minutes before event start to remind",
+          "type": "integer",
+          "x-ms-summary": "Reminder",
+          "x-ms-visibility": "advanced"
+        },
+        "isReminderOn": {
+          "description": "Set to true if an alert is set to remind the user of the event.",
+          "type": "boolean",
+          "x-ms-summary": "Is reminder on",
+          "x-ms-visibility": "advanced"
+        },
+        "showAs": {
+          "description": "Status to show during the event.",
+          "type": "string",
+          "enum": [ "free", "tentative", "busy", "oof", "workingElsewhere", "unknown" ],
+          "x-ms-summary": "Show as",
+          "x-ms-visibility": "advanced"
+        },
+        "responseRequested": {
+          "description": "Set to true if the sender would like a response when the event is accepted.",
+          "type": "boolean",
+          "x-ms-summary": "Response Requested",
+          "x-ms-visibility": "advanced"
+        },
+        "isOnlineMeeting": {
+          "type": "boolean",
+          "description": "isOnlineMeeting",
+          "default": true,
+          "x-ms-summary": "Online Meeting Enabled",
+          "x-ms-visibility": "internal"
+        },
+        "onlineMeetingProvider": {
+          "type": "string",
+          "description": "onlineMeetingProvider",
+          "default": "teamsForBusiness",
+          "x-ms-summary": "Online Meeting Provider",
+          "x-ms-visibility": "internal"
+        }
+      }
+    },
+    "NewMeetingRespone": {
+      "description": "Response for new meeting that was created",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Id"
+        },
+        "createdDateTime": {
+          "type": "string",
+          "description": "Created DateTime"
+        },
+        "lastModifiedDateTime": {
+          "type": "string",
+          "description": "Last Modified DateTime"
+        },
+        "categories": {
+          "type": "array",
+          "items": {},
+          "description": "Categories"
+        },
+        "timeZone": {
+          "type": "string",
+          "description": "Time Zone"
+        },
+        "reminderMinutesBeforeStart": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Reminder Minutes Before Start"
+        },
+        "isReminderOn": {
+          "type": "boolean",
+          "description": "Is Reminder On"
+        },
+        "hasAttachments": {
+          "type": "boolean",
+          "description": "Has Attachments"
+        },
+        "subject": {
+          "type": "string",
+          "description": "Subject"
+        },
+        "bodyPreview": {
+          "type": "string",
+          "description": "Body Preview"
+        },
+        "importance": {
+          "type": "string",
+          "description": "Importance"
+        },
+        "sensitivity": {
+          "type": "string",
+          "description": "Sensitivity"
+        },
+        "isAllDay": {
+          "type": "boolean",
+          "description": "Is All Day"
+        },
+        "isCancelled": {
+          "type": "boolean",
+          "description": "Is Cancelled"
+        },
+        "isOrganizer": {
+          "type": "boolean",
+          "description": "Is Organizer"
+        },
+        "responseRequested": {
+          "type": "boolean",
+          "description": "Response Requested"
+        },
+        "showAs": {
+          "type": "string",
+          "description": "Show As"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type"
+        },
+        "webLink": {
+          "type": "string",
+          "description": "Web Link"
+        },
+        "onlineMeetingUrl": {
+          "type": "string",
+          "description": "Online Meeting Url"
+        },
+        "allowNewTimeProposals": {
+          "type": "boolean",
+          "description": "Allow New Time Proposals"
+        },
+        "recurrence": {
+          "type": "object",
+          "description": "Recurrence",
+          "properties": {
+            "pattern": {
+              "type": "object",
+              "description": "Recurrence Pattern"
+            },
+            "range": {
+              "type": "object",
+              "description": "Recurrence Range"
+            }
+          }
+        },
+        "responseStatus": {
+          "type": "object",
+          "properties": {
+            "response": {
+              "type": "string",
+              "description": "Response"
+            },
+            "time": {
+              "type": "string",
+              "description": "Time"
+            }
+          },
+          "description": "Response Status"
+        },
+        "body": {
+          "type": "object",
+          "properties": {
+            "contentType": {
+              "type": "string",
+              "description": "Content Type"
+            },
+            "content": {
+              "type": "string",
+              "description": "Content"
+            }
+          },
+          "description": "Body"
+        },
+        "start": {
+          "type": "object",
+          "properties": {
+            "dateTime": {
+              "type": "string",
+              "description": "DateTime"
+            }
+          },
+          "description": "Start"
+        },
+        "end": {
+          "type": "object",
+          "properties": {
+            "dateTime": {
+              "type": "string",
+              "description": "DateTime"
+            }
+          },
+          "description": "End"
+        },
+        "location": {
+          "type": "object",
+          "properties": {
+            "displayName": {
+              "type": "string",
+              "description": "Display Name"
+            }
+          },
+          "description": "Location"
+        },
+        "attendees": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Type"
+              },
+              "status": {
+                "type": "object",
+                "properties": {
+                  "response": {
+                    "type": "string",
+                    "description": "Response"
+                  },
+                  "time": {
+                    "type": "string",
+                    "description": "Time"
+                  }
+                },
+                "description": "Status"
+              },
+              "emailAddress": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name"
+                  },
+                  "address": {
+                    "type": "string",
+                    "description": "Address"
+                  }
+                },
+                "description": "Email Address"
+              }
+            }
+          },
+          "description": "Attendees"
+        },
+        "organizer": {
+          "type": "object",
+          "properties": {
+            "emailAddress": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name"
+                },
+                "address": {
+                  "type": "string",
+                  "description": "Address"
+                }
+              },
+              "description": "Email Address"
+            }
+          },
+          "description": "Organizer"
+        },
+        "onlineMeeting": {
+          "type": "object",
+          "properties": {
+            "joinUrl": {
+              "type": "string",
+              "description": "Join Url"
+            }
+          },
+          "description": "Online Meeting"
+        }
+      }
+    },
+    "LastModifiedBy": {
+      "x-ms-summary": "Last Modified By",
+      "description": "Last Modified By",
+      "type": "object",
+      "properties": {
+        "application": {
+          "x-ms-summary": "Application",
+          "description": "Application",
+          "type": "string"
+        },
+        "device": {
+          "x-ms-summary": "Device",
+          "description": "Device",
+          "type": "string"
+        },
+        "conversation": {
+          "x-ms-summary": "Conversation",
+          "description": "Conversation",
+          "type": "string"
+        },
+        "user": {
+          "x-ms-summary": "User",
+          "description": "User",
+          "type": "object",
+          "properties": {
+            "id": {
+              "x-ms-summary": "Id",
+              "description": "Id",
+              "type": "string"
+            },
+            "displayName": {
+              "x-ms-summary": "Display Name",
+              "description": "Display Name",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "MemberSettings": {
+      "description": "Member Settings Entity",
+      "type": "object",
+      "properties": {
+        "allowCreateUpdateChannels": {
+          "x-ms-summary": "Allow Create Update Channels",
+          "description": "Allow to create and update channels",
+          "type": "boolean"
+        },
+        "allowDeleteChannels": {
+          "x-ms-summary": "Allow Delete Channels",
+          "description": "Allow to delete channels",
+          "type": "boolean"
+        },
+        "allowAddRemoveApps": {
+          "x-ms-summary": "Allow Add Remove Apps",
+          "description": "Allow to add and remove apps",
+          "type": "boolean"
+        },
+        "allowCreateUpdateRemoveTabs": {
+          "x-ms-summary": "Allow Create Update Remove Tabs",
+          "description": "Allow to create, update and remove tabs",
+          "type": "boolean"
+        },
+        "allowCreateUpdateRemoveConnectors": {
+          "x-ms-summary": "Allow Create Update Remove Connectors",
+          "description": "Allow to create, update and remove connectors",
+          "type": "boolean"
+        }
+      }
+    },
+    "GuestSettings": {
+      "description": "Guest Settings Entity",
+      "type": "object",
+      "properties": {
+        "allowCreateUpdateChannels": {
+          "x-ms-summary": "Allow Create Update Channels",
+          "description": "Allow to create and update channels",
+          "type": "boolean"
+        },
+        "allowDeleteChannels": {
+          "x-ms-summary": "Allow Delete Channels",
+          "description": "Allow to delete channels",
+          "type": "boolean"
+        }
+      }
+    },
+    "MessagingSettings": {
+      "description": "Messaging Settings Entity",
+      "type": "object",
+      "properties": {
+        "allowUserEditMessages": {
+          "x-ms-summary": "Allow User Edit Messages",
+          "description": "Allow User Edit Messages",
+          "type": "boolean"
+        },
+        "allowUserDeleteMessages": {
+          "x-ms-summary": "Allow User Delete Messages",
+          "description": "Allow User Delete Messages",
+          "type": "boolean"
+        },
+        "allowOwnerDeleteMessages": {
+          "x-ms-summary": "Allow Owner Delete Messages",
+          "description": "Allow Owner Delete Messages",
+          "type": "boolean"
+        },
+        "allowTeamMentions": {
+          "x-ms-summary": "Allow Team Mentions",
+          "description": "Allow Team Mentions",
+          "type": "boolean"
+        },
+        "allowChannelMentions": {
+          "x-ms-summary": "Allow Channel Mentions",
+          "description": "Allow Channel Mentions",
+          "type": "boolean"
+        }
+      }
+    },
+    "FunSettings": {
+      "description": "Guest Settings Entity",
+      "type": "object",
+      "properties": {
+        "allowGiphy": {
+          "x-ms-summary": "Allow Giphy",
+          "description": "Allow Giphy",
+          "type": "boolean"
+        },
+        "giphyContentRating": {
+          "x-ms-summary": "Giphy Content Rating",
+          "description": "Giphy Content Rating",
+          "type": "string"
+        },
+        "allowStickersAndMemes": {
+          "x-ms-summary": "Allow Stickers And Memes",
+          "description": "Allow Stickers And Memes",
+          "type": "boolean"
+        },
+        "allowCustomMemes": {
+          "x-ms-summary": "Allow Custom Memes",
+          "description": "Allow Custom Memes",
+          "type": "boolean"
+        }
+      }
+    },
+    "DiscoverySettings": {
+      "description": "Guest Settings Entity",
+      "type": "object",
+      "properties": {
+        "showInTeamsSearchAndSuggestions": {
+          "x-ms-summary": "Show In Teams Search And Suggestions",
+          "description": "Show In Teams Search And Suggestions",
+          "type": "boolean"
+        }
+      }
+    },
+    "SelectedMessageTriggerMetadata": {
+      "description": "Metadata of data coming from Microsoft Teams for a selected message",
+      "type": "object",
+      "properties": {
+        "TeamsFlowRunContext": {
+          "$ref": "#/definitions/Object"
+        },
+        "CardOutputs": {
+          "$ref": "#/definitions/Object"
+        }
+      },
+      "x-ms-visibility": "advanced"
+    },
+    "ComposeMessageTriggerMetadata": {
+      "description": "Metadata of data coming from Microsoft Teams for composing a message",
+      "type": "object",
+      "properties": {
+        "TeamsFlowRunContext": {
+          "$ref": "#/definitions/Object"
+        },
+        "CardOutputs": {
+          "$ref": "#/definitions/Object"
+        }
+      },
+      "x-ms-visibility": "advanced"
+    },
+    "CardResponseTriggerMetadata": {
+      "description": "Metadata of data coming from Microsoft Teams for a response to an adaptive card",
+      "type": "object",
+      "properties": {
+        "TeamsFlowRunContext": {
+          "$ref": "#/definitions/Object"
+        },
+        "CardOutputs": {
+          "$ref": "#/definitions/Object"
+        }
+      },
+      "x-ms-visibility": "advanced"
+    },
+    "VirtualAgentBots": {
+      "type": "object",
+      "properties": {
+        "@odata.context": {
+          "type": "string",
+          "x-ms-visibility": "internal"
+        },
+        "value": {
+          "description": "List of the virtual agent bots",
+          "type": "array",
+          "x-ms-summary": "Virtual Agent bot list",
+          "items": {
+            "type": "object",
+            "x-ms-summary": "Virtual Agent Bot",
+            "description": "Properties associated with a single virtual agent bot.",
+            "properties": {
+              "name": {
+                "description": "bot name",
+                "type": "string",
+                "x-ms-summary": "Name",
+                "x-ms-visibility": "important"
+              },
+              "botid": {
+                "description": "Unique ID of the bot.",
+                "type": "string",
+                "x-ms-summary": "Id",
+                "x-ms-visibility": "advanced"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "groupId__in_path": {
+      "name": "groupId",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetAllTeams",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value"
+      },
+      "x-ms-summary": "Team",
+      "x-ms-test-value": "173837de-575f-4e0e-935c-0ac64ea29e9d",
+      "description": "Add team ID",
+      "type": "string"
+    },
+    "groupId__in_query": {
+      "name": "groupId",
+      "in": "query",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetAllTeams",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value"
+      },
+      "x-ms-summary": "Team",
+      "x-ms-test-value": "173837de-575f-4e0e-935c-0ac64ea29e9d",
+      "description": "Add team ID",
+      "type": "string"
+    },
+    "recipientType__in_path": {
+      "name": "recipientType",
+      "in": "path",
+      "description": "Type of the recipient of the action",
+      "required": true,
+      "x-ms-summary": "Type of the recipient of the action",
+      "type": "string"
+    },
+    "channelId__in_path": {
+      "name": "channelId",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetChannelsForGroup",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "groupId": {
+            "parameter": "groupId"
+          }
+        }
+      },
+      "x-ms-summary": "Channel",
+      "x-ms-test-value": "19:976f050cb80c4d57a2a5e28b8942e6ec@thread.skype",
+      "description": "Add channel ID",
+      "type": "string"
+    },
+    "channelId__in_query": {
+      "name": "channelId",
+      "in": "query",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetChannelsForGroup",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "groupId": {
+            "parameter": "groupId"
+          }
+        }
+      },
+      "x-ms-summary": "Channel",
+      "x-ms-test-value": "19:976f050cb80c4d57a2a5e28b8942e6ec@thread.skype",
+      "description": "Add channel ID",
+      "type": "string"
+    },
+    "messageId__in_path": {
+      "name": "messageId",
+      "in": "path",
+      "required": true,
+      "x-ms-summary": "Message",
+      "x-ms-test-value": "1552086306463",
+      "description": "Add message ID",
+      "type": "string"
+    },
+    "teamId__in_path": {
+      "name": "teamId",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetAllTeams",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value"
+      },
+      "x-ms-summary": "Team",
+      "description": "Add team ID",
+      "type": "string"
+    },
+    "memberId__in_path": {
+      "name": "memberId",
+      "in": "path",
+      "required": true,
+      "x-ms-summary": "Member",
+      "description": "Add member AAD ID",
+      "type": "string"
+    },
+    "tagId__in_path": {
+      "name": "tagId",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetTags",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "groupId": {
+            "parameter": "groupId"
+          }
+        }
+      },
+      "x-ms-summary": "Tag ID",
+      "description": "Add tag ID",
+      "type": "string"
+    },
+    "posterWithPowerApps__in_path": {
+      "name": "poster",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Select an option",
+      "x-ms-summary": "Post as",
+      "default": "Flow bot",
+      "x-ms-enum-values": [
+        {
+          "displayName": "User",
+          "value": "User"
+        },
+        {
+          "displayName": "Flow bot",
+          "value": "Flow bot"
+        },
+        {
+          "displayName": "Power Virtual Agents (Preview)",
+          "value": "Power Virtual Agents"
+        },
+        {
+          "displayName": "Power Apps (Preview)",
+          "value": "Power Apps"
+        }
+      ],
+      "enum": [
+        "Power Apps",
+        "Power Virtual Agents",
+        "Flow bot",
+        "User"
+      ]
+    },
+    "poster__in_path": {
+      "name": "poster",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Select an option",
+      "x-ms-summary": "Post as",
+      "default": "Flow bot",
+      "x-ms-enum-values": [
+        {
+          "displayName": "User",
+          "value": "User"
+        },
+        {
+          "displayName": "Flow bot",
+          "value": "Flow bot"
+        },
+        {
+          "displayName": "Power Virtual Agents (Preview)",
+          "value": "Power Virtual Agents"
+        }
+      ],
+      "enum": [
+        "Power Virtual Agents",
+        "Flow bot",
+        "User"
+      ]
+    },
+    "posterWithoutPVA__in_path": {
+      "name": "poster",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Select an option",
+      "x-ms-summary": "Post as",
+      "default": "Flow bot",
+      "enum": [
+        "Flow bot",
+        "User"
+      ]
+    },
+    "posterWithoutUser__in_path": {
+      "name": "poster",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Select an option",
+      "x-ms-summary": "Post as",
+      "default": "Flow bot",
+      "x-ms-enum-values": [
+        {
+          "displayName": "Power Virtual Agents (Preview)",
+          "value": "Power Virtual Agents"
+        },
+        {
+          "displayName": "Flow bot",
+          "value": "Flow bot"
+        }
+      ],
+      "enum": [
+        "Power Virtual Agents",
+        "Flow bot"
+      ]
+    },
+    "posterJustFlowbot__in_path": {
+      "name": "poster",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Select an option",
+      "x-ms-summary": "Post as",
+      "default": "Flow bot",
+      "x-ms-enum-values": [
+        {
+          "displayName": "Flow bot",
+          "value": "Flow bot"
+        }
+      ],
+      "enum": [
+        "Flow bot"
+      ]
+    },
+    "location__in_path": {
+      "name": "location",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetMessageLocations",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "messageType": "ParentMessage",
+          "poster": {
+            "parameter": "poster"
+          }
+        }
+      },
+      "x-ms-summary": "Post in",
+      "description": "Select an option",
+      "type": "string"
+    },
+    "reply__in_path": {
+      "name": "location",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetMessageLocations",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "messageType": "Reply",
+          "poster": {
+            "parameter": "poster"
+          }
+        }
+      },
+      "x-ms-summary": "Post in",
+      "description": "Select an option",
+      "type": "string"
+    },
+    "update_location__in_path": {
+      "name": "location",
+      "in": "path",
+      "required": true,
+      "x-ms-dynamic-values": {
+        "operationId": "GetMessageLocations",
+        "value-path": "id",
+        "value-title": "displayName",
+        "value-collection": "value",
+        "parameters": {
+          "messageType": "Update",
+          "poster": {
+            "parameter": "poster"
+          }
+        }
+      },
+      "x-ms-summary": "Post in",
+      "description": "Select an option",
+      "type": "string"
+    },
+    "chatType__in_path": {
+      "name": "chatType",
+      "in": "path",
+      "description": "Filter by type",
+      "required": true,
+      "x-ms-summary": "Chat Types",
+      "type": "string",
+      "default": "all",
+      "enum": [
+        "all",
+        "group",
+        "meeting",
+        "oneOnOne"
+      ],
+      "x-ms-enum-values": [
+        {
+          "displayName": "All chat types",
+          "value": "all"
+        },
+        {
+          "displayName": "Group",
+          "value": "group"
+        },
+        {
+          "displayName": "Meeting",
+          "value": "meeting"
+        },
+        {
+          "displayName": "One on one",
+          "value": "oneOnOne"
+        }
+      ]
+    },
+    "topic__in_path": {
+      "name": "topic",
+      "in": "path",
+      "description": "Filter by whether or not the topic name is defined",
+      "required": true,
+      "x-ms-summary": "Topic",
+      "type": "string",
+      "default": "all",
+      "enum": [
+        "all",
+        "isDefined",
+        "notDefined"
+      ],
+      "x-ms-enum-values": [
+        {
+          "displayName": "All Chats",
+          "value": "all"
+        },
+        {
+          "displayName": "Is Defined",
+          "value": "isDefined"
+        },
+        {
+          "displayName": "Is Not Defined",
+          "value": "notDefined"
+        }
+      ]
+    },
+    "messageType__in_path": {
+      "name": "messageType",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Message Type",
+      "x-ms-summary": "Message Type"
+    },
+    "actionType__in_path": {
+      "name": "actionType",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Unified Action",
+      "x-ms-summary": "Unified Action"
+    },
+    "triggerType__in_path": {
+      "name": "triggerType",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Trigger type",
+      "x-ms-summary": "Trigger type"
+    },
+    "notificationType__in_path": {
+      "name": "notificationType",
+      "in": "path",
+      "description": "Choose notification type",
+      "required": true,
+      "x-ms-summary": "Notification type",
+      "type": "string",
+      "enum": [
+        "groupchat",
+        "team"
+      ],
+      "x-ms-enum-values": [
+        {
+          "displayName": "Team",
+          "value": "team"
+        },
+        {
+          "displayName": "Group chat",
+          "value": "groupchat"
+        }
+      ]
+    },
+    "threadType__in_path": {
+      "name": "threadType",
+      "in": "path",
+      "description": "Choose message type",
+      "required": true,
+      "x-ms-summary": "Message type",
+      "type": "string",
+      "enum": [
+        "groupchat",
+        "channel"
+      ],
+      "x-ms-enum-values": [
+        {
+          "displayName": "Channel",
+          "value": "channel"
+        },
+        {
+          "displayName": "Group chat",
+          "value": "groupchat"
+        }
+      ]
+    },
+    "listMembersThreadType__in_path": {
+      "name": "threadType",
+      "in": "path",
+      "description": "Choose message type",
+      "required": true,
+      "x-ms-summary": "Thread type",
+      "type": "string",
+      "enum": [
+        "groupchat"
+      ],
+      "x-ms-enum-values": [
+        {
+          "displayName": "Group chat",
+          "value": "groupchat"
+        }
+      ]
+    }
+  },
+  "x-ms-capabilities": {
+    "testConnection": {
+      "operationId": "GetTeamwork"
+    }
+  },
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://products.office.com/microsoft-teams/group-chat-software"
+    }
+  ]
+}


### PR DESCRIPTION
- OpenApiResponses can be 2xx and we were only looking at 200 Response. We'll now look at all 2xx responses and take lowest
- Update GetParameterSuggestionsAsync to use ConnectorParameter instead of a string
- add GetConnectorTypeAsync (for ConnectorParameter or ConnectorType) to allow discovery chaining of types
- renamed GetConnectorReturnSchemaAsync to GetConnectorReturnTypeAsync
- 