### PR TITLE
Fix connection deprecated function logic 

### DIFF
--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -582,7 +582,12 @@ namespace Microsoft.PowerFx.Tests
                 SessionId = "ce55fe97-6e74-4f56-b8cf-529e275b253f"
             };
 
-            config.AddActionConnector("Office365Outlook", apiDoc);
+            IReadOnlyList<ConnectorFunction> functions = config.AddActionConnector("Office365Outlook", apiDoc);
+            Assert.True(functions.First(f => f.Name == "GetEmailsV2").IsDeprecated);
+            Assert.False(functions.First(f => f.Name == "SendEmailV2").IsDeprecated);
+            Assert.Equal("OpenApiOperation is deprecated", functions.First(f => f.Name == "GetEmailsV2").NotSupportedReason);
+            Assert.Equal(string.Empty, functions.First(f => f.Name == "SendEmailV2").NotSupportedReason);
+
             RecalcEngine engine = new RecalcEngine(config);
             RuntimeConfig runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Office365Outlook", client));
 


### PR DESCRIPTION
When 2 functions share the same Path, we need to separate their deprecation status
One could be deprecated and not the other