### PR TITLE
NamedFormula edit experience improvement

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Errors/IRuleError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/IRuleError.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license.
 
 using Microsoft.AppMagic.Transport;
+using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Errors
 {
     [TransportType(TransportKind.ByValue)]
     internal interface IRuleError : IDocumentError
     {
+        IRuleError Clone(Span span);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Errors/TexlError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Errors/TexlError.cs
@@ -51,6 +51,11 @@ namespace Microsoft.PowerFx.Core.Errors
             _nameMapIDs = new List<string>();
         }
 
+        IRuleError IRuleError.Clone(Span span)
+        {
+            return new TexlError(this.Tok.Clone(span), this.Severity, this.ErrorResourceKey, this.MessageArgs);
+        }
+
         public void MarkSinkTypeError(DName name)
         {
             Contracts.AssertValid(name);

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/NamedFormula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/NamedFormula.cs
@@ -12,13 +12,16 @@ namespace Microsoft.PowerFx.Core.Parser
 
         internal Formula Formula { get; }
 
-        public NamedFormula(IdentToken ident, Formula formula)
+        internal int StartingIndex { get; }
+
+        public NamedFormula(IdentToken ident, Formula formula, int startingIndex)
         {
             Contracts.AssertValue(ident);
             Contracts.AssertValue(formula);
             
             Ident = ident;
             Formula = formula;
+            StartingIndex = startingIndex;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -290,24 +290,6 @@ namespace Microsoft.PowerFx.Core.Parser
             }
         }
 
-        private Token GetNewOrExistingToken(Token existingToken)
-        {
-            var isNamedFormulaMode = _flagsMode.Peek().HasFlag(Flags.NamedFormulas);
-            if (existingToken == null || !isNamedFormulaMode || existingToken.Span.BaseIndex != null)
-            {
-                return existingToken;
-            }
-
-            Token tok = existingToken;
-            Contracts.Assert(tok.Span.Min >= _startingIndex);
-            Contracts.Assert(tok.Span.Lim >= _startingIndex);
-
-            var min = tok.Span.Min - _startingIndex;
-            var lim = tok.Span.Lim - _startingIndex;
-
-            return tok.Clone(new Span(min, lim, _startingIndex));
-        }
-
         private ParseUserDefinitionResult ParseUDFsAndNamedFormulas(string script, ParserOptions parserOptions)
         {
             var udfs = new List<UDF>();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -890,5 +890,30 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(namedFormulaCount, userDefinitionResult.NamedFormulas.Count());
             Assert.Equal(expectErrors, userDefinitionResult.Errors?.Any() ?? false);
         }
+
+        [Theory]
+
+        [InlineData("a = 10; b = a + c ; c = 20;", 3, false, new int[] { 0, 8, 20 })]
+        [InlineData("a = 10; b = in(valid ; c = 20;", 3, true, new int[] { 0, 8, 23 })]
+        public void TestNamedFormulaStarIndex(string script, int namedFormulaCount, bool expectErrors, int[] expectedStartingIndex)
+        {
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = false
+            };
+
+            var userDefinitions = UserDefinitions.ProcessUserDefinitions(script, parserOptions, out var userDefinitionResult);
+
+            var nfs = userDefinitionResult.NamedFormulas;
+            Assert.Equal(namedFormulaCount, nfs.Count());
+            Assert.Equal(expectErrors, userDefinitionResult.Errors?.Any() ?? false);
+
+            int i = 0;
+            foreach (var nf in nfs)
+            {
+                Assert.Equal(expectedStartingIndex[i], nf.StartingIndex);
+                i++;
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds a base index in NF formula parse results for NF identifier. This is needed so that when Formulas property rule changes, we don't need to rebind each and every named formula every time. We can only rebind the rules which are changed. Currently we need to do that as span for each named formula rule is not relative to named formula identifier token. With this base index information, we can then just use new base Index and previous base index to calculate the offset for each NF edit, which we can then use for the error reporting. 