### PR TITLE
New GetConnectorSuggestionsAsync API with ConnectorType parameter

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -292,7 +292,7 @@ namespace Microsoft.PowerFx.Connectors
             cancellationToken.ThrowIfCancellationRequested();
 
             List<ConnectorParameterWithSuggestions> parametersWithSuggestions = new List<ConnectorParameterWithSuggestions>();
-            ConnectorEnhancedSuggestions suggestions = GetConnectorSuggestionsAsync(knownParameters, connectorParameter, runtimeContext, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            ConnectorEnhancedSuggestions suggestions = GetConnectorSuggestionsAsync(knownParameters, connectorParameter.ConnectorType, runtimeContext, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
 
             foreach (ConnectorParameter parameter in RequiredParameters.Union(OptionalParameters))
             {
@@ -309,6 +309,56 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         /// <summary>
+        /// Get connector function parameter suggestions.
+        /// </summary>
+        /// <param name="knownParameters">Known parameters.</param>
+        /// <param name="connectorType">Connector type for which we need a set of suggestions.</param>
+        /// <param name="runtimeContext">Runtime connector context.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>ConnectorParameters class with suggestions.</returns>
+        public async Task<ConnectorEnhancedSuggestions> GetConnectorSuggestionsAsync(NamedValue[] knownParameters, ConnectorType connectorType, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)
+        {            
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (connectorType != null)
+            {
+                if (connectorType.DynamicList != null)
+                {
+                    return await GetConnectorSuggestionsFromDynamicListAsync(knownParameters, runtimeContext, connectorType.DynamicList, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (connectorType.DynamicValues != null && string.IsNullOrEmpty(connectorType.DynamicValues.Capability))
+                {
+                    return await GetConnectorSuggestionsFromDynamicValueAsync(knownParameters, runtimeContext, connectorType.DynamicValues, cancellationToken).ConfigureAwait(false);
+                }
+
+                ConnectorType outputConnectorType = null;
+                SuggestionMethod suggestionMethod = SuggestionMethod.None;
+
+                if (connectorType.DynamicProperty != null && !string.IsNullOrEmpty(connectorType.DynamicProperty.ItemValuePath))
+                {
+                    outputConnectorType = await GetConnectorSuggestionsFromDynamicPropertyAsync(knownParameters, runtimeContext, connectorType.DynamicProperty, cancellationToken).ConfigureAwait(false);
+                    suggestionMethod = SuggestionMethod.DynamicProperty;
+                }
+                else
+                if (connectorType.DynamicSchema != null && !string.IsNullOrEmpty(connectorType.DynamicSchema.ValuePath))
+                {
+                    outputConnectorType = await GetConnectorSuggestionsFromDynamicSchemaAsync(knownParameters, runtimeContext, connectorType.DynamicSchema, cancellationToken).ConfigureAwait(false);
+                    suggestionMethod = SuggestionMethod.DynamicSchema;
+                }
+
+                if (outputConnectorType != null && outputConnectorType.FormulaType is RecordType rt)
+                {
+                    return new ConnectorEnhancedSuggestions(suggestionMethod, rt.FieldNames.Select(fn => new ConnectorSuggestion(FormulaValue.NewBlank(rt.GetFieldType(fn)), fn)).ToList(), outputConnectorType);
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Dynamic intellisense (dynamic property/schema) on a given parameter.
         /// </summary>
         /// <param name="knownParameters">Known parameters.</param>
@@ -316,7 +366,7 @@ namespace Microsoft.PowerFx.Connectors
         /// <param name="context">Connector context.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Formula Type determined by dynamic Intellisense.</returns>
-        public async Task<ConnectorType> GetConnectorTypeAsync(NamedValue[] knownParameters, ConnectorParameter connectorParameter, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
+        public async Task<ConnectorType> GetConnectorParameterTypeAsync(NamedValue[] knownParameters, ConnectorParameter connectorParameter, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return await GetConnectorTypeAsync(knownParameters, connectorParameter.ConnectorType ?? ReturnParameterType, context, cancellationToken).ConfigureAwait(false);           
@@ -453,51 +503,7 @@ namespace Microsoft.PowerFx.Connectors
             result = await PostProcessResultAsync(result, context, invoker, cancellationToken).ConfigureAwait(false);
 
             return result;
-        }        
-
-        internal async Task<ConnectorEnhancedSuggestions> GetConnectorSuggestionsAsync(NamedValue[] knownParameters, ConnectorParameter parameter, BaseRuntimeConnectorContext context, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();            
-
-            if (parameter != null)
-            {
-                ConnectorExtensions connectorExtensions = parameter.ConnectorExtensions;
-
-                if (connectorExtensions.ConnectorDynamicList != null)
-                {
-                    return await GetConnectorSuggestionsFromDynamicListAsync(knownParameters, context, connectorExtensions.ConnectorDynamicList, cancellationToken).ConfigureAwait(false);
-                }
-
-                if (connectorExtensions.ConnectorDynamicValue != null && string.IsNullOrEmpty(connectorExtensions.ConnectorDynamicValue.Capability))
-                {
-                    return await GetConnectorSuggestionsFromDynamicValueAsync(knownParameters, context, connectorExtensions.ConnectorDynamicValue, cancellationToken).ConfigureAwait(false);
-                }
-
-                ConnectorType connectorType = null;
-                SuggestionMethod suggestionMethod = SuggestionMethod.None;
-
-                if (connectorExtensions.ConnectorDynamicProperty != null && !string.IsNullOrEmpty(connectorExtensions.ConnectorDynamicProperty.ItemValuePath))
-                {
-                    connectorType = await GetConnectorSuggestionsFromDynamicPropertyAsync(knownParameters, context, connectorExtensions.ConnectorDynamicProperty, cancellationToken).ConfigureAwait(false);
-                    suggestionMethod = SuggestionMethod.DynamicProperty;
-                }
-                else
-                if (connectorExtensions.ConnectorDynamicSchema != null && !string.IsNullOrEmpty(connectorExtensions.ConnectorDynamicSchema.ValuePath))
-                {
-                    connectorType = await GetConnectorSuggestionsFromDynamicSchemaAsync(knownParameters, context, connectorExtensions.ConnectorDynamicSchema, cancellationToken).ConfigureAwait(false);
-                    suggestionMethod = SuggestionMethod.DynamicSchema;
-                }
-
-                if (connectorType != null && connectorType.FormulaType is RecordType rt)
-                {
-                    return new ConnectorEnhancedSuggestions(suggestionMethod, rt.FieldNames.Select(fn => new ConnectorSuggestion(FormulaValue.NewBlank(rt.GetFieldType(fn)), fn)).ToList(), connectorType);
-                }
-
-                return null;
-            }
-
-            return null;
-        }       
+        }
 
         private static JsonElement ExtractFromJson(StringValue sv, string location)
         {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Internal/ConnectorExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Internal/ConnectorExtensions.cs
@@ -7,20 +7,11 @@ namespace Microsoft.PowerFx.Connectors
 {
     internal class ConnectorExtensions
     {
-        internal ConnectorDynamicValue ConnectorDynamicValue;
-        internal ConnectorDynamicList ConnectorDynamicList;
-        internal ConnectorDynamicSchema ConnectorDynamicSchema;
-        internal ConnectorDynamicProperty ConnectorDynamicProperty;
         internal string Summary;
         internal bool ExplicitInput;
 
         internal ConnectorExtensions(IOpenApiExtensible extension, IOpenApiExtensible body, bool numberIsFloat)
         {
-            ConnectorDynamicValue = extension.GetDynamicValue(numberIsFloat);
-            ConnectorDynamicList = extension.GetDynamicList(numberIsFloat);
-            ConnectorDynamicSchema = extension.GetDynamicSchema(numberIsFloat);
-            ConnectorDynamicProperty = extension.GetDynamicProperty(numberIsFloat);
-
             Summary = (body ?? extension).GetSummary();
             ExplicitInput = (body ?? extension).GetExplicitInput();
         }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorEnhancedSuggestions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorEnhancedSuggestions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerFx.Connectors
     {
         public ConnectorType ConnectorType { get; }
 
-        internal ConnectorSuggestions ConnectorSuggestions { get; }
+        public ConnectorSuggestions ConnectorSuggestions { get; }
 
         internal ConnectorEnhancedSuggestions(SuggestionMethod suggestionMethod, IReadOnlyList<ConnectorSuggestion> suggestions, ConnectorType connectorType = null)
         {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSchema.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSchema.cs
@@ -25,33 +25,9 @@ namespace Microsoft.PowerFx.Connectors
        
         internal RecordType HiddenRecordType => ConnectorType.HiddenRecordType;
 
-        /// <summary>
-        /// "x-ms-dynamic-values".
-        /// </summary>
-        internal ConnectorDynamicValue DynamicValue => ConnectorExtensions.ConnectorDynamicValue;
+        public string Summary => ConnectorExtensions.Summary;
 
-        /// <summary>
-        /// "x-ms-dynamic-list".
-        /// </summary>
-        internal ConnectorDynamicList DynamicList => ConnectorExtensions.ConnectorDynamicList;
-
-        /// <summary>
-        /// "x-ms-dynamic-schema".
-        /// </summary>
-        internal ConnectorDynamicSchema DynamicSchema => ConnectorExtensions.ConnectorDynamicSchema;
-
-        /// <summary>
-        /// "x-ms-dynamic-properties".
-        /// </summary>
-        internal ConnectorDynamicProperty DynamicProperty => ConnectorExtensions.ConnectorDynamicProperty;
-
-        public string Summary => ConnectorExtensions.Summary;        
-
-        public bool SupportsDynamicValuesOrList => DynamicValue != null || DynamicList != null;
-
-        public bool SupportsDynamicSchemaOrProperty => DynamicSchema != null || DynamicProperty != null;
-
-        public bool SupportsDynamicIntellisense => SupportsDynamicValuesOrList || SupportsDynamicSchemaOrProperty;
+        public bool SupportsDynamicIntellisense => ConnectorType.SupportsDynamicIntellisense;
 
         internal ConnectorSchema(OpenApiParameter openApiParameter, IOpenApiExtensible bodyExtensions, bool useHiddenTypes, bool numberIsFloat)
         {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
@@ -59,13 +59,21 @@ namespace Microsoft.PowerFx.Connectors
 
         public Visibility Visibility { get; internal set; }
 
-        internal RecordType HiddenRecordType { get; }
+        internal RecordType HiddenRecordType { get; }       
 
-        public bool SupportsSuggestions => DynamicSchema != null || DynamicProperty != null;
+        public bool SupportsDynamicValuesOrList => DynamicValues != null || DynamicList != null;
+
+        public bool SupportsDynamicSchemaOrProperty => DynamicSchema != null || DynamicProperty != null;
+
+        public bool SupportsDynamicIntellisense => SupportsDynamicValuesOrList || SupportsDynamicSchemaOrProperty;
 
         internal ConnectorDynamicSchema DynamicSchema { get; private set; }
 
         internal ConnectorDynamicProperty DynamicProperty { get; private set; }
+
+        internal ConnectorDynamicValue DynamicValues { get; private set; }
+
+        internal ConnectorDynamicList DynamicList { get; private set; }
 
         internal ConnectorType(OpenApiSchema schema, OpenApiParameter openApiParameter, FormulaType formulaType, bool numberIsFloat)
         {
@@ -100,6 +108,8 @@ namespace Microsoft.PowerFx.Connectors
 
             DynamicSchema = openApiParameter.GetDynamicSchema(numberIsFloat);
             DynamicProperty = openApiParameter.GetDynamicProperty(numberIsFloat);
+            DynamicValues = openApiParameter.GetDynamicValue(numberIsFloat);
+            DynamicList = openApiParameter.GetDynamicList(numberIsFloat);
         }
 
         internal ConnectorType()

--- a/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             NamedValue[] namedValues = knownParameters.Select((kp, i) => new NamedValue(ConnectorFunction.RequiredParameters[i].Name, kp)).ToArray();
-            return (await ConnectorFunction.GetConnectorSuggestionsAsync(namedValues.ToArray(), ConnectorFunction.RequiredParameters[argPosition], runtimeContext, cancellationToken).ConfigureAwait(false))?.ConnectorSuggestions;
+            return (await ConnectorFunction.GetConnectorSuggestionsAsync(namedValues.ToArray(), ConnectorFunction.RequiredParameters[argPosition].ConnectorType, runtimeContext, cancellationToken).ConfigureAwait(false))?.ConnectorSuggestions;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/ConnectorSuggestions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/ConnectorSuggestions.cs
@@ -6,7 +6,7 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Intellisense
 {
-    internal class ConnectorSuggestions
+    public class ConnectorSuggestions
     {
         public IReadOnlyList<ConnectorSuggestion> Suggestions { get; }
                 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/DynamicTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/DynamicTests.cs
@@ -239,11 +239,14 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.Equal("![Database:![], Date:d, Index:w, Summary:s, SummaryEnum:w, TemperatureC:w, TemperatureF:w]", cParameters.ParametersWithSuggestions[3].FormulaType.ToStringWithDisplayNames());
             Assert.Equal(Visibility.Important, cParameters.ParametersWithSuggestions[3].ConnectorType.Fields[4].Visibility);
 
-            ConnectorType cType = await getWithDynamicValuesMultipleDynamic.GetConnectorTypeAsync(Array.Empty<NamedValue>(), getWithDynamicValuesMultipleDynamic.OptionalParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
+            ConnectorType cType = await getWithDynamicValuesMultipleDynamic.GetConnectorParameterTypeAsync(Array.Empty<NamedValue>(), getWithDynamicValuesMultipleDynamic.OptionalParameters[0], connectorContext, CancellationToken.None).ConfigureAwait(false);
             Assert.Equal("![Database:![], Date:d, Index:w, Summary:s, SummaryEnum:w, TemperatureC:w, TemperatureF:w]", cType.FormulaType.ToStringWithDisplayNames());
 
-            cType = await getWithDynamicValuesMultipleDynamic.GetConnectorTypeAsync(Array.Empty<NamedValue>(), cType.Fields[5], connectorContext, CancellationToken.None).ConfigureAwait(false);
-            Assert.Equal("![Name:s, PrimaryKey:s]", cType.FormulaType.ToStringWithDisplayNames());
+            ConnectorType innerType = await getWithDynamicValuesMultipleDynamic.GetConnectorTypeAsync(Array.Empty<NamedValue>(), cType.Fields.First(field => field.Name == "Database"), connectorContext, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal("![Index:w, Name:s, PrimaryKey:s]", innerType.FormulaType.ToStringWithDisplayNames());
+
+            ConnectorEnhancedSuggestions ces = await getWithDynamicValuesMultipleDynamic.GetConnectorSuggestionsAsync(Array.Empty<NamedValue>(), innerType.Fields.First(field => field.Name == "Index"), connectorContext, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal("110|120", string.Join("|", ces.ConnectorSuggestions.Suggestions.Select(cs => cs.DisplayName)));            
         }
 
         [SkippableFact]

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/OpenApiParserTests.cs
@@ -701,7 +701,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.NotNull(suggestions2.Suggestions);
             Assert.Single(suggestions2.Suggestions);
             
-            Assert.True(executeProcedureV2.ReturnParameterType.SupportsSuggestions);
+            Assert.True(executeProcedureV2.ReturnParameterType.SupportsDynamicIntellisense);
 
             testConnector.SetResponseFromFile(@"Responses\SQL Server Intellisense Response2 1.json");
             ConnectorType returnType = await executeProcedureV2.GetConnectorReturnTypeAsync(

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -157,7 +157,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 // Most evaluators should never need these. 
                 "Microsoft.PowerFx.Intellisense.CodeFixHandler",
                 "Microsoft.PowerFx.Intellisense.CodeFixSuggestion",
-                "Microsoft.PowerFx.Intellisense.ConnectorSuggestion",                
+                "Microsoft.PowerFx.Intellisense.ConnectorSuggestion",
+                "Microsoft.PowerFx.Intellisense.ConnectorSuggestions",
                 "Microsoft.PowerFx.Intellisense.IIntellisenseResult",
                 "Microsoft.PowerFx.Intellisense.IIntellisenseSuggestion",
                 "Microsoft.PowerFx.Intellisense.IntellisenseOperations",


### PR DESCRIPTION
New GetConnectorSuggestionsAsync API with ConnectorType parameter
Renamed GetConnectorTypeAsync w/ ConnectorParameter to GetConnectorParameterTypeAsync
Removed internal GetConnectorSuggestionsAsync with ConnectorParameter (using ConnectorType now)
Cleaned ConnectorExtensions