### PR TITLE
Fixes sorting issue.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LocalPackageVersion>0.3.0-local</LocalPackageVersion>
+    <LocalPackageVersion>1.3.0-local</LocalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/buildAndRefresh.bat
+++ b/src/buildAndRefresh.bat
@@ -9,4 +9,4 @@ call buildLocalPackages.cmd
 @echo  ^<add key="Local" value="%~dp0outputpackages" /^>
 @echo .  
 @echo 2) Set your current PowerFx version to 
-@echo  0.3.0-local
+@echo  1.3.0-local

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -330,8 +330,8 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
                     Kind = GetCompletionItemKind(item.Kind),
 
                     // The order of the results should be preserved.  To do that, we embed the index
-                    // into the sort text, which clients may sort lexigraphically.
-                    SortText = index.ToString(CultureInfo.InvariantCulture),
+                    // into the sort text, which clients may sort lexicographically.
+                    SortText = index.ToString("D3", CultureInfo.InvariantCulture),
 
                     // If the current position is in front of a single quote and the completion result starts with a single quote,
                     // we don't want to make it harder on the end user by inserting an extra single quote.

--- a/src/refreshLocalNugetCache.ps1
+++ b/src/refreshLocalNugetCache.ps1
@@ -4,7 +4,7 @@ $localCache = $Env:USERPROFILE + "\.nuget\packages"
 Write-Host "Deleting Microsoft.PowerFx.*\0.3.0-local from nuget cache. This will cause the newly built packages to be downloaded."
 
 Get-ChildItem $localCache Microsoft.PowerFx.* | ForEach-Object { 
-    $path = ($_.FullName + "\0.3.0-local")
+    $path = ($_.FullName + "\1.3.0-local")
 
     if (Test-Path $path) {
       Remove-Item $path -Recurse 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -532,8 +532,8 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Assert.Equal(payload.id, response.Id);
             var foundItems = response.Result.Items.Where(item => item.Label == "AliceBlue");
             Assert.True(Enumerable.Count(foundItems) == 1, "AliceBlue should be found from suggestion result");
-            Assert.True(foundItems.First().InsertText == "AliceBlue");
-            Assert.True(foundItems.First().SortText == "0");
+            Assert.Equal("AliceBlue", foundItems.First().InsertText);
+            Assert.Equal("000", foundItems.First().SortText);
 
             _sendToClientData.Clear();
             payload = GetCompletionPayload(params2);
@@ -545,8 +545,8 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             foundItems = response.Result.Items.Where(item => item.Label == "AliceBlue");
             Assert.Equal(CompletionItemKind.Variable, foundItems.First().Kind);
             Assert.True(Enumerable.Count(foundItems) == 1, "AliceBlue should be found from suggestion result");
-            Assert.True(foundItems.First().InsertText == "AliceBlue");
-            Assert.True(foundItems.First().SortText == "0");
+            Assert.Equal("AliceBlue", foundItems.First().InsertText);
+            Assert.Equal("000", foundItems.First().SortText);
 
             _sendToClientData.Clear();
             payload = GetCompletionPayload(params3);
@@ -559,20 +559,20 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             foundItems = response.Result.Items.Where(item => item.Label == "a");
             Assert.True(Enumerable.Count(foundItems) == 1, "'a' should be found from suggestion result");
             Assert.Equal(CompletionItemKind.Variable, foundItems.First().Kind);
-            Assert.True(foundItems.First().InsertText == "a");
-            Assert.True(foundItems.First().SortText == "0");
+            Assert.Equal("a", foundItems.First().InsertText);
+            Assert.Equal("000", foundItems.First().SortText);
 
             foundItems = response.Result.Items.Where(item => item.Label == "b");
             Assert.True(Enumerable.Count(foundItems) == 1, "'b' should be found from suggestion result");
             Assert.Equal(CompletionItemKind.Variable, foundItems.First().Kind);
-            Assert.True(foundItems.First().InsertText == "b");
-            Assert.True(foundItems.First().SortText == "1");
+            Assert.Equal("b", foundItems.First().InsertText);
+            Assert.Equal("001", foundItems.First().SortText);
 
             foundItems = response.Result.Items.Where(item => item.Label == "c");
             Assert.True(Enumerable.Count(foundItems) == 1, "'c' should be found from suggestion result");
             Assert.Equal(CompletionItemKind.Variable, foundItems.First().Kind);
-            Assert.True(foundItems.First().InsertText == "c");
-            Assert.True(foundItems.First().SortText == "2");
+            Assert.Equal("c", foundItems.First().InsertText);
+            Assert.Equal("002", foundItems.First().SortText);
 
             // missing 'expression' in documentUri
             _sendToClientData.Clear();
@@ -619,8 +619,8 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
 
             // Test that the Identifier delimiter is ignored in case of insertText,
             // when preceding character is also the same identifier delimiter
-            Assert.True(foundItems.First().InsertText == "Account'");
-            Assert.True(foundItems.First().SortText == "0");
+            Assert.Equal("Account'", foundItems.First().InsertText);
+            Assert.Equal("000", foundItems.First().SortText);
         }
 
         private static (string payload, string id) GetCompletionPayload(CompletionParams completionParams)


### PR DESCRIPTION
-sortText does lexicographical sort and hence we need to prepend string with 0s

otherwise,
e.g. if you had more than 10 suggestions... it would have sorted to
0
1
10
11
2
3
4
5
6
7
8
9