### PR TITLE
Updates to REPL StandardFormatter to integrate Dataverse tables

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Repl.Services


### PR DESCRIPTION
Merges the Dataverse primary name and primary key fields into the standard table formatter, making it consistent with non-Dataverse table and record output.

Features include:
- Limits table and records to primary name and key by default.
- Shows "..." column on the right to indicate that there are more columns.
- Limits table output to 10 records by default.
- Shows "(showing first 10 records)" below the table if it is longer than 10 records.
- Shows "..." in record values after the primary name and key.

```
>> Contacts

  contactid                                      fullname                     ...
 ============================================== ============================ =====
  GUID("e3fda297-f859-ee11-be6f-002248046ef8")   Yvonne McKay (sample)
  GUID("e5fda297-f859-ee11-be6f-002248046ef8")   Susanna Stubberod (sample)
  GUID("e7fda297-f859-ee11-be6f-002248046ef8")   Nancy Anderson (sample)
  GUID("e9fda297-f859-ee11-be6f-002248046ef8")   Maria Campbell (sample)
  GUID("ebfda297-f859-ee11-be6f-002248046ef8")   Sidney Higa (sample)
  GUID("edfda297-f859-ee11-be6f-002248046ef8")   Scott Konersmann (sample)
  GUID("effda297-f859-ee11-be6f-002248046ef8")   Robert Lyon (sample)
  GUID("f1fda297-f859-ee11-be6f-002248046ef8")   Paul Cannon (sample)
  GUID("f3fda297-f859-ee11-be6f-002248046ef8")   Rene Valdes (sample)
  GUID("f5fda297-f859-ee11-be6f-002248046ef8")   Jim Glynn (sample)
  (showing first 10 records)

>> First(Contacts)
{contactid:GUID("e3fda297-f859-ee11-be6f-002248046ef8"), fullname:"Yvonne McKay (sample)", ...}

>> Table({a:1,b:2},{c:3,a:4},{a:5,c:9})

  a   b   c
 === === ===
  1   2
  4       3
  5       9

>> First(Table({a:1,b:2},{c:3,a:4},{a:5,c:9}))
{a:1, b:2, c:Blank()}
```