### PR TITLE
Use exact floating point numbers in Text/ExcelCompat tests

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat.txt
@@ -1398,32 +1398,32 @@ Blank()
 >> Text(0.7931251736111111, "HH:mm:SS.FFF")
 "19:02:06.FFF"
 
->> Text(0.043125, "H:M:S.00")
-"1:2:6.00"
+>> Text(0.04296875, "H:M:S.00")
+"1:1:52.50"
 
->> Text(0.043125, "h:m:s.00")
-"1:2:6.00"
+>> Text(0.04296875, "h:m:s.00")
+"1:1:52.50"
 
->> Text(0.043125, "HH:MM:SS.00")
-"01:02:06.00"
+>> Text(0.04296875, "HH:MM:SS.00")
+"01:01:52.50"
 
->> Text(0.043125, "hh:mm:ss.00")
-"01:02:06.00"
+>> Text(0.04296875, "hh:mm:ss.00")
+"01:01:52.50"
 
->> Text(0.0431251736111111, "h:m:s.000")
-"1:2:6.015"
+>> Text(0.0458984375, "h:m:s.000")
+"1:6:5.625"
 
->> Text(0.793125, "H:M:S.00")
-"19:2:6.00"
+>> Text(0.794921875, "H:M:S.00")
+"19:4:41.25"
 
->> Text(0.793125, "h:m:s.00")
-"19:2:6.00"
+>> Text(0.794921875, "h:m:s.00")
+"19:4:41.25"
 
->> Text(0.793125, "HH:MM:SS.00")
-"19:02:06.00"
+>> Text(0.794921875, "HH:MM:SS.00")
+"19:04:41.25"
 
->> Text(0.793125, "hh:mm:ss.00")
-"19:02:06.00"
+>> Text(0.794921875, "hh:mm:ss.00")
+"19:04:41.25"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, MM dd, yyyy hh:mm:ss")
 "Friday, 06 03, 1983 02:53:09"
@@ -1592,11 +1592,11 @@ Blank()
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h\a/p")
 "2a/p"
 
->> Text(70.82430555555555555555555,"h:mm:ss \am/pm")
-"19:47:00 a47/p47"
+>> Text(70.82421875,"h:mm:ss \am/pm")
+"19:46:52 a46/p46"
 
->> Text(70.82430555555555555555555,"h:mm:ss ""am/pm""")
-"19:47:00 am/pm"
+>> Text(70.82421875,"h:mm:ss ""am/pm""")
+"19:46:52 am/pm"
 
 // Errors pass through Text
 >> Text(1/0,"###")
@@ -1639,7 +1639,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(0, "###.0")
-#skip
+".0"
 
 >> Text(0, "##.")
 #skip
@@ -1651,7 +1651,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(0, "#.0")
-#skip
+".0"
 
 >> Text(12345, "#.")
 #skip
@@ -1675,7 +1675,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(12345, "#.0")
-#skip
+"12345.0"
 
 >> Text(12345.6789, "#.")
 #skip
@@ -1687,7 +1687,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(12345.6789, "#,###.0")
-#skip
+"12,345.7"
 
 >> Text(12345.6789, "#,###.")
 #skip
@@ -1699,7 +1699,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(12345.6789, "#.0")
-#skip
+"12345.7"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "#.")
 #skip
@@ -1711,7 +1711,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "##.0")
-#skip
+"30470.1"
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "##.")
 #skip
@@ -1723,7 +1723,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "#.0")
-#skip
+"30470.1"
 
 >> Text(12345, "###"".""#")
 #skip
@@ -1747,7 +1747,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(0, "#.0", "vi-VN")
-#skip
+",0"
 
 >> Text(12345, "#.", "vi-VN")
 #skip
@@ -1774,7 +1774,7 @@ Error({Kind:ErrorKind.Div0})
 #skip
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "#.0", "vi-VN")
-#skip
+"30470,1"
 
 >> Text(1234567.1234567, "mmm ddd yyye")
 "Feb Thu 5280e"


### PR DESCRIPTION
We run the .txt tests in different platforms, including those without decimal support. In one of those we were seeing different (off-by-one) result in some tests because the floating point representation of the numbers used in the test was not exact. Since the purpose of the tests was not to test floating point arithmetic, this change updates the tests to use values that have an exact representation in floating point to avoid this problem. 