### PR TITLE
Refactor type determination for output properties that infer type from primary input property

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControlProperty.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControlProperty.cs
@@ -21,6 +21,8 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         bool UseForDataQuerySelects { get; }
 
+        bool IsTypeInferredFromPrimaryInput { get; }
+
         PropertyRuleCategory PropertyCategory { get; }
 
         bool IsScopeVariable { get; }

--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControlTemplate.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalControlTemplate.cs
@@ -23,6 +23,10 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         IEnumerable<IExternalControlProperty> ExpandoProperties { get; }
 
+        bool HasPropsInferringTypeFromPrimaryInProperty { get; }
+
+        IEnumerable<IExternalControlProperty> PropsInferringTypeFromPrimaryInProperty { get; }
+
         string ThisItemInputInvariantName { get; }
 
         IExternalControlProperty PrimaryOutputProperty { get; }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3479,7 +3479,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // an expensive operation especially for form control which generally has tons of nested controls. So we calculate the type here.
                     // There might be cases where we are getting the schema from imported data that once belonged to a control and now,
                     // we don't have a pass-through input associated with it. Therefore, we need to get the opaqueType to avoid localizing the schema.
-                    // We apply the same logic for output properties inferring their type from primary input properties.
+                    // We apply the same logic for output properties that infer their type from primary input properties.
                     if (property.PassThroughInput == null && !property.IsTypeInferredFromPrimaryInput)
                     {
                         typeRhs = property.GetOpaqueType();

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3479,15 +3479,18 @@ namespace Microsoft.PowerFx.Core.Binding
                     // an expensive operation especially for form control which generally has tons of nested controls. So we calculate the type here.
                     // There might be cases where we are getting the schema from imported data that once belonged to a control and now,
                     // we don't have a pass-through input associated with it. Therefore, we need to get the opaqueType to avoid localizing the schema.
-                    if (property.PassThroughInput == null)
+                    // We apply the same logic for output properties inferring their type from primary input properties.
+                    if (property.PassThroughInput == null && !property.IsTypeInferredFromPrimaryInput)
                     {
                         typeRhs = property.GetOpaqueType();
                     }
                     else
                     {
                         var firstNodeLhs = node.Left.AsFirstName();
-                        if (template.HasExpandoProperties &&
-                            template.ExpandoProperties.Any(p => p.InvariantName == property.InvariantName) &&
+
+                        if (((template.HasPropsInferringTypeFromPrimaryInProperty &&
+                            template.PropsInferringTypeFromPrimaryInProperty.Any(p => p.InvariantName == property.InvariantName)) ||
+                            (template.HasExpandoProperties && template.ExpandoProperties.Any(p => p.InvariantName == property.InvariantName))) &&
                             controlInfo != null && (firstNodeLhs == null || _txb.GetInfo(firstNodeLhs).Kind != BindKind.ScopeVariable))
                         {
                             // If visiting an expando type property of control type variable, we cannot calculate the type here because


### PR DESCRIPTION
Currently during binding, output properties that infer their type from the primary input property have their type retrieved from the control's template. This PR changes the logic for this determination and handles it similar to pass through input property type calculation