### PR TITLE
Fixed RecordNode GetCompleteSpan logic

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/RecordNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/RecordNode.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
@@ -115,7 +116,21 @@ namespace Microsoft.PowerFx.Syntax
         /// <inheritdoc />
         public override Span GetCompleteSpan()
         {
-            return new Span(GetTextSpan());
+            int lim;
+            if (CurlyClose != null)
+            {
+                lim = CurlyClose.Span.Lim;
+            }
+            else if (Children.Count() == 0)
+            {
+                lim = Token.VerifyValue().Span.Lim;
+            }
+            else
+            {
+                lim = Children.VerifyValue().Last().VerifyValue().GetCompleteSpan().Lim;
+            }
+
+            return new Span(Token.VerifyValue().Span.Min, lim);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -694,6 +694,9 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("[{A]", 0, 4)]
         [InlineData("[{A:2}]", 0, 7)]
         [InlineData("With({A:2", 0, 9)]
+        [InlineData("Filter(CDS, {A:2", 0, 16)]
+        [InlineData("{", 0, 1)]
+        [InlineData("Filter(CDS, {", 0, 13)]
         public void TestParseRecordNodesSpan(string script, int min, int lim)
         {
             var result = TexlParser.ParseScript(script);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -117,6 +117,18 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
+        [InlineData("[{A]", 0, 4)]
+        [InlineData("[{A:2}]", 0, 7)]
+        [InlineData("With({A:2", 0, 9)]
+        public void TexlParseRecordNodes(string script, int min, int lim)
+        {
+            var result = TexlParser.ParseScript(script);
+            var span = result.Root.GetCompleteSpan();
+            Assert.Equal(min, span.Min);
+            Assert.Equal(lim, span.Lim);
+        }
+
+        [Theory]
         [InlineData("true")]
         [InlineData("false")]
         public void TexlParseBoolLiterals(string script)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -117,18 +117,6 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("[{A]", 0, 4)]
-        [InlineData("[{A:2}]", 0, 7)]
-        [InlineData("With({A:2", 0, 9)]
-        public void TexlParseRecordNodes(string script, int min, int lim)
-        {
-            var result = TexlParser.ParseScript(script);
-            var span = result.Root.GetCompleteSpan();
-            Assert.Equal(min, span.Min);
-            Assert.Equal(lim, span.Lim);
-        }
-
-        [Theory]
         [InlineData("true")]
         [InlineData("false")]
         public void TexlParseBoolLiterals(string script)
@@ -700,6 +688,18 @@ namespace Microsoft.PowerFx.Core.Tests
         public void TestParseRecordsNegative(string script)
         {
             TestParseErrors(script);
+        }
+
+        [Theory]
+        [InlineData("[{A]", 0, 4)]
+        [InlineData("[{A:2}]", 0, 7)]
+        [InlineData("With({A:2", 0, 9)]
+        public void TestParseRecordNodesSpan(string script, int min, int lim)
+        {
+            var result = TexlParser.ParseScript(script);
+            var span = result.Root.GetCompleteSpan();
+            Assert.Equal(min, span.Min);
+            Assert.Equal(lim, span.Lim);
         }
 
         [Theory]


### PR DESCRIPTION
RecordNode doesn't currently report the correct complete span when there are parse errors in expression. This change fixes that.