### PR TITLE
Send back empty control tokens

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -704,7 +704,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         /// <param name="queryParams">Collection of query params.</param>
         private void PublishControlTokenNotification(ControlTokens controlTokensObj, NameValueCollection queryParams)
         {
-            if (controlTokensObj == null || controlTokensObj.Size() == 0 || queryParams == null)
+            if (controlTokensObj == null || queryParams == null)
             {
                 return;
             }


### PR DESCRIPTION
We previously anticipated wrongly that we do not need to send back empty control tokens. We actually need to do send back empty control tokens and that's the only way we know we went from having atleast one control token in a formula to zero control tokens in the formula. This is a small change that we need to do 