### PR TITLE
Add newline for REPL output

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerFx
         public ParserOptions ParserOptions { get; set; } = new ParserOptions() { AllowsSideEffects = true };
 
         // example override, switching to [1], [2] etc.
-        public virtual string Prompt => ">> ";
+        public virtual string Prompt => "\n>> ";
 
         // prompt for multiline continuation
         public virtual string PromptContinuation => ".. ";

--- a/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
@@ -28,6 +28,10 @@ namespace Microsoft.PowerFx.Repl.Services
         // Set to Int32.MaxInt to remove restriction.
         public int MaxTableRows { get; set; } = 10;
 
+        // Append a newline to the end of a formatted table.
+        // If the REPL does not include a newline for the prompt, set this to true for proper spacing.
+        public bool FormatTableNewLine { get; set; } = false;
+
         private string FormatRecordCore(RecordValue record)
         {
             return FormatStandardRecord(record, TryGetSpecialFieldNames(record));
@@ -253,11 +257,14 @@ namespace Microsoft.PowerFx.Repl.Services
                         }
                     }
 
-                    resultString.Append("\n ");
-
                     if (maxRows2 < 0)
                     {
-                        resultString.Append($" (showing first {MaxTableRows} records)\n ");
+                        resultString.Append($"\n (showing first {MaxTableRows} records)");
+                    }
+
+                    if (FormatTableNewLine)
+                    {
+                        resultString.Append("\n ");
                     }
                 }
                 else

--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -113,7 +113,6 @@ namespace Microsoft.PowerFx
 #pragma warning disable CA1303 // Do not pass literals as localized parameters
             Console.WriteLine("Enter Excel formulas.  Use \"Help()\" for details, \"Option()\" for options.");
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
-            Console.WriteLine();
 
             REPL();
         }


### PR DESCRIPTION
The current REPL library doesn't provide whitespace between the expression and the output.  With the REPL here, we have the ability to color the prompt which helps.  to visually group the expression with the output.  But with the PAC CLI, we don't have this ability and it all bleeds together.  This is particularly true for Power Fx where an expression could cause recalc of other values which are rightly shown in the output.

In short, we want to change this:
![image](https://github.com/microsoft/Power-Fx/assets/15149773/ff33efe5-552d-492e-a3c1-7a9151242ed5)

Into the slightly longer, but much easier to parse and read:
![image](https://github.com/microsoft/Power-Fx/assets/15149773/f0979d2c-1e71-4aab-b57f-b15f0ffda597)

We could have fixed this just in the PAC CLI, however I prefer this whitespace here too and consistency is good.  This also ensures that table formatting works correctly with added newlines.  It also mirrors the tests cases.  