### PR TITLE
Update required range for exponential notation

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_DefaultNumber_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_DefaultNumber_Float.txt
@@ -43,9 +43,6 @@
 
 // There is a gap here where each platform may decide a different point to flip to scientific notation.
 
->> Text( 3e20 )
-"3E+20"
-
 >> Text( 3e21 )
 "3E+21"
 


### PR DESCRIPTION
We had defined a certain range where the default number-to-text conversion should go from decimal numbers to exponential notation, while leaving some to be implementation-dependent (until 1e10 should use decimal notation; starting from 1e20 should use exponential). In JavaScript, the exponential notation is used starting from 1e**21**, so we can relax the requirement and start requiring exponential notation from that as well.