### PR TITLE
[Suggestion] Add public TryGetValue method to recalcengine

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -320,6 +320,24 @@ namespace Microsoft.PowerFx
             return value;
         }
 
+        /// <summary>
+        /// Try to get the current value of a formula.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public bool TryGetValue(string name, out FormulaValue value)
+        {
+            value = null;
+            if (!TryGetByName(name, out var fi))
+            {
+                return false;
+            }
+
+            value = _symbolValues.Get(fi.Slot);
+            return true;
+        }
+
         internal RecalcFormulaInfo GetByName(string name)
         {
             if (TryGetByName(name, out var fi))

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/RecalcEngineTests.cs
@@ -1275,6 +1275,18 @@ namespace Microsoft.PowerFx.Tests
             }
         }
 
+        [Fact]
+        public void TryGetValueShouldNotThrowOnNonExistingValue()
+        {
+            var config = new PowerFxConfig();
+            var engine = new RecalcEngine(config);
+
+            var success = engine.TryGetValue("Invalid", out var shouldBeNull);
+
+            Assert.False(success);
+            Assert.Null(shouldBeNull);
+        }
+
         private class TestRandService : IRandomService
         {
             public double _value = 0.5;


### PR DESCRIPTION
Was just playing around with the recalc engine, and noticed that i got an internal null-reference error when trying to fetch a non-existing value using the existing `GetValue` method (see image)
<img width="828" alt="image" src="https://github.com/microsoft/Power-Fx/assets/25065744/d2e67559-7d09-4e4d-9034-353159e04e9b">

This pr just introduces a new method to the RecalcEngine that returns a boolean if it fails to find the value.
