### PR TITLE
Fixes AsType() for interpreter

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -72,6 +72,11 @@ namespace Microsoft.PowerFx
         internal bool CoalesceShortCircuit { get; set; }
 
         /// <summary>
+        /// This is required by AsType() in Legacy Analysis.
+        /// </summary>
+        internal bool IsLegacyAnalysis { get; set; }
+
+        /// <summary>
         /// This is specific for Cards team and it is a temporary feature.
         /// It will be soon deleted.
         /// </summary>
@@ -101,6 +106,7 @@ namespace Microsoft.PowerFx
             FirstLastNRequiresSecondArguments = true,
             PowerFxV1CompatibilityRules = true,
             CoalesceShortCircuit = true,
+            IsLegacyAnalysis = false,
         };
 
         internal Features()

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             var tableArgType = argTypes[1];
 
-            if (tableArgType.AssociatedDataSources.Any())
+            if (context.Features.IsLegacyAnalysis && tableArgType.AssociatedDataSources.Any())
             {
                 var tableDsInfo = tableArgType.AssociatedDataSources.Single();
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PowerFx.Functions
                     replaceBlankValues: DoNotReplaceBlank,
                     checkRuntimeTypes: ExactValueTypeOrBlank<FormulaValue>,
                     checkRuntimeValues: DeferRuntimeValueChecking,
-                    returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
                     targetFunction: AsType)
             },
             {


### PR DESCRIPTION
-Legacy analysis requires a hack that changes the return type to include ExpandInfo, this causes the runtime type mismatch in the interpreter. 
-Hence putting it behind a new flag