### PR TITLE
Do not remove trailing whitespaces around the string literals in interpolated strings when "Removing Whitespaces/Unformatting"

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -415,6 +415,12 @@ namespace Microsoft.PowerFx.Syntax
             return result;
         }
 
+        /// <summary>
+        /// Given the expression and list of tokens that make up the expression, generates the minified version of the given expression.
+        /// </summary>
+        /// <param name="text">Expression to minify.</param>
+        /// <param name="tokens">List of tokens that make up the given expression.</param>
+        /// <returns>Minified Expression.</returns>
         public string GetMinifiedScript(string text, List<Token> tokens)
         {
             Contracts.AssertValue(text);
@@ -422,20 +428,22 @@ namespace Microsoft.PowerFx.Syntax
 
             var stringBuilder = new StringBuilder();
 
-            foreach (var tk in tokens)
+            for (var i = 0; i < tokens.Count; i++)
             {
-                if (tk.Kind == TokKind.Comment)
+                var currentToken = tokens[i];
+                if (currentToken.Kind == TokKind.Comment)
                 {
-                    stringBuilder.Append(tk.Span.GetFragment(text));
+                    stringBuilder.Append(currentToken.Span.GetFragment(text));
                 }
-                else if (RequiresWhiteSpace(tk))
+                else if (RequiresWhiteSpace(currentToken))
                 {
-                    stringBuilder.Append(" " + tk.Span.GetFragment(text) + " ");
+                    stringBuilder.Append(" " + currentToken.Span.GetFragment(text) + " ");
                 }
                 else
                 {
-                    var tokenString = tk.Span.GetFragment(text);
-                    var newString = tokenString.Trim();
+                    var tokenString = currentToken.Span.GetFragment(text);
+                    var shouldNotTrim = IsStringAPartOfALargerInterpolatedString(i - 1 >= 0 ? tokens[i - 1] : null, currentToken, i + 1 < tokens.Count ? tokens[i + 1] : null);
+                    var newString = shouldNotTrim ? tokenString : tokenString.Trim();
 
                     stringBuilder.Append(newString);
                 }
@@ -443,6 +451,37 @@ namespace Microsoft.PowerFx.Syntax
 
             var result = stringBuilder.ToString();
             return result;
+        }
+
+        /// <summary>
+        /// Determines if current token is string literal inside a larger interpolated string.
+        /// </summary>
+        /// <param name="precedingToken">A token before the current token.</param>
+        /// <param name="currentToken">Current token that might be a string literal inside a larger interpolated string.</param>
+        /// <param name="followingToken">A token after the current token.</param>
+        /// <returns>True if current token represents a string literal inside a larger interpolated string or false otherwise.</returns>
+        private static bool IsStringAPartOfALargerInterpolatedString(Token precedingToken, Token currentToken, Token followingToken)
+        {
+            if (currentToken == null || currentToken.Kind != TokKind.StrLit)
+            {
+                return false;
+            }
+
+            // See if current token is preceded by start of the interpolated string or an end of an island
+            // Example $"<current token>, }<current token>
+            if (precedingToken != null && (precedingToken.Kind == TokKind.StrInterpStart || precedingToken.Kind == TokKind.IslandEnd))
+            {
+                return true;
+            }
+
+            // See if current token is followed by end of the interpolated string or the start of an island
+            // Example <current token>", <current token>{
+            if (followingToken != null && (followingToken.Kind == TokKind.StrInterpEnd || followingToken.Kind == TokKind.IslandStart))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public string RemoveWhiteSpace(string text)

--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -442,7 +442,7 @@ namespace Microsoft.PowerFx.Syntax
                 else
                 {
                     var tokenString = currentToken.Span.GetFragment(text);
-                    var shouldNotTrim = IsStringAPartOfALargerInterpolatedString(i - 1 >= 0 ? tokens[i - 1] : null, currentToken, i + 1 < tokens.Count ? tokens[i + 1] : null);
+                    var shouldNotTrim = IsStringPartOfALargerInterpolatedString(i - 1 >= 0 ? tokens[i - 1] : null, currentToken, i + 1 < tokens.Count ? tokens[i + 1] : null);
                     var newString = shouldNotTrim ? tokenString : tokenString.Trim();
 
                     stringBuilder.Append(newString);
@@ -460,7 +460,7 @@ namespace Microsoft.PowerFx.Syntax
         /// <param name="currentToken">Current token that might be a string literal inside a larger interpolated string.</param>
         /// <param name="followingToken">A token after the current token.</param>
         /// <returns>True if current token represents a string literal inside a larger interpolated string or false otherwise.</returns>
-        private static bool IsStringAPartOfALargerInterpolatedString(Token precedingToken, Token currentToken, Token followingToken)
+        private static bool IsStringPartOfALargerInterpolatedString(Token precedingToken, Token currentToken, Token followingToken)
         {
             if (currentToken == null || currentToken.Kind != TokKind.StrLit)
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FormatterTests.cs
@@ -133,6 +133,13 @@ namespace Microsoft.PowerFx.Tests
         [InlineData("RGBA(\n    255,\n    /*r   */255,\n    255,\n    1\n)//com   ", "RGBA(255,\n    /*r   */255,255,1)//com   ")]
         [InlineData("If(\n    Text(\n        Coalesce(\n            Sum(\n                Filter(\n                    Expenses,\n                    BudgetTitle = Gallery1.Selected.BudgetTitle && BudgetId=Gallery1.Selected.BudgetId\n                ),\n                Value(Expense)\n            ),\n            0\n        ),\n        \"$#,##\"\n    )=\"$\",\n    \"$0\",\n    Text(\n        Coalesce(\n            Sum(\n                Filter(\n                    Expenses,\n                    BudgetId = Gallery1.Selected.BudgetId\n                ),\n                Value(Expense)\n            ),\n            0\n        ),\n        \"$#,##\"\n    )\n)", "If(Text(Coalesce(Sum(Filter(Expenses,BudgetTitle=Gallery1.Selected.BudgetTitle&&BudgetId=Gallery1.Selected.BudgetId),Value(Expense)),0),\"$#,##\")=\"$\",\"$0\",Text(Coalesce(Sum(Filter(Expenses,BudgetId=Gallery1.Selected.BudgetId),Value(Expense)),0),\"$#,##\"))")]
         [InlineData("If(\n    Text(\n        Value(ThisItem.Expense)\n    )= \"0\",\n    \"$\",\n    Text(\n        Value(ThisItem.Expense),\n        \"$#,##\"\n    )\n)", "If(Text(Value(ThisItem.Expense))=\"0\",\"$\",Text(Value(ThisItem.Expense),\"$#,##\"))")]
+        [InlineData("$\"1 + 2 is\n\n{6} not 3\"", "$\"1 + 2 is\n\n{6} not 3\"")]
+        [InlineData("$\"\n\n1 + 2 is\n\n{6} not 3\n\n\t\"", "$\"\n\n1 + 2 is\n\n{6} not 3\n\n\t\"")]
+        [InlineData("$\" Foo\n\n\n\n\n Bar\"\"{{1}}\"", "$\" Foo\n\n\n\n\n Bar\"\"{{1}}\"")]
+        [InlineData("$\"{\"ddddd\"} Foo is bar\"", "$\"{\"ddddd\"} Foo is bar\"")]
+        [InlineData("$\"        Foo is bar           \n\"", "$\"        Foo is bar           \n\"")]
+        [InlineData("$\" String n{$\" Foo\"\"\n bar {4+4} rr\"} between {223} trail\"", "$\" String n{$\" Foo\"\"\n bar {4+4} rr\"} between {223} trail\"")]
+        [InlineData("\" Foo bar space\" ; 34", "\" Foo bar space\";34")]
         public void TestRemoveWhiteSpace(string script, string expected)
         {
             var result = TexlLexer.InvariantLexer.RemoveWhiteSpace(script);


### PR DESCRIPTION
This pr fixes #1645. The Remove Whitespace functionality used to blindly remove training whitespaces around the string literals inside interpolated strings. This is erroneous behavior as those whitespaces are part of string literals and should not be deleted. For example [dollar symbol]"1 + 2 = {1 + 2}" should stay as [dollar symbol]"1 + 2 = {1 + 2}" but instead becomes [dollar symbol]"1 + 2 ={1 + 2}"

Before:
![UnformattingBeforeFix](https://github.com/microsoft/Power-Fx/assets/25670945/1b1f55c5-b132-4689-94a7-321dbe97aac1)

After:
![UnformattingFix](https://github.com/microsoft/Power-Fx/assets/25670945/02ce8abb-5b31-4f06-9ce4-0d59f713189d)

