### PR TITLE
Turn off SA1407 rule

### DIFF
--- a/src/PowerFx.Tests.ruleset
+++ b/src/PowerFx.Tests.ruleset
@@ -130,7 +130,7 @@
     <Rule Id="SA1404" Action="Error" />
     <Rule Id="SA1405" Action="Error" />
     <Rule Id="SA1406" Action="Error" />
-    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1407" Action="None" />      <!-- SA1407: ArithmeticExpressionsMustDeclarePrecedence-->
     <Rule Id="SA1408" Action="Error" />
     <Rule Id="SA1410" Action="Error" />
     <Rule Id="SA1411" Action="Error" />

--- a/src/PowerFx.ruleset
+++ b/src/PowerFx.ruleset
@@ -130,7 +130,7 @@
     <Rule Id="SA1404" Action="Error" />
     <Rule Id="SA1405" Action="Error" />
     <Rule Id="SA1406" Action="Error" />
-    <Rule Id="SA1407" Action="Error" />
+    <Rule Id="SA1407" Action="None" />       <!-- SA1407: ArithmeticExpressionsMustDeclarePrecedence-->
     <Rule Id="SA1408" Action="Error" />
     <Rule Id="SA1410" Action="Error" />
     <Rule Id="SA1411" Action="Error" />


### PR DESCRIPTION
This rule should be excluding real obvious operator precedence like `a*b+c`