### PR TITLE
IsBlank can operate on controls without coercing

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -49,6 +49,9 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 if (context.Features.PrimaryOutputPropertyCoercionDeprecated)
                 {
+                    // Even when primary output property coercion is not supported,
+                    // IsBlank can be a valid operation on control types, e.g. a variable of 
+                    // Type control, could have been set to Blank();
                     return true;
                 }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/IsBlank.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             {
                 if (context.Features.PrimaryOutputPropertyCoercionDeprecated)
                 {
-                    return false;
+                    return true;
                 }
 
                 // If primary output property coercion is enabled,


### PR DESCRIPTION
This scenario can occur, e.g. if a component has an input property expecting a `Screen` type, and is passed `Blank()`. In that case, IsBlank() is a valid operation on the control type, even if we're not coercing to the primary output property. 