### PR TITLE
Enhances optionset intellisense.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseHelper.cs
@@ -353,14 +353,17 @@ namespace Microsoft.PowerFx.Intellisense
                         }
                     }
 
-                    if (info.ScopeIdentifier != default)
+                    if (!intellisenseData.TryAddSuggestionForCurrentBinaryOp(checkForOptionSetOnly: true))
                     {
-                        AddSuggestion(intellisenseData, info.ScopeIdentifier, SuggestionKind.Global, SuggestionIconKind.Other, type, requiresSuggestionEscaping: false);
-                    }
+                        if (info.ScopeIdentifier != default)
+                        {
+                            AddSuggestion(intellisenseData, info.ScopeIdentifier, SuggestionKind.Global, SuggestionIconKind.Other, type, requiresSuggestionEscaping: false);
+                        }
 
-                    if (!info.RequiresScopeIdentifier)
-                    {
-                        AddTopLevelSuggestions(intellisenseData, type);
+                        if (!info.RequiresScopeIdentifier)
+                        {
+                            AddTopLevelSuggestions(intellisenseData, type);
+                        }
                     }
                 }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/InterpreterSuggestTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [InlineData("Option|", "OptionSet", "OtherOptionSet", "TopOptionSetField", "TraceOptions", "TraceOptions.IgnoreUnsupportedTypes", "TraceOptions.None")]
         [InlineData("Opt|", "OptionSet", "OtherOptionSet", "TopOptionSetField", "TraceOptions", "TraceOptions.IgnoreUnsupportedTypes", "TraceOptions.None")]
         [InlineData("Opti|on", "OptionSet", "OtherOptionSet", "TopOptionSetField", "TraceOptions", "TraceOptions.IgnoreUnsupportedTypes", "TraceOptions.None")]
-        [InlineData("TopOptionSetField <> |", "TopOptionSetField", "XXX")]
+        [InlineData("TopOptionSetField <> |", "OptionSet", "TopOptionSetField", "XXX")]
         [InlineData("TopOptionSetField <> Opt|", "OptionSet", "TopOptionSetField", "OtherOptionSet", "TraceOptions", "TraceOptions.IgnoreUnsupportedTypes", "TraceOptions.None")]
         public void TestSuggestOptionSets(string expression, params string[] expectedSuggestions)
         {


### PR DESCRIPTION
Fixes https://github.com/microsoft/Power-Fx/issues/1873

Earlier:
(Filter(Accounts, ThisRecord.Status =  |) suggested all the column names, but now it would only suggest the relevant Option set.