### PR TITLE
Make Office365Outlook_V4CalendarPostItem test reliable

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/FormulaValueSerializer.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/FormulaValueSerializer.cs
@@ -232,7 +232,7 @@ namespace Microsoft.PowerFx.Connectors.Execution
                         }
                         else if (propertySchema.Format == "date-no-tz")
                         {
-                            WriteDateTimeValue(dtv.GetConvertedValue(TimeZoneInfo.Utc));
+                            WriteDateValue(dtv.GetConvertedValue(TimeZoneInfo.Utc));
                         }
                         else
                         {

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -13,6 +13,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.PowerFx.Connectors;
 using Microsoft.PowerFx.Connectors.Tests;
 using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Intellisense;
 using Microsoft.PowerFx.Types;
 using Xunit;
@@ -656,6 +657,11 @@ namespace Microsoft.PowerFx.Tests
             AssertEqual(expected, actual);
         }
 
+        internal class TestClockService : IClockService
+        {
+            public DateTime UtcNow { get; set; } = new DateTime(2023, 6, 2, 3, 15, 7, DateTimeKind.Utc);
+        }
+
         [Fact]
         public async Task Office365Outlook_V4CalendarPostItem()
         {
@@ -678,14 +684,17 @@ namespace Microsoft.PowerFx.Tests
             IReadOnlyList<ConnectorFunction> functions = config.AddActionConnector("Office365Outlook", apiDoc);
 
             RecalcEngine engine = new RecalcEngine(config);
-            RuntimeConfig runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Office365Outlook", client));
+
+            RuntimeConfig runtimeConfig = new RuntimeConfig();
+            runtimeConfig.SetClock(new TestClockService());
+            runtimeConfig.SetTimeZone(TimeZoneInfo.Utc);
+            runtimeConfig.AddRuntimeContext(new TestConnectorRuntimeContext("Office365Outlook", client));            
 
             testConnector.SetResponseFromFile(@"Responses\Office 365 Outlook V4CalendarPostItem.json");
             FormulaValue result = await engine.EvalAsync(@"Office365Outlook.V4CalendarPostItem(""Calendar"", ""Subject"", Today(), Today(), ""(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"")", CancellationToken.None, options: new ParserOptions() { AllowsSideEffects = true }, runtimeConfig: runtimeConfig).ConfigureAwait(false);
             Assert.Equal(@"![body:s, categories:*[Value:s], createdDateTime:d, end:d, endWithTimeZone:d, iCalUId:s, id:s, importance:s, isAllDay:b, isHtml:b, isReminderOn:b, lastModifiedDateTime:d, location:s, numberOfOccurences:w, optionalAttendees:s, organizer:s, recurrence:s, recurrenceEnd:D, reminderMinutesBeforeStart:w, requiredAttendees:s, resourceAttendees:s, responseRequested:b, responseTime:d, responseType:s, selectedDaysOfWeek:N, sensitivity:s, seriesMasterId:s, showAs:s, start:d, startWithTimeZone:d, subject:s, timeZone:s, webLink:s]", result.Type._type.ToString());
 
-            var actual = testConnector._log.ToString();
-            var today = DateTime.UtcNow.Date.ToString("O");
+            var actual = testConnector._log.ToString();            
             var version = PowerPlatformConnectorClient.Version;
             var expected = @$"POST https://b60ed9ea-c17c-e39a-8682-e33a20d51e14.15.common.tip1eu.azure-apihub.net/invoke
  authority: b60ed9ea-c17c-e39a-8682-e33a20d51e14.15.common.tip1eu.azure-apihub.net
@@ -698,7 +707,7 @@ namespace Microsoft.PowerFx.Tests
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/datasets/calendars/v4/tables/Calendar/items
  x-ms-user-agent: PowerFx/{version}
  [content-header] Content-Type: application/json; charset=utf-8
- [body] {{""subject"":""Subject"",""start"":""{today}"",""end"":""{today}"",""timeZone"":""(UTC\u002B01:00) Brussels, Copenhagen, Madrid, Paris""}}
+ [body] {{""subject"":""Subject"",""start"":""2023-06-02"",""end"":""2023-06-02"",""timeZone"":""(UTC\u002B01:00) Brussels, Copenhagen, Madrid, Paris""}}
 ";
 
             AssertEqual(expected, actual);


### PR DESCRIPTION
This test could be unpredictable depending on the your local timezone and/or time in the day