### PR TITLE
ConnectorSettings : Replace IgnoreUnknownExtensions with FailOnUnknownExtension

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorHelperFunctions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorHelperFunctions.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerFx.Connectors
 
             return $"{nameof(connectorSettings.Namespace)} {connectorSettings.Namespace ?? Null(nameof(connectorSettings.Namespace))}, " +
                    $"{nameof(connectorSettings.MaxRows)} {connectorSettings.MaxRows}, " +
-                   $"{nameof(connectorSettings.IgnoreUnknownExtensions)} {connectorSettings.IgnoreUnknownExtensions}, " +
+                   $"{nameof(connectorSettings.FailOnUnknownExtension)} {connectorSettings.FailOnUnknownExtension}, " +
                    $"{nameof(connectorSettings.AllowUnsupportedFunctions)} {connectorSettings.AllowUnsupportedFunctions}, ";           
         }
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiParser.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerFx.Connectors
                 return functions;
             }
 
-            if (!ValidateSupportedOpenApiDocument(openApiDocument, ref connectorIsSupported, ref connectorNotSupportedReason, connectorSettings.IgnoreUnknownExtensions, configurationLogger))
+            if (!ValidateSupportedOpenApiDocument(openApiDocument, ref connectorIsSupported, ref connectorNotSupportedReason, connectorSettings.FailOnUnknownExtension, configurationLogger))
             {
                 return functions;
             }
@@ -99,7 +99,7 @@ namespace Microsoft.PowerFx.Connectors
                     continue;
                 }
 
-                ValidateSupportedOpenApiPathItem(ops, ref isSupportedForPath, ref notSupportedReasonForPath, connectorSettings.IgnoreUnknownExtensions, configurationLogger);
+                ValidateSupportedOpenApiPathItem(ops, ref isSupportedForPath, ref notSupportedReasonForPath, connectorSettings.FailOnUnknownExtension, configurationLogger);
 
                 foreach (KeyValuePair<OperationType, OpenApiOperation> kv2 in ops.Operations)
                 {
@@ -122,8 +122,8 @@ namespace Microsoft.PowerFx.Connectors
                         continue;
                     }
 
-                    ValidateSupportedOpenApiOperation(op, ref isSupportedForOperation, ref notSupportedReasonForOperation, connectorSettings.IgnoreUnknownExtensions, configurationLogger);
-                    ValidateSupportedOpenApiParameters(op, ref isSupportedForOperation, ref notSupportedReasonForOperation, connectorSettings.IgnoreUnknownExtensions, configurationLogger);
+                    ValidateSupportedOpenApiOperation(op, ref isSupportedForOperation, ref notSupportedReasonForOperation, connectorSettings.FailOnUnknownExtension, configurationLogger);
+                    ValidateSupportedOpenApiParameters(op, ref isSupportedForOperation, ref notSupportedReasonForOperation, connectorSettings.FailOnUnknownExtension, configurationLogger);
 
                     string operationName = NormalizeOperationId(op.OperationId ?? path);
 
@@ -159,7 +159,7 @@ namespace Microsoft.PowerFx.Connectors
             return functions;
         }
 
-        private static bool ValidateSupportedOpenApiDocument(OpenApiDocument openApiDocument, ref bool isSupported, ref string notSupportedReason, bool ignoreUnknownExtensions, ConnectorLogger logger = null)
+        private static bool ValidateSupportedOpenApiDocument(OpenApiDocument openApiDocument, ref bool isSupported, ref string notSupportedReason, bool failOnUnknownExtensions, ConnectorLogger logger = null)
         {
             // OpenApiDocument - https://learn.microsoft.com/en-us/dotnet/api/microsoft.openapi.models.openapidocument?view=openapi-dotnet
             // AutoRest Extensions for OpenAPI 2.0 - https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md            
@@ -170,7 +170,7 @@ namespace Microsoft.PowerFx.Connectors
                 return false;
             }
 
-            if (!ignoreUnknownExtensions)
+            if (failOnUnknownExtensions)
             {
                 // All these Info properties can be ignored
                 // openApiDocument.Info.Description 
@@ -223,7 +223,7 @@ namespace Microsoft.PowerFx.Connectors
 
                 // openApiDocument.Examples can be ignored
 
-                if (isSupported && !ignoreUnknownExtensions)
+                if (isSupported && !failOnUnknownExtensions)
                 {
                     if (openApiDocument.Components.Extensions.Any())
                     {
@@ -254,7 +254,7 @@ namespace Microsoft.PowerFx.Connectors
                 // openApiDocument.Components.SecuritySchemes are critical but as we don't manage them at all, we'll ignore this parameter                
             }
 
-            if (isSupported && !ignoreUnknownExtensions)
+            if (isSupported && !failOnUnknownExtensions)
             {
                 List<string> extensions = openApiDocument.Extensions.Where(e => !((e.Value is OpenApiArray oaa && oaa.Count == 0) || (e.Value is OpenApiObject oao && oao.Count == 0))).Select(e => e.Key).ToList();
 
@@ -290,9 +290,9 @@ namespace Microsoft.PowerFx.Connectors
             return true;
         }
 
-        private static void ValidateSupportedOpenApiPathItem(OpenApiPathItem ops, ref bool isSupported, ref string notSupportedReason, bool ignoreUnknownExtensions, ConnectorLogger logger = null)
+        private static void ValidateSupportedOpenApiPathItem(OpenApiPathItem ops, ref bool isSupported, ref string notSupportedReason, bool failOnUnknownExtensions, ConnectorLogger logger = null)
         {
-            if (!ignoreUnknownExtensions)
+            if (failOnUnknownExtensions)
             {
                 List<string> pathExtensions = ops.Extensions.Keys.ToList();
 
@@ -310,7 +310,7 @@ namespace Microsoft.PowerFx.Connectors
             }
         }
 
-        private static void ValidateSupportedOpenApiOperation(OpenApiOperation op, ref bool isSupported, ref string notSupportedReason, bool ignoreUnknownExtensions, ConnectorLogger logger = null)
+        private static void ValidateSupportedOpenApiOperation(OpenApiOperation op, ref bool isSupported, ref string notSupportedReason, bool failOnUnknownExtensions, ConnectorLogger logger = null)
         {
             if (!isSupported)
             {
@@ -331,7 +331,7 @@ namespace Microsoft.PowerFx.Connectors
                 logger?.LogWarning($"OperationId {op.OperationId} is deprecated");
             }
 
-            if (!ignoreUnknownExtensions)
+            if (failOnUnknownExtensions)
             {
                 List<string> opExtensions = op.Extensions.Keys.ToList();
 
@@ -372,7 +372,7 @@ namespace Microsoft.PowerFx.Connectors
             }
         }
 
-        private static void ValidateSupportedOpenApiParameters(OpenApiOperation op, ref bool isSupported, ref string notSupportedReason, bool ignoreUnknownExtensions, ConnectorLogger logger = null)
+        private static void ValidateSupportedOpenApiParameters(OpenApiOperation op, ref bool isSupported, ref string notSupportedReason, bool failOnUnknownExtensions, ConnectorLogger logger = null)
         {
             foreach (OpenApiParameter param in op.Parameters)
             {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
@@ -26,9 +26,9 @@ namespace Microsoft.PowerFx.Connectors
         public int MaxRows { get; init; } = 1000;
 
         /// <summary>
-        /// Unknown extensions in swagger file will be ignored during the validation process.
+        /// Unknown extensions in swagger file are ignored by default during the validation process.
         /// </summary>
-        public bool IgnoreUnknownExtensions { get; init; } = false;
+        public bool FailOnUnknownExtension { get; init; } = false;
 
         /// <summary>
         /// Allow using functions that are identified as unsupported.

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/LivePublicSwaggerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/LivePublicSwaggerTests.cs
@@ -12,19 +12,11 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
 using Microsoft.PowerFx.Types;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.PowerFx.Connectors.Tests
 {
     public class LivePublicSwaggerTests
     {
-        private readonly ITestOutputHelper _output;
-
-        public LivePublicSwaggerTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [Fact(Skip = "These APIs are rate limited and HTTP error 429 is possible")]
         public async Task RealTest()
         {
@@ -41,7 +33,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             // No BaseAdress specified, we'll use the 1st HTTPS one found in the swagger file
             using var client = new HttpClient(); // public auth             
-            var funcs = config.AddActionConnector("Math", doc, new ConsoleLogger(_output));
+            var funcs = config.AddActionConnector("Math", doc);
 
             var engine = new RecalcEngine(config);
             var expr = "Math.numberscardinal({number: 1791941})";
@@ -50,7 +42,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.True(ok);
 
-            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Math", client, console: _output));
+            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Math", client));
             FormulaValue result = await engine.EvalAsync(expr, CancellationToken.None, runtimeConfig: runtimeConfig).ConfigureAwait(false);
 
             if (result is ErrorValue ev)
@@ -84,8 +76,8 @@ namespace Microsoft.PowerFx.Connectors.Tests
             // Here we specify the BaseAddress
             using var client = new HttpClient() { BaseAddress = new Uri("https://api.math.tools") };
 
-            // Set IgnoreUnknownExtensions to true as this swagger uses some extensions we don't honnor like x-apisguru-categories, x-origin, x-providerName
-            var funcs = config.AddActionConnector(new ConnectorSettings("Math") { IgnoreUnknownExtensions = true }, doc, new ConsoleLogger(_output)); 
+            // FailOnUnknownExtension in connectorsettings is set to false (default) as this swagger uses some extensions we don't honnor like x-apisguru-categories, x-origin, x-providerName
+            var funcs = config.AddActionConnector(new ConnectorSettings("Math"), doc); 
 
             var engine = new RecalcEngine(config);
             var expr = "Math.numbersbasebinary(632506623)";
@@ -94,7 +86,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.True(ok, string.Join(", ", check.Errors.Select(er => er.Message)));
 
-            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Math", client, console: _output));
+            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Math", client));
             FormulaValue result = await engine.EvalAsync(expr, CancellationToken.None, runtimeConfig: runtimeConfig).ConfigureAwait(false);
 
             if (result is ErrorValue ev)
@@ -138,7 +130,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             OpenApiDocument doc = await ReadSwaggerFromUrl(swaggerUrl).ConfigureAwait(false);
             using var client = new HttpClient() { BaseAddress = new Uri("https://date.nager.at") };
-            var funcs = config.AddActionConnector("Holiday", doc, new ConsoleLogger(_output));
+            var funcs = config.AddActionConnector("Holiday", doc);
 
             var engine = new RecalcEngine(config);
             var expr = @"Index(Holiday.PublicHolidayPublicHolidaysV3(2023, ""US""), 8)";
@@ -149,7 +141,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             var ok = check.IsSuccess;
             Assert.True(ok, string.Join(", ", check.Errors.Select(er => er.Message)));
 
-            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Holiday", client, console: _output));
+            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Holiday", client));
             FormulaValue result = await engine.EvalAsync(expr, CancellationToken.None, runtimeConfig: runtimeConfig).ConfigureAwait(false);            
 
             if (result is ErrorValue ev)
@@ -185,11 +177,11 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             using var clientXkcd = new HttpClient() { BaseAddress = new Uri(@"http://xkcd.com/") };
             using var clientWorldTime = new HttpClient() { BaseAddress = new Uri(@"http://worldtimeapi.org/api/") };
-            var funcsXkcd = config.AddActionConnector(new ConnectorSettings("Xkcd") { IgnoreUnknownExtensions = true }, docXkcd, new ConsoleLogger(_output));
-            var funcsWorldTime = config.AddActionConnector(new ConnectorSettings("WorldTime") { IgnoreUnknownExtensions = true }, docWorldTime, new ConsoleLogger(_output));
+            var funcsXkcd = config.AddActionConnector(new ConnectorSettings("Xkcd"), docXkcd);
+            var funcsWorldTime = config.AddActionConnector(new ConnectorSettings("WorldTime"), docWorldTime);
 
             var engine = new RecalcEngine(config);
-            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Xkcd", clientXkcd, console: _output).Add("WorldTime", clientWorldTime));                                                   
+            var runtimeConfig = new RuntimeConfig().AddRuntimeContext(new TestConnectorRuntimeContext("Xkcd", clientXkcd).Add("WorldTime", clientWorldTime));                                                   
 
             FormulaValue fv1 = await engine.EvalAsync(@"Xkcd.comicIdinfo0json(1).transcript", CancellationToken.None, runtimeConfig: runtimeConfig).ConfigureAwait(false);
             string transcript = ((StringValue)fv1).Value.Replace("\n", "\r\n");

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/LoggerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/LoggerTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.Empty(functions);
             Assert.Equal(
-                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace <Namespace is null>, MaxRows 1000, IgnoreUnknownExtensions False, AllowUnsupportedFunctions False, |" +
+                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace <Namespace is null>, MaxRows 1000, FailOnUnknownExtension False, AllowUnsupportedFunctions False, |" +
                 @"[ERROR] connectorSettings.Namespace is null|" +
                 @"[INFO ] Exiting ConfigExtensions.AddActionConnector, returning 0 functions", logger.GetLogs());            
         }
@@ -81,7 +81,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.Empty(functions);
             Assert.Equal(
-                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace Test, MaxRows 1000, IgnoreUnknownExtensions False, AllowUnsupportedFunctions False, |" +
+                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace Test, MaxRows 1000, FailOnUnknownExtension False, AllowUnsupportedFunctions False, |" +
                 @"[ERROR] openApiDocument is null|" +
                 @"[INFO ] Exiting ConfigExtensions.AddActionConnector, returning 0 functions", logger.GetLogs());            
         }
@@ -95,7 +95,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.Empty(functions);
             Assert.Equal(
-                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace Test, MaxRows 1000, IgnoreUnknownExtensions False, AllowUnsupportedFunctions False, |" +
+                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace Test, MaxRows 1000, FailOnUnknownExtension False, AllowUnsupportedFunctions False, |" +
                 @"[ERROR] OpenApiDocument is invalid, it has no Path|" +
                 @"[INFO ] Exiting ConfigExtensions.AddActionConnector, returning 0 functions", logger.GetLogs());            
         }
@@ -109,7 +109,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.Empty(functions);
             Assert.Equal(
-                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace , MaxRows 1000, IgnoreUnknownExtensions False, AllowUnsupportedFunctions False, |" +
+                @"[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace , MaxRows 1000, FailOnUnknownExtension False, AllowUnsupportedFunctions False, |" +
                 @"[ERROR] connectorSettings.Namespace is not a valid DName|" +
                 @"[INFO ] Exiting ConfigExtensions.AddActionConnector, returning 0 functions", logger.GetLogs());            
         }
@@ -124,7 +124,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             Assert.NotEmpty(functions);
             Assert.Equal(
-                "[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace SQL, MaxRows 1000, IgnoreUnknownExtensions False, AllowUnsupportedFunctions False, |" +
+                "[INFO ] Entering in ConfigExtensions.AddActionConnector, with ConnectorSettings Namespace SQL, MaxRows 1000, FailOnUnknownExtension False, AllowUnsupportedFunctions False, |" +
                 "[INFO ] Operation GET /{connectionId}/datasets({dataset})/tables({table})/onnewitems is trigger|" +
                 "[INFO ] Operation GET /{connectionId}/datasets({dataset})/tables({table})/onupdateditems is trigger|" +
                 "[INFO ] Operation GET /{connectionId}/datasets/{server},{database}/tables/{table}/onupdateditems is trigger|" +


### PR DESCRIPTION
This is to reproduce Power Apps behavior (= ignore unknown extensions)
Default value remains false.
