### PR TITLE
Further REPL improvements

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
@@ -210,7 +210,7 @@ namespace Microsoft.PowerFx
 
             if (expression != null)
             {
-                await this.HandleCommandAsync(expression, lineNumber: lineNumber);
+                await this.HandleCommandAsync(expression, cancel: cancel, lineNumber: lineNumber);
             }
         }
 
@@ -240,7 +240,7 @@ namespace Microsoft.PowerFx
             {
                 await this.WritePromptAsync(cancel);
 
-                // better to strip any newline and add one ourselves, in case the expression didn't come in with one
+                // better to strip any newline and add one ourselves (with WriteLine), in case the expression didn't come in with one
                 await this.Output.WriteLineAsync(expression.TrimEnd(), OutputKind.Repl, cancel);
             }
 

--- a/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
@@ -34,12 +34,16 @@ namespace Microsoft.PowerFx
         // Allow repl to create new definitions, such as Set(). 
         public bool AllowSetDefinitions { get; set; }
 
-        // Do we print each command?
-        // Useful if we're running a file, or ir input UI is separated from output UI. 
+        // Do we print each command before evaluation?
+        // Useful if we're running a file and are debugging, or if input UI is separated from output UI. 
         public bool Echo { get; set; } = false;
 
+        // Do we print each result after evaluation?
+        // Useful if we're running in interactive mode, or with Echo enabled.
+        public bool PrintResult { get; set; } = true;
+
         // Has Exit() been called?
-        // Host can check this flag after each command is executed.
+        // Host can check this flag after each command is executed to see if the repl should close.
         public bool ExitRequested { get; set; } = false;
 
         /// <summary>
@@ -191,10 +195,11 @@ namespace Microsoft.PowerFx
         /// This allows continuations via the policy set in <see cref="MultilineProcessor"/>.
         /// </summary>
         /// <param name="line">A line of input.</param>
+        /// <param name="lineNumber">Line number.</param>
         /// <param name="cancel"></param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException">If cancelled.</exception>
-        public async Task HandleLineAsync(string line, CancellationToken cancel = default)
+        public async Task HandleLineAsync(string line, CancellationToken cancel = default, uint? lineNumber = null)
         {
             if (this.Engine == null)
             {
@@ -205,7 +210,7 @@ namespace Microsoft.PowerFx
 
             if (expression != null)
             {
-                await this.HandleCommandAsync(expression, cancel);
+                await this.HandleCommandAsync(expression, lineNumber: lineNumber);
             }
         }
 
@@ -214,10 +219,13 @@ namespace Microsoft.PowerFx
         /// </summary>
         /// <param name="expression">expression to run.</param>
         /// <param name="cancel">cancellation token.</param>
+        /// <param name="lineNumber">line number to attribute errors to.</param>
         /// <returns>status object with details.</returns>
         /// <exception cref="InvalidOperationException">invalid.</exception>
-        public virtual async Task<ReplResult> HandleCommandAsync(string expression, CancellationToken cancel = default)
+        public virtual async Task<ReplResult> HandleCommandAsync(string expression, CancellationToken cancel = default, uint? lineNumber = null)
         {
+            string lineError = lineNumber == null ? string.Empty : $"Line {lineNumber}: ";
+
             if (this.Engine == null)
             {
                 throw new InvalidOperationException($"Engine is not set.");
@@ -231,7 +239,9 @@ namespace Microsoft.PowerFx
             if (this.Echo)
             {
                 await this.WritePromptAsync(cancel);
-                await this.Output.WriteAsync(expression, OutputKind.Repl, cancel);
+
+                // better to strip any newline and add one ourselves, in case the expression didn't come in with one
+                await this.Output.WriteLineAsync(expression.TrimEnd(), OutputKind.Repl, cancel);
             }
 
             var extraSymbolTable = this.ExtraSymbolValues?.SymbolTable;
@@ -302,7 +312,7 @@ namespace Microsoft.PowerFx
                         }
                         catch (Exception ex)
                         {
-                            await this.Output.WriteLineAsync(ex.Message, OutputKind.Error, cancel)
+                            await this.Output.WriteLineAsync(lineError + "Error: " + ex.Message, OutputKind.Error, cancel)
                                 .ConfigureAwait(false);
                         }
 
@@ -313,7 +323,7 @@ namespace Microsoft.PowerFx
                         foreach (var error in formulaCheck.Errors)
                         {
                             var kind = error.IsWarning ? OutputKind.Warning : OutputKind.Error;
-                            await this.Output.WriteLineAsync(error.ToString(), kind, cancel)
+                            await this.Output.WriteLineAsync(lineError + error.ToString(), kind, cancel)
                                 .ConfigureAwait(false);
                         }
 
@@ -395,7 +405,7 @@ namespace Microsoft.PowerFx
                         }
                     }
 
-                    await this.Output.WriteLineAsync(msg, kind, cancel)
+                    await this.Output.WriteLineAsync(lineError + msg, kind, cancel)
                         .ConfigureAwait(false);
                 }
 
@@ -433,23 +443,30 @@ namespace Microsoft.PowerFx
                 EvalResult = result,
             };
 
-            foreach (var varName in varsToDisplay)
+            if (PrintResult)
             {
-                var varValue = this.Engine.GetValue(varName);
-                replResult.DeclaredVars[varName] = varValue;
+                // Print results for updated named formulas
+                foreach (var varName in varsToDisplay)
+                {
+                    var varValue = this.Engine.GetValue(varName);
+                    replResult.DeclaredVars[varName] = varValue;
 
-                await this.WriteLineVarAsync(varValue, cancel, $"{varName}: ");
+                    await this.WriteLineVarAsync(varValue, cancel, $"{varName}: ");
+                }
+
+                // Now print the result for this expression
+                await this.WriteLineVarAsync(result, cancel);
             }
-
-            // Now print the result
-            await this.WriteLineVarAsync(result, cancel);
 
             return replResult;
         }
 
         public virtual async void OnFormulaUpdate(string name, FormulaValue newValue)
         {
-            await this.WriteLineVarAsync(newValue, CancellationToken.None, $"{name}: ");
+            if (PrintResult)
+            {
+                await this.WriteLineVarAsync(newValue, CancellationToken.None, $"{name}: ");
+            }
         }
 
         private async Task WriteLineVarAsync(FormulaValue result, CancellationToken cancel, string prefix = null)
@@ -473,7 +490,7 @@ namespace Microsoft.PowerFx
     }
 
     /// <summary>
-    /// Result from <see cref="PowerFxREPL.HandleCommandAsync(string, CancellationToken)"/>.
+    /// Result from <see cref="PowerFxREPL.HandleCommandAsync(string, CancellationToken, uint?)"/>.
     /// </summary>
     public class ReplResult
     {

--- a/src/tests/Microsoft.PowerFx.Repl.Tests/ReplTests.cs
+++ b/src/tests/Microsoft.PowerFx.Repl.Tests/ReplTests.cs
@@ -593,6 +593,7 @@ true
         public void LineNumbersInErrors()
         {
             _repl.HandleCommandAsync(@"2 +-* s", lineNumber: 7891).Wait();
+
             var errors = _output.Get(OutputKind.Error, trim: false);
 
             // make sure there is at least one error

--- a/src/tests/Microsoft.PowerFx.Repl.Tests/ReplTests.cs
+++ b/src/tests/Microsoft.PowerFx.Repl.Tests/ReplTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -541,6 +542,75 @@ Notify(z)
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Repl, trim: false) == string.Empty);
+        }
+
+        [Fact]
+        public void EchoAndPrintResult()
+        {
+            _repl.Echo = false;
+            _repl.PrintResult = false;
+            _repl.HandleCommandAsync(@"Notify( 1234 )").Wait();
+            Assert.True(_output.Get(OutputKind.Notify, trim: false) == @"1234
+");
+            Assert.True(_output.Get(OutputKind.Repl, trim: false) == string.Empty);
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == string.Empty);
+
+            _repl.Echo = true;
+            _repl.PrintResult = false;
+            _repl.HandleCommandAsync(@"Notify( 2345 )").Wait();
+            Assert.True(_output.Get(OutputKind.Notify, trim: false) == @"2345
+");
+            Assert.True(_output.Get(OutputKind.Repl, trim: false) == @"Notify( 2345 )
+");
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == @"
+>> ");
+
+            _repl.Echo = false;
+            _repl.PrintResult = true;
+            _repl.HandleCommandAsync(@"Notify( 3456 )").Wait();
+            Assert.True(_output.Get(OutputKind.Notify, trim: false) == @"3456
+");
+            Assert.True(_output.Get(OutputKind.Repl, trim: false) == @"true
+");
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == string.Empty);
+
+            _repl.Echo = true;
+            _repl.PrintResult = true;
+            _repl.HandleCommandAsync(@"Notify( 4567 )").Wait();
+            Assert.True(_output.Get(OutputKind.Notify, trim: false) == @"4567
+");
+            Assert.True(_output.Get(OutputKind.Repl, trim: false) == @"Notify( 4567 )
+true
+");
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == @"
+>> ");
+
+            Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
+            Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
+        }
+
+        [Fact]
+        public void LineNumbersInErrors()
+        {
+            _repl.HandleCommandAsync(@"2 +-* s", lineNumber: 7891).Wait();
+            var errors = _output.Get(OutputKind.Error, trim: false);
+
+            // make sure there is at least one error
+            Assert.StartsWith("Line ", errors);
+
+            using (StringReader reader = new StringReader(errors))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    Assert.StartsWith("Line 7891: ", errors);
+                }
+            }
+
+            Assert.True(_output.Get(OutputKind.Notify, trim: false) == string.Empty);
+            Assert.True(_output.Get(OutputKind.Repl, trim: false) == string.Empty);
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == string.Empty);
+            Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
         }
     }
 

--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PowerFx
             Console.WriteLine("Enter Excel formulas.  Use \"Help()\" for details, \"Option()\" for options.");
 #pragma warning restore CA1303 // Do not pass literals as localized parameters
 
-            REPL(Console.In, prompt: true, echo: false);
+            REPL(Console.In, prompt: true, echo: false, printResult: true, lineNumber: null);
         }
 
         // Hook repl engine with customizations.
@@ -143,11 +143,11 @@ namespace Microsoft.PowerFx
             }
         }
 
-        public static void REPL(TextReader input, bool prompt, bool echo)
+        public static void REPL(TextReader input, bool prompt, bool echo, bool printResult, uint? lineNumber)
         {
             while (true)
             {
-                var repl = new MyRepl() { Echo = echo };
+                var repl = new MyRepl() { Echo = echo, PrintResult = printResult };
 
                 while (!_reset)
                 {
@@ -164,7 +164,7 @@ namespace Microsoft.PowerFx
                         return;
                     }
 
-                    repl.HandleLineAsync(line).Wait();
+                    repl.HandleLineAsync(line, lineNumber: lineNumber++).Wait();
 
                     // Exit() function called
                     if (repl.ExitRequested)
@@ -212,7 +212,7 @@ namespace Microsoft.PowerFx
                 try
                 {
                     var reader = new StreamReader(file.Value);
-                    REPL(reader, prompt: false, echo: echo.Value);
+                    REPL(reader, prompt: false, echo: echo.Value, printResult: echo.Value, lineNumber: 1);
                     reader.Dispose();
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Addresses:
- https://github.com/microsoft/Power-Fx/issues/2015
- https://github.com/microsoft/Power-Fx/issues/2014

Without Echo (default if running in the local REPL in this repo), only Notify calls will display - see first run.  All other results will only be shown if Echo is on - see second run.
![image](https://github.com/microsoft/Power-Fx/assets/15149773/535a6e9a-9875-41c7-9224-02ccbe4d5387)

Line numbers are now shown with errors, if the host passes the line number information in.  This is very helpful if processing a file.
![image](https://github.com/microsoft/Power-Fx/assets/15149773/1574a34c-618d-4856-ae6a-760b6e57866b)

