### PR TITLE
Revert "Add Intellisense in Repl, with TAB, ESC, UP, DOWN keys management"

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Repl/Services/MultilineProcessor.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Services/MultilineProcessor.cs
@@ -29,13 +29,7 @@ namespace Microsoft.PowerFx.Repl.Services
         {
             _commandBuffer.AppendLine(line);
 
-            string commandBufferString = _commandBuffer.ToString();
-
-            // Remove the trailing newline if it exists as it disturbs Intellisense
-            if (commandBufferString.EndsWith("\r\n", StringComparison.OrdinalIgnoreCase))
-            {
-                commandBufferString = commandBufferString.Substring(0, commandBufferString.Length - 2);
-            }
+            var commandBufferString = _commandBuffer.ToString();
 
             // We use the parser results to determine if the command is complete or more lines are needed.
             // The Engine features and parser options do not need to match what we will actually use,

--- a/src/tests/Microsoft.PowerFx.Repl.Tests/MultilineProcessorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Repl.Tests/MultilineProcessorTests.cs
@@ -36,19 +36,16 @@ namespace Microsoft.PowerFx.Repl.Tests
                 Assert.Equal(isFirstLine, _processor.IsFirstLine);
 
                 var result = _processor.HandleLine(line);
+                sb.AppendLine(line);
 
                 if (!isLast)
                 {
-                    sb.AppendLine(line);
-
                     Assert.Null(result);
 
                     Assert.False(_processor.IsFirstLine); // always false after HandleLine();
                 } 
                 else
                 {
-                    sb.Append(line);
-
                     // Last line completes
                     Assert.Equal(sb.ToString(), result);
 

--- a/src/tests/Microsoft.PowerFx.Repl.Tests/ReplTests.cs
+++ b/src/tests/Microsoft.PowerFx.Repl.Tests/ReplTests.cs
@@ -77,7 +77,7 @@ Set(z, x * 5 + y)
 Notify(z)
 ";
             var lines = file.Split("\n");
-
+            
             foreach (var line in lines)
             {
                 _repl.HandleLine(line);
@@ -150,7 +150,7 @@ Notify(z)
 
             // Failed to define at all. 
             var ok = _repl.Engine.TryGetVariableType("x", out var type);
-            Assert.False(ok);
+            Assert.False(ok);            
         }
 
         [Fact]
@@ -212,8 +212,8 @@ Notify(z)
             SymbolTable st = new SymbolTable() { DebugName = "ExtraValues" };
             var slot = st.AddVariable("Const1", FormulaType.Decimal, new SymbolProperties
             {
-                CanMutate = false,
-                CanSet = false
+                 CanMutate = false,
+                 CanSet = false
             });
             var extraValues = st.CreateValues();
             extraValues.Set(slot, FormulaValue.New(10));
@@ -228,7 +228,7 @@ Notify(z)
 
             // But can't set (doesn't declare a shadow copy).
             var replResult = _repl.HandleCommandAsync("Set(Const1, 99)").Result;
-            Assert.False(replResult.IsSuccess);
+            Assert.False(replResult.IsSuccess); 
         }
 
         [Fact]
@@ -350,7 +350,8 @@ Notify(z)
             _repl.WritePromptAsync().Wait();
 
             var log1 = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1 == @">> ");
+            Assert.True(log1 == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -362,7 +363,8 @@ Notify(z)
         {
             _repl.WritePromptAsync().Wait();
             var log1p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1p == @">> ");
+            Assert.True(log1p == @"
+>> ");
 
             _repl.HandleLineAsync("Sqrt(4").Wait();     // intentionally left unclosed
 
@@ -378,7 +380,8 @@ Notify(z)
 
             _repl.WritePromptAsync().Wait();
             var log3p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log3p == @">> ");
+            Assert.True(log3p == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -391,7 +394,8 @@ Notify(z)
             _repl.WritePromptAsync().Wait();
 
             var log1p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1p == @">> ");
+            Assert.True(log1p == @"
+>> ");
 
             _repl.HandleCommandAsync(
 "[1,2,3]").Wait();
@@ -401,7 +405,8 @@ Notify(z)
 
             _repl.WritePromptAsync().Wait();
             var log2p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log2p == @">> ");
+            Assert.True(log2p == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -414,7 +419,8 @@ Notify(z)
             _repl.WritePromptAsync().Wait();
 
             var log1p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1p == @">> ");
+            Assert.True(log1p == @"
+>> ");
 
             _repl.HandleCommandAsync(
 "[1,2,3]").Wait();
@@ -432,7 +438,8 @@ Notify(z)
 
             _repl.WritePromptAsync().Wait();
             var log2p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log2p == @">> ");
+            Assert.True(log2p == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -445,7 +452,8 @@ Notify(z)
             _repl.WritePromptAsync().Wait();
 
             var log1p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1p == @">> ");
+            Assert.True(log1p == @"
+>> ");
 
             // compare but ignore trailing whitespace at the end of each line
             _repl.HandleCommandAsync(
@@ -461,7 +469,8 @@ Notify(z)
 
             _repl.WritePromptAsync().Wait();
             var log2p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log2p == @">> ");
+            Assert.True(log2p == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -473,7 +482,8 @@ Notify(z)
         {
             _repl.WritePromptAsync().Wait();
             var log1p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1p == @">> ");
+            Assert.True(log1p == @"
+>> ");
 
             // compare but ignore trailing whitespace at the end of each line
             _repl.HandleCommandAsync(
@@ -489,7 +499,8 @@ Notify(z)
 
             _repl.WritePromptAsync().Wait();
             var log2p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log2p == @">> ");
+            Assert.True(log2p == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -501,7 +512,8 @@ Notify(z)
         {
             _repl.WritePromptAsync().Wait();
             var log1p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log1p == @">> ");
+            Assert.True(log1p == @"
+>> ");
 
             _repl.HandleCommandAsync(
 "MyTable = Table({a:1},{b:2})").Wait();
@@ -524,7 +536,8 @@ Notify(z)
 
             _repl.WritePromptAsync().Wait();
             var log2p = _output.Get(OutputKind.Control, trim: false);
-            Assert.True(log2p == @">> ");
+            Assert.True(log2p == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);
@@ -549,7 +562,8 @@ Notify(z)
 ");
             Assert.True(_output.Get(OutputKind.Repl, trim: false) == @"Notify( 2345 )
 ");
-            Assert.True(_output.Get(OutputKind.Control, trim: false) == @">> ");
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == @"
+>> ");
 
             _repl.Echo = false;
             _repl.PrintResult = true;
@@ -568,7 +582,8 @@ Notify(z)
             Assert.True(_output.Get(OutputKind.Repl, trim: false) == @"Notify( 4567 )
 true
 ");
-            Assert.True(_output.Get(OutputKind.Control, trim: false) == @">> ");
+            Assert.True(_output.Get(OutputKind.Control, trim: false) == @"
+>> ");
 
             Assert.True(_output.Get(OutputKind.Error, trim: false) == string.Empty);
             Assert.True(_output.Get(OutputKind.Warning, trim: false) == string.Empty);

--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -4,15 +4,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Core;
-using Microsoft.PowerFx.Intellisense;
 using Microsoft.PowerFx.Repl;
 using Microsoft.PowerFx.Repl.Functions;
 using Microsoft.PowerFx.Repl.Services;
@@ -21,7 +18,7 @@ using Microsoft.PowerFx.Types;
 namespace Microsoft.PowerFx
 {
     public static class ConsoleRepl
-    {
+    { 
         private const string OptionFormatTable = "FormatTable";
 
         private const string OptionNumberIsFloat = "NumberIsFloat";
@@ -46,7 +43,7 @@ namespace Microsoft.PowerFx
         private static bool _reset;
 
         private static RecalcEngine ReplRecalcEngine()
-        {
+        { 
             var config = new PowerFxConfig(_features);
 
             if (_largeCallDepth)
@@ -99,13 +96,17 @@ namespace Microsoft.PowerFx
 
         public static void Main()
         {
-            Console.InputEncoding = Encoding.Unicode;
-            Console.OutputEncoding = Encoding.Unicode;
+            var enabled = new StringBuilder();
+
+            Console.InputEncoding = System.Text.Encoding.Unicode;
+            Console.OutputEncoding = System.Text.Encoding.Unicode;
 
             var version = typeof(RecalcEngine).Assembly.GetName().Version.ToString();
             Console.WriteLine($"Microsoft Power Fx Console Formula REPL, Version {version}");
-            Console.WriteLine("Enter Excel formulas.  Use \"Help()\" for details, \"Option()\" for options. CTRL-Z to exit.");
-            Console.WriteLine("TAB for auto-completion, ESC for showing Intellisense suggestions. SHIFT-ESC to clear. UP/DOWN for history.");
+
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+            Console.WriteLine("Enter Excel formulas.  Use \"Help()\" for details, \"Option()\" for options.");
+#pragma warning restore CA1303 // Do not pass literals as localized parameters
 
             REPL(Console.In, prompt: true, echo: false, printResult: true, lineNumber: null);
         }
@@ -147,7 +148,6 @@ namespace Microsoft.PowerFx
             while (true)
             {
                 var repl = new MyRepl() { Echo = echo, PrintResult = printResult };
-                List<string> expressions = new List<string>();
 
                 while (!_reset)
                 {
@@ -156,166 +156,7 @@ namespace Microsoft.PowerFx
                         repl.WritePromptAsync().Wait();
                     }
 
-                    string line = string.Empty;
-
-                    // intellisense context
-                    int iStart = -1;
-                    int iEnd = -1;
-                    int tabCount = 0;
-                    string tabLine = null;
-                    List<IIntellisenseSuggestion> list = null;
-
-                    // history context
-                    int index = 0;
-
-                    while (true)
-                    {
-                        ConsoleKeyInfo cki = Console.ReadKey(true);
-                        ClearIntellisense(ref iStart, iEnd);
-
-                        // SHIFT-ESC = clear line
-                        if (cki.Key == ConsoleKey.Escape && (cki.Modifiers & ConsoleModifiers.Shift) != 0)
-                        {
-                            ClearIntellisense(ref iStart, iEnd);
-                            line = string.Empty;
-                            DisplayCurrentLine(repl, line);
-                            tabCount = 0;
-                            index = 0;
-                            continue;
-                        }
-
-                        // TAB or ESC = intellisense
-                        if ((cki.Key == ConsoleKey.Tab && tabCount == 0) || cki.Key == ConsoleKey.Escape)
-                        {
-                            ReplResult rr = repl.HandleLineAsync(line, suggest: true).Result;
-
-                            if (rr?.IntellisenseResult != null && rr.IntellisenseResult.Suggestions != null && rr.IntellisenseResult.Suggestions.Any())
-                            {
-                                tabLine = line;
-                                list = rr.IntellisenseResult.Suggestions.OrderBy(s => s.DisplayText.HighlightStart.ToString("0000", CultureInfo.InvariantCulture) + s.DisplayText.Text, StringComparer.OrdinalIgnoreCase).ToList();
-                            }
-                            else
-                            {
-                                list = null;
-                            }
-                        }
-
-                        if (cki.Key == ConsoleKey.Tab || cki.Key == ConsoleKey.Escape)
-                        {
-                            // TAB = complete with 1st suggestion (and next ones on subsequent TABs)
-                            if (cki.Key == ConsoleKey.Tab && list != null)
-                            {                                
-                                IIntellisenseSuggestion suggestion = list.Skip(tabCount % list.Count).First();
-                                int hs = suggestion.DisplayText.HighlightStart;
-                                int he = suggestion.DisplayText.HighlightEnd;
-                                line = string.Concat(tabLine.AsSpan(0, tabLine.Length - he + hs), suggestion.DisplayText.Text);                                
-                                DisplayCurrentLine(repl, line);
-                                tabCount++;
-                            }
-
-                            // ESC = show suggestions we have found
-                            if (cki.Key == ConsoleKey.Escape && list != null)
-                            {
-                                ClearIntellisense(ref iStart, iEnd);
-
-                                int cl = Console.CursorLeft;
-                                int ct = Console.CursorTop;
-
-                                iStart = ct + 1;
-                                Console.ForegroundColor = ConsoleColor.DarkGray;
-
-                                foreach (var suggestion in list)
-                                {
-                                    Console.WriteLine();
-
-                                    bool lastLine = Console.CursorTop == Console.BufferHeight - 1;
-                                    Console.Write(suggestion.DisplayText.Text + (lastLine ? $" (... {list.Count() - Console.BufferHeight + ct + 1} more)" : string.Empty));
-
-                                    if (lastLine)
-                                    {
-                                        break;
-                                    }
-                                }
-
-                                iEnd = Console.CursorTop;
-                                Console.ResetColor();
-                                Console.SetCursorPosition(cl, ct);
-                            }
-
-                            index = 0;
-                            continue;
-                        }
-
-                        tabCount = 0;                        
-                        
-                        // UP and DOWN, search in history
-                        if (cki.Key == ConsoleKey.UpArrow || cki.Key == ConsoleKey.DownArrow)
-                        {                            
-                            if (expressions.Count > 0)
-                            {
-                                // Keep an empty expression at the end of the list so that we can add new expressions
-                                if (expressions.Last() != string.Empty)
-                                {
-                                    expressions.Add(string.Empty);
-                                }
-
-                                if (cki.Key == ConsoleKey.UpArrow)
-                                {
-                                    index++;
-                                }
-
-                                if (cki.Key == ConsoleKey.DownArrow)
-                                {
-                                    index--;
-                                }
-
-                                if (index < 0)
-                                {
-                                    index = expressions.Count - 1;
-                                }
-
-                                List<string> e = new List<string>(expressions);
-                                e.Reverse();
-                                line = e[index % e.Count];
-                                DisplayCurrentLine(repl, line);                           
-                            }
-
-                            continue;
-                        }
-
-                        index = 0;
-
-                        // CTRL-Z = Exit
-                        if ((cki.Modifiers & ConsoleModifiers.Control) != 0 && cki.Key == ConsoleKey.Z)
-                        {
-                            Console.WriteLine("Exiting...");
-                            return;
-                        }
-                       
-                        // backspace
-                        if (cki.KeyChar == 8)
-                        {
-                            if (line.Length > 0)
-                            {
-                                Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
-                                Console.Write(' ');
-                                Console.SetCursorPosition(Console.CursorLeft - 1, Console.CursorTop);
-                                line = line.Substring(0, line.Length - 1);
-                            }
-
-                            continue;
-                        }
-
-                        // CR / LF = end of line
-                        if (cki.KeyChar == 13 || cki.KeyChar == 10)
-                        {
-                            Console.WriteLine();
-                            break;
-                        }
-
-                        Console.Write(cki.KeyChar);
-                        line += cki.KeyChar;
-                    }
+                    var line = input.ReadLine();
 
                     // End of file
                     if (line == null)
@@ -330,54 +171,11 @@ namespace Microsoft.PowerFx
                     {
                         return;
                     }
-
-                    if (expressions.Any() && expressions.Last() == string.Empty)
-                    {
-                        expressions.RemoveAt(expressions.Count - 1);
-                    }
-
-                    if (expressions.Count >= 19)
-                    {
-                        expressions.RemoveAt(0);
-                    }
-
-                    expressions.Add(line);
                 }
 
                 _reset = false;
             }
         }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        private static void DisplayCurrentLine(PowerFxREPL repl, string line)
-#pragma warning restore CS0618 // Type or member is obsolete
-        {
-            Console.SetCursorPosition(0, Console.CursorTop);
-            Console.Write(new string(' ', Console.BufferWidth));
-            Console.SetCursorPosition(0, Console.CursorTop);
-            repl.WritePromptAsync().Wait();
-            Console.Write(line);
-        }
-
-        private static void ClearIntellisense(ref int iStart, int iEnd)
-        {
-            if (iStart == -1)
-            {
-                return;
-            }
-
-            int cl = Console.CursorLeft;
-            int ct = Console.CursorTop;
-
-            for (int i = iStart; i <= Math.Min(iEnd, Console.BufferHeight - 1); i++)
-            {
-                Console.SetCursorPosition(0, i);
-                Console.Write(new string(' ', Console.BufferWidth));
-            }
-
-            Console.SetCursorPosition(cl, ct);
-            iStart = -1;
-        }       
 
         private class ResetFunction : ReflectionFunction
         {

--- a/src/tools/Repl/Repl.csproj
+++ b/src/tools/Repl/Repl.csproj
@@ -8,14 +8,6 @@
     <Configurations>Debug;Release</Configurations>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
-    <NoWarn>$(NoWarn);NU5125;CA1303</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
-    <NoWarn>$(NoWarn);NU5125;CA1303</NoWarn>
-  </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\libraries\Microsoft.PowerFx.Core\Microsoft.PowerFx.Core.csproj" />


### PR DESCRIPTION
Reverts microsoft/Power-Fx#2000

This needs some more work.
- Not designed for REPL library consumers, like the PAC CLI.
- Isn't working for me.
- Use of ESC and TAB keys breaks multiline detection.
- The extra newline in the prompt was there for a reason when used with the PAC CLI and should be retained.