### PR TITLE
Also mark ScopeCollection references as stateful

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2995,7 +2995,8 @@ namespace Microsoft.PowerFx.Core.Binding
                 UpdateBindKindUseFlags(lookupInfo.Kind);
 
                 // Update statefulness of global datasources excluding dynamic datasources.
-                if (lookupInfo.Kind == BindKind.Data && !_txb._glue.IsDynamicDataSourceInfo(lookupInfo.Data))
+                if ((lookupInfo.Kind == BindKind.Data && !_txb._glue.IsDynamicDataSourceInfo(lookupInfo.Data)) ||
+                    lookupInfo.Kind == BindKind.ScopeCollection)
                 {
                     _txb.SetStateful(node, true);
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2995,8 +2995,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 UpdateBindKindUseFlags(lookupInfo.Kind);
 
                 // Update statefulness of global datasources excluding dynamic datasources.
-                if ((lookupInfo.Kind == BindKind.Data && !_txb._glue.IsDynamicDataSourceInfo(lookupInfo.Data)) ||
-                    lookupInfo.Kind == BindKind.ScopeCollection)
+                if (_txb.IsInfoKindDataSource(fnInfo) && !_txb._glue.IsDynamicDataSourceInfo(lookupInfo.Data))
                 {
                     _txb.SetStateful(node, true);
                 }


### PR DESCRIPTION
BindKind.Data is used for non-component collections in legacy PA cases, but for components, ScopeCollection is used. This matches the behavior for those so that both are considered stateful and not lifted out of row scopes. 