### PR TITLE
Intellisense now displays connector optional parameters as record

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
@@ -56,7 +56,18 @@ namespace Microsoft.PowerFx.Connectors
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return ConnectorFunction.RequiredParameters.Select<ConnectorParameter, TexlStrings.StringGetter>(p => (locale) => p.Name).ToArray();
-            yield return ConnectorFunction.OptionalParameters.Select<ConnectorParameter, TexlStrings.StringGetter>(p => (locale) => p.Name).ToArray();
+            yield return OptionalParametersSignature();
+        }
+
+        private TexlStrings.StringGetter[] OptionalParametersSignature()
+        {
+            if (ConnectorFunction.OptionalParameters.Count() > 0)
+            {
+                TexlStrings.StringGetter optionalParms = (b) => $"{{{string.Join(",", ConnectorFunction.OptionalParameters.Select(parm => $"{parm.Name}:{parm.FormulaType}"))}}}";
+                return new TexlStrings.StringGetter[] { optionalParms };
+            }
+
+            return new ConnectorParameter[0].Select<ConnectorParameter, TexlStrings.StringGetter>(p => (locale) => p.Name).ToArray();
         }
 
         public override bool TryGetParamDescription(string paramName, out string paramDescription)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -344,6 +344,25 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(7m, ((DecimalValue)fv).Value);
         }
 
+        [Theory]
+        [InlineData("Office365Outlook.FindMeetingTimesV2(")]
+        public void IntellisenseHelpStringsOptionalParms(string expr)
+        {
+            var apiDocOutlook = Helpers.ReadSwagger(@"Swagger\Office_365_Outlook.json");
+
+            var config = new PowerFxConfig();
+            config.AddActionConnector("Office365Outlook", apiDocOutlook, new ConsoleLogger(_output));
+
+            var engine = new Engine(config);
+            var check = engine.Check(expr, RecordType.Empty(), new ParserOptions() { AllowsSideEffects = true });
+
+            var result = engine.Suggest(check, expr.Length);
+
+            var overload = result.FunctionOverloads.Single();
+            Assert.Equal(Intellisense.SuggestionKind.Function, overload.Kind);
+            Assert.Equal("FindMeetingTimesV2({RequiredAttendees:String,OptionalAttendees:String,ResourceAttendees:String,MeetingDuration:Decimal,Start:DateTime,End:DateTime,MaxCandidates:Decimal,MinimumAttendeePercentage:String,IsOrganizerOptional:Boolean,ActivityDomain:String})", overload.DisplayText.Text);
+        }
+
         // Very documentation strings from the Swagger show up in the intellisense.
         [Theory]
         [InlineData("MSNWeather.CurrentWeather(", false, false)]


### PR DESCRIPTION
Issue https://github.com/microsoft/Power-Fx/issues/2045.
This fix addresses the intellisense problem only. Other mentioned issues are now individual filed issues.