### PR TITLE
Prevent assert on DType.TryGetPath

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1242,6 +1242,11 @@ namespace Microsoft.PowerFx.Core.Types
 
             var fRet = TryGetType(path.Parent, out type);
 
+            if (!fRet)
+            {
+                return false;
+            }
+
             if (type.IsEnum)
             {
                 type = type.GetEnumSupertype();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TypeSystemTests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TypeSystemTests/DTypeTests.cs
@@ -816,6 +816,24 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal(DType.Boolean, result);
         }
 
+        [Theory]
+        [InlineData("*[A:s]", "B")]
+        [InlineData("*[A:s]", "B.C")]
+        [InlineData("*[A:s,B:![D:n]]", "A.C")]
+        [InlineData("*[A:s,B:![D:n]]", "B.C")]
+        public void TryGetTypeNegativeTests(string dType, string dPath)
+        {
+            var type = TestUtils.DT(dType);
+            var path = DPath.Root;
+            foreach (var pathPart in dPath.Split('.'))
+            {
+                path = path.Append(new DName(pathPart));
+            }
+
+            Assert.False(type.TryGetType(path, out var result));
+            Assert.Equal(DType.Invalid, result);
+        }
+
         [Fact]
         public void RecordAndTableDTypeTests()
         {


### PR DESCRIPTION
A call to TryGetPath was asserting on a valid invocation (last case in the newly added tests). It shouldn't assert - it should just return false in that case.