### PR TITLE
Handling date-no-tz type as datetime

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -369,9 +369,8 @@ namespace Microsoft.PowerFx.Connectors
                         case "date":
                             return new ConnectorType(schema, openApiParameter, FormulaType.Date);
                         case "date-time":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTime);
                         case "date-no-tz":
-                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTimeNoTimeZone);
+                            return new ConnectorType(schema, openApiParameter, FormulaType.DateTime);
 
                         case "binary":
                             return new ConnectorType(schema, openApiParameter, FormulaType.String, binary: true);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/PowerPlatformConnectorTests.cs
@@ -681,8 +681,10 @@ namespace Microsoft.PowerFx.Tests
             public DateTime UtcNow { get; set; } = new DateTime(2023, 6, 2, 3, 15, 7, DateTimeKind.Utc);
         }
 
-        [Fact]
-        public async Task Office365Outlook_V4CalendarPostItem()
+        [Theory]
+        [InlineData(@"Office365Outlook.V4CalendarPostItem(""Calendar"", ""Subject"", Today(), Today(), ""(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"")")]
+        [InlineData(@"Office365Outlook.V4CalendarPostItem(""Calendar"", ""Subject"", DateTime(2023, 6, 2, 11, 00, 00), DateTime(2023, 6, 2, 11, 30, 00), ""(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"")")]
+        public async Task Office365Outlook_V4CalendarPostItem(string expr)
         {
             using var testConnector = new LoggingTestServer(@"Swagger\Office_365_Outlook.json");
             var apiDoc = testConnector._apiDocument;
@@ -710,7 +712,7 @@ namespace Microsoft.PowerFx.Tests
             runtimeConfig.AddRuntimeContext(new TestConnectorRuntimeContext("Office365Outlook", client));            
 
             testConnector.SetResponseFromFile(@"Responses\Office 365 Outlook V4CalendarPostItem.json");
-            FormulaValue result = await engine.EvalAsync(@"Office365Outlook.V4CalendarPostItem(""Calendar"", ""Subject"", Today(), Today(), ""(UTC+01:00) Brussels, Copenhagen, Madrid, Paris"")", CancellationToken.None, options: new ParserOptions() { AllowsSideEffects = true }, runtimeConfig: runtimeConfig).ConfigureAwait(false);
+            FormulaValue result = await engine.EvalAsync(expr, CancellationToken.None, options: new ParserOptions() { AllowsSideEffects = true }, runtimeConfig: runtimeConfig).ConfigureAwait(false);
             Assert.Equal(@"![body:s, categories:*[Value:s], createdDateTime:d, end:d, endWithTimeZone:d, iCalUId:s, id:s, importance:s, isAllDay:b, isHtml:b, isReminderOn:b, lastModifiedDateTime:d, location:s, numberOfOccurences:w, optionalAttendees:s, organizer:s, recurrence:s, recurrenceEnd:D, reminderMinutesBeforeStart:w, requiredAttendees:s, resourceAttendees:s, responseRequested:b, responseTime:d, responseType:s, selectedDaysOfWeek:N, sensitivity:s, seriesMasterId:s, showAs:s, start:d, startWithTimeZone:d, subject:s, timeZone:s, webLink:s]", result.Type._type.ToString());
 
             var actual = testConnector._log.ToString();            


### PR DESCRIPTION
Issue https://github.com/microsoft/Power-Fx/issues/2052.

This fix does not address the exception since https://github.com/microsoft/Power-Fx/pull/2033 was fixed previously.
This PR addresses a new situation when running the expression described on this issue.