### PR TITLE
Fix null reference when trying to get suggestions for BuiltInOperation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -368,7 +368,10 @@ namespace Microsoft.PowerFx.Connectors
                     return suggestions;
                 }
 
-                if (connectorType.DynamicValues != null && string.IsNullOrEmpty(connectorType.DynamicValues.Capability))
+                // BuiltInOperation and capability are currently not supported
+                if (connectorType.DynamicValues != null 
+                    && string.IsNullOrEmpty(connectorType.DynamicValues.Capability)
+                    && string.IsNullOrEmpty(connectorType.DynamicValues.BuiltInOperation))
                 {
                     ConnectorEnhancedSuggestions suggestions = await GetConnectorSuggestionsFromDynamicValueAsync(knownParameters, runtimeContext, connectorType.DynamicValues, cancellationToken).ConfigureAwait(false);
                     runtimeContext.ExecutionLogger?.LogDebug($"Exiting {this.LogFunction(nameof(GetConnectorSuggestionsInternalAsync))}, returning from {nameof(GetConnectorSuggestionsFromDynamicValueAsync)} with {LogConnectorEnhancedSuggestions(suggestions)}");

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -369,9 +369,7 @@ namespace Microsoft.PowerFx.Connectors
                 }
 
                 // BuiltInOperation and capability are currently not supported
-                if (connectorType.DynamicValues != null 
-                    && string.IsNullOrEmpty(connectorType.DynamicValues.Capability)
-                    && string.IsNullOrEmpty(connectorType.DynamicValues.BuiltInOperation))
+                if (connectorType.DynamicValues != null)
                 {
                     ConnectorEnhancedSuggestions suggestions = await GetConnectorSuggestionsFromDynamicValueAsync(knownParameters, runtimeContext, connectorType.DynamicValues, cancellationToken).ConfigureAwait(false);
                     runtimeContext.ExecutionLogger?.LogDebug($"Exiting {this.LogFunction(nameof(GetConnectorSuggestionsInternalAsync))}, returning from {nameof(GetConnectorSuggestionsFromDynamicValueAsync)} with {LogConnectorEnhancedSuggestions(suggestions)}");

--- a/src/libraries/Microsoft.PowerFx.Connectors/Internal/ConnectorDynamicValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Internal/ConnectorDynamicValue.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         public string ValueCollection = null;
 
+        /* Support the following two parameters some day in the future
         /// <summary>
         /// "capability" in "x-ms-dynamic-values".
         /// https://github.com/nk-gears/pa-custom-connector-filepicker/blob/main/README.md.
@@ -35,5 +36,6 @@ namespace Microsoft.PowerFx.Connectors
         /// "builtInOperation" in "x-ms-dynamic-values".
         /// </summary>
         public string BuiltInOperation = null;
+        */
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -737,6 +737,13 @@ namespace Microsoft.PowerFx.Connectors
                 apiObj.WhenPresent("capability", (op_capStr) => cdv.Capability = op_capStr);
                 apiObj.WhenPresent("builtInOperation", (op_bioStr) => cdv.BuiltInOperation = op_bioStr);
 
+                if (!string.IsNullOrEmpty(cdv.BuiltInOperation) || !string.IsNullOrEmpty(cdv.Capability))
+                {
+                    // we don't support BuiltInOperations or capabilities right now
+                    // return null to indicate that the call to get suggestions is not needed for this parameter
+                    return null;
+                }
+
                 return cdv;
             }
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -734,15 +734,11 @@ namespace Microsoft.PowerFx.Connectors
                 apiObj.WhenPresent("value-title", (opValTitle) => cdv.ValueTitle = opValTitle);
                 apiObj.WhenPresent("value-path", (opValPath) => cdv.ValuePath = opValPath);
                 apiObj.WhenPresent("value-collection", (opValCollection) => cdv.ValueCollection = opValCollection);
-                apiObj.WhenPresent("capability", (op_capStr) => cdv.Capability = op_capStr);
-                apiObj.WhenPresent("builtInOperation", (op_bioStr) => cdv.BuiltInOperation = op_bioStr);
 
-                if (!string.IsNullOrEmpty(cdv.BuiltInOperation) || !string.IsNullOrEmpty(cdv.Capability))
-                {
-                    // we don't support BuiltInOperations or capabilities right now
-                    // return null to indicate that the call to get suggestions is not needed for this parameter
-                    return null;
-                }
+                // we don't support BuiltInOperations or capabilities right now
+                // return null to indicate that the call to get suggestions is not needed for this parameter
+                apiObj.WhenPresent("capability", (string op_capStr) => cdv = null);
+                apiObj.WhenPresent("builtInOperation", (string op_bioStr) => cdv = null);
 
                 return cdv;
             }


### PR DESCRIPTION
*Issue description*
When the x-ms-dynamic-values has "BuiltInOperation" instead of a normal operation, PowerFX reports that the parameter supports Suggestion calls. When this call is done, PowerFX throws with NullRefException:

Object reference not set to an instance of an object., Callstack
    at Microsoft.PowerFx.Connectors.ConnectorFunction.GetArguments(ConnectionDynamicApi dynamicApi, NamedValue[] knownParameters, BaseRuntimeConnectorContext runtimeContext)\r\n
   at Microsoft.PowerFx.Connectors.ConnectorFunction.GetConnectorSuggestionsFromDynamicValueAsync(NamedValue[] knownParameters, BaseRuntimeConnectorContext runtimeContext, ConnectorDynamicValue cdv, CancellationToken cancellationToken)\r\n
   at Microsoft.PowerFx.Connectors.ConnectorFunction.GetConnectorSuggestionsInternalAsync(NamedValue[] knownParameters, ConnectorType connectorType, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)\r\n
   at Microsoft.PowerFx.Connectors.ConnectorFunction.GetParameterSuggestionsInternalAsync(NamedValue[] knownParameters, ConnectorParameter connectorParameter, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)\r\n
   at Microsoft.PowerFx.Connectors.ConnectorFunction.GetParameterSuggestionsAsync(NamedValue[] knownParameters, ConnectorParameter connectorParameter, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)"} 