### PR TITLE
Fix logic to determine selects for a some functions with column names as identifiers

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
@@ -174,6 +174,20 @@ namespace Microsoft.PowerFx
             return false;
         }
 
+        public virtual bool TryLookupEnum(DName name, out NameLookupInfo lookupInfo)
+        {
+            foreach (INameResolver table in _symbolTables)
+            {
+                if (table.TryLookupEnum(name, out lookupInfo))
+                {
+                    return true;
+                }
+            }
+
+            lookupInfo = default;
+            return false;
+        }
+
         internal override IExternalEntityScope InternalEntityScope
         {
             get

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -461,7 +461,8 @@ namespace Microsoft.PowerFx
 
         bool INameResolver.TryLookupEnum(DName name, out NameLookupInfo lookupInfo)
         {
-            throw new NotImplementedException();
+            lookupInfo = default;
+            return false;
         }
 
         bool INameResolver.TryGetInnermostThisItemScope(out NameLookupInfo nameInfo)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RenameColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/RenameColumns.cs
@@ -233,38 +233,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (var i = 1; i < args.Count - 1; i += 2)
             {
-                string columnName;
-                DType columnType;
-                if (binding.Features.SupportColumnNamesAsIdentifiers)
-                {
-                    FirstNameNode columnNode = args[i].AsFirstName();
-
-                    // This is a bug in the existing implementation - with column names as
-                    // string this will always return a string, although it seems like it
-                    // intended to return the type of the column being renamed. Since this code
-                    // will be obsoleted soon, just keep the existing logic for now.
-                    columnType = DType.String;
-
-                    if (columnType.Kind != DKind.String || columnNode == null)
-                    {
-                        continue;
-                    }
-
-                    columnName = columnNode.Ident.Name.Value;
-                }
-                else
-                {
-                    columnType = binding.GetType(args[i]);
-                    StrLitNode columnNode = args[i].AsStrLit();
-                    if (columnType.Kind != DKind.String || columnNode == null)
-                    {
-                        continue;
-                    }
-
-                    columnName = columnNode.Value;
-                }
-
-                Contracts.Assert(dsType.Contains(new DName(columnName)));
+                base.TryGetColumnLogicalName(dsType, binding.Features.SupportColumnNamesAsIdentifiers, args[i], DefaultErrorContainer, out var columnName, out var columnType).Verify();
+                Contracts.Assert(dsType.Contains(columnName));
 
                 retval |= dsType.AssociateDataSourcesToSelect(dataSourceToQueryOptionsMap, columnName, columnType, true);
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -263,7 +263,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return true;
         }
 
-        private bool IsValidSortableColumnNode(TexlNode node, TexlBinding binding, SortOpMetadata metadata)
+        private bool IsValidSortableColumnNode(DType dataSourceType, TexlNode node, TexlBinding binding, SortOpMetadata metadata)
         {
             Contracts.AssertValue(node);
             Contracts.AssertValue(binding);
@@ -274,26 +274,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return false;
             }
 
-            DName columnName;
-            if (binding.Features.SupportColumnNamesAsIdentifiers)
-            {
-                if (node is not FirstNameNode identifierNode)
-                {
-                    return false;
-                }
-
-                columnName = identifierNode.Ident.Name;
-            }
-            else
-            {
-                if (node.Kind != NodeKind.StrLit)
-                {
-                    return false;
-                }
-
-                columnName = new DName(node.AsStrLit().VerifyValue().Value);
-            }
-            
+            base.TryGetColumnLogicalName(dataSourceType, binding.Features.SupportColumnNamesAsIdentifiers, node, DefaultErrorContainer, out var columnName).Verify();
             return IsColumnSortable(node, columnName, binding, metadata);
         }
 
@@ -353,12 +334,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             if (callNode.Args.Count == 3)
             {
                 // Check if using the SortByColumns(source, column, ordertable) overload, which is not delegable
-                var secondArgType = binding.GetType(callNode.Args.ChildNodes[2]);
-                if (secondArgType.IsTable)
+                var thirdArgType = binding.GetType(callNode.Args.ChildNodes[2]);
+                if (thirdArgType.IsTable)
                 {
                     return false;
                 }
             }
+
+            var dsType = binding.GetType(callNode.Args.ChildNodes[0]);
 
             SortOpMetadata metadata = null;
             if (TryGetEntityMetadata(callNode, binding, out IDelegationMetadata delegationMetadata))
@@ -388,21 +371,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (var i = 1; i < cargs; i += 2)
             {
-                if (!IsValidSortableColumnNode(args[i], binding, metadata))
+                if (!IsValidSortableColumnNode(dsType, args[i], binding, metadata))
                 {
                     SuggestDelegationHint(args[i], binding);
                     return false;
                 }
 
-                DName columnName;
-                if (binding.Features.SupportColumnNamesAsIdentifiers)
-                {
-                    columnName = args[i].AsFirstName().VerifyValue().Ident.Name;
-                }
-                else
-                {
-                    columnName = new DName(args[i].AsStrLit().VerifyValue().Value);
-                }
+                base.TryGetColumnLogicalName(dsType, binding.Features.SupportColumnNamesAsIdentifiers, args[i], DefaultErrorContainer, out var columnName).Verify();
 
                 var sortOrderNode = (i + 1) < cargs ? args[i + 1] : null;
                 var sortOrder = sortOrderNode == null ? defaultSortOrder : string.Empty;
@@ -494,67 +469,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             if (callNode.Args.Count == 3 && binding.GetType(callNode.Args.ChildNodes[2]).IsTableNonObjNull)
             {
-                // Using the SortByColumns(source, column, ordertable) overload
-                if (binding.Features.SupportColumnNamesAsIdentifiers)
-                {
-                    var firstName = args[1].AsFirstName();
-                    if (firstName == null)
-                    {
-                        return false;
-                    }
-
-                    columnName = firstName.Ident.Name;
-                }
-                else
-                {
-                    var strLitNode = args[1].AsStrLit();
-                    if (strLitNode == null)
-                    {
-                        return false;
-                    }
-
-                    columnName = new DName(strLitNode.Value);
-                }
-
-                Contracts.Assert(dsType.Contains(new DName(columnName)));
-
-                if (!dsType.TryGetType(columnName, out columnType))
-                {
-                    return false;
-                }
-
+                base.TryGetColumnLogicalName(dsType, binding.Features.SupportColumnNamesAsIdentifiers, args[1], DefaultErrorContainer, out columnName, out columnType).Verify();
                 return dsType.AssociateDataSourcesToSelect(dataSourceToQueryOptionsMap, columnName, columnType, true);
             }
 
             for (var i = 1; i < args.Count; i += 2)
             {
-                if (binding.Features.SupportColumnNamesAsIdentifiers)
-                {
-                    var firstName = args[i].AsFirstName();
-                    if (firstName == null)
-                    {
-                        continue;
-                    }
-
-                    columnName = firstName.Ident.Name;
-                }
-                else
-                {
-                    var strLitNode = args[i].AsStrLit();
-                    if (strLitNode == null)
-                    {
-                        continue;
-                    }
-
-                    columnName = new DName(strLitNode.Value);
-                }
-
-                Contracts.Assert(dsType.Contains(columnName));
-                if (!dsType.TryGetType(columnName, out columnType))
-                {
-                    continue;
-                }
-
+                base.TryGetColumnLogicalName(dsType, binding.Features.SupportColumnNamesAsIdentifiers, args[i], DefaultErrorContainer, out columnName, out columnType).Verify();
                 retVal |= dsType.AssociateDataSourcesToSelect(dataSourceToQueryOptionsMap, columnName, columnType, true);
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDVEntity.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDVEntity.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Core.Entities.Delegation;
+using Microsoft.PowerFx.Core.Functions.Delegation;
+using Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata;
+using Microsoft.PowerFx.Core.Tests.Helpers;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+
+namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
+{
+    public class AccountsEntity : IExternalEntity, IExternalDataSource
+    {
+        public DName EntityName => new DName("Accounts");
+
+        public string Name => "Accounts";
+
+        public bool IsSelectable => true;
+
+        public bool IsDelegatable => true;
+
+        public bool IsRefreshable => true;
+
+        public bool RequiresAsync => true;
+
+        public bool IsPageable => true;
+
+        DType IExternalEntity.Type => AccountsTypeHelper.GetDType();
+
+        IExternalDataEntityMetadataProvider IExternalDataSource.DataEntityMetadataProvider => throw new NotImplementedException();
+
+        DataSourceKind IExternalDataSource.Kind => throw new NotImplementedException();
+
+        IExternalTableMetadata IExternalDataSource.TableMetadata => throw new NotImplementedException();
+
+        IDelegationMetadata IExternalDataSource.DelegationMetadata => new AccountsDelegationMetadata();
+    }
+
+    internal static class AccountsTypeHelper
+    {
+        internal const string SimplifiedAccountsSchema = "*[accountid:g, accountnumber:s, address1_addresstypecode:l, address1_city:s, address1_composite:s, address1_country:s, address1_county:s, address1_fax:s, address1_freighttermscode:l, address1_latitude:n, address1_line1:s, address1_line2:s, address1_line3:s, address1_longitude:n, address1_name:s, address1_postalcode:s, address1_postofficebox:s, address1_primarycontactname:s, address1_shippingmethodcode:l, address1_stateorprovince:s, address1_telephone1:s, address1_telephone2:s, address1_telephone3:s, address1_upszone:s, address1_utcoffset:n, createdon:d, description:s, emailaddress1:s, emailaddress2:s, emailaddress3:s, modifiedon:d, name:s, numberofemployees:n, primarytwitterid:s, stockexchange:s, telephone1:s, telephone2:s, telephone3:s, tickersymbol:s, versionnumber:n, websiteurl:h]";
+
+        public static DType GetDType()
+        {
+            DType accountsType = TestUtils.DT(SimplifiedAccountsSchema);
+            var dataSource = new TestDataSource(
+                "Accounts", 
+                accountsType, 
+                keyColumns: new[] { "accountid" },
+                selectableColumns: new[] { "name", "address1_city", "accountid", "address1_country", "address1_line1" });
+            var displayNameMapping = dataSource.DisplayNameMapping;
+            displayNameMapping.Add("name", "Name");
+            displayNameMapping.Add("address1_city", "Address 1: City");
+            displayNameMapping.Add("address1_line1", "Address 1: Street 1");
+            return DType.AttachDataSourceInfo(accountsType, dataSource);
+        }
+    }
+
+    internal class AccountsDelegationMetadata : IDelegationMetadata
+    {
+        public DType Schema => AccountsTypeHelper.GetDType();
+
+        public DelegationCapability TableAttributes => throw new NotImplementedException();
+
+        public DelegationCapability TableCapabilities => new DelegationCapability(DelegationCapability.SupportsAll);
+
+        public SortOpMetadata SortDelegationMetadata => new SortOpMetadata(Schema, new Dictionary<DPath, DelegationCapability>());
+
+        public FilterOpMetadata FilterDelegationMetadata => throw new NotImplementedException();
+
+        public GroupOpMetadata GroupDelegationMetadata => throw new NotImplementedException();
+
+        public Dictionary<DPath, DPath> ODataPathReplacementMap => throw new NotImplementedException();
+    }
+
+    internal class TestDVEntity
+    {
+        private class MyExpandInfo : IExpandInfo
+        {
+            public string Identity => "An identity";
+
+            public bool IsTable => true;
+
+            public string Name => "Name";
+
+            public string PolymorphicParent => throw new NotImplementedException();
+
+            public IExternalDataSource ParentDataSource => throw new NotImplementedException();
+
+            public ExpandPath ExpandPath => throw new NotImplementedException();
+
+            public IExpandInfo Clone()
+            {
+                throw new NotImplementedException();
+            }
+
+            public string ToDebugString()
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UpdateEntityInfo(IExternalDataSource dataSource, string relatedEntityPath)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public static DType Create()
+        {
+            return DType.CreateExpandType(new MyExpandInfo());
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestUpdateDataQuerySelects.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestUpdateDataQuerySelects.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.PowerFx.Core.Entities.QueryOptions;
+using Microsoft.PowerFx.Core.Tests.Helpers;
+using Microsoft.PowerFx.Core.Texl;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
+{
+    public class TestUpdateDataQuery
+    {
+        [Theory]
+        [InlineData("SortByColumns(Accounts, Name, SortOrder.Ascending)", "accountid,name")]
+        [InlineData("SortByColumns(Accounts, Name, SortOrder.Ascending, 'Address 1: City')", "accountid,name,address1_city")]
+        [InlineData("SortByColumns(Accounts, Name, SortOrder.Descending, 'Address 1: Street 1')", "accountid,name,address1_line1")]
+        [InlineData("SortByColumns(Accounts, name, SortOrder.Descending, address1_line1)", "accountid,name,address1_line1")]
+        [InlineData("ShowColumns(Accounts, Name, 'Address 1: City')", "accountid,name,address1_city")]
+        [InlineData("RenameColumns(Accounts, Name, 'The name', 'Address 1: City', 'The city')", "accountid,name,address1_city")]
+        public void TestSelects(string expression, string expectedSelects)
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddEntity(new AccountsEntity());
+
+            var config = new PowerFxConfig()
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+            Assert.True(result.IsSuccess);
+
+            var callNode = result.Binding.Top.AsCall();
+            Assert.NotNull(callNode);
+
+            var callInfo = result.Binding.GetInfo(callNode);
+            var dataSourceToQueryOptionsMap = new DataSourceToQueryOptionsMap();
+            callInfo.Function.UpdateDataQuerySelects(callNode, result.Binding, dataSourceToQueryOptionsMap);
+            var queryOptions = dataSourceToQueryOptionsMap.GetQueryOptions();
+            var actualSelectsList = new List<string>();
+            foreach (var queryOption in queryOptions)
+            {
+                actualSelectsList.AddRange(queryOption.Selects);
+            }
+
+            var expectedSelectsList = expectedSelects.Split(",").ToList();
+            Assert.Equal(expectedSelectsList.Count, actualSelectsList.Count);
+            foreach (var expectedSelect in expectedSelectsList)
+            {
+                Assert.Contains(expectedSelect, actualSelectsList);
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FunctionTests.cs
@@ -37,6 +37,30 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TestFunctionWithIdentifiersHaveIdentifierParameters()
+        {
+            var texlFunctionsLibrary = BuiltinFunctionsCore.TestOnly_AllBuiltinFunctions;
+            var functions = texlFunctionsLibrary.Where(x => !x.FunctionCategoriesMask.HasFlag(FunctionCategories.REST));
+
+            foreach (var function in functions)
+            {
+                if (function.MaxArity == 0)
+                {
+                    continue;
+                }
+
+                var functionHasColumnIdentifiers = function.HasColumnIdentifiers;
+                var functionHasIdentifierParameters = Enumerable.Range(0, Math.Min(function.MaxArity, 5))
+                    .Where(argIndex => function.GetIdentifierParamStatus(argIndex) != TexlFunction.ParamIdentifierStatus.NeverIdentifier)
+                    .Any();
+
+                Assert.True(
+                    functionHasColumnIdentifiers == functionHasIdentifierParameters,
+                    $"Function {function.Name} ({function.GetType().FullName}) is HasColumnIdentifiers = {functionHasColumnIdentifiers} and functionHasIdentifierParameters = {functionHasIdentifierParameters}");
+            }
+        }
+
+        [Fact]
         public void TextFunctionSet_Ctor()
         {
             var tfs = new TexlFunctionSet();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
@@ -169,11 +170,19 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
     {
         internal IExternalDataEntityMetadataProvider ExternalDataEntityMetadataProvider;
 
-        internal TestDataSource(string name, DType schema)
+        private readonly string[] _keyColumns;
+        private readonly HashSet<string> _selectableColumns;
+        private readonly TabularDataQueryOptions _tabularDataQueryOptions;
+
+        internal TestDataSource(string name, DType schema, string[] keyColumns = null, IEnumerable<string> selectableColumns = null)
         {
             ExternalDataEntityMetadataProvider = new ExternalDataEntityMetadataProvider();
             Type = DType.AttachDataSourceInfo(schema, this);
             Name = name;
+            DisplayNameMapping = new BidirectionalDictionary<string, string>();
+            _keyColumns = keyColumns;
+            _selectableColumns = new HashSet<string>(selectableColumns ?? Enumerable.Empty<string>());
+            _tabularDataQueryOptions = new TabularDataQueryOptions(this);
         }
 
         public string Name { get; }
@@ -198,11 +207,11 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         public bool IsPageable => false;
 
-        public virtual TabularDataQueryOptions QueryOptions => throw new NotImplementedException();
+        public virtual TabularDataQueryOptions QueryOptions => _tabularDataQueryOptions;
 
         public bool IsConvertingDisplayNameMapping => false;
 
-        public BidirectionalDictionary<string, string> DisplayNameMapping => new BidirectionalDictionary<string, string>();
+        public BidirectionalDictionary<string, string> DisplayNameMapping { get; }
 
         public BidirectionalDictionary<string, string> PreviousDisplayNameMapping => null;
 
@@ -222,7 +231,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         public virtual bool CanIncludeSelect(string selectColumnName)
         {
-            throw new NotImplementedException();
+            return _selectableColumns.Contains(selectColumnName);
         }
 
         public bool CanIncludeSelect(IExpandInfo expandInfo, string selectColumnName)
@@ -232,7 +241,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         public virtual IReadOnlyList<string> GetKeyColumns()
         {
-            throw new NotImplementedException();
+            return _keyColumns;
         }
 
         public IEnumerable<string> GetKeyColumns(IExpandInfo expandInfo)


### PR DESCRIPTION
The logic to detect which columns need to be selected from data source was not working properly in a few functions if column names as identifiers were used. This fixes it, and adds a test with a data source to the core test library.