### PR TITLE
Fix delegation validation for Search function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Search.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Search.cs
@@ -164,14 +164,17 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.AssertValue(binding);
             Contracts.AssertValue(dataSource);
 
-            if (binding.ErrorContainer.HasErrors(node) || node.Kind != NodeKind.StrLit)
+            if (binding.ErrorContainer.HasErrors(node))
             {
                 return false;
             }
 
-            StrLitNode columnNode = Contracts.VerifyValue(node.AsStrLit());
-            string columnName = columnNode.Value;
-            if (string.IsNullOrEmpty(columnName) || !IsColumnSearchable(DPath.Root.Append(new DName(columnName)), dataSource))
+            if (!base.TryGetColumnLogicalName(dataSource.Type, binding.Features.SupportColumnNamesAsIdentifiers, node, DefaultErrorContainer, out var columnName))
+            {
+                return false;
+            }
+
+            if (!IsColumnSearchable(DPath.Root.Append(columnName), dataSource))
             {
                 SuggestDelegationHint(node, binding);
                 return false;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/SortByColumns.cs
@@ -274,7 +274,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return false;
             }
 
-            base.TryGetColumnLogicalName(dataSourceType, binding.Features.SupportColumnNamesAsIdentifiers, node, DefaultErrorContainer, out var columnName).Verify();
+            if (!base.TryGetColumnLogicalName(dataSourceType, binding.Features.SupportColumnNamesAsIdentifiers, node, DefaultErrorContainer, out var columnName))
+            {
+                return false;
+            }
+
             return IsColumnSortable(node, columnName, binding, metadata);
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDVEntity.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDVEntity.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
 
     internal static class AccountsTypeHelper
     {
-        internal const string SimplifiedAccountsSchema = "*[accountid:g, accountnumber:s, address1_addresstypecode:l, address1_city:s, address1_composite:s, address1_country:s, address1_county:s, address1_fax:s, address1_freighttermscode:l, address1_latitude:n, address1_line1:s, address1_line2:s, address1_line3:s, address1_longitude:n, address1_name:s, address1_postalcode:s, address1_postofficebox:s, address1_primarycontactname:s, address1_shippingmethodcode:l, address1_stateorprovince:s, address1_telephone1:s, address1_telephone2:s, address1_telephone3:s, address1_upszone:s, address1_utcoffset:n, createdon:d, description:s, emailaddress1:s, emailaddress2:s, emailaddress3:s, modifiedon:d, name:s, numberofemployees:n, primarytwitterid:s, stockexchange:s, telephone1:s, telephone2:s, telephone3:s, tickersymbol:s, versionnumber:n, websiteurl:h]";
+        internal const string SimplifiedAccountsSchema = "*[accountid:g, accountnumber:s, address1_addresstypecode:l, address1_city:s, address1_composite:s, address1_country:s, address1_county:s, address1_fax:s, address1_freighttermscode:l, address1_latitude:n, address1_line1:s, address1_line2:s, address1_line3:s, address1_longitude:n, address1_name:s, address1_postalcode:s, address1_postofficebox:s, address1_primarycontactname:s, address1_shippingmethodcode:l, address1_stateorprovince:s, address1_telephone1:s, address1_telephone2:s, address1_telephone3:s, address1_upszone:s, address1_utcoffset:n, createdon:d, description:s, emailaddress1:s, emailaddress2:s, emailaddress3:s, modifiedon:d, name:s, numberofemployees:n, primarytwitterid:s, stockexchange:s, telephone1:s, telephone2:s, telephone3:s, tickersymbol:s, versionnumber:n, websiteurl:h, nonsearchablestringcol:s, nonsortablestringcolumn:s]";
 
         public static DType GetDType()
         {
@@ -57,6 +57,8 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             displayNameMapping.Add("name", "Account Name");
             displayNameMapping.Add("address1_city", "Address 1: City");
             displayNameMapping.Add("address1_line1", "Address 1: Street 1");
+            displayNameMapping.Add("nonsearchablestringcol", "Non-searchable string column");
+            displayNameMapping.Add("nonsortablestringcolumn", "Non-sortable string column");
             return DType.AttachDataSourceInfo(accountsType, dataSource);
         }
     }
@@ -69,7 +71,7 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
 
         public DelegationCapability TableCapabilities => new DelegationCapability(DelegationCapability.SupportsAll);
 
-        public SortOpMetadata SortDelegationMetadata => new SortOpMetadata(Schema, new Dictionary<DPath, DelegationCapability>());
+        public SortOpMetadata SortDelegationMetadata { get; }
 
         public FilterOpMetadata FilterDelegationMetadata { get; }
 
@@ -80,49 +82,21 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         public AccountsDelegationMetadata()
         {
             FilterDelegationMetadata = new FilterOpMetadata(
-                Schema,
-                new Dictionary<DPath, DelegationCapability>(),
-                new Dictionary<DPath, DelegationCapability>(),
-                DelegationCapability.SupportsAll,
-                DelegationCapability.SupportsAll);
-        }
-    }
+                tableSchema: Schema,
+                columnRestrictions: new Dictionary<DPath, DelegationCapability>
+                {
+                    { DPath.Root.Append(new DName("nonsearchablestringcol")), DelegationCapability.Filter }
+                },
+                columnCapabilities: new Dictionary<DPath, DelegationCapability>(),
+                filterFunctionsSupportedByAllColumns: DelegationCapability.SupportsAll,
+                filterFunctionsSupportedByTable: DelegationCapability.SupportsAll);
 
-    internal class TestDVEntity
-    {
-        private class MyExpandInfo : IExpandInfo
-        {
-            public string Identity => "An identity";
-
-            public bool IsTable => true;
-
-            public string Name => "Name";
-
-            public string PolymorphicParent => throw new NotImplementedException();
-
-            public IExternalDataSource ParentDataSource => throw new NotImplementedException();
-
-            public ExpandPath ExpandPath => throw new NotImplementedException();
-
-            public IExpandInfo Clone()
-            {
-                throw new NotImplementedException();
-            }
-
-            public string ToDebugString()
-            {
-                throw new NotImplementedException();
-            }
-
-            public void UpdateEntityInfo(IExternalDataSource dataSource, string relatedEntityPath)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        public static DType Create()
-        {
-            return DType.CreateExpandType(new MyExpandInfo());
+            SortDelegationMetadata = new SortOpMetadata(
+                schema: Schema,
+                columnRestrictions: new Dictionary<DPath, DelegationCapability>
+                {
+                    { DPath.Root.Append(new DName("nonsortablestringcolumn")), DelegationCapability.Sort }
+                });
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.PowerFx.Core.Entities.QueryOptions;
+using Microsoft.PowerFx.Core.Tests.Helpers;
+using Microsoft.PowerFx.Core.Texl;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
+{
+    public class TestDelegationValidation
+    {
+        [Theory]
+        [InlineData("SortByColumns(Accounts, 'Account Name', SortOrder.Ascending)", true)]
+        [InlineData("SortByColumns(Accounts, 'Account Name', SortOrder.Ascending, 'Address 1: City')", true)]
+        [InlineData("SortByColumns(Accounts, 'Account Name', SortOrder.Descending, 'Non-sortable string column')", false)]
+        [InlineData("SortByColumns(Accounts, name, SortOrder.Descending, address1_line1)", true)]
+        [InlineData("ShowColumns(Accounts, 'Account Name', 'Address 1: City')", false)]
+        [InlineData("RenameColumns(Accounts, 'Account Name', 'The name', 'Address 1: City', 'The city')", false)]
+        [InlineData("Search(Accounts, \"something to search\", 'Account Name', address1_line1, 'Address 1: City')", true)]
+        [InlineData("Search(Accounts, \"something to search\", 'Account Name', 'Non-searchable string column', 'Address 1: City')", false)]
+        [InlineData("Filter(Accounts, IsBlank('Address 1: City'))", true)]
+        [InlineData("Filter(Accounts, IsBlank(ThisRecord.'Address 1: City'))", true)]
+        [InlineData("CountIf(Accounts, IsBlank('Address 1: City'))", true)]
+        [InlineData("CountIf(Accounts, Sqrt(ThisRecord.accountnumber) > 1)", false)]
+        public void TestDelegableExpressions(string expression, bool isDelegable)
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddEntity(new AccountsEntity());
+
+            var config = new PowerFxConfig()
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+            Assert.True(result.IsSuccess);
+
+            var callNode = result.Binding.Top.AsCall();
+            Assert.NotNull(callNode);
+
+            var callInfo = result.Binding.GetInfo(callNode);
+            var dataSourceToQueryOptionsMap = new DataSourceToQueryOptionsMap();
+
+            var actualIsDelegable = callInfo.Function.IsServerDelegatable(callNode, result.Binding);
+            Assert.Equal(isDelegable, actualIsDelegable);
+        }
+
+        [Theory]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Ascending)", true)]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Ascending, \"address1_city\")", true)]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Descending, \"nonsortablestringcolumn\")", false)]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Descending, \"address1_line1\")", true)]
+        [InlineData("ShowColumns(Accounts, \"name\", \"address1_city\")", false)]
+        [InlineData("RenameColumns(Accounts, \"name\", \"The name\", \"address1_city\", \"The city\")", false)]
+        [InlineData("Search(Accounts, \"something to search\", \"name\", \"address1_line1\", \"address1_city\")", true)]
+        [InlineData("Search(Accounts, \"something to search\", \"name\", \"nonsearchablestringcol\", \"address1_city\")", false)]
+        public void TestDelegableExpressions_ColumnNamesAsLiteralStrings(string expression, bool isDelegable)
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddEntity(new AccountsEntity());
+
+            var features = new Features(Features.PowerFxV1)
+            {
+                SupportColumnNamesAsIdentifiers = false
+            };
+
+            var config = new PowerFxConfig(features)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+            Assert.True(result.IsSuccess);
+
+            var callNode = result.Binding.Top.AsCall();
+            Assert.NotNull(callNode);
+
+            var callInfo = result.Binding.GetInfo(callNode);
+            var dataSourceToQueryOptionsMap = new DataSourceToQueryOptionsMap();
+
+            var actualIsDelegable = callInfo.Function.IsServerDelegatable(callNode, result.Binding);
+            Assert.Equal(isDelegable, actualIsDelegable);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -29,6 +29,9 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         [InlineData("CountIf(Accounts, IsBlank('Address 1: City'))", true)]
         [InlineData("CountIf(Accounts, Sqrt(ThisRecord.numberofemployees) > 1)", false)]
         [InlineData("Filter(Accounts, And(Not IsBlank('Address 1: City'), numberofemployees > 100))", true)]
+        [InlineData("Sort(Accounts, 'Account Name')", true)]
+        [InlineData("Sort(Accounts, 'Account Name', SortOrder.Descending)", true)]
+        [InlineData("Sort(Accounts, 'Non-sortable string column', SortOrder.Ascending)", false)]
         public void TestDelegableExpressions(string expression, bool isDelegable)
         {
             var symbolTable = new DelegatableSymbolTable();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         [InlineData("Search(Accounts, \"something to search\", 'Account Name', 'Non-searchable string column', 'Address 1: City')", false)]
         [InlineData("Filter(Accounts, IsBlank('Address 1: City'))", true)]
         [InlineData("Filter(Accounts, IsBlank(ThisRecord.'Address 1: City'))", true)]
+        [InlineData("Filter(Accounts, Sqrt(ThisRecord.accountnumber) > 1)", false)]
         [InlineData("CountIf(Accounts, IsBlank('Address 1: City'))", true)]
         [InlineData("CountIf(Accounts, Sqrt(ThisRecord.accountnumber) > 1)", false)]
         public void TestDelegableExpressions(string expression, bool isDelegable)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -25,9 +25,10 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         [InlineData("Search(Accounts, \"something to search\", 'Account Name', 'Non-searchable string column', 'Address 1: City')", false)]
         [InlineData("Filter(Accounts, IsBlank('Address 1: City'))", true)]
         [InlineData("Filter(Accounts, IsBlank(ThisRecord.'Address 1: City'))", true)]
-        [InlineData("Filter(Accounts, Sqrt(ThisRecord.accountnumber) > 1)", false)]
+        [InlineData("Filter(Accounts, Sqrt(ThisRecord.numberofemployees) > 1)", false)]
         [InlineData("CountIf(Accounts, IsBlank('Address 1: City'))", true)]
-        [InlineData("CountIf(Accounts, Sqrt(ThisRecord.accountnumber) > 1)", false)]
+        [InlineData("CountIf(Accounts, Sqrt(ThisRecord.numberofemployees) > 1)", false)]
+        [InlineData("Filter(Accounts, And(Not IsBlank('Address 1: City'), numberofemployees > 100))", true)]
         public void TestDelegableExpressions(string expression, bool isDelegable)
         {
             var symbolTable = new DelegatableSymbolTable();
@@ -46,7 +47,6 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             Assert.NotNull(callNode);
 
             var callInfo = result.Binding.GetInfo(callNode);
-            var dataSourceToQueryOptionsMap = new DataSourceToQueryOptionsMap();
 
             var actualIsDelegable = callInfo.Function.IsServerDelegatable(callNode, result.Binding);
             Assert.Equal(isDelegable, actualIsDelegable);
@@ -84,7 +84,6 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             Assert.NotNull(callNode);
 
             var callInfo = result.Binding.GetInfo(callNode);
-            var dataSourceToQueryOptionsMap = new DataSourceToQueryOptionsMap();
 
             var actualIsDelegable = callInfo.Function.IsServerDelegatable(callNode, result.Binding);
             Assert.Equal(isDelegable, actualIsDelegable);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestUpdateDataQuerySelects.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestUpdateDataQuerySelects.cs
@@ -56,5 +56,52 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
                 Assert.Contains(expectedSelect, actualSelectsList);
             }
         }
+
+        [Theory]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Ascending)", "accountid,name")]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Ascending, \"address1_city\")", "accountid,name,address1_city")]
+        [InlineData("SortByColumns(Accounts, \"name\", SortOrder.Descending, \"address1_line1\")", "accountid,name,address1_line1")]
+        [InlineData("ShowColumns(Accounts, \"name\", \"address1_city\")", "accountid,name,address1_city")]
+        [InlineData("RenameColumns(Accounts, \"name\", \"The name\", \"address1_city\", \"The city\")", "accountid,name,address1_city")]
+        [InlineData("Search(Accounts, \"something to search\", \"name\", \"address1_line1\", \"address1_city\")", "accountid,name,address1_city,address1_line1")]
+        public void TestSelects_ColumnNamesAsLiteralStrings(string expression, string expectedSelects)
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddEntity(new AccountsEntity());
+
+            var features = new Features(Features.PowerFxV1)
+            {
+                SupportColumnNamesAsIdentifiers = false
+            };
+
+            var config = new PowerFxConfig(features)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+            Assert.True(result.IsSuccess);
+
+            var callNode = result.Binding.Top.AsCall();
+            Assert.NotNull(callNode);
+
+            var callInfo = result.Binding.GetInfo(callNode);
+            var dataSourceToQueryOptionsMap = new DataSourceToQueryOptionsMap();
+            callInfo.Function.UpdateDataQuerySelects(callNode, result.Binding, dataSourceToQueryOptionsMap);
+            var queryOptions = dataSourceToQueryOptionsMap.GetQueryOptions();
+            var actualSelectsList = new List<string>();
+            foreach (var queryOption in queryOptions)
+            {
+                actualSelectsList.AddRange(queryOption.Selects);
+            }
+
+            var expectedSelectsList = expectedSelects.Split(",").ToList();
+            Assert.Equal(expectedSelectsList.Count, actualSelectsList.Count);
+            foreach (var expectedSelect in expectedSelectsList)
+            {
+                Assert.Contains(expectedSelect, actualSelectsList);
+            }
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
@@ -187,7 +187,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         public string Name { get; }
 
-        public virtual bool IsSelectable => throw new NotImplementedException();
+        public virtual bool IsSelectable => true;
 
         public virtual bool IsDelegatable => throw new NotImplementedException();
 


### PR DESCRIPTION
The logic to determine the delegability of the Search function does not work properly with column names as identifiers. This fixes it.