### PR TITLE
Add tests for IfError to cover legacy bug

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inScalar.txt
@@ -62,6 +62,9 @@ true
 >> "1+2" in "3"
 false
 
+>> "345" in 123456
+true
+
 // Test some examples with potential wildcard and escape characters. 
 
 >> "[[]" in "SQL literal ["

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/inTable.txt
@@ -48,3 +48,30 @@ true
 
 >> "hello" exactin Table({Result:"Hello"},{Result:"World"})
 false
+
+>> "hello" in Table({a:"hello",b:true},{a:"world",b:false})
+Errors: Error 11-56: Invalid schema, expected a one-column table.
+
+>> true in [Today()]
+Errors: Error 0-4: Can't convert this data type. Power Apps can't convert this Boolean to a Date.
+
+>> 123 in ["123", "456"]
+true
+
+>> 123 in {a:123}
+Errors: Error 7-14: Invalid argument type. Cannot use Record values in this context.
+
+>> {a:true} in true
+Errors: Error 12-16: Invalid argument type. Cannot use Boolean values in this context.
+
+>> {a:true} in Table({a:{b:true}})
+Errors: Error 0-8: Invalid argument type. Expecting a Record value, but of a different schema.|Error 0-8: Incompatible type. The 'a' column in the data source you’re updating expects a 'Record' type and you’re using a 'Boolean' type.|Error 12-31: Invalid argument type. Expecting a Table value, but of a different schema.|Error 12-31: Incompatible type. The 'a' column in the data source you’re updating expects a 'Boolean' type and you’re using a 'Record' type.
+
+>> {a:123} in {a:123}
+Errors: Error 11-18: Invalid argument type. Cannot use Record values in this context.
+
+>> [123] in Table({a:123,b:true},{a:345,b:false})
+Errors: Error 9-46: Invalid schema, expected a one-column table.
+
+>> [123] in [123]
+Errors: Error 0-5: Invalid argument type. Cannot use Table values in this context.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -353,12 +353,74 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("RenameColumns({A:\"hello\",B:1}, AB, B)")]
         [InlineData("RenameColumns({A:\"hello\",B:1}, A1, B)")]
         [InlineData("RenameColumns([{A:\"hello\",B:1}], \"A\", \"B\")")]
+        [InlineData("RenameColumns([{A:\"hello\",B:1}], A, A1, A, A2)")]
+        [InlineData("RenameColumns(true, A, A1)")]
         public void TexlFunctionTypeSemanticsRenameColumns_Negative(string expression)
         {
             var engine = new Engine(new PowerFxConfig());
             var result = engine.Check(expression);
 
             Assert.False(result.IsSuccess);
+        }
+
+        [Theory]
+        [InlineData("IfError(\"Hello\", \"one\")", "s")]
+        [InlineData("IfError(\"Hello\", 1)", "s")]
+        [InlineData("IfError(\"Hello\", 1, 3)", "n")]
+        [InlineData("IfError(\"Hello\", \"one\", \"world\", 2, 1)", "n")]
+        [InlineData("IfError({a:1}, \"one\", [1,2,3], 2, 1)", "n")]
+        public void TexlFunctionTypeSemanticsIfError(string expression, string expectedType)
+        {
+            var engine = new Engine(new PowerFxConfig());
+            var options = new ParserOptions() { NumberIsFloat = true };
+            var result = engine.Check(expression, options);
+
+            Assert.True(DType.TryParse(expectedType, out var expectedDType));
+            Assert.Equal(expectedDType, result.Binding.ResultType);
+            Assert.True(result.IsSuccess);
+        }
+
+        [Theory]
+        [InlineData("IfError(\"Hello\", {a:\"one\"})")]
+        [InlineData("IfError(\"Hello\", 1, {a:2})", false, true)]
+        [InlineData("IfError(\"Hello\", 1, 3, [true])")]
+        [InlineData("IfError({a:1}, true)")]
+        [InlineData("IfError(1, [1], true, {a:1}, \"hello\")", false, true)]
+        [InlineData("IfError(IfError({a:1}, true), true)")]
+        [InlineData("false; IfError({a:1}, true); true", true)]
+        [InlineData("IsError(false; IfError({a:1}, true); true)", true)]
+        public void TexlFunctionTypeSemanticsIfError_MismatchedTypes(string expression, bool usesChain = false, bool preV1Bug = false)
+        {
+            foreach (var usePowerFxV1Rules in new[] { false, true })
+            {
+                if (!usePowerFxV1Rules && preV1Bug)
+                {
+                    // Bug on pre-V1 logic; will not fix for legacy reasons
+                    continue;
+                }
+
+                foreach (var isBehavior in new[] { false, true })
+                {
+                    var features = new Features(Features.PowerFxV1)
+                    {
+                        PowerFxV1CompatibilityRules = usePowerFxV1Rules
+                    };
+
+                    var engine = new Engine(new PowerFxConfig(features));
+                    var parserOptions = new ParserOptions() { NumberIsFloat = true, AllowsSideEffects = isBehavior };
+                    var result = engine.Check(expression, parserOptions);
+
+                    if (usePowerFxV1Rules && !usesChain)
+                    {
+                        Assert.True(result.IsSuccess);
+                        Assert.Equal(DType.Void, result.Binding.ResultType);
+                    }
+                    else
+                    {
+                        Assert.True(isBehavior == result.IsSuccess, $"For PFxV1={usePowerFxV1Rules} and isBehavior={isBehavior}, expression {expression} should {(isBehavior ? "succeed" : "fail")}");
+                    }
+                }
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Found a bug in IfError in Power Apps, which uses the legacy (pre-Power Fx 1.0) logic. It may be risky to fix it, so just adding some tests to document it.