### PR TITLE
Prune expected returntype intellisense.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseData/IntellisenseData.cs
@@ -464,8 +464,27 @@ namespace Microsoft.PowerFx.Intellisense.IntellisenseData
                 CurFunc == null && 
                 ExpectedExpressionReturnType.IsRecord) 
             {
-                FunctionRecordNameSuggestionHandler.AddSuggestionForAggregateAndParentRecord(parentNode, ExpectedExpressionReturnType, this);
+                // only top level record suggestions are added here. So we can avoid expanding the DV type.
+                var topLevelRecord = CreateTopLevelType(ExpectedExpressionReturnType);
+                FunctionRecordNameSuggestionHandler.AddSuggestionForAggregateAndParentRecord(parentNode, topLevelRecord, this);
             }
+        }
+
+        private static DType CreateTopLevelType(DType type)
+        {
+            if (!type.IsRecord)
+            {
+                throw new InvalidOperationException("Type must be a record type");
+            }
+
+            var fields = type.GetRootFieldNames();
+            var topLevelRecord = RecordType.Empty();
+            foreach (var field in fields)
+            {
+                topLevelRecord = topLevelRecord.Add(field.Value, FormulaType.Blank);
+            }
+
+            return topLevelRecord._type;
         }
 
         /// <summary>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SuggestTest.cs
@@ -492,16 +492,26 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
 
         [Theory]
         [InlineData("{|", "output1:", "output2:")]
-        [InlineData("{output1: {|", "Arg1F1:", "Arg1F2:")]
+
+        [InlineData("{output1: 1, |", "output1:", "output2:")]
+
+        // We do not suggest nested type, as this can explode if type is DV.
+        [InlineData("{output1: {|")]
 
         // output2 is tabletype, so don't show suggestion if current node is not a table.
         [InlineData("{output2: {|")]
-        [InlineData("{output2: [{|", "Arg2Field1:", "Arg2Field2:")]
+
+        // We do not suggest nested type, as this can explode if type is DV.
+        [InlineData("{output2: [{|")]
 
         // output2 is tabletype, so don't show suggestion if current node is not a table.
         [InlineData("{output1: {Arg1F1: 1, Arg1F2:\"test\"}, output2: {|")]
-        [InlineData("{output1: {Arg1F1: 1, Arg1F2:\"test\"}, output2: [{|", "Arg2Field1:", "Arg2Field2:")]
-        [InlineData("{output2: {Arg2Field1: 1, Arg2Field2:\"test\"}, output1: {|", "Arg1F1:", "Arg1F2:")]
+
+        // We do not suggest nested type, as this can explode if type is DV.
+        [InlineData("{output1: {Arg1F1: 1, Arg1F2:\"test\"}, output2: [{|")]
+
+        // We do not suggest nested type, as this can explode if type is DV.
+        [InlineData("{output2: {Arg2Field1: 1, Arg2Field2:\"test\"}, output1: {|")]
         public void SuggestAggregateReturnType(string expression, params string[] expected)
         {
             (var exp, var cursorPosition) = Decode(expression);


### PR DESCRIPTION
Expected returntype can have Dataverse type as expected return type. And that can cause intellisense to explode as that type can potentially point to different DV Tables.

This PR mitigates that by limiting intellisense to top-level fields, so intellisense never drills into nested fields. That helps us with the speed and out primary use case for the expected return type is to suggest top-level field anyways.