### PR TITLE
Add AI disclaimer

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -279,7 +279,19 @@ namespace Microsoft.PowerFx.Core.Functions
         /// <summary>
         /// This function requires an AI disclaimer. 
         /// </summary>
-        public virtual bool ShowAIDisclaimer => this.Name.StartsWith("AI", StringComparison.OrdinalIgnoreCase);
+        public virtual bool ShowAIDisclaimer => _aiWhitelist.Contains(this.Name);
+
+        // Move away from whitelist: https://github.com/microsoft/Power-Fx/issues/2118
+        private static readonly ISet<string> _aiWhitelist = new HashSet<string>()
+        {
+            "AIClassify", 
+            "AIExtract",
+            "AIReply",
+            "AISentiment",
+            "AISummarize",
+            "AISummarizeRecord",
+            "AITranslate"
+        };
 
         // A forward link to the function help.
         public virtual string HelpLink =>

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -279,9 +279,7 @@ namespace Microsoft.PowerFx.Core.Functions
         /// <summary>
         /// This function requires an AI disclaimer. 
         /// </summary>
-        // $$$ Pass this flag in
-        //public bool UseAIDisclaimer => this.Name.StartsWith("AI");
-        public bool ShowAIDisclaimer => true;
+        public virtual bool ShowAIDisclaimer => this.Name.StartsWith("AI", StringComparison.OrdinalIgnoreCase);
 
         // A forward link to the function help.
         public virtual string HelpLink =>

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -276,6 +276,13 @@ namespace Microsoft.PowerFx.Core.Functions
         // A description associated with this function.
         public string Description => _description(null);
 
+        /// <summary>
+        /// This function requires an AI disclaimer. 
+        /// </summary>
+        // $$$ Pass this flag in
+        //public bool UseAIDisclaimer => this.Name.StartsWith("AI");
+        public bool ShowAIDisclaimer => true;
+
         // A forward link to the function help.
         public virtual string HelpLink =>
 

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -748,5 +748,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrSearchWrongTableType = new ErrorResourceKey("ErrSearchWrongTableType");
 
         public static ErrorResourceKey ErrDeprecatedDotUseShowColumns = new ErrorResourceKey("ErrDeprecatedDotUseShowColumns");
+
+        public static ErrorResourceKey IntellisenseAiDisclaimer = new ErrorResourceKey("IntellisenseAiDisclaimer");
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseResult.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerFx.Intellisense
             }
             else
             {
-                DisclaimerProvider aiDisclaimer = new DisclaimerProvider(null);
+                Func<MarkdownString> aiDisclaimer = new DisclaimerProvider(null).Getter;                
 
                 IsFunctionScope = true;
                 var highlightStart = -1;
@@ -151,7 +151,7 @@ namespace Microsoft.PowerFx.Intellisense
                         {
                             // Use overload description and not IntellisenseData.CurrFunc overload
                             Documentation = !string.IsNullOrWhiteSpace(possibleOverload?.Description) ? possibleOverload.Description : func.Description,
-                            ShowAIDisclaimer = possibleOverload.ShowAIDisclaimer ? aiDisclaimer : null,
+                            GetDisclaimerMarkdown = possibleOverload.ShowAIDisclaimer ? aiDisclaimer : null,
                             Label = CreateFunctionSignature(func.Name, parameters, shouldAddEllipsis),
                             Parameters = parameters.ToArray(),
                         };
@@ -173,7 +173,7 @@ namespace Microsoft.PowerFx.Intellisense
                     var signatureInformation = new SignatureInformation()
                     {
                         Documentation = func.Description,
-                        ShowAIDisclaimer = func.ShowAIDisclaimer ? aiDisclaimer : null,
+                        GetDisclaimerMarkdown = func.ShowAIDisclaimer ? aiDisclaimer : null,
                         Label = CreateFunctionSignature(func.Name),
                         Parameters = new ParameterInformation[0],
                     };

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseResult.cs
@@ -78,6 +78,8 @@ namespace Microsoft.PowerFx.Intellisense
             }
             else
             {
+                DisclaimerProvider aiDisclaimer = new DisclaimerProvider(null);
+
                 IsFunctionScope = true;
                 var highlightStart = -1;
                 var highlightEnd = -1;
@@ -149,7 +151,7 @@ namespace Microsoft.PowerFx.Intellisense
                         {
                             // Use overload description and not IntellisenseData.CurrFunc overload
                             Documentation = !string.IsNullOrWhiteSpace(possibleOverload?.Description) ? possibleOverload.Description : func.Description,
-                            ShowAIDisclaimer = possibleOverload.ShowAIDisclaimer,
+                            ShowAIDisclaimer = possibleOverload.ShowAIDisclaimer ? aiDisclaimer : null,
                             Label = CreateFunctionSignature(func.Name, parameters, shouldAddEllipsis),
                             Parameters = parameters.ToArray(),
                         };
@@ -171,7 +173,7 @@ namespace Microsoft.PowerFx.Intellisense
                     var signatureInformation = new SignatureInformation()
                     {
                         Documentation = func.Description,
-                        ShowAIDisclaimer = func.ShowAIDisclaimer,
+                        ShowAIDisclaimer = func.ShowAIDisclaimer ? aiDisclaimer : null,
                         Label = CreateFunctionSignature(func.Name),
                         Parameters = new ParameterInformation[0],
                     };

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseResult.cs
@@ -149,6 +149,7 @@ namespace Microsoft.PowerFx.Intellisense
                         {
                             // Use overload description and not IntellisenseData.CurrFunc overload
                             Documentation = !string.IsNullOrWhiteSpace(possibleOverload?.Description) ? possibleOverload.Description : func.Description,
+                            ShowAIDisclaimer = possibleOverload.ShowAIDisclaimer,
                             Label = CreateFunctionSignature(func.Name, parameters, shouldAddEllipsis),
                             Parameters = parameters.ToArray(),
                         };
@@ -170,6 +171,7 @@ namespace Microsoft.PowerFx.Intellisense
                     var signatureInformation = new SignatureInformation()
                     {
                         Documentation = func.Description,
+                        ShowAIDisclaimer = func.ShowAIDisclaimer,
                         Label = CreateFunctionSignature(func.Name),
                         Parameters = new ParameterInformation[0],
                     };

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerFx.Intellisense
+{
+    /// <summary>
+    /// A string that represents Github flavored markdown. 
+    /// For use in displaying in intellisense. 
+    /// </summary>
+    public class MarkdownString
+    {
+        public MarkdownString(string markdown)
+        {
+            this.Markdown = markdown;
+        }
+
+        public string Markdown { get; }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Intellisense
 
         // See escaping rules: https://github.com/mattcone/markdown-guide/blob/master/_basic-syntax/escaping-characters.md
         // Escape with a \
-        private static readonly HashSet<char> _ecapeChars = new HashSet<char>
+        private static readonly ISet<char> _ecapeChars = new HashSet<char>
         {
             '\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '(', ')', '#', '+', '-', '.', '!', '|'
         };

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace Microsoft.PowerFx.Intellisense
 {
@@ -11,13 +13,58 @@ namespace Microsoft.PowerFx.Intellisense
     /// A string that represents Github flavored markdown. 
     /// For use in displaying in intellisense. 
     /// </summary>
+    [DebuggerDisplay("MARKDOWN: {Markdown}")]
     public class MarkdownString
     {
-        public MarkdownString(string markdown)
+        // private constructor to force use of factory method.
+        private MarkdownString() 
         {
-            this.Markdown = markdown;
         }
 
-        public string Markdown { get; }
+        public static MarkdownString FromMarkdown(string markdown)
+        {
+            return new MarkdownString
+            {
+                Markdown = markdown
+            };
+        }
+
+        // See escaping rules: https://github.com/mattcone/markdown-guide/blob/master/_basic-syntax/escaping-characters.md
+        // Escape with a \
+        private static readonly HashSet<char> _ecapeChars = new HashSet<char>
+        {
+            '\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '(', ')', '#', '+', '-', '.', '!', '|'
+        };
+
+        public static MarkdownString FromString(string plainText)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var c in plainText)
+            {
+                if (_ecapeChars.Contains(c))
+                {
+                    sb.Append('\\');
+                }
+
+                sb.Append(c);
+            }
+
+            return new MarkdownString
+            {
+                Markdown = sb.ToString()
+            };
+        }
+
+        public string Markdown { get; init; }
+
+        public static MarkdownString operator +(MarkdownString left, MarkdownString right) => Add(left, right);
+
+        public static MarkdownString Add(MarkdownString left, MarkdownString right)
+        {
+            return new MarkdownString
+            {
+                Markdown = left.Markdown + right.Markdown
+            };
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
@@ -21,6 +21,11 @@ namespace Microsoft.PowerFx.Intellisense
         {
         }
 
+        /// <summary>
+        /// Create an instance over existing markdown. This doesn't validate and the markdown string must be valid.
+        /// </summary>
+        /// <param name="markdown"></param>
+        /// <returns></returns>
         public static MarkdownString FromMarkdown(string markdown)
         {
             return new MarkdownString
@@ -29,6 +34,11 @@ namespace Microsoft.PowerFx.Intellisense
             };
         }
 
+        /// <summary>
+        /// Newline in markdown. 
+        /// </summary>
+        public static readonly MarkdownString Newline = MarkdownString.FromMarkdown("\n\n");
+
         // See escaping rules: https://github.com/mattcone/markdown-guide/blob/master/_basic-syntax/escaping-characters.md
         // Escape with a \
         private static readonly ISet<char> _ecapeChars = new HashSet<char>
@@ -36,6 +46,11 @@ namespace Microsoft.PowerFx.Intellisense
             '\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '(', ')', '#', '+', '-', '.', '!', '|'
         };
 
+        /// <summary>
+        /// Create an instance over plain text. This will escape the plaintext if needed. 
+        /// </summary>
+        /// <param name="plainText"></param>
+        /// <returns></returns>
         public static MarkdownString FromString(string plainText)
         {
             StringBuilder sb = new StringBuilder();
@@ -55,10 +70,25 @@ namespace Microsoft.PowerFx.Intellisense
             };
         }
 
+        /// <summary>
+        /// Get the raw markdown string. 
+        /// </summary>
         public string Markdown { get; init; }
 
+        /// <summary>
+        /// Concatenate two markdown strings. 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
         public static MarkdownString operator +(MarkdownString left, MarkdownString right) => Add(left, right);
 
+        /// <summary>
+        /// Concatenate two markdown strings. 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
         public static MarkdownString Add(MarkdownString left, MarkdownString right)
         {
             return new MarkdownString

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/MarkdownString.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerFx.Intellisense
     /// For use in displaying in intellisense. 
     /// </summary>
     [DebuggerDisplay("MARKDOWN: {Markdown}")]
+    [ThreadSafeImmutable]
     public class MarkdownString
     {
         // private constructor to force use of factory method.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/DisclaimerProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/DisclaimerProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Intellisense.SignatureHelp
                 (var shortMessage, var _) = ErrorUtils.GetLocalizedErrorContent(
                     TexlStrings.IntellisenseAiDisclaimer, _locale, out _);
 
-                return new MarkdownString(shortMessage);
+                return MarkdownString.FromMarkdown(shortMessage);
             }
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/DisclaimerProvider.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/DisclaimerProvider.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Globalization;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Localization;
+
+namespace Microsoft.PowerFx.Intellisense.SignatureHelp
+{
+    /// <summary>
+    /// Get Markdown for AI disclaimer. 
+    /// </summary>
+    internal class DisclaimerProvider
+    {
+        private readonly CultureInfo _locale;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisclaimerProvider"/> class.
+        /// </summary>
+        /// <param name="locale">locale for language to show messages in.</param>
+        public DisclaimerProvider(CultureInfo locale)
+        {
+            _locale = locale;
+        }
+
+        /// <summary>
+        /// Get the disclaimer in markdown. This may contain bold, hyperlinks, etc. 
+        /// </summary>
+        /// <returns></returns>
+        public MarkdownString DisclaimerMarkdown
+        {
+            get
+            {
+                (var shortMessage, var _) = ErrorUtils.GetLocalizedErrorContent(
+                    TexlStrings.IntellisenseAiDisclaimer, _locale, out _);
+
+                return new MarkdownString(shortMessage);
+            }
+        }
+
+        public Func<MarkdownString> Getter => () => this.DisclaimerMarkdown;
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/SignatureInformation.cs
@@ -13,6 +13,11 @@ namespace Microsoft.PowerFx.Intellisense.SignatureHelp
 
         public ParameterInformation[] Parameters { get; set; }
 
+        // $$$ Make this an object? 
+        // $$$ Enable a path for Reflection function?
+        // This function requires an AI disclaimer. 
+        public bool ShowAIDisclaimer { get; set; }
+
         public bool Equals(SignatureInformation other)
         {
             if (other == null)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/SignatureInformation.cs
@@ -2,44 +2,9 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Globalization;
-using Microsoft.PowerFx.Core.Errors;
-using Microsoft.PowerFx.Core.Localization;
 
 namespace Microsoft.PowerFx.Intellisense.SignatureHelp
 {
-    /// <summary>
-    /// Get Markdown for AI disclaimer. 
-    /// </summary>
-    public class DisclaimerProvider
-    {
-        private readonly CultureInfo _locale;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DisclaimerProvider"/> class.
-        /// </summary>
-        /// <param name="locale">locale for language to show messages in.</param>
-        public DisclaimerProvider(CultureInfo locale)
-        {
-            _locale = locale;
-        }
-
-        /// <summary>
-        /// Get the disclaimer in markdown. This may contain bold, hyperlinks, etc. 
-        /// </summary>
-        /// <returns></returns>
-        public string DisclaimerMarkdown 
-        {
-            get
-            {
-                (var shortMessage, var _) = ErrorUtils.GetLocalizedErrorContent(
-                    TexlStrings.IntellisenseAiDisclaimer, _locale, out _);
-
-                return shortMessage;
-            }
-        }
-    }
-
     public class SignatureInformation : IEquatable<SignatureInformation>
     {
         public string Label { get; set; }
@@ -48,9 +13,8 @@ namespace Microsoft.PowerFx.Intellisense.SignatureHelp
 
         public ParameterInformation[] Parameters { get; set; }
 
-        // If non-null, then append an AI disclaimer to the function. 
-        // $$$ Better name? Not just AI... Generic getter? Func<MarkdownString>
-        public DisclaimerProvider ShowAIDisclaimer { get; set; }
+        // If non-null, then show an disclaimer after the description. 
+        public Func<MarkdownString> GetDisclaimerMarkdown { get; set; }
 
         public bool Equals(SignatureInformation other)
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/SignatureHelp/SignatureInformation.cs
@@ -2,9 +2,44 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Globalization;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Localization;
 
 namespace Microsoft.PowerFx.Intellisense.SignatureHelp
 {
+    /// <summary>
+    /// Get Markdown for AI disclaimer. 
+    /// </summary>
+    public class DisclaimerProvider
+    {
+        private readonly CultureInfo _locale;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisclaimerProvider"/> class.
+        /// </summary>
+        /// <param name="locale">locale for language to show messages in.</param>
+        public DisclaimerProvider(CultureInfo locale)
+        {
+            _locale = locale;
+        }
+
+        /// <summary>
+        /// Get the disclaimer in markdown. This may contain bold, hyperlinks, etc. 
+        /// </summary>
+        /// <returns></returns>
+        public string DisclaimerMarkdown 
+        {
+            get
+            {
+                (var shortMessage, var _) = ErrorUtils.GetLocalizedErrorContent(
+                    TexlStrings.IntellisenseAiDisclaimer, _locale, out _);
+
+                return shortMessage;
+            }
+        }
+    }
+
     public class SignatureInformation : IEquatable<SignatureInformation>
     {
         public string Label { get; set; }
@@ -13,10 +48,9 @@ namespace Microsoft.PowerFx.Intellisense.SignatureHelp
 
         public ParameterInformation[] Parameters { get; set; }
 
-        // $$$ Make this an object? 
-        // $$$ Enable a path for Reflection function?
-        // This function requires an AI disclaimer. 
-        public bool ShowAIDisclaimer { get; set; }
+        // If non-null, then append an AI disclaimer to the function. 
+        // $$$ Better name? Not just AI... Generic getter? Func<MarkdownString>
+        public DisclaimerProvider ShowAIDisclaimer { get; set; }
 
         public bool Equals(SignatureInformation other)
         {

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -375,7 +375,19 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             var cursorPosition = GetPosition(expression, signatureHelpParams.Position.Line, signatureHelpParams.Position.Character);
             var result = scope.Suggest(expression, cursorPosition);
 
-            _sendToClient(JsonRpcHelper.CreateSuccessResult(id, result.SignatureHelp));
+            var lspObj = new SignatureHelp(result.SignatureHelp);
+
+            /* $$$
+            if (lspObj.Signatures != null)
+            {
+                foreach (var sig in lspObj.Signatures)
+                {
+                    
+                    sig.Documentation = GetDisclaimer(sig.Documentation.ToString());
+                }
+            }*/
+
+            _sendToClient(JsonRpcHelper.CreateSuccessResult(id, lspObj));
         }
 
         private void HandleInitialFixupRequest(string id, string paramsJson)

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -375,9 +375,9 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
             var cursorPosition = GetPosition(expression, signatureHelpParams.Position.Line, signatureHelpParams.Position.Character);
             var result = scope.Suggest(expression, cursorPosition);
 
-            var lspObj = new SignatureHelp(result.SignatureHelp);
+            var signatureHelp = new SignatureHelp(result.SignatureHelp);
 
-            _sendToClient(JsonRpcHelper.CreateSuccessResult(id, lspObj));
+            _sendToClient(JsonRpcHelper.CreateSuccessResult(id, signatureHelp));
         }
 
         private void HandleInitialFixupRequest(string id, string paramsJson)

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -377,16 +377,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 
             var lspObj = new SignatureHelp(result.SignatureHelp);
 
-            /* $$$
-            if (lspObj.Signatures != null)
-            {
-                foreach (var sig in lspObj.Signatures)
-                {
-                    
-                    sig.Documentation = GetDisclaimer(sig.Documentation.ToString());
-                }
-            }*/
-
             _sendToClient(JsonRpcHelper.CreateSuccessResult(id, lspObj));
         }
 

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/MarkupContent.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/MarkupContent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
+{
+    /// <summary>
+    /// Github flavored Markdown string.
+    /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent.
+    /// </summary>
+    public class MarkupContent
+    {
+        public string MarkupKind = "markdown"; // "plaintext"
+
+        public string Value { get; set; }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ParameterInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ParameterInformation.cs
@@ -3,12 +3,24 @@
 
 namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
+    using ParameterInformationCore = Microsoft.PowerFx.Intellisense.SignatureHelp.ParameterInformation;
+
     /// <summary>
     /// Represents a parameter of a callable-signature. A parameter can
     /// have a label and a doc-comment.
     /// </summary>
     public class ParameterInformation
     {
+        public ParameterInformation()
+        {
+        }
+
+        public ParameterInformation(ParameterInformationCore param)
+        {
+            this.Label = param.Label;
+            this.Documentation = param.Documentation;
+        }
+
         /// <summary>
         /// The label of this parameter information.
         ///

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureHelp.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureHelp.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
+    using System;
+    using SignatureHelpCore = Microsoft.PowerFx.Intellisense.SignatureHelp.SignatureHelp;
+
     /// <summary>
     /// Signature help represents the signature of something
     /// callable. There can be multiple signatures but only one
@@ -10,6 +13,29 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     /// </summary>
     public class SignatureHelp
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignatureHelp"/> class.
+        /// </summary>
+        public SignatureHelp() 
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignatureHelp"/> class.
+        /// Copy a LSP signature from a Core signature. 
+        /// </summary>
+        /// <param name="sig"></param>
+        public SignatureHelp(SignatureHelpCore sig) 
+        {
+            if (sig.Signatures != null)
+            {
+                this.Signatures = Array.ConvertAll(sig.Signatures, x => new SignatureInformation(x));
+            }
+            
+            this.ActiveSignature = sig.ActiveSignature;
+            this.ActiveParameter = sig.ActiveParameter;
+        }
+
         /// <summary>
         /// One or more signatures. If no signatures are available the signature help
         /// request should return `null`.

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -26,13 +26,17 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
             }
 
             this.Label = info.Label;
-            this.Documentation = info.Documentation;    
+            this.Documentation = info.Documentation;
             if (info.ShowAIDisclaimer != null)
             {
+                // Append disclaimer to create a final markdown string to send to LSP. 
                 string disclaimer = info.ShowAIDisclaimer.DisclaimerMarkdown;
                 string original = info.Documentation;
 
-                this.Documentation = original + "\r\n" + disclaimer;
+                this.Documentation = new MarkdownString
+                {
+                    Value = original + "\r\n" + disclaimer
+                };
             }
                         
             // info doesn't have ActiveParameter

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
                 string disclaimer = info.ShowAIDisclaimer.DisclaimerMarkdown;
                 string original = info.Documentation;
 
-                this.Documentation = new MarkdownString
+                this.Documentation = new MarkdownStringHolder
                 {
                     Value = original + "\r\n" + disclaimer
                 };
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// The human-readable doc-comment of this signature. Will be shown
         /// in the UI but can be omitted.
         /// If this is a string, it's plain text. 
-        /// If this is a <see cref="MarkdownString"/>, then it's github markdown. 
+        /// If this is a <see cref="MarkdownStringHolder"/>, then it's github markdown. 
         /// </summary>
         public object Documentation { get; set; }
 
@@ -73,7 +73,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     /// Github flavored Markdown string.
     /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent.
     /// </summary>
-    public class MarkdownString
+    public class MarkdownStringHolder
     {
         public string MarkupKind = "markdown"; // "plaintext"
 

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -5,6 +5,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
     using System;
     using System.Globalization;
+    using Microsoft.PowerFx.Intellisense;
     using SignatureInformationCore = Microsoft.PowerFx.Intellisense.SignatureHelp.SignatureInformation;
 
     /// <summary>
@@ -27,15 +28,15 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 
             this.Label = info.Label;
             this.Documentation = info.Documentation;
-            if (info.ShowAIDisclaimer != null)
+            if (info.GetDisclaimerMarkdown != null)
             {
                 // Append disclaimer to create a final markdown string to send to LSP. 
-                string disclaimer = info.ShowAIDisclaimer.DisclaimerMarkdown;
+                MarkdownString disclaimer = info.GetDisclaimerMarkdown();
                 string original = info.Documentation;
 
                 this.Documentation = new MarkdownStringHolder
                 {
-                    Value = original + "\r\n" + disclaimer
+                    Value = original + "\r\n" + disclaimer.Markdown
                 };
             }
                         

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
                 MarkdownString disclaimer = info.GetDisclaimerMarkdown();
                 string original = info.Documentation;
 
-                MarkdownString final = MarkdownString.FromString(original) + disclaimer;
+                MarkdownString final = MarkdownString.FromString(original) + MarkdownString.Newline + disclaimer;
 
                 this.SetDocumentation(final);
             }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
     using System;
+    using System.Globalization;
     using SignatureInformationCore = Microsoft.PowerFx.Intellisense.SignatureHelp.SignatureInformation;
 
     /// <summary>
@@ -26,26 +27,16 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 
             this.Label = info.Label;
             this.Documentation = info.Documentation;    
-            if (info.ShowAIDisclaimer)
+            if (info.ShowAIDisclaimer != null)
             {
-                this.Documentation = GetDisclaimer(info.Documentation);
+                string disclaimer = info.ShowAIDisclaimer.DisclaimerMarkdown;
+                string original = info.Documentation;
+
+                this.Documentation = original + "\r\n" + disclaimer;
             }
                         
             // info doesn't have ActiveParameter
-        }
-
-        // Given a string, get the AI disclaimer. 
-        private static MarkdownString GetDisclaimer(string original)
-        {
-            // $$$ Get these from resources. 
-            var link = "https://go.microsoft.com/fwlink/?linkid=2225491";
-            var msg = $"**Disclaimer:** AI-generated content can have mistakes. Make sure it's accurate and appropriate before using it. [See terms]({link})";
-
-            return new MarkdownString
-            {
-                Value = original + "\r\n" + msg
-            };
-        }
+        }      
 
         /// <summary>
         /// The label of this signature. Will be shown in

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -27,17 +27,20 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
             }
 
             this.Label = info.Label;
-            this.Documentation = info.Documentation;
-            if (info.GetDisclaimerMarkdown != null)
+
+            if (info.GetDisclaimerMarkdown == null)
             {
+                this.SetDocumentation(info.Documentation);
+            }
+            else 
+            { 
                 // Append disclaimer to create a final markdown string to send to LSP. 
                 MarkdownString disclaimer = info.GetDisclaimerMarkdown();
                 string original = info.Documentation;
 
-                this.Documentation = new MarkdownStringHolder
-                {
-                    Value = original + "\r\n" + disclaimer.Markdown
-                };
+                MarkdownString final = MarkdownString.FromString(original) + disclaimer;
+
+                this.SetDocumentation(final);
             }
                         
             // info doesn't have ActiveParameter
@@ -53,9 +56,30 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// The human-readable doc-comment of this signature. Will be shown
         /// in the UI but can be omitted.
         /// If this is a string, it's plain text. 
-        /// If this is a <see cref="MarkdownStringHolder"/>, then it's github markdown. 
+        /// If this is a <see cref="MarkupContent"/>, then it's github markdown. 
         /// </summary>
         public object Documentation { get; set; }
+
+        /// <summary>
+        /// Helper to set the documentation to plaintext. 
+        /// </summary>
+        /// <param name="plainText"></param>
+        public void SetDocumentation(string plainText)
+        {
+            this.Documentation = plainText;
+        }
+
+        /// <summary>
+        /// Helper to set the documentation to markdown. 
+        /// </summary>
+        /// <param name="markdown"></param>
+        public void SetDocumentation(MarkdownString markdown)
+        {
+            this.Documentation = new MarkupContent
+            {
+                Value = markdown.Markdown
+            };
+        }
 
         /// <summary>
         /// The parameters of this signature.
@@ -68,16 +92,5 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// If provided, this is used in place of `SignatureHelp.activeParameter`.
         /// </summary>
         public uint ActiveParameter { get; set; }
-    }
-
-    /// <summary>
-    /// Github flavored Markdown string.
-    /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent.
-    /// </summary>
-    public class MarkdownStringHolder
-    {
-        public string MarkupKind = "markdown"; // "plaintext"
-
-        public string Value { get; set; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
+    using System;
+    using SignatureInformationCore = Microsoft.PowerFx.Intellisense.SignatureHelp.SignatureInformation;
+
     /// <summary>
     /// Represents the signature of something callable. A signature
     /// can have a label, like a function-name, a doc-comment, and
@@ -10,6 +13,40 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     /// </summary>
     public class SignatureInformation
     {
+        public SignatureInformation() 
+        { 
+        }
+
+        public SignatureInformation(SignatureInformationCore info)
+        {
+            if (info.Parameters != null)
+            {
+                this.Parameters = Array.ConvertAll(info.Parameters, x => new ParameterInformation(x));
+            }
+
+            this.Label = info.Label;
+            this.Documentation = info.Documentation;    
+            if (info.ShowAIDisclaimer)
+            {
+                this.Documentation = GetDisclaimer(info.Documentation);
+            }
+                        
+            // info doesn't have ActiveParameter
+        }
+
+        // Given a string, get the AI disclaimer. 
+        private static MarkdownString GetDisclaimer(string original)
+        {
+            // $$$ Get these from resources. 
+            var link = "https://go.microsoft.com/fwlink/?linkid=2225491";
+            var msg = $"**Disclaimer:** AI-generated content can have mistakes. Make sure it's accurate and appropriate before using it. [See terms]({link})";
+
+            return new MarkdownString
+            {
+                Value = original + "\r\n" + msg
+            };
+        }
+
         /// <summary>
         /// The label of this signature. Will be shown in
         /// the UI.
@@ -19,8 +56,10 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// <summary>
         /// The human-readable doc-comment of this signature. Will be shown
         /// in the UI but can be omitted.
+        /// If this is a string, it's plain text. 
+        /// If this is a <see cref="MarkdownString"/>, then it's github markdown. 
         /// </summary>
-        public string Documentation { get; set; }
+        public object Documentation { get; set; }
 
         /// <summary>
         /// The parameters of this signature.
@@ -33,5 +72,16 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// If provided, this is used in place of `SignatureHelp.activeParameter`.
         /// </summary>
         public uint ActiveParameter { get; set; }
+    }
+
+    /// <summary>
+    /// Github flavored Markdown string.
+    /// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent.
+    /// </summary>
+    public class MarkdownString
+    {
+        public string MarkupKind = "markdown"; // "plaintext"
+
+        public string Value { get; set; }
     }
 }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4373,4 +4373,8 @@
     <value>Deprecated use of '.'. Please use the 'ShowColumns' function instead.</value>
     <comment>{Locked='ShowColumns'}</comment>
   </data>
+  <data name="IntellisenseAiDisclaimer" xml:space="preserve">
+    <value>**Disclaimer:** AI-generated content can have mistakes. Make sure it's accurate and appropriate before using it. [See terms](https://go.microsoft.com/fwlink/?linkid=2225491)</value>
+    <comment>The disclaimer we show on AI functions. This is github flavored markdown. So ** marks text in bold. </comment>
+  </data>
 </root>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BindingEngineTests.cs
@@ -503,6 +503,31 @@ namespace Microsoft.PowerFx.Tests
             }
         }
 
+        // Example of function that requires AI disclaimer.
+        internal class AISummarizeFunction : TexlFunction
+        {
+            public AISummarizeFunction()
+                : base(
+                      DPath.Root,
+                      "AISummarize",
+                      "AISummarize",
+                      TexlStrings.AboutSet, // just to add something
+                      FunctionCategories.Information,
+                      DType.Boolean,
+                      0, // no lambdas
+                      0, // no args
+                      0)
+            {
+            }
+
+            public override bool IsSelfContained => false;
+
+            public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+            {
+                yield break;
+            }
+        }
+
         internal class LambdaAndColumnIdentifierFunction : TexlFunction
         {
             public LambdaAndColumnIdentifierFunction()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/DisclaimerProviderTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/DisclaimerProviderTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Intellisense.SignatureHelp;
+using Xunit;
+
+namespace Microsoft.PowerFx.Intellisense.SignatureHelp
+{
+    public class DisclaimerProviderTests
+    {
+        [Fact]
+        public void Tests()
+        {
+            var ai = new DisclaimerProvider(null);
+            var str = ai.DisclaimerMarkdown;
+
+            // We don't know excatly what text will be, but we can sanity check. 
+            Assert.StartsWith("**Disclaimer:** AI-generated content", str);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/DisclaimerProviderTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/DisclaimerProviderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerFx.Intellisense.SignatureHelp
         public void Tests()
         {
             var ai = new DisclaimerProvider(null);
-            var str = ai.DisclaimerMarkdown;
+            var str = ai.DisclaimerMarkdown.Markdown;
 
             // We don't know excatly what text will be, but we can sanity check. 
             Assert.StartsWith("**Disclaimer:** AI-generated content", str);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/MarkdownStringTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/MarkdownStringTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.PowerFx.Intellisense.SignatureHelp;
+using Xunit;
+
+namespace Microsoft.PowerFx.Intellisense.SignatureHelp
+{
+    public class MarkdownStringTests
+    {
+        [Theory]
+        [InlineData("1*2", @"1\*2")]
+        [InlineData("1#2", @"1\#2")]
+        public void Escape(string plainText, string markdown)
+        {
+            var md = MarkdownString.FromString(plainText);
+            Assert.Equal(markdown, md.Markdown); // escaped
+
+            // if we treat it as markdown, then no escaping. 
+            var md2 = MarkdownString.FromMarkdown(plainText);
+            Assert.Equal(plainText, md2.Markdown);
+        }
+
+        [Fact]
+        public void Add()
+        {
+            MarkdownString md1 = MarkdownString.FromMarkdown("1");
+            MarkdownString md2 = MarkdownString.FromMarkdown("2");
+
+            MarkdownString md3 = md1 + md2;
+            Assert.Equal("12", md3.Markdown);
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SignatureHelpTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/IntellisenseTests/SignatureHelpTest.cs
@@ -81,9 +81,11 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
 
         private JObject ReadSignatureHelpFile(string signatureHelpPath) => JObject.Parse(File.ReadAllText(signatureHelpPath));
 
-        private JObject SerializeSignatureHelp(SignatureHelp signatureHelp) => JObject.Parse(JsonConvert.SerializeObject(signatureHelp));
+        private string SerializeSig(SignatureHelp signatureHelp) => JsonConvert.SerializeObject(signatureHelp, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Formatting.Indented });
 
-        private void WriteSignatureHelp(string path, SignatureHelp signatureHelp) => File.WriteAllText(path, JsonConvert.SerializeObject(signatureHelp, Formatting.Indented));
+        private JObject SerializeSignatureHelp(SignatureHelp signatureHelp) => JObject.Parse(SerializeSig(signatureHelp));
+
+        private void WriteSignatureHelp(string path, SignatureHelp signatureHelp) => File.WriteAllText(path, SerializeSig(signatureHelp));
 
         /// <summary>
         /// These use json value comparisons to test the signature help output of

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -173,6 +173,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Intellisense.SuggestionKind",
                 "Microsoft.PowerFx.Intellisense.TokenResultType",
                 "Microsoft.PowerFx.Intellisense.UIString",
+                "Microsoft.PowerFx.Intellisense.MarkdownString",
 
                 // TBD ...
                 "Microsoft.PowerFx.BasicUserInfo",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Assert.Equal("AISummarize()", sig.Label);
 
             var je = (JsonElement)sig.Documentation;
-            var markdown = JsonSerializer.Deserialize<MarkdownString>(je.ToString(), _jsonSerializerOptions);
+            var markdown = JsonSerializer.Deserialize<MarkdownStringHolder>(je.ToString(), _jsonSerializerOptions);
             Assert.Equal("markdown", markdown.MarkupKind);
             Assert.StartsWith("Create and set a global variable", markdown.Value); // function's normal description 
             Assert.Contains("**Disclaimer:** AI-generated content", markdown.Value); // disclaimer appended. 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -1006,7 +1006,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Assert.Equal("AISummarize()", sig.Label);
 
             var je = (JsonElement)sig.Documentation;
-            var markdown = JsonSerializer.Deserialize<MarkdownStringHolder>(je.ToString(), _jsonSerializerOptions);
+            var markdown = JsonSerializer.Deserialize<MarkupContent>(je.ToString(), _jsonSerializerOptions);
             Assert.Equal("markdown", markdown.MarkupKind);
             Assert.StartsWith("Create and set a global variable", markdown.Value); // function's normal description 
             Assert.Contains("**Disclaimer:** AI-generated content", markdown.Value); // disclaimer appended. 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.DidOpenTextDocumentParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.InitialFixupParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.LanguageServerRequestBaseParams",
-                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.MarkdownStringHolder",
+                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.MarkupContent",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.ParameterInformation",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.Position",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.PublishDiagnosticsParams",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
@@ -70,6 +70,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.DidOpenTextDocumentParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.InitialFixupParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.LanguageServerRequestBaseParams",
+                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.MarkdownStringHolder",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.ParameterInformation",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.Position",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.PublishDiagnosticsParams",


### PR DESCRIPTION
Fix #1202

The disclaimer is markdown (including a help link) in the resources.

1. TexlFunction gets a virtual flag noting whether the function needs a disclaimer.  Default impl is based on a whitelist of AI functions, but we can override this flag next.
2. LSP will get flag and append , and send markdown to formula bar. 

This productizes the POC from #2099 .
