### PR TITLE
Increase local NuGet version to a large number

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LocalPackageVersion>1.3.0-local</LocalPackageVersion>
+    <LocalPackageVersion>1.99.0-local</LocalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/buildAndRefresh.bat
+++ b/src/buildAndRefresh.bat
@@ -9,4 +9,4 @@ call buildLocalPackages.cmd
 @echo  ^<add key="Local" value="%~dp0outputpackages" /^>
 @echo .  
 @echo 2) Set your current PowerFx version to 
-@echo  1.3.0-local
+@echo  1.99.0-local

--- a/src/refreshLocalNugetCache.ps1
+++ b/src/refreshLocalNugetCache.ps1
@@ -1,10 +1,10 @@
 ﻿
 $localCache = $Env:USERPROFILE + "\.nuget\packages"
 
-Write-Host "Deleting Microsoft.PowerFx.*\0.3.0-local from nuget cache. This will cause the newly built packages to be downloaded."
+Write-Host "Deleting Microsoft.PowerFx.*\1.99.0-local from nuget cache. This will cause the newly built packages to be downloaded."
 
 Get-ChildItem $localCache Microsoft.PowerFx.* | ForEach-Object { 
-    $path = ($_.FullName + "\1.3.0-local")
+    $path = ($_.FullName + "\1.99.0-local")
 
     if (Test-Path $path) {
       Remove-Item $path -Recurse 


### PR DESCRIPTION
As we increase our official NuGet version, the version from a local build should have a higher version number. This increases it to a very large number, which should be enough until our major version update.