### PR TITLE
Add helpers for getting function parameter names.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -278,6 +278,9 @@ namespace Microsoft.PowerFx.Core.Functions
         // A description associated with this function.
         public string Description => _description(null);
 
+        // Locale aware description.
+        public string GetDescription(string locale) => _description(locale);
+
         /// <summary>
         /// This function requires an AI disclaimer. 
         /// </summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -589,6 +589,30 @@ namespace Microsoft.PowerFx
             return FormulaType.Build(type);
         }
 
+        /// <summary>
+        /// Get binding data for this call node and determine how it was resolved.
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns>Null if the node is not bound.</returns>
+        public FunctionInfo GetFunctionInfo(CallNode node)
+        {
+            if (node == null)
+            {
+                throw new ArgumentNullException(nameof(node));
+            }
+
+            var binding = this.ApplyBindingInternal();
+            var info = binding.GetInfo(node);
+            var func = info.Function;
+
+            if (func == null)
+            {
+                return null;
+            }
+
+            return new FunctionInfo(func);            
+        }
+
         // Called by language server to get custom tokens.
         // If binding is available, returns context sensitive tokens.  $$$
         // Keeping this temporarily for custom publish tokens notification

--- a/src/libraries/Microsoft.PowerFx.Core/Public/FunctionInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/FunctionInfo.cs
@@ -44,7 +44,19 @@ namespace Microsoft.PowerFx
         /// <summary>
         /// Get a short description of the function.  
         /// </summary>
+        [Obsolete("Use GetDescription() which takes a locale")]
         public string Description => _fnc.Description;
+
+        /// <summary>
+        /// Get a short description of the function.
+        /// </summary>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        public string GetDescription(CultureInfo culture = null)
+        {
+            culture ??= CultureInfo.InvariantCulture;
+            return _fnc.GetDescription(culture.Name);
+        }
 
         /// <summary>
         /// An optional URL for more help on this function. 
@@ -84,9 +96,10 @@ namespace Microsoft.PowerFx
         /// </summary>
         public int Length => _paramNames.Count;
 
-        public string[] GetParameterNames(CultureInfo locale = null)
+        public string[] GetParameterNames(CultureInfo culture = null)
         {
-            var localeName = locale?.Name;
+            culture ??= CultureInfo.InvariantCulture;
+            var localeName = culture.Name;
 
             List<string> result = new List<string>();
 
@@ -100,14 +113,14 @@ namespace Microsoft.PowerFx
         }
 
         // Keep this debug-only, since there are too many possible formats to pick just one. 
-        internal string DebugToString()
+        internal string DebugToString(CultureInfo culture = null)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append(_parent.Name);
             sb.Append('(');
 
             var sep = string.Empty;
-            foreach (var param in GetParameterNames(null))
+            foreach (var param in GetParameterNames(culture))
             {
                 sb.Append(sep);
                 sb.Append(param);

--- a/src/tests/Microsoft.PowerFx.Core.Tests/CheckResultTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/CheckResultTests.cs
@@ -263,6 +263,46 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Throws<InvalidOperationException>(() => check.ApplyBinding());
         }
 
+        [Fact]
+        public void GetFunctionInfoTest()
+        {
+            var check = new CheckResult(new Engine())
+                .SetText("Power(3,2)")
+                .SetBindingInfo();
+
+            var node = (CallNode)check.ApplyParse().Root;
+
+            var info = check.GetFunctionInfo(node);
+            
+            Assert.Equal("Power", info.Name);
+            var sigs = info.Signatures.Single();
+            Assert.Equal("Power(base, exponent)", sigs.DebugToString());
+        }
+
+        [Fact]
+        public void GetFunctionInfoTestNull()
+        {
+            var check = new CheckResult(new Engine())
+                .SetText("Power(3,2)")
+                .SetBindingInfo();
+
+            Assert.Throws<ArgumentNullException>(() => check.GetFunctionInfo(null));
+        }
+
+        [Fact]
+        public void GetFunctionMissingTest()
+        {
+            var check = new CheckResult(new Engine())
+                .SetText("Missing(3,2)")
+                .SetBindingInfo();
+
+            var node = (CallNode)check.ApplyParse().Root;
+
+            // No function Info.
+            var info = check.GetFunctionInfo(node);
+            Assert.Null(info);
+        }
+
         [Theory]
         
         // ****When Coercion is not allowed.****

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Extensions.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Extensions.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
@@ -141,6 +144,33 @@ namespace Microsoft.PowerFx.Core.Tests
             }
 
             sb.Append("]");
+        }
+
+        // Run on an isolated thread.
+        // Useful for testing per-thread properties
+        internal static void RunOnIsolatedThread(this CultureInfo culture, Action<CultureInfo> worker)
+        {
+            Exception exception = null;
+
+            var t = new Thread(() =>
+            {
+                try
+                {
+                    worker(culture);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+            });
+
+            t.Start();
+            t.Join();
+
+            if (exception != null)
+            {
+                throw exception;
+            }
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FunctionInfoTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FunctionInfoTests.cs
@@ -24,6 +24,11 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(3, infoMid.MaxArity);
             Assert.Equal("Mid", infoMid.Name);
             Assert.Equal("https://go.microsoft.com/fwlink/?LinkId=722347#m", infoMid.HelpLink);
+
+            var sigs = infoMid.Signatures.ToArray();
+            Assert.Equal(2, sigs.Length);
+            Assert.Equal("Mid(text, start_num)", sigs[0].DebugToString());
+            Assert.Equal("Mid(text, start_num, num_chars)", sigs[1].DebugToString());
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/FunctionInfoTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/FunctionInfoTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Xunit;
@@ -19,7 +20,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var infos = engine.FunctionInfos.ToArray();
             var infoMid = infos.Where(info => info.Name == "Mid").First();
 
-            Assert.Equal("Returns the characters from the middle of a text value, given a starting position and length.", infoMid.Description);
+            Assert.Equal("Returns the characters from the middle of a text value, given a starting position and length.", infoMid.GetDescription(null));
             Assert.Equal(2, infoMid.MinArity);
             Assert.Equal(3, infoMid.MaxArity);
             Assert.Equal("Mid", infoMid.Name);
@@ -29,6 +30,29 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(2, sigs.Length);
             Assert.Equal("Mid(text, start_num)", sigs[0].DebugToString());
             Assert.Equal("Mid(text, start_num, num_chars)", sigs[1].DebugToString());
+        }
+
+        [Fact]
+        public void LocaleTests()
+        {
+            var engine = new Engine();
+            var infos = engine.FunctionInfos.ToArray();
+            var infoMid = infos.Where(info => info.Name == "Mid").First();
+            
+            CultureInfo fr = new CultureInfo("fr-FR");
+            fr.RunOnIsolatedThread((culture) =>
+            {
+                // Ensure it does not use current culture
+                var descr = infoMid.GetDescription(null);
+                Assert.StartsWith("Returns the ", descr); // null is invariant, is english. 
+            });
+
+            var descr2 = infoMid.GetDescription(null);
+            Assert.StartsWith("Returns the ", descr2); // null is invariant, is english. 
+
+            // Now explicitly ask for another locale. 
+            var descr3 = infoMid.GetDescription(fr);
+            Assert.StartsWith("Retourne les", descr3); // in french
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Features",
                 "Microsoft.PowerFx.FormulaWithParameters",
                 "Microsoft.PowerFx.FunctionInfo",
+                "Microsoft.PowerFx.FunctionInfoSignature",
                 "Microsoft.PowerFx.NameCollisionException",
                 "Microsoft.PowerFx.OptionSet",
                 "Microsoft.PowerFx.ParseResult",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/ConfigTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
+using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
 using Xunit;
@@ -886,27 +887,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         // Useful for testing per-thread properties
         internal static void RunOnIsolatedThread(CultureInfo culture, Action<CultureInfo> worker)
         {
-            Exception exception = null;
-
-            var t = new Thread(() =>
-            {
-                try
-                {                    
-                    worker(culture);
-                }
-                catch (Exception ex)
-                {
-                    exception = ex;
-                }
-            });
-
-            t.Start();
-            t.Join();
-
-            if (exception != null)
-            {
-                throw exception;
-            }
+            culture.RunOnIsolatedThread(worker);
         }
     }
 


### PR DESCRIPTION
Add public helpers for getting function intellisense and parameter names.
These exist on TexlFunction, but is not exposed. 
