### PR TITLE
Fix Formula Bar now showing correct active parameter in Signature Help Regression

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/SignatureInformation.cs
@@ -85,12 +85,5 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// The parameters of this signature.
         /// </summary>
         public ParameterInformation[] Parameters { get; set; }
-
-        /// <summary>
-        /// The index of the active parameter.
-        ///
-        /// If provided, this is used in place of `SignatureHelp.activeParameter`.
-        /// </summary>
-        public uint ActiveParameter { get; set; }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/LanguageServerTests.cs
@@ -1075,7 +1075,6 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Assert.Equal(0U, response.Result.ActiveParameter);
             var foundItems = response.Result.Signatures.Where(item => item.Label.StartsWith("Power"));
             Assert.True(Enumerable.Count(foundItems) >= 1, "Power should be found from signatures result");
-            Assert.Equal(0U, foundItems.First().ActiveParameter);
             Assert.Equal(2, foundItems.First().Parameters.Length);
             Assert.Equal("base", foundItems.First().Parameters[0].Label);
             Assert.Equal("exponent", foundItems.First().Parameters[1].Label);
@@ -1092,7 +1091,6 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
             Assert.Equal(1U, response.Result.ActiveParameter);
             foundItems = response.Result.Signatures.Where(item => item.Label.StartsWith("Power"));
             Assert.True(Enumerable.Count(foundItems) >= 1, "Power should be found from signatures result");
-            Assert.Equal(0U, foundItems.First().ActiveParameter);
             Assert.Equal(2, foundItems.First().Parameters.Length);
             Assert.Equal("base", foundItems.First().Parameters[0].Label);
             Assert.Equal("exponent", foundItems.First().Parameters[1].Label);


### PR DESCRIPTION
A regression was caused during AI Disclaimer changes that resulted in formula bar always showing first parameter in signature help as active parameter even when a user is not typing a first parameter and is on let's say a fourth parameter.

This happened due to the addition of "ActiveParameter" property in SignatureInformation model. There are two "active parameter" properties as shown below
![image](https://github.com/microsoft/Power-Fx/assets/25670945/1a9cfc68-6a95-4d16-95b4-c647ed29e15c)

On the left is active parameter for specific signature information which we never had but was introduced with Ai disclaimer change. On the right is a global one that we used and applied to all signatures. 

Active parameter for specific signature info takes precedence over global one so in this case since we introduced this property for each signature info but never set it to anything, it was always being set to "0" causing formula bar to set first parameter as an active parameter

This pr removes that active parameter property for each specific signature info as we never had it and we always used global one

Current Regression: 
![image](https://github.com/microsoft/Power-Fx/assets/25670945/6c155495-106c-4ad2-961a-65ed993f02d8)

After this Pr:
![image](https://github.com/microsoft/Power-Fx/assets/25670945/bce3f25c-de7c-41d6-8c24-2c609277ef9e)

