### PR TITLE
Added Count to ErrorContainer

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
@@ -18,6 +18,8 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
 
         public DocumentErrorSeverity DefaultSeverity => DocumentErrorSeverity.Critical;
 
+        public int Count => CollectionUtils.Size(_errors);
+
         public void MergeErrors(IEnumerable<TexlError> errors)
         {
             if (_errors == null)


### PR DESCRIPTION
Issue: During tight loops we sometimes need only error count and at this time we can only call GetErrors() which returns IEnumerable and the iterate though each error using Count() extension. It would improve performance if we can have native Count property