### PR TITLE
Allow access to design properties via Gallery.Selected

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3468,13 +3468,6 @@ namespace Microsoft.PowerFx.Core.Binding
                         return;
                     }
 
-                    // Explicitly block access to design properties referenced via Selected/AllItems.
-                    if (leftControl.IsDataLimitedControl && property.PropertyCategory != PropertyRuleCategory.Data)
-                    {
-                        SetDottedNameError(node, TexlStrings.ErrNotAccessibleInCurrentContext);
-                        return;
-                    }
-
                     // For properties requiring default references, block non-defaultable properties
                     if (_txb.CurrentPropertyRequiresDefaultableReferences && property.UnloadedDefault == null)
                     {

--- a/src/libraries/Microsoft.PowerFx.Core/Types/IExternalControlType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/IExternalControlType.cs
@@ -9,8 +9,6 @@ namespace Microsoft.PowerFx.Core.Types
     {
         IExternalControlTemplate ControlTemplate { get; }
 
-        bool IsDataLimitedControl { get; }
-
         bool IsMetaField { get; }
     }
 }


### PR DESCRIPTION
This removes a pointless restriction on property access via Gallery.Selected.
These properties were already accessible directly on children of the gallery, and this restriction doesn't have any runtime justification for existing. It also blocks deprecation of primary output properties (Icon has a design primary output prop, others might as well)