### PR TITLE
Remove time zone conversion from DateValue parsing

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -566,10 +566,6 @@ namespace Microsoft.PowerFx.Functions
                     result = _epoch.Add(result.TimeOfDay);
                 }
 
-                var tzi = runner.TimeZoneInfo;
-
-                result = DateTimeValue.GetConvertedDateTimeValue(result, tzi);
-
                 return new DateValue(irContext, result.Date);
             }
             else

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
@@ -8,7 +8,6 @@ Date(2024,10,28)
 >> DateAdd(DateTime(2024, 10, 27, 0, 0, 0), 1)
 DateTime(2024,10,28,0,0,0,0)
 
-// FAILING, actual result is DateTime(2024,10,27,23,0,0,0)
 >> DateAdd("2024-10-27", 1)
 DateTime(2024,10,28,0,0,0,0)
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
@@ -1,0 +1,23 @@
+﻿// (UTC+0:00) London
+#SETUP: TimeZoneInfo("GMT Standard Time")
+
+// Adding a day when clocks are set forward back during the day (1am here) should still result in the next day
+>> DateAdd(Date(2024, 10, 27), 1)
+Date(2024,10,28)
+
+>> DateAdd(DateTime(2024, 10, 27, 0, 0, 0), 1)
+DateTime(2024,10,28,0,0,0,0)
+
+// FAILING, actual result is DateTime(2024,10,27,23,0,0,0)
+>> DateAdd("2024-10-27", 1)
+DateTime(2024,10,28,0,0,0,0)
+
+// Adding a day when clocks are set back during that day (1am here) should still result in the next day
+>> DateAdd(Date(2024, 3, 31), 1)
+Date(2024,4,1)
+
+>> DateAdd(DateTime(2024, 03, 31, 0, 0, 0), 1)
+DateTime(2024,4,1,0,0,0,0)
+
+>> DateAdd("2024-03-31", 1)
+DateTime(2024,4,1,0,0,0,0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
@@ -1,7 +1,7 @@
 ﻿// (UTC+0:00) London
 #SETUP: TimeZoneInfo("GMT Standard Time")
 
-// Adding a day when clocks are set forward back during the day (1am here) should still result in the next day
+// Adding a day when clocks are set forward back during the day (1am->2am here) should still result in the next day
 >> DateAdd(Date(2024, 10, 27), 1)
 Date(2024,10,28)
 
@@ -12,7 +12,7 @@ DateTime(2024,10,28,0,0,0,0)
 >> DateAdd("2024-10-27", 1)
 DateTime(2024,10,28,0,0,0,0)
 
-// Adding a day when clocks are set back during that day (1am here) should still result in the next day
+// Adding a day when clocks are set back during that day (2am->1am here) should still result in the next day
 >> DateAdd(Date(2024, 3, 31), 1)
 Date(2024,4,1)
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue_TimeZone_London.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue_TimeZone_London.txt
@@ -1,0 +1,11 @@
+﻿// (UTC+0:00) London
+#SETUP: TimeZoneInfo("GMT Standard Time")
+
+>> DateValue("2024-10-26")
+Date(2024,10,26)
+
+>> DateValue("2024-10-27")
+Date(2024,10,27)
+
+>> DateValue("2024-03-31")
+Date(2024,3,31)


### PR DESCRIPTION
This PR removes time zone conversion from `DateValue` parsing. 

This fixes issues with `DateValue(str)` being 1-day off for GMT time zone during Daylight Savings Time, which also caused issues with `DateAdd(str, 1)` in GMT.

I don't see why we would need to consider time zones in date (not datetime) parsing, but please let me know if I'm missing something and I can restore any scenarios that would be broken with this change.

### Fixed scenarios

The following tests included in this PR were failing with these results. All are GMT time zone tests.
```
// FAILING, actual result is DateTime(2024,10,27,23,0,0,0)
>> DateAdd("2024-10-27", 1)
DateTime(2024,10,28,0,0,0,0)

// FAILING, actual result is Date(2024,10,25)
>> DateValue("2024-10-26")
Date(2024,10,26)

// FAILING, actual result is Date(2024,10,26)
>> DateValue("2024-10-27")
Date(2024,10,27)
```

Other new tests were already passing, but are included to specify intended behavior in related scenarios.

