### PR TITLE
Fix handling of GMT time zone

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DateTimeValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DateTimeValue.cs
@@ -60,11 +60,11 @@ namespace Microsoft.PowerFx.Types
                 // https://github.com/microsoft/Power-Fx/issues/1931
                 return DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
             }
-            else if (value.Kind == DateTimeKind.Unspecified && timeZoneInfo.BaseUtcOffset == TimeSpan.Zero)
+            else if (value.Kind == DateTimeKind.Unspecified && timeZoneInfo.Equals(TimeZoneInfo.Utc))
             {
                 return TimeZoneInfo.ConvertTimeToUtc(value, timeZoneInfo);
             }
-            else if (value.Kind == DateTimeKind.Utc && timeZoneInfo.BaseUtcOffset != TimeSpan.Zero)
+            else if (value.Kind == DateTimeKind.Utc && !timeZoneInfo.Equals(TimeZoneInfo.Utc))
             {
                 return TimeZoneInfo.ConvertTime(value, timeZoneInfo);
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DateTimeValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DateTimeValue.cs
@@ -50,11 +50,11 @@ namespace Microsoft.PowerFx.Types
             }
             
             // Since we can't convert LocalKind time to UTC, if the time was of kind local just change kind.
-            if (value.Kind == DateTimeKind.Local && timeZoneInfo.BaseUtcOffset == TimeSpan.Zero)
+            if (value.Kind == DateTimeKind.Local && timeZoneInfo.Equals(TimeZoneInfo.Utc))
             {
                 return DateTime.SpecifyKind(value, DateTimeKind.Utc);
             }
-            else if (value.Kind == DateTimeKind.Local && timeZoneInfo.BaseUtcOffset != TimeSpan.Zero)
+            else if (value.Kind == DateTimeKind.Local && !timeZoneInfo.Equals(TimeZoneInfo.Utc))
             {
                 // This code should be modified as we don't return a UTC time here
                 // https://github.com/microsoft/Power-Fx/issues/1931

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerFx
 
         public TimeZoneInfo TimeZoneInfo { get; private set; }
 
-        public DateTimeKind DateTimeKind => TimeZoneInfo == TimeZoneInfo.Utc ? DateTimeKind.Utc : DateTimeKind.Unspecified;
+        public DateTimeKind DateTimeKind => TimeZoneInfo.Equals(TimeZoneInfo.Utc) ? DateTimeKind.Utc : DateTimeKind.Unspecified;
 
         public Governor Governor { get; private set; }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerFx
 
         public TimeZoneInfo TimeZoneInfo { get; private set; }
 
-        public DateTimeKind DateTimeKind => TimeZoneInfo.BaseUtcOffset == TimeSpan.Zero ? DateTimeKind.Utc : DateTimeKind.Unspecified;
+        public DateTimeKind DateTimeKind => TimeZoneInfo == TimeZoneInfo.Utc ? DateTimeKind.Utc : DateTimeKind.Unspecified;
 
         public Governor Governor { get; private set; }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx.Functions
 
             var now = runner.SafeUtcNow();
 
-            if (timeZoneInfo.BaseUtcOffset != TimeSpan.Zero)
+            if (!timeZoneInfo.Equals(TimeZoneInfo.Utc))
             {
                 now = TimeZoneInfo.ConvertTimeFromUtc(now, timeZoneInfo);
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_TimeZone_London.txt
@@ -1,0 +1,22 @@
+﻿// (UTC+0:00) London
+#SETUP: TimeZoneInfo("GMT Standard Time")
+
+// Adding a day when clocks are set forward back during the day (1am->2am here) should still result in the next day
+>> DateAdd(Date(2024, 10, 27), 1)
+Date(2024,10,28)
+
+>> DateAdd(DateTime(2024, 10, 27, 0, 0, 0), 1)
+DateTime(2024,10,28,0,0,0,0)
+
+>> DateAdd("2024-10-27", 1)
+DateTime(2024,10,28,0,0,0,0)
+
+// Adding a day when clocks are set back during that day (2am->1am here) should still result in the next day
+>> DateAdd(Date(2024, 3, 31), 1)
+Date(2024,4,1)
+
+>> DateAdd(DateTime(2024, 03, 31, 0, 0, 0), 1)
+DateTime(2024,4,1,0,0,0,0)
+
+>> DateAdd("2024-03-31", 1)
+DateTime(2024,4,1,0,0,0,0)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue_TimeZone_London.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateValue_TimeZone_London.txt
@@ -1,0 +1,11 @@
+﻿// (UTC+0:00) London
+#SETUP: TimeZoneInfo("GMT Standard Time")
+
+>> DateValue("2024-10-26")
+Date(2024,10,26)
+
+>> DateValue("2024-10-27")
+Date(2024,10,27)
+
+>> DateValue("2024-03-31")
+Date(2024,3,31)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/DateTimeUTCTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/DateTimeUTCTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Fact]
         public async void DateTimeFunctionTest()
         {
-            var currentTimeZoneKind = TimeZoneInfo.Local.BaseUtcOffset == TimeSpan.Zero ?
+            var currentTimeZoneKind = TimeZoneInfo.Local.Equals(TimeZoneInfo.Utc) ?
                 DateTimeKind.Utc :
                 DateTimeKind.Unspecified;
 


### PR DESCRIPTION
There were some parts of the code that were mistakenly treating the GMT (i.e., London) time zone as UTC. Those are the same for part of the year, but not for all of it, which was causing some issues with parsing and adding date values. This change addresses it.