### PR TITLE
Add [Partial] combination attribute support for Named Formulas

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2246,7 +2246,7 @@ namespace Microsoft.PowerFx.Core.Binding
         {
             // We generate a transient CallNode (with no arguments) to the Concatenate function
             var func = BuiltinFunctionsCore.Concatenate;
-            var ident = new IdentToken(func.Name, node.Token.Span);
+            var ident = new IdentToken(func.Name, node.Token.Span, isNonSourceIdentToken: true);
             var id = node.Id;
             var listNodeId = 0;
             var minChildId = node.MinChildID;

--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/Tokens/IdentToken.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/Tokens/IdentToken.cs
@@ -26,16 +26,22 @@ namespace Microsoft.PowerFx.Syntax
         /// </summary>
         public DName Name { get; }
 
-        internal const string StrInterpIdent = "Concatenate";
-
-        internal IdentToken(string val, Span span)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IdentToken"/> class.
+        /// </summary>
+        /// <param name="val">The identifier.</param>
+        /// <param name="span">Source location the identifier is associated with.</param>
+        /// <param name="isNonSourceIdentToken">The compiler sometimes generates identifier tokens that don't map
+        /// 1-1 with specific source locations. This is done for cases like string interpolation, where a fake
+        /// Concatenate call node is added, using a Concatenate ident token that doesn't appear in the actual source.</param>
+        internal IdentToken(string val, Span span, bool isNonSourceIdentToken = false)
             : this(val, span, false, false)
         {
             Contracts.AssertValue(val);
 
             // String interpolation sometimes creates tokens that do not exist in the source code
             // so we skip validating the span length for the Ident that the parser generates
-            Contracts.Assert(val.Length == span.Lim - span.Min || val == StrInterpIdent);
+            Contracts.Assert(val.Length == span.Lim - span.Min || isNonSourceIdentToken);
             _value = val;
             Name = DName.MakeValid(val, out IsModified);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -774,5 +774,9 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrDeprecatedDotUseShowColumns = new ErrorResourceKey("ErrDeprecatedDotUseShowColumns");
 
         public static ErrorResourceKey IntellisenseAiDisclaimer = new ErrorResourceKey("IntellisenseAiDisclaimer");
+
+        public static ErrorResourceKey ErrOnlyPartialAttribute = new ErrorResourceKey("ErrOnlyPartialAttribute");
+        public static ErrorResourceKey ErrOperationDoesntMatch = new ErrorResourceKey("ErrOperationDoesntMatch");
+        public static ErrorResourceKey ErrUnknownPartialOp = new ErrorResourceKey("ErrUnknownPartialOp");
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/NamedFormula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/NamedFormula.cs
@@ -6,7 +6,7 @@ using Microsoft.PowerFx.Syntax;
 
 namespace Microsoft.PowerFx.Core.Parser
 {
-    internal class NamedFormula 
+    internal class NamedFormula
     {
         internal IdentToken Ident { get; }
 
@@ -14,14 +14,17 @@ namespace Microsoft.PowerFx.Core.Parser
 
         internal int StartingIndex { get; }
 
-        public NamedFormula(IdentToken ident, Formula formula, int startingIndex)
+        internal PartialAttribute Attribute { get; }
+
+        public NamedFormula(IdentToken ident, Formula formula, int startingIndex, PartialAttribute attribute = null)
         {
             Contracts.AssertValue(ident);
             Contracts.AssertValue(formula);
-            
+
             Ident = ident;
             Formula = formula;
             StartingIndex = startingIndex;
+            Attribute = attribute;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParserOptions.cs
@@ -52,6 +52,12 @@ namespace Microsoft.PowerFx
         /// </summary>
         internal bool AllowParseAsTypeLiteral { get; set; }
 
+        /// <summary>
+        /// Allow parsing of attributes on user definitions
+        /// This is an early prototype, and so is internal.
+        /// </summary>
+        internal bool AllowAttributes { get; set; }
+
         public ParserOptions()
         {
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/PartialAttribute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/PartialAttribute.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerFx.Core.Parser
+{
+    internal sealed class PartialAttribute
+    {
+        public enum AttributeOperationKind
+        {
+            Error,
+            PartialAnd,
+            PartialOr,
+            PartialTable,
+            PartialRecord
+        }
+
+        public readonly IdentToken AttributeName;
+
+        // This probably should be a TexlNode, but for now we're prototyping a simple case
+        // of just [Partial And]-type attributes, where they're pairs of name and operation.
+        public readonly Token AttributeOperationToken;
+
+        public readonly AttributeOperationKind AttributeOperation;
+
+        public PartialAttribute(IdentToken attributeName, Token attributeOperationToken)
+        {
+            AttributeName = attributeName;
+            AttributeOperationToken = attributeOperationToken;
+            AttributeOperation = ToKind(attributeOperationToken);
+        }
+
+        private AttributeOperationKind ToKind(Token attributeOperation)
+        {
+            if (attributeOperation is KeyToken keyTok)
+            {
+                if (keyTok.Kind == TokKind.KeyAnd)
+                {
+                    return AttributeOperationKind.PartialAnd;
+                }
+                else if (keyTok.Kind == TokKind.KeyOr)
+                {
+                    return AttributeOperationKind.PartialOr;
+                }
+            }
+            else if (attributeOperation is IdentToken identTok)
+            {
+                if (identTok.Name.Value == "Table")
+                {
+                    return AttributeOperationKind.PartialTable;
+                }
+                else if (identTok.Name.Value == "Record")
+                {
+                    return AttributeOperationKind.PartialRecord;
+                }
+            }
+
+            return AttributeOperationKind.Error;
+        }
+
+        public bool SameAttribute(PartialAttribute other)
+        {
+            return AttributeName.Name.Value == other.AttributeName.Name.Value &&
+                AttributeOperation == other.AttributeOperation;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
@@ -13,6 +13,7 @@ using Microsoft.PowerFx.Core.Parser;
 using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax.SourceInformation;
 
 namespace Microsoft.PowerFx.Syntax
 {
@@ -67,7 +68,12 @@ namespace Microsoft.PowerFx.Syntax
 
         private bool ProcessUserDefinitions(out UserDefinitionResult userDefinitionResult)
         {
-            var parseResult = TexlParser.ParseUserDefinitionScript(_script, _parserOptions);
+            var parseResult = Parse(_script, _parserOptions);
+
+            if (_parserOptions.AllowAttributes)
+            {
+                parseResult = ProcessPartialAttributes(parseResult);
+            }
             
             // Parser returns both complete & incomplete UDFs, and we are only interested in creating TexlFunctions for valid UDFs. 
             var functions = CreateUserDefinedFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out var errors);
@@ -155,5 +161,124 @@ namespace Microsoft.PowerFx.Syntax
 
             return isReturnTypeCheckSuccessful;
         }
+
+// This code is intended as a prototype of the Partial attribute system, for use in solution layering cases
+// Provides order-independent ways of merging named formulas
+        #region Partial Attributes
+
+        private static readonly string _renamedFormulaGuid = Guid.NewGuid().ToString("N");
+
+        /// <summary>
+        /// For NamedFormulas with partial attributes,
+        /// validates that the same attribute is applied to all matching names,
+        /// then applies name mangling to all, and constructs a separate
+        /// formula with the operation applied and the original name.
+        /// </summary>
+        private ParseUserDefinitionResult ProcessPartialAttributes(ParseUserDefinitionResult parsed)
+        {
+            var groupedFormulas = parsed.NamedFormulas.GroupBy(nf => nf.Ident.Name.Value);
+            var errors = parsed.Errors?.ToList() ?? new List<TexlError>();
+            var newFormulas = new List<NamedFormula>();
+
+            foreach (var nameGroup in groupedFormulas)
+            {
+                var name = nameGroup.Key;
+                var firstAttribute = nameGroup.Select(nf => nf.Attribute).FirstOrDefault(att => att != null);
+
+                if (firstAttribute == null || nameGroup.Count() == 1)
+                {
+                    newFormulas.AddRange(nameGroup);
+                    continue;
+                }
+
+                var updatedGroupFormulas = new List<NamedFormula>();
+                var id = 0;
+                foreach (var formula in nameGroup)
+                {
+                    // This is just for the prototype, since we only have the one kind.
+                    if (formula.Attribute.AttributeName.Name != "Partial")
+                    {
+                        errors.Add(new TexlError(formula.Attribute.AttributeOperationToken, DocumentErrorSeverity.Severe, TexlStrings.ErrOnlyPartialAttribute));
+                        continue;
+                    }
+
+                    if (!firstAttribute.SameAttribute(formula.Attribute))
+                    {
+                        errors.Add(new TexlError(formula.Attribute.AttributeOperationToken, DocumentErrorSeverity.Severe, TexlStrings.ErrOperationDoesntMatch));
+                        continue;
+                    }
+
+                    var newName = new IdentToken(name + _renamedFormulaGuid + id, formula.Ident.Span, isNonSourceIdentToken: true);
+                    id++;
+                    updatedGroupFormulas.Add(new NamedFormula(newName, formula.Formula, formula.StartingIndex, formula.Attribute));
+                }
+
+                if (firstAttribute.AttributeOperation == PartialAttribute.AttributeOperationKind.Error)
+                {
+                    errors.Add(new TexlError(firstAttribute.AttributeOperationToken, DocumentErrorSeverity.Severe, TexlStrings.ErrUnknownPartialOp));
+
+                    // None of the "namemangled" formulas are valid at this point, even if they all matched, as we're not using a valid partial operation.
+                    updatedGroupFormulas.Clear();
+                }
+
+                if (updatedGroupFormulas.Count != nameGroup.Count())
+                {
+                    // Not all matched, don't use renamed formulas
+                    newFormulas.AddRange(nameGroup);
+                    continue;
+                }
+
+                newFormulas.AddRange(updatedGroupFormulas);
+                newFormulas.Add(
+                    new NamedFormula(
+                        new IdentToken(name, firstAttribute.AttributeName.Span, isNonSourceIdentToken: true),
+                        GetPartialCombinedFormula(name, firstAttribute.AttributeOperation, updatedGroupFormulas),
+                        0,
+                        firstAttribute));
+            }
+
+            return new ParseUserDefinitionResult(newFormulas, parsed.UDFs, parsed.DefinedTypes, errors, parsed.Comments);
+        }
+
+        private Formula GetPartialCombinedFormula(string name, PartialAttribute.AttributeOperationKind operationKind, IList<NamedFormula> formulas)
+        {
+            return operationKind switch
+            {
+                PartialAttribute.AttributeOperationKind.PartialAnd => GeneratePartialFunction("And", name, formulas),
+                PartialAttribute.AttributeOperationKind.PartialOr => GeneratePartialFunction("Or", name, formulas),
+                PartialAttribute.AttributeOperationKind.PartialTable => GeneratePartialFunction("TableConcatenate", name, formulas),
+                PartialAttribute.AttributeOperationKind.PartialRecord => GeneratePartialFunction("MergeRecords", name, formulas),
+                _ => throw new InvalidOperationException("Unknown partial op while generating merged NF")
+            };
+        }
+
+        private Formula GeneratePartialFunction(string functionName, string name, IList<NamedFormula> formulas)
+        {
+            var listSeparator = TexlLexer.GetLocalizedInstance(_parserOptions.Culture).LocalizedPunctuatorListSeparator;
+
+            // We're going to construct these texlnodes by hand so the spans match up with real code locations
+            var script = $"{functionName}({string.Join($"{listSeparator} ", Enumerable.Range(0, formulas.Count).Select(i => name + _renamedFormulaGuid + i))})";
+
+            var arguments = new List<TexlNode>();
+            var id = 0;
+            foreach (var nf in formulas)
+            {
+                arguments.Add(new FirstNameNode(ref id, nf.Ident, new Identifier(nf.Ident)));
+            }
+
+            var firstAttributeOpToken = formulas.First().Attribute.AttributeOperationToken;
+
+            var functionCall = new CallNode(
+                ref id,
+                firstAttributeOpToken,
+                new SourceList(firstAttributeOpToken),
+                new Identifier(new IdentToken(functionName, firstAttributeOpToken.Span, true)),
+                headNode: null,
+                args: new ListNode(ref id, tok: firstAttributeOpToken, args: arguments.ToArray(), delimiters: null, sourceList: new SourceList(firstAttributeOpToken)),
+                tokParenClose: firstAttributeOpToken);
+
+            return new Formula(script, functionCall);
+        }
+        #endregion
     }
 }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4453,11 +4453,15 @@
     <comment>Error message when the user attempted to use the attribute syntax on a named formula definition, but we didn't recognize the attribute name they specified.</comment>
   </data>
   <data name="ErrOperationDoesntMatch" xml:space="preserve">
-    <value>All Partial operations on matching named formulas must be the same.</value>
-    <comment>{Locked=Partial} Error message when the user attempted to use a partial operator on multiple named formulas, but didn't specify the same operator on each one.</comment>
+    <value>All Partial operators on matching named formulas must be the same.</value>
+    <comment>{Locked=Partial} Error message when the user attempted to use a partial operator on multiple named formulas, but didn't specify the same operator on each one.
+      A partial operator is the 2nd part of a statement `[Partial Op]` and can be one of "And", "Or", "Table" or "Record".
+      It's used to determine how to combine multiple expressions with the same name and operator.</comment>
   </data>
   <data name="ErrUnknownPartialOp" xml:space="preserve">
-    <value>Unknown Partial operation.</value>
-    <comment>{Locked=Partial}. Error message when the user attempted to use a Partial operator that we don't recognize.</comment>
+    <value>Unknown Partial operator.</value>
+    <comment>{Locked=Partial}. Error message when the user attempted to use a Partial operator that we don't recognize.
+      A partial operator is the 2nd part of a statement `[Partial Op]` and can be one of "And", "Or", "Table" or "Record".
+      It's used to determine how to combine multiple expressions with the same name and operator.</comment>
   </data>
 </root>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1053,11 +1053,11 @@
   </data>
   <data name="AboutEDate_date" xml:space="preserve">
     <value>A date value to be adjusted by the specified number of months.</value>
-    <comment>Description of the first argument to the 'EDate' function.</comment>      
+    <comment>Description of the first argument to the 'EDate' function.</comment>
   </data>
   <data name="AboutEDate_months" xml:space="preserve">
     <value>Number of months by which to change the date. A positive value yields a future date, a negative value a past date, and zero will not change the month.</value>
-    <comment>Description of the second argument to the 'EDate' function.</comment>    
+    <comment>Description of the second argument to the 'EDate' function.</comment>
   </data>
   <data name="AboutEOMonth" xml:space="preserve">
     <value>Returns the last day of the month for a specified date, adjusted by a number of months.</value>
@@ -1073,11 +1073,11 @@
   </data>
   <data name="AboutEOMonth_date" xml:space="preserve">
     <value>A date value to be adjusted by the specified number of months.</value>
-    <comment>Description of the first argument to the 'EOMonth' function.</comment>      
+    <comment>Description of the first argument to the 'EOMonth' function.</comment>
   </data>
   <data name="AboutEOMonth_months" xml:space="preserve">
     <value>Number of months by which to change the date. A positive value yields a future date, a negative value a past date, and zero will not change the month.</value>
-    <comment>Description of the second argument to the 'EOMonth' function.</comment>     
+    <comment>Description of the second argument to the 'EOMonth' function.</comment>
   </data>
   <data name="AboutInt" xml:space="preserve">
     <value>Truncates 'number' by rounding toward negative infinity.</value>
@@ -4375,7 +4375,7 @@
     <comment>{Locked=JSON}. Error message shown to the user if they try to serialize an object which contain a nested property of a type which is not supported in the JSON function. Both parameters are strings. E.g.: The JSON function cannot serialize tables / objects with a nested property called 'value' of type 'Polymorphic'.</comment>
   </data>
   <data name="ErrJSONArg1UnsupportedTypeWithNonBehavioral" xml:space="preserve">
-    <value>The JSON function cannot serialize binary data in non-behavioral expression.</value>    
+    <value>The JSON function cannot serialize binary data in non-behavioral expression.</value>
   </data>
   <data name="ErrTraceInvalidCustomRecordType" xml:space="preserve">
     <value>The parameter {0} contains a property of type {1} which is not supported.</value>
@@ -4447,5 +4447,17 @@
   </data>
   <data name="AboutUniChar_column_of_numbers" xml:space="preserve">
     <value>A table column of numeric values to be converted into Unicode characters.</value>
+  </data>
+  <data name="ErrOnlyPartialAttribute" xml:space="preserve">
+    <value>Unsupported attribute kind</value>
+    <comment>Error message when the user attempted to use the attribute syntax on a named formula definition, but we didn't recognize the attribute name they specified.</comment>
+  </data>
+  <data name="ErrOperationDoesntMatch" xml:space="preserve">
+    <value>All Partial operations on matching named formulas must be the same.</value>
+    <comment>{Locked=Partial} Error message when the user attempted to use a partial operator on multiple named formulas, but didn't specify the same operator on each one.</comment>
+  </data>
+  <data name="ErrUnknownPartialOp" xml:space="preserve">
+    <value>Unknown Partial operation.</value>
+    <comment>{Locked=Partial}. Error message when the user attempted to use a Partial operator that we don't recognize.</comment>
   </data>
 </root>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AttributeParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AttributeParserTests.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.PowerFx.Syntax;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    public class AttributeParserTests
+    {
+        private readonly ParserOptions _parseOptions = new ParserOptions() { AllowAttributes = true };
+
+        [Fact]
+        public void TestNamedFormulaAttributes()
+        {
+            UserDefinitions.ProcessUserDefinitions(
+            @"
+                [SomeName Ident]
+                Foo = 123;
+            ", _parseOptions,
+            out var result);
+
+            Assert.False(result.HasErrors);
+
+            Assert.Equal("Foo", result.NamedFormulas.First().Ident.Name.Value);
+            Assert.Equal("SomeName", result.NamedFormulas.First().Attribute.AttributeName.Name.Value);
+            Assert.Equal(Parser.PartialAttribute.AttributeOperationKind.Error, result.NamedFormulas.First().Attribute.AttributeOperation);
+        }
+
+        [Fact]
+        public void TestNFAttributeSingleKeyAnd()
+        {
+            UserDefinitions.ProcessUserDefinitions(
+            @"
+                [Partial And]
+                Foo = 123;
+            ", _parseOptions,
+            out var result);
+
+            Assert.False(result.HasErrors);
+
+            var formulas = result.NamedFormulas.ToList();
+
+            Assert.Single(result.NamedFormulas);
+
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value); 
+            Assert.Equal("Partial", formulas[0].Attribute.AttributeName.Name.Value);
+            Assert.Equal(Parser.PartialAttribute.AttributeOperationKind.PartialAnd, formulas[0].Attribute.AttributeOperation);
+        }
+
+        [Theory]
+        [InlineData("And", "And")]
+        [InlineData("Or", "Or")]
+        [InlineData("Record", "MergeRecords")]
+        [InlineData("Table", "TableConcatenate")]
+        public void TestNFAttributeOperationsCombined(string op, string combinedFunctionName)
+        {
+            UserDefinitions.ProcessUserDefinitions(
+            $@"
+                [Partial {op}]
+                Foo = false;
+                [Partial {op}]
+                Foo = true;
+            ", _parseOptions,
+            out var result);
+
+            Assert.False(result.HasErrors);
+
+            // Process added the combined nf
+            Assert.Equal(3, result.NamedFormulas.Count());
+
+            var genNf = result.NamedFormulas.Last();
+            Assert.StartsWith(combinedFunctionName, genNf.Formula.Script);
+        }
+
+        [Fact]
+        public void TestNFAttributeOperationInvalid()
+        {
+            UserDefinitions.ProcessUserDefinitions(
+            $@"
+                [Partial Unknown]
+                Foo = false;
+                [Partial Unknown]
+                Foo = true;
+            ", _parseOptions,
+            out var result);
+
+            Assert.True(result.HasErrors);
+
+            // Combined expression not generated
+            Assert.Equal(2, result.NamedFormulas.Count());
+        }
+
+        [Fact]
+        public void TestMultipleNamedFormulaAttributes()
+        {
+            UserDefinitions.ProcessUserDefinitions(
+            @"
+                [SomeName Ident]
+                Foo = 123;
+
+                [SomeName1 Ident1]
+                Foo1 = 123;
+
+                [SomeName2 Ident2]
+                Foo2 = 123;
+            ", _parseOptions,
+            out var result);
+
+            Assert.False(result.HasErrors);
+
+            var formulas = result.NamedFormulas.ToList();
+
+            Assert.Equal(3, result.NamedFormulas.Count());
+
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("SomeName", formulas[0].Attribute.AttributeName.Name.Value);
+            Assert.Equal("Ident", formulas[0].Attribute.AttributeOperationToken.As<IdentToken>().Name.Value);
+
+            Assert.Equal("Foo1", formulas[1].Ident.Name.Value);
+            Assert.Equal("SomeName1", formulas[1].Attribute.AttributeName.Name.Value);
+            Assert.Equal("Ident1", formulas[1].Attribute.AttributeOperationToken.As<IdentToken>().Name.Value);
+
+            Assert.Equal("Foo2", formulas[2].Ident.Name.Value);
+            Assert.Equal("SomeName2", formulas[2].Attribute.AttributeName.Name.Value);
+            Assert.Equal("Ident2", formulas[2].Attribute.AttributeOperationToken.As<IdentToken>().Name.Value);
+        }
+
+        [Fact]
+        public void TestErrorNamedFormulaAttributes()
+        {
+            UserDefinitions.ProcessUserDefinitions(
+            @"
+                [SomeNa.me Iden()t]
+                Foo = 123;
+
+                [SomeName1 Ident1]
+                Foo1 = 123;
+
+                [SomeName2 Ident2]
+                Foo2 = 123;
+            ", _parseOptions,
+            out var result);
+
+            Assert.True(result.HasErrors);
+
+            Assert.Equal(2, result.NamedFormulas.Count());
+
+            // Error in the first definition's attribute, it gets skipped and we restart on the next one
+            var formulas = result.NamedFormulas.ToList();
+
+            Assert.Equal("Foo1", formulas[0].Ident.Name.Value);
+            Assert.Equal("SomeName1", formulas[0].Attribute.AttributeName.Name.Value);
+            Assert.Equal("Ident1", formulas[0].Attribute.AttributeOperationToken.As<IdentToken>().Name.Value);
+
+            Assert.Equal("Foo2", formulas[1].Ident.Name.Value);
+            Assert.Equal("SomeName2", formulas[1].Attribute.AttributeName.Name.Value);
+            Assert.Equal("Ident2", formulas[1].Attribute.AttributeOperationToken.As<IdentToken>().Name.Value);
+        }
+    }
+}


### PR DESCRIPTION
This is an early prototype of support for a [Partial] attribute that enables combining named formulas.
This is done via name-mangling in the parser, renaming each NF to foo_Guid_0, foo_guid_1, ... and then creating a new hidden nf
Foo = Op(foo_guid0, foo_guid1, ...). This allows us to update the formulas independently in authoring, and process them without real changes to NF handling on the PA side. 

![Animation 1](https://github.com/microsoft/Power-Fx/assets/69215460/12923e11-01b0-4e71-80f5-b053dfb50fe4)
