### PR TITLE
Make AsType strictly need Data Sources as it's second argument

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/AsType.cs
@@ -91,8 +91,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var ads = argTypes[1].AssociatedDataSources?.FirstOrDefault();
 
             if (!binding.TryGetFirstNameInfo(tableArg.Id, out var tableInfo) ||
-                !(IsExternalSource(ads) ||
-                IsExternalSource(tableInfo.Data)))
+                !(IsExternalSource(ads) || IsExternalSource(tableInfo.Data)) ||
+                tableInfo.Kind != BindKind.Data)
             {
                 errors.EnsureError(tableArg, TexlStrings.ErrAsTypeAndIsTypeExpectConnectedDataSource);
             }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -2058,9 +2058,24 @@
     <value>This function cannot be invoked within {0}.</value>
     <comment>Error Message.</comment>
   </data>
-  <data name="ErrAsTypeAndIsTypeExpectConnectedDataSource" xml:space="preserve">
-    <value>Incorrect argument. This formula expects a table from a connected data source. The AsType and IsType functions require connected data sources.</value>
+  <data name="ErrorResource_ErrAsTypeAndIsTypeExpectConnectedDataSource_ShortMessage" xml:space="preserve">
+    <value>Incorrect argument. The AsType and IsType functions require a table from a connected data source.</value>
     <comment>{Locked=AsType}{Locked=IsType} Error message provided when the user attempts to use a non-Connected data source table as the second argument to AsType or IsType.</comment>
+  </data>
+  <data name="ErrorResource_ErrAsTypeAndIsTypeExpectConnectedDataSource_LongMessage" xml:space="preserve">
+    <value>Sometimes this is the result of name collisions with a table's fields, you may need the global disambiguation operator to ensure you're referencing the table.</value>
+  </data>
+  <data name="ErrorResource_ErrAsTypeAndIsTypeExpectConnectedDataSource_HowToFix_1" xml:space="preserve">
+    <value>As an example, you can use [@Users] instead of Users</value>
+    <comment>1 How to fix the error.</comment>
+  </data>
+  <data name="ErrorResource_ErrAsTypeAndIsTypeExpectConnectedDataSource_Link_1" xml:space="preserve">
+    <value>Article: Disambiguation Operator</value>
+    <comment>Article: Disambiguation Operator</comment>
+  </data>
+  <data name="ErrorResource_ErrAsTypeAndIsTypeExpectConnectedDataSource_Link_1_URL" xml:space="preserve">
+    <value>https://go.microsoft.com/fwlink/?linkid=2259922</value>
+    <comment>{Locked}</comment>
   </data>
   <data name="InfoMessage" xml:space="preserve">
     <value>Message: </value>


### PR DESCRIPTION
We initially supported relationships for resiliency to name collisions (we would grab the associated data source info off of them) but this just resulted in further issues for analysis/translation later on. This change makes this a strict requirement but also enhances the messaging around the error and provides fix and documentation in app checker.

![image](https://github.com/microsoft/Power-Fx/assets/93291567/d9ace893-be47-4e7a-afbb-1889f777bdb0)
![image](https://github.com/microsoft/Power-Fx/assets/93291567/235ad3c4-1618-4fd4-ad09-55f0171924e8)
