### PR TITLE
Don't create new DType instances for primitive FormulaType classes

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/BlankType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/BlankType.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerFx.Types
     public class BlankType : FormulaType
     {
         internal BlankType()
-            : base(new DType(DKind.ObjNull))
+            : base(DType.ObjNull)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/BooleanType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/BooleanType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerFx.Types
     public class BooleanType : FormulaType
     {
         internal BooleanType()
-            : base(new DType(DKind.Boolean))
+            : base(DType.Boolean)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/DecimalType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/DecimalType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerFx.Types
     public class DecimalType : FormulaType
     {
         internal DecimalType()
-            : base(new DType(DKind.Decimal))
+            : base(DType.Decimal)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/NumberType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/NumberType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerFx.Types
     public class NumberType : FormulaType
     {
         internal NumberType()
-            : base(new DType(DKind.Number))
+            : base(DType.Number)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/StringType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/StringType.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerFx.Types
     public class StringType : FormulaType
     {
         public StringType()
-            : base(new DType(DKind.String))
+            : base(DType.String)
         {
         }
 


### PR DESCRIPTION
Small perf improvement: we don't need to create new DType instances for primitive types.