### PR TITLE
Nl2Fx: Handle Small Null Ref and Make Const Public

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -693,7 +693,7 @@ namespace Microsoft.PowerFx
             }
             else
             {
-                this._allSymbols.EnumerateNames(symbolEntries, new ReadOnlySymbolTable.EnumerateNamesOptions());
+                this._allSymbols?.EnumerateNames(symbolEntries, new ReadOnlySymbolTable.EnumerateNamesOptions());
             }
 
             var summary = new CheckContextSummary

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         /// <summary>
         /// This const represents the dummy formula that is used to create an infrastructure needed to get the symbols for Nl2Fx operation.
         /// </summary>
-        internal static readonly string Nl2FxDummyFormula = "\"f7979178-07f0-424d-8f8b-00fee6fd19b8\"";
+        public static readonly string Nl2FxDummyFormula = "\"f7979178-07f0-424d-8f8b-00fee6fd19b8\"";
 
         public delegate void SendToClient(string data);
 


### PR DESCRIPTION
Small pr that handles a null ref and makes const public since Power Apps doesn't seem to have internal access to Language Server SDK and i cannot access the internal static const


