### PR TITLE
Fix IDE rules to not complain about existing code.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -41,10 +41,10 @@ dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 
 # this. preferences
-dotnet_style_qualification_for_field = false:error
-dotnet_style_qualification_for_property = false:error
-dotnet_style_qualification_for_method = false:error
-dotnet_style_qualification_for_event = false:error
+dotnet_style_qualification_for_field = false:none
+dotnet_style_qualification_for_property = false:none
+dotnet_style_qualification_for_method = false:none
+dotnet_style_qualification_for_event = false:none
 
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:error
@@ -68,7 +68,7 @@ dotnet_style_coalesce_expression = true:error
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:none
 dotnet_prefer_inferred_tuple_names = true:error
 dotnet_prefer_inferred_anonymous_type_member_names = true:error
-dotnet_style_prefer_auto_properties = true:error
+dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
 
@@ -104,8 +104,8 @@ dotnet_code_quality_unused_parameters = all:suggestion
 ###############################
 [*.cs]
 # var preferences
-csharp_style_var_for_built_in_types = true:error
-csharp_style_var_when_type_is_apparent = true:error
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = false:none
 csharp_style_var_elsewhere = false:none
 
 # Expression-bodied members
@@ -195,6 +195,8 @@ csharp_style_prefer_not_pattern = true:suggestion
 csharp_style_prefer_extended_property_pattern = true:suggestion
 
 # IDE0003: Name can be simplified
+# Beware - updates to IDE0000 rules may also require an update to the options above. 
+# See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
 dotnet_diagnostic.IDE0003.severity = none
 # IDE0004: Cast is redundant
 dotnet_diagnostic.IDE0004.severity = warning


### PR DESCRIPTION
Opening in VS 17.9.0, something has changed about how VS reads IDE rules and it's now complinaing about 100s of things.