### PR TITLE
Prevent NullReferenceException on JSON function on blank/error records

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Json/Functions/JsonFunctionImpl.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/Functions/JsonFunctionImpl.cs
@@ -256,7 +256,18 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                     foreach (DValue<RecordValue> row in tableValue.Rows)
                     {
-                        row.Value.Visit(this);
+                        if (row.IsBlank)
+                        {
+                            row.Blank.Visit(this);
+                        }
+                        else if (row.IsError)
+                        {
+                            row.Error.Visit(this);
+                        }
+                        else
+                        {
+                            row.Value.Visit(this);
+                        }
                     }
 
                     _writer.WriteEndArray();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/JSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/JSON.txt
@@ -117,7 +117,7 @@ Error({Kind:ErrorKind.Numeric})
 Error({Kind:ErrorKind.Div0})
 
 // Blank records
->> JSON([{a:1},Blank(),{a:3}])
+>> JSON(Table({a:1},Blank(),{a:3}))
 "[{""a"":1},null,{""a"":3}]"
 
 // Error records

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/JSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/JSON.txt
@@ -115,3 +115,11 @@ Error({Kind:ErrorKind.Numeric})
 
 >> JSON([{a:1,b:[2]},{a:3,b:[4,5]},{a:6,b:[7,1/0,9]}])
 Error({Kind:ErrorKind.Div0})
+
+// Blank records
+>> JSON([{a:1},Blank(),{a:3}])
+"[{""a"":1},null,{""a"":3}]"
+
+// Error records
+>> JSON(Filter([-2,-1,0,1,2], 1/Value>0))
+Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Json.Tests/JSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests/JSONTests.cs
@@ -132,6 +132,39 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.Equal("The JSON function cannot serialize tables / objects with a nested property called 'Property' of type 'Record'.", result.Errors.First().Message);
         }
 
+        [Fact]
+        public void Json_Handles_Null_Records()
+        {
+            var config = new PowerFxConfig(Features.PowerFxV1);
+            config.EnableJsonFunctions();
+
+            var engine = new RecalcEngine(config);
+
+            var checkResult = engine.Check("JSON([{a:1},Blank(),{a:3}])");
+
+            Assert.True(checkResult.IsSuccess);
+
+            var evalResult = checkResult.GetEvaluator().Eval();
+            Assert.Equal("[{\"a\":1},null,{\"a\":3}]", (evalResult as StringValue).Value);
+        }
+
+        [Fact]
+        public void Json_Handles_Error_Records()
+        {
+            var config = new PowerFxConfig(Features.PowerFxV1);
+            config.EnableJsonFunctions();
+
+            var engine = new RecalcEngine(config);
+
+            var checkResult = engine.Check("JSON(Filter(Sequence(5,-2), 1/Value > 0))");
+
+            Assert.True(checkResult.IsSuccess);
+
+            var evalResult = checkResult.GetEvaluator().Eval();
+            Assert.True(evalResult is ErrorValue);
+            Assert.Equal(ErrorKind.Div0, (evalResult as ErrorValue).Errors.First().Kind);
+        }
+
         public class LazyRecordValue : RecordValue
         {
             private readonly int _i;


### PR DESCRIPTION
The JSON function implementation currently throws a NullReferenceException when passed a table with null or error records. This addresses it.

Fixes #2224 