### PR TITLE
REPL fix to print blank records

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
@@ -127,7 +127,16 @@ namespace Microsoft.PowerFx.Repl.Services
                 foreach (var row in table.Rows)
                 {
                     resultString.Append(separator);
-                    resultString.Append(FormatField(row.Value.Fields.First(), false));
+
+                    if (row.IsValue)
+                    {
+                        resultString.Append(FormatField(row.Value.Fields.First(), false));
+                    }
+                    else
+                    {
+                        resultString.Append(row.IsError ? row.Error?.Errors?[0].Message : "Blank()");
+                    }
+
                     separator = ", ";
                 }
 

--- a/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Services/StandardFormatter.cs
@@ -118,9 +118,9 @@ namespace Microsoft.PowerFx.Repl.Services
             }
 
             // special treatment for single column table named Value
-            else if (table.Rows.Count() > 0 && 
-                     table.Rows.First().Value?.Fields.Count() == 1 && 
-                     table.Rows.First().Value?.Fields.First().Name == "Value")
+            else if (table.Rows.Count() > 0 &&
+                     table.Type.FieldNames.Count() == 1 &&
+                     table.Type.FieldNames.First() == "Value")
             {
                 var separator = string.Empty;
                 resultString = new StringBuilder("[");


### PR DESCRIPTION
Fix for a small issue I found while using REPL.
`Table({Value:1}, Blank())`