### PR TITLE
Mark ScopeCollection as mutable

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2882,10 +2882,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
                 else if (lookupInfo.Kind == BindKind.ScopeCollection)
                 {
-                    if (lookupInfo.Data is IExternalDataSource ds)
-                    {
-                        _txb.SetMutable(node, ds.IsWritable);
-                    }
+                    _txb.SetMutable(node, true);
                 }
 
                 Contracts.Assert(lookupInfo.Kind != BindKind.LambdaField);

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDataSource.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalDataSource.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerFx.Core.Entities
 
         bool RequiresAsync { get; }
 
-        bool IsWritable { get; }
-
         IExternalDataEntityMetadataProvider DataEntityMetadataProvider { get; }
 
         DataSourceKind Kind { get; }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDVEntity.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AssociatedDataSourcesTests/TestDVEntity.cs
@@ -29,8 +29,6 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
 
         public bool IsPageable => true;
 
-        public bool IsWritable => true;
-
         DType IExternalEntity.Type => AccountsTypeHelper.GetDType();
 
         IExternalDataEntityMetadataProvider IExternalDataSource.DataEntityMetadataProvider => throw new NotImplementedException();

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
@@ -218,8 +218,6 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         IDelegationMetadata IExternalDataSource.DelegationMetadata => DelegationMetadata;
 
-        public bool IsWritable => throw new NotImplementedException();
-
         public bool CanIncludeExpand(IExpandInfo expandToAdd)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
PA is presenting a bug when mutating a collection with PFxV1 active.