### PR TITLE
Update the Delegation logic for LookUp Call nodes

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return false;
             }
 
-            return IsValidCallNodeInternal(node, binding, metadata, trackingFunction ?? Function);
+            return base.IsValidCallNode(node, binding, metadata, trackingFunction ?? Function);
         }
     }
 }


### PR DESCRIPTION
Incorrect logic for determining whether a LookUp Call node could be delegated was added in a previous PR https://github.com/microsoft/Power-Fx/pull/2065

Updating the logic to ensure proper handling of edge cases