### PR TITLE
Making PropertyRuleCategory and Extensions public

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/PropertyRuleCategory.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/PropertyRuleCategory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
     /// Please keep these values in sync with src/AppMagic/js/AppMagic.Controls/Constants.ts.
     /// </summary>
     [TransportType(TransportKind.Enum)]
-    internal enum PropertyRuleCategory
+    public enum PropertyRuleCategory
     {
         Data = 0,
         Design = 1,

--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/PropertyRuleCategoryExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/PropertyRuleCategoryExtensions.cs
@@ -3,12 +3,12 @@
 
 namespace Microsoft.PowerFx.Core.App.Controls
 {
-    internal static class PropertyRuleCategoryExtensions
+    public static class PropertyRuleCategoryExtensions
     {
-        internal static bool IsValid(this PropertyRuleCategory category) =>
+        public static bool IsValid(this PropertyRuleCategory category) =>
             category >= PropertyRuleCategory.Data && category <= PropertyRuleCategory.Functions;
 
-        internal static bool IsBehavioral(this PropertyRuleCategory category) =>
+        public static bool IsBehavioral(this PropertyRuleCategory category) =>
             category == PropertyRuleCategory.Behavior || category == PropertyRuleCategory.OnDemandData;
     }
 }


### PR DESCRIPTION
Making PropertyRuleCategory and Extensions public so they can be used outside of PowerFx.Core