### PR TITLE
Fix for TableFromJsonArray: handling empty arrays with specified TableType #2267

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BindInfo/NameLookupInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BindInfo/NameLookupInfo.cs
@@ -47,22 +47,21 @@ namespace Microsoft.PowerFx.Core.Binding.BindInfo
 
         public bool TryToSymbolEntry(out SymbolEntry x)
         {
-            var ns = this.Data as NameSymbol;
-            if (ns == null)
+            if (this.Data is NameSymbol ns)
             {
-                x = null;
-                return false;
+                x = new SymbolEntry
+                {
+                    Name = ns.Name,
+                    DisplayName = this.DisplayName,                
+                    Properties = ns.Props,
+                    Type = FormulaType.Build(this.Type),
+                    Slot = ns
+                };
+                return true;
             }
 
-            x = new SymbolEntry
-            {
-                Name = ns.Name,
-                DisplayName = this.DisplayName,                
-                Properties = ns.Props,
-                Type = FormulaType.Build(this.Type),
-                Slot = ns
-            };
-            return true;
+            x = null;
+            return false;
         }            
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SlotMap.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SlotMap.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx
             _lowest = _items.Count + 1;
 
             _count++;
-            _items.Add(default(T));
+            _items.Add(default);
             return _items.Count - 1;
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.PowerFx
                 return value != null;
             }
 
-            value = default(T);
+            value = default;
             return false;
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.PowerFx
 
             _count--;
             Contracts.Assert(_count >= 0);
-            _items[index] = default(T);
+            _items[index] = default;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -210,7 +210,23 @@ namespace Microsoft.PowerFx.Types
             // since in that case nested elements are not object and hence needs to be handled differently.
             var nestedElementsAreObjects = array.EnumerateArray().Any(nestedElement => nestedElement.ValueKind == JsonValueKind.Object);
             bool isArray = tableType?._type.IsColumn == true && !nestedElementsAreObjects;
-            FormulaType ft = isArray ? tableType.ToRecord().GetFieldType("Value") : tableType?.ToRecord();
+            FormulaType ft;
+
+            if (isArray)
+            {
+                if (array.GetArrayLength() == 0)
+                {
+                    ft = tableType?.ToRecord();
+                }
+                else
+                {
+                    ft = tableType?.ToRecord().GetFieldType("Value");
+                }
+            }
+            else
+            {
+                ft = tableType?.ToRecord();
+            }
 
             for (var i = 0; i < array.GetArrayLength(); ++i)
             {

--- a/src/tests/Microsoft.PowerFx.Json.Tests/ParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests/ParseJSONTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Core.Tests;
 using Microsoft.PowerFx.Types;
 using Xunit;
@@ -547,6 +548,37 @@ namespace Microsoft.PowerFx.Json.Tests
                         break;
                 }
             }
+        }
+
+        [Theory]
+        [InlineData("[{\"Name\": \"Peter\"}]", "[]")]
+        [InlineData("[1,2,3]", "[]")]
+        [InlineData("[1,2,3]", "[5, 6]")]
+        [InlineData("[\"A\", \"B\"]", "[\"1\"]")]
+        [InlineData("[{\"Name\": \"Peter\"}]", "[{\"Name\": \"Julia\"}]")]
+        [InlineData("[]", "[]")]
+        public void FromArrayWithType(string prototypeJson, string valueJson)
+        {
+            FormulaValue prototypeValue = FormulaValueJSON.FromJson(prototypeJson);
+            FormulaValue value = FormulaValueJSON.FromJson(valueJson, prototypeValue.Type);
+            Assert.Equal(prototypeValue.Type, value.Type);
+        }
+
+        [Theory]
+        [InlineData("[{\"Name\": \"Peter\"}]", "[{\"OtherName\": \"Julia\"}]")]
+        public void FromArrayWithDifferentTableColumnType(string prototypeJson, string valueJson)
+        {
+            FormulaValue prototypeValue = FormulaValueJSON.FromJson(prototypeJson);
+            FormulaValue value = FormulaValueJSON.FromJson(valueJson, prototypeValue.Type);
+            Assert.NotEqual(prototypeValue.Type, value.Type);
+        }
+
+        [Theory]
+        [InlineData("[{\"Name\": \"Peter\"}]", "[1,2,3]")]
+        public async Task FromArrayWithIncompatibleType2(string prototypeJson, string valueJson)
+        {
+            FormulaValue prototypeValue = FormulaValueJSON.FromJson(prototypeJson);
+            Assert.Throws<InvalidOperationException>(() => FormulaValueJSON.FromJson(valueJson, prototypeValue.Type));
         }
     }
 }


### PR DESCRIPTION
Applied the significant changes suggested in the comments from the previous pull request.