### PR TITLE
Change Error Span for "Function X has some invalid arguments"

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
@@ -131,9 +131,7 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
 
             if (!HasErrors(token, severity))
             {
-                var err = new TexlError(token, severity, errKey, args);
-                CollectionUtils.Add(ref _errors, err);
-                return err;
+                Error(severity, token, errKey, args);
             }
 
             return null;
@@ -157,12 +155,27 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
             return Error(DefaultSeverity, node, errKey, args);
         }
 
+        public TexlError Error(Token token, ErrorResourceKey errKey, params object[] args)
+        {
+            return Error(DefaultSeverity, token, errKey, args);
+        }
+
         public TexlError Error(DocumentErrorSeverity severity, TexlNode node, ErrorResourceKey errKey, params object[] args)
         {
             Contracts.AssertValue(node);
             Contracts.AssertValue(args);
 
             var err = new TexlError(node, severity, errKey, args);
+            CollectionUtils.Add(ref _errors, err);
+            return err;
+        }
+
+        public TexlError Error(DocumentErrorSeverity severity, Token token, ErrorResourceKey errKey, params object[] args)
+        {
+            Contracts.AssertValue(token);
+            Contracts.AssertValue(args);
+
+            var err = new TexlError(token, severity, errKey, args);
             CollectionUtils.Add(ref _errors, err);
             return err;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4920,7 +4920,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 // If PreVisit resulted in errors for the node (and a non-null CallInfo),
                 // we're done -- we have a match and appropriate errors logged already.
-                if (_txb.ErrorContainer.HasErrors(node))
+                if (_txb.ErrorContainer.HasErrors(node) || _txb.ErrorContainer.HasErrors(node.Head.Token))
                 {
                     Contracts.Assert(info != null);
 
@@ -5035,7 +5035,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     var functionsWithLambdas = LookupFunctions(funcNamespace, node.Head.Name.Value).Where(fnc => fnc.HasLambdas);
 
-                    if (functionsWithLambdas.Any() && !_txb.ErrorContainer.HasErrors(node))
+                    if (functionsWithLambdas.Any() && !_txb.ErrorContainer.HasErrors(node) && !_txb.ErrorContainer.HasErrors(node.Head.Token))
                     {
                         // PreVisitBottomUp is called along the arity error code path. For functions such as Sum,
                         // there is an overload with a lambda as well as an overload with scalars. Using untyped

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4221,7 +4221,7 @@ namespace Microsoft.PowerFx.Core.Binding
             private void UntypedObjectScopeError(CallNode node, TexlFunction maybeFunc, TexlNode firstArg)
             {
                 _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, firstArg, TexlStrings.ErrUntypedObjectScope);
-                _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
+                _txb.ErrorContainer.Error(node.Head.Token, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
 
                 _txb.SetInfo(node, new CallInfo(maybeFunc, node, null, default, false, _currentScope.Nest));
                 _txb.SetType(node, maybeFunc.ReturnType);
@@ -4485,7 +4485,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         // If there is a single function with this name, and the first arg is not
                         // a good match, then we have an erroneous invocation.
                         _txb.ErrorContainer.EnsureError(DocumentErrorSeverity.Severe, nodeInput, TexlStrings.ErrBadType);
-                        _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
+                        _txb.ErrorContainer.Error(node.Head.Token, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
                         _txb.SetInfo(node, new CallInfo(maybeFunc, node, typeScope, scopeIdent, identRequired, _currentScope.Nest));
                         _txb.SetType(node, maybeFunc.ReturnType);
                     }
@@ -4609,7 +4609,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // on their argument types.
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node.Head.Token, TexlStrings.ErrInvalidArgs_Func, maybeFunc.Name);
                 }
 
                 // Set the inferred return type for the node.
@@ -4951,7 +4951,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!fArgsValid)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, func.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node.Head.Token, TexlStrings.ErrInvalidArgs_Func, func.Name);
                 }
 
                 _txb.SetType(node, returnType);
@@ -4969,7 +4969,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 var info = _txb.GetInfo(node);
                 Contracts.AssertValueOrNull(info);
-                Contracts.Assert(info == null || _txb.ErrorContainer.HasErrors(node));
+                Contracts.Assert(info == null || _txb.ErrorContainer.HasErrors(node) || _txb.ErrorContainer.HasErrors(node.Head.Token));
 
                 // Attempt to get the overloads, so we can determine the scope to use for datasource name matching
                 // We're only interested in the overloads without lambdas, since those were
@@ -5065,7 +5065,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 // If PreVisit resulted in errors for the node (and a non-null CallInfo),
                 // we're done -- we have a match and appropriate errors logged already.
-                if (_txb.ErrorContainer.HasErrors(node))
+                if (_txb.ErrorContainer.HasErrors(node) || _txb.ErrorContainer.HasErrors(node.Head.Token))
                 {
                     Contracts.Assert(info != null);
 
@@ -5144,7 +5144,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!fArgsValid && !func.HasPreciseErrors)
                 {
-                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node, TexlStrings.ErrInvalidArgs_Func, func.Name);
+                    _txb.ErrorContainer.Error(DocumentErrorSeverity.Severe, node.Head.Token, TexlStrings.ErrInvalidArgs_Func, func.Name);
                 }
 
                 _txb.SetType(node, returnType);
@@ -5242,7 +5242,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 // We exhausted the overloads without finding an exact match, so post a document error.
                 if (!someFunc.HasPreciseErrors)
                 {
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrInvalidArgs_Func, someFunc.Name);
+                    _txb.ErrorContainer.Error(node.Head.Token, TexlStrings.ErrInvalidArgs_Func, someFunc.Name);
                 }
 
                 // The final CheckInvocation call will post all the necessary document errors.

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -1472,7 +1472,7 @@ namespace Microsoft.PowerFx.Core.Functions
             Contracts.AssertValue(callNode);
             Contracts.AssertValue(binding);
 
-            if (binding.ErrorContainer.HasErrors(callNode, errorSeverity))
+            if (binding.ErrorContainer.HasErrors(callNode, errorSeverity) || binding.ErrorContainer.HasErrors(callNode.Head.Token, errorSeverity))
             {
                 return false;
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AbsT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AbsT.txt
@@ -10,7 +10,7 @@ Table({Value:1},{Value:0})
 Table({Value:10},{Value:10.123})
 
 >> Abs([])
-Errors: Error 0-7: The function 'Abs' has some invalid arguments.|Error 4-6: Invalid schema, expected a one-column table.
+Errors: Error 0-3: The function 'Abs' has some invalid arguments.|Error 4-6: Invalid schema, expected a one-column table.
 
 >> Abs(If(1<0,[1]))
 Blank()

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns.txt
@@ -8,11 +8,11 @@ Table({Double:2,Value:1},{Double:4,Value:2},{Double:6,Value:3},{Double:8,Value:4
 {Double:6,Value:3}
 
 >> AddColumns([1,2,3,4,5], "Value", Value * 2)
-Errors: Warning 24-31: A column named 'Value' already exists.|Error 0-43: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 24-31: A column named 'Value' already exists.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 // Record overload
 >> AddColumns({Value:1}, "Value", Value * 2)
-Errors: Warning 22-29: A column named 'Value' already exists.|Error 0-41: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 22-29: A column named 'Value' already exists.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns([1,2,3,4,5], "Blanks", Blank())
 Table({Blanks:Blank(),Value:1},{Blanks:Blank(),Value:2},{Blanks:Blank(),Value:3},{Blanks:Blank(),Value:4},{Blanks:Blank(),Value:5})
@@ -63,7 +63,7 @@ Table({a:1,b:{c:3},'b d':1},{a:2,b:{c:4},'b d':8})
 {a:2,b:{c:4},'b d':8}
 
 >> AddColumns(Table({a: 1}, {a: 2}), "b", c)
-Errors: Error 39-40: Name isn't valid. 'c' isn't recognized.|Error 0-41: The function 'AddColumns' has some invalid arguments.
+Errors: Error 39-40: Name isn't valid. 'c' isn't recognized.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 // Record overload
 >> AddColumns({a: 1}, "b", c)
@@ -98,14 +98,14 @@ Errors: Error 47-49: Name isn't valid. 'sq' isn't recognized.
 Errors: Error 49-51: Name isn't valid. 'sq' isn't recognized.
 
 >> AddColumns([1, 2, 3], 5, Value * Value)
-Errors: Error 22-23: Argument '5' is invalid, expected a text literal.|Error 0-39: The function 'AddColumns' has some invalid arguments.
+Errors: Error 22-23: Argument '5' is invalid, expected a text literal.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns([1, 2, 3], "", Value * Value)
-Errors: Error 22-24: Argument '' is not a valid identifier.|Error 0-40: The function 'AddColumns' has some invalid arguments.
+Errors: Error 22-24: Argument '' is not a valid identifier.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns([1, 2, 3], "a", Value^2, "a", Value^3)
-Errors: Warning 36-39: Column name conflict for 'a'.|Error 0-49: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 36-39: Column name conflict for 'a'.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 // Record overload
 >> AddColumns({Value:3}, "a", Value^2, "a", Value^3)
-Errors: Warning 36-39: Column name conflict for 'a'.|Error 0-49: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 36-39: Column name conflict for 'a'.|Error 0-10: The function 'AddColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns_SupportColumnNamesAsIdentifiers.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns_SupportColumnNamesAsIdentifiers.txt
@@ -8,11 +8,11 @@ Table({Double:2,Value:1},{Double:4,Value:2},{Double:6,Value:3},{Double:8,Value:4
 {Double:6,Value:3}
 
 >> AddColumns([1,2,3,4,5], Value, Value * 2)
-Errors: Warning 24-29: A column named 'Value' already exists.|Error 0-41: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 24-29: A column named 'Value' already exists.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 // Record overload
 >> AddColumns({Value:1}, Value, Value * 2)
-Errors: Warning 22-27: A column named 'Value' already exists.|Error 0-39: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 22-27: A column named 'Value' already exists.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns([1,2,3,4,5], Blanks, Blank())
 Table({Blanks:Blank(),Value:1},{Blanks:Blank(),Value:2},{Blanks:Blank(),Value:3},{Blanks:Blank(),Value:4},{Blanks:Blank(),Value:5})
@@ -49,7 +49,7 @@ Table({a:1,b:1},{a:2,b:8})
 {a:2,b:8}
 
 >> AddColumns(Table({a: 1, b: {c: 3}}, {a: 2, b: {c: 4}}), b.d, a * a * a)
-Errors: Error 56-57: Name isn't valid. 'b' isn't recognized.|Error 57-59: Invalid use of '.'|Error 0-71: The function 'AddColumns' has some invalid arguments.
+Errors: Error 56-57: Name isn't valid. 'b' isn't recognized.|Error 57-59: Invalid use of '.'|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns(Table({a: 1, b: {c: 3}}, {a: 2, b: {c: 4}}), 'b.d', a * a * a)
 Table({a:1,b:{c:3},'b.d':1},{a:2,b:{c:4},'b.d':8})
@@ -58,7 +58,7 @@ Table({a:1,b:{c:3},'b.d':1},{a:2,b:{c:4},'b.d':8})
 Table({a:1,b:{c:3},'b d':1},{a:2,b:{c:4},'b d':8})
 
 >> AddColumns(Table({a: 1}, {a: 2}), b, c)
-Errors: Error 37-38: Name isn't valid. 'c' isn't recognized.|Error 0-39: The function 'AddColumns' has some invalid arguments.
+Errors: Error 37-38: Name isn't valid. 'c' isn't recognized.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 // Record overload
 >> AddColumns({a: 1}, b, c)
@@ -98,11 +98,11 @@ Table({Value:1,_:1},{Value:2,_:4})
 Table({Value:1,z:Blank()},{Value:2,z:Blank()})
 
 >> AddColumns([1,2], 3, Value * Value)
-Errors: Error 18-19: Expected identifier name|Error 0-35: The function 'AddColumns' has some invalid arguments.
+Errors: Error 18-19: Expected identifier name|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns([1, 2, 3], a, Value^2, a, Value^3)
-Errors: Warning 34-35: Column name conflict for 'a'.|Error 0-45: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 34-35: Column name conflict for 'a'.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 // Record overload
 >> AddColumns({Value:3}, a, Value^2, a, Value^3)
-Errors: Warning 34-35: Column name conflict for 'a'.|Error 0-45: The function 'AddColumns' has some invalid arguments.
+Errors: Warning 34-35: Column name conflict for 'a'.|Error 0-10: The function 'AddColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/BooleanT.txt
@@ -17,7 +17,7 @@ Table({Value:false},{Value:Error({Kind:ErrorKind.InvalidArgument})})
 Table({Value:false},{Value:true})
 
 >> Boolean([])
-Errors: Error 0-11: The function 'Boolean' has some invalid arguments.|Error 8-10: Invalid schema, expected a one-column table.
+Errors: Error 0-7: The function 'Boolean' has some invalid arguments.|Error 8-10: Invalid schema, expected a one-column table.
 
 >> Boolean([false])
 Table({Value:false})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Clear.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Clear.txt
@@ -18,4 +18,4 @@ Errors: Error 0-7: Invalid number of arguments: received 0, expected 1.
 Errors: Error 0-13: Invalid number of arguments: received 2, expected 1.
 
 >> Clear(Foo)
-Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 0-10: The function 'Clear' has some invalid arguments.
+Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 0-5: The function 'Clear' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Clear_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Clear_V1Compat.txt
@@ -7,13 +7,13 @@ Errors: Error 6-13: The value passed to the 'Clear' function cannot be changed.
 Errors: Error 6-36: The value passed to the 'Clear' function cannot be changed.
 
 >> Clear(1)
-Errors: Error 6-7: Invalid argument type (Decimal). Expecting a Table value instead.|Error 6-7: The value passed to the 'Clear' function cannot be changed.|Error 0-8: The function 'Clear' has some invalid arguments.
+Errors: Error 6-7: Invalid argument type (Decimal). Expecting a Table value instead.|Error 6-7: The value passed to the 'Clear' function cannot be changed.|Error 0-5: The function 'Clear' has some invalid arguments.
 
 >> Clear(1/0)
-Errors: Error 7-8: Invalid argument type (Decimal). Expecting a Table value instead.|Error 7-8: The value passed to the 'Clear' function cannot be changed.|Error 0-10: The function 'Clear' has some invalid arguments.
+Errors: Error 7-8: Invalid argument type (Decimal). Expecting a Table value instead.|Error 7-8: The value passed to the 'Clear' function cannot be changed.|Error 0-5: The function 'Clear' has some invalid arguments.
 
 >> IsError(Clear(1))
-Errors: Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 14-15: The value passed to the 'Clear' function cannot be changed.|Error 8-16: The function 'Clear' has some invalid arguments.
+Errors: Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 14-15: The value passed to the 'Clear' function cannot be changed.|Error 8-13: The function 'Clear' has some invalid arguments.
 
 >> Clear(t1);Clear(t2)
 If(true, {test:1}, "Void value (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Clear_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Clear_V1CompatDisabled.txt
@@ -7,13 +7,13 @@ true
 Error({Kind:ErrorKind.Custom})
 
 >> Clear(1)
-Errors: Error 6-7: Invalid argument type (Decimal). Expecting a Table value instead.|Error 0-8: The function 'Clear' has some invalid arguments.
+Errors: Error 6-7: Invalid argument type (Decimal). Expecting a Table value instead.|Error 0-5: The function 'Clear' has some invalid arguments.
 
 >> Clear(1/0)
-Errors: Error 7-8: Invalid argument type (Decimal). Expecting a Table value instead.|Error 0-10: The function 'Clear' has some invalid arguments.
+Errors: Error 7-8: Invalid argument type (Decimal). Expecting a Table value instead.|Error 0-5: The function 'Clear' has some invalid arguments.
 
 >> IsError(Clear(1))
-Errors: Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 8-16: The function 'Clear' has some invalid arguments.
+Errors: Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 8-13: The function 'Clear' has some invalid arguments.
 
 >> Clear(t1);Clear(t2)
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Coalesce.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Coalesce.txt
@@ -196,19 +196,19 @@ true
 // Boolean-Date type conversion is not supported
 
 >> Coalesce(If(1<0,false), Date(2000,2,12))
-Errors: Error 24-39: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-40: The function 'Coalesce' has some invalid arguments.
+Errors: Error 24-39: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-8: The function 'Coalesce' has some invalid arguments.
 
 // BOOLEAN-TIME
 // Boolean-Time type conversion is not supported
 
 >> Coalesce(If(1<0,false), Time(12,34,56))
-Errors: Error 24-38: Invalid argument type (Time). Expecting a Boolean value instead.|Error 0-39: The function 'Coalesce' has some invalid arguments.
+Errors: Error 24-38: Invalid argument type (Time). Expecting a Boolean value instead.|Error 0-8: The function 'Coalesce' has some invalid arguments.
 
 // BOOLEAN-DATETIME
 // Boolean-DateTime type conversion is not supported
 
 >> Coalesce(If(1<0,false), DateTime(2000,1,2,12,34,56))
-Errors: Error 24-51: Invalid argument type (DateTime). Expecting a Boolean value instead.|Error 0-52: The function 'Coalesce' has some invalid arguments.
+Errors: Error 24-51: Invalid argument type (DateTime). Expecting a Boolean value instead.|Error 0-8: The function 'Coalesce' has some invalid arguments.
 
 // DATE-NUMBER
 >> Coalesce(If(1<0,Date(2000,12,11)), 2)
@@ -225,19 +225,19 @@ Date(2021,9,7)
 // Date-Boolean type conversion is not supported
 
 >> Coalesce(If(1<0,Date(2000,2,12)), false)
-Errors: Error 34-39: Invalid argument type (Boolean). Expecting a Date value instead.|Error 0-40: The function 'Coalesce' has some invalid arguments.
+Errors: Error 34-39: Invalid argument type (Boolean). Expecting a Date value instead.|Error 0-8: The function 'Coalesce' has some invalid arguments.
 
 // TIME-BOOLEAN
 // Time-Boolean type conversion is not supported
 
 >> Coalesce(If(1<0,Time(12,34,56)), true)
-Errors: Error 33-37: Invalid argument type (Boolean). Expecting a Time value instead.|Error 0-38: The function 'Coalesce' has some invalid arguments.
+Errors: Error 33-37: Invalid argument type (Boolean). Expecting a Time value instead.|Error 0-8: The function 'Coalesce' has some invalid arguments.
 
 // DATETIME-BOOLEAN
 // DateTime-Boolean type conversion is not supported
 
 >> Coalesce(If(1<0,DateTime(2000,1,2,12,34,56)), false)
-Errors: Error 46-51: Invalid argument type (Boolean). Expecting a DateTime value instead.|Error 0-52: The function 'Coalesce' has some invalid arguments.
+Errors: Error 46-51: Invalid argument type (Boolean). Expecting a DateTime value instead.|Error 0-8: The function 'Coalesce' has some invalid arguments.
 
 // DATE-DATE
 >> Coalesce(If(1<0,Date(2022,1,1)), Date(2021,9,8))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect.txt
@@ -36,22 +36,22 @@ Errors: Error 0-19: Invalid number of arguments: received 3, expected 2.
 Errors: Error 0-25: Invalid number of arguments: received 3, expected 2.
 
 >> Collect(t1, "x")
-Errors: Error 12-15: Invalid argument type (Text). Expecting a Record value instead.|Error 12-15: Invalid argument type. Cannot use Text values in this context.|Error 0-16: The function 'Collect' has some invalid arguments.
+Errors: Error 12-15: Invalid argument type (Text). Expecting a Record value instead.|Error 12-15: Invalid argument type. Cannot use Text values in this context.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(t1, 1)
-Errors: Error 12-13: Invalid argument type (Decimal). Expecting a Record value instead.|Error 12-13: Invalid argument type. Cannot use Decimal values in this context.|Error 0-14: The function 'Collect' has some invalid arguments.
+Errors: Error 12-13: Invalid argument type (Decimal). Expecting a Record value instead.|Error 12-13: Invalid argument type. Cannot use Decimal values in this context.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Foo,r2)
-Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-14: The specified column 'Field1' does not exist.|Error 0-15: The function 'Collect' has some invalid arguments.
+Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-14: The specified column 'Field1' does not exist.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Foo,Bar)
-Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-15: Name isn't valid. 'Bar' isn't recognized.|Error 0-16: The function 'Collect' has some invalid arguments.
+Errors: Error 8-11: Name isn't valid. 'Foo' isn't recognized.|Error 12-15: Name isn't valid. 'Bar' isn't recognized.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(1/0,Foo)
 Errors: Error 12-15: Name isn't valid. 'Foo' isn't recognized.
 
 >> Collect(t1,{Price:200}).Price
-Errors: Error 11-22: The specified column 'Price' does not exist.|Error 0-23: The function 'Collect' has some invalid arguments.|Error 23-29: Name isn't valid. 'Price' isn't recognized.
+Errors: Error 11-22: The specified column 'Price' does not exist.|Error 0-7: The function 'Collect' has some invalid arguments.|Error 23-29: Name isn't valid. 'Price' isn't recognized.
 
 >> Collect(t_empty,{Value:200}).Value
 200

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect_V1Compat.txt
@@ -1,22 +1,22 @@
 ﻿#SETUP: EnableExpressionChaining,MutationFunctionsTestSetup,PowerFxV1CompatibilityRules
 
 >> Collect(Table({name: "VC"}), {surname: "textInput1"})
-Errors: Error 29-52: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 8-27: The value passed to the 'Collect' function cannot be changed.|Error 0-53: The function 'Collect' has some invalid arguments.
+Errors: Error 29-52: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 8-27: The value passed to the 'Collect' function cannot be changed.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(FirstN(t_name, 0), {name: "textInput1"})
 Errors: Error 8-25: The value passed to the 'Collect' function cannot be changed.
 
 >> Collect(Error({Kind:ErrorKind.Custom}), r2)
-Errors: Error 40-42: The specified column 'Field1' does not exist.|Error 8-38: The value passed to the 'Collect' function cannot be changed.|Error 0-43: The function 'Collect' has some invalid arguments.
+Errors: Error 40-42: The specified column 'Field1' does not exist.|Error 8-38: The value passed to the 'Collect' function cannot be changed.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Error({Kind:ErrorKind.Custom}), Error({Kind:ErrorKind.Div0}))
 Errors: Error 8-38: The value passed to the 'Collect' function cannot be changed.
 
 >> Collect(Blank(), r2)
-Errors: Error 17-19: The specified column 'Field1' does not exist.|Error 8-15: The value passed to the 'Collect' function cannot be changed.|Error 0-20: The function 'Collect' has some invalid arguments.
+Errors: Error 17-19: The specified column 'Field1' does not exist.|Error 8-15: The value passed to the 'Collect' function cannot be changed.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Blank(), Blank())
 Errors: Error 8-15: The value passed to the 'Collect' function cannot be changed.
 
 >> Collect("", "")
-Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instead.|Error 12-14: Invalid argument type (Text). Expecting a Record value instead.|Error 12-14: Invalid argument type. Cannot use Text values in this context.|Error 8-10: The value passed to the 'Collect' function cannot be changed.|Error 0-15: The function 'Collect' has some invalid arguments.
+Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instead.|Error 12-14: Invalid argument type (Text). Expecting a Record value instead.|Error 12-14: Invalid argument type. Cannot use Text values in this context.|Error 8-10: The value passed to the 'Collect' function cannot be changed.|Error 0-7: The function 'Collect' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Collect_V1CompatDisabled.txt
@@ -1,22 +1,22 @@
 ﻿#SETUP: EnableExpressionChaining,MutationFunctionsTestSetup,disable:PowerFxV1CompatibilityRules
 
 >> Collect(Table({name: "VC"}), {surname: "textInput1"})
-Errors: Error 29-52: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 0-53: The function 'Collect' has some invalid arguments.
+Errors: Error 29-52: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(FirstN(t_name, 0), {name: "textInput1"})
 {name:"textInput1"}
 
 >> Collect(Error({Kind:ErrorKind.Custom}), r2)
-Errors: Error 40-42: The specified column 'Field1' does not exist.|Error 0-43: The function 'Collect' has some invalid arguments.
+Errors: Error 40-42: The specified column 'Field1' does not exist.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Error({Kind:ErrorKind.Custom}), Error({Kind:ErrorKind.Div0}))
 Error({Kind:ErrorKind.Custom})
 
 >> Collect(Blank(), r2)
-Errors: Error 17-19: The specified column 'Field1' does not exist.|Error 0-20: The function 'Collect' has some invalid arguments.
+Errors: Error 17-19: The specified column 'Field1' does not exist.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Blank(), Blank())
 Blank()
 
 >> Collect("", "")
-Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instead.|Error 12-14: Invalid argument type (Text). Expecting a Record value instead.|Error 12-14: Invalid argument type. Cannot use Text values in this context.|Error 0-15: The function 'Collect' has some invalid arguments.
+Errors: Error 8-10: Invalid argument type (Text). Expecting a Table value instead.|Error 12-14: Invalid argument type (Text). Expecting a Record value instead.|Error 12-14: Invalid argument type. Cannot use Text values in this context.|Error 0-7: The function 'Collect' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Count.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Count.txt
@@ -84,13 +84,13 @@ Error({Kind:ErrorKind.Numeric})
 // ******** COMPILE ERRORS - NON-NUMERIC TABLES, NOT SINGLE-COLUMN ********
 
 >> Count([])
-Errors: Error 6-8: The first argument of 'Count' should be a one-column table.|Error 0-9: The function 'Count' has some invalid arguments.
+Errors: Error 6-8: The first argument of 'Count' should be a one-column table.|Error 0-5: The function 'Count' has some invalid arguments.
 
 >> Count(Table({a:1,b:2},{a:3,b:4}))
-Errors: Error 6-32: The first argument of 'Count' should be a one-column table.|Error 0-33: The function 'Count' has some invalid arguments.
+Errors: Error 6-32: The first argument of 'Count' should be a one-column table.|Error 0-5: The function 'Count' has some invalid arguments.
 
 >> Count(["1"])
-Errors: Warning 6-11: Invalid schema, expected a column of Number values for 'Value'.|Error 0-12: The function 'Count' has some invalid arguments.
+Errors: Warning 6-11: Invalid schema, expected a column of Number values for 'Value'.|Error 0-5: The function 'Count' has some invalid arguments.
 
 >> Count(Table({a:Date(2022,12,12)}))
-Errors: Warning 6-33: Invalid schema, expected a column of Number values for 'a'.|Error 0-34: The function 'Count' has some invalid arguments.
+Errors: Warning 6-33: Invalid schema, expected a column of Number values for 'a'.|Error 0-5: The function 'Count' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountA.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountA.txt
@@ -129,8 +129,8 @@ Error({Kind:ErrorKind.Div0})
 // ******** ERROR SCENARIOS ********
 
 >> CountA([])
-Errors: Error 7-9: The first argument of 'CountA' should be a one-column table.|Error 0-10: The function 'CountA' has some invalid arguments.
+Errors: Error 7-9: The first argument of 'CountA' should be a one-column table.|Error 0-6: The function 'CountA' has some invalid arguments.
 
 >> CountA(Table({a:1,b:2},{a:3,b:4}))
-Errors: Error 7-33: The first argument of 'CountA' should be a one-column table.|Error 0-34: The function 'CountA' has some invalid arguments.
+Errors: Error 7-33: The first argument of 'CountA' should be a one-column table.|Error 0-6: The function 'CountA' has some invalid arguments.
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountIf.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/CountIf.txt
@@ -52,7 +52,7 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> CountIf([1, 2, 3, 4], Today())
-Errors: Error 22-29: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-30: The function 'CountIf' has some invalid arguments.
+Errors: Error 22-29: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-7: The function 'CountIf' has some invalid arguments.
 
 >> CountIf(Table({a:1},Blank(),{a:3}), IsBlank(ThisRecord))
 1

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd.txt
@@ -371,7 +371,7 @@ DateTime(2000,1,2,0,0,0,0)
 
 // Boolean to date
 >> DateAdd(false, 1)
-Errors: Error 8-13: Invalid argument type (Boolean). Expecting a DateTime value instead.|Error 0-17: The function 'DateAdd' has some invalid arguments.
+Errors: Error 8-13: Invalid argument type (Boolean). Expecting a DateTime value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.
 
 // Date to number
 >> DateAdd(Date(1900,1,1), Date(2022,1,1))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_StronglyTypedBuiltinEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_StronglyTypedBuiltinEnums.txt
@@ -20,4 +20,4 @@ Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) v
 Errors: Error 26-28: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.
 
 >> DateAdd(Date(2000,1,1),1,Text(1/0))
-Errors: Error 25-34: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.6
+Errors: Error 25-34: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_StronglyTypedBuiltinEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DateAdd_StronglyTypedBuiltinEnums.txt
@@ -1,23 +1,23 @@
 ﻿#SETUP: StronglyTypedBuiltinEnums
 
 >> DateAdd(Date(2011,1,15), 100000000, "milliseconds")
-Errors: Error 36-50: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-51: The function 'DateAdd' has some invalid arguments.
+Errors: Error 36-50: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.
 
 >> DateAdd(Date(2011,1,15), 100000000, "milliseconds") + Time(0,0,0)
-Errors: Error 36-50: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-51: The function 'DateAdd' has some invalid arguments.
+Errors: Error 36-50: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.
 
 >> Month(DateAdd(Date(2001,1,1), 3, "Quarters"))
-Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 6-44: The function 'DateAdd' has some invalid arguments.
+Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 6-13: The function 'DateAdd' has some invalid arguments.
 
 >> Month(DateAdd(Date(2001,1,1), 3, "quarters"))
-Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 6-44: The function 'DateAdd' has some invalid arguments.
+Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 6-13: The function 'DateAdd' has some invalid arguments.
 
 >> Month(DateAdd(Date(2001,1,1), 3, "quaRTers"))
-Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 6-44: The function 'DateAdd' has some invalid arguments.
+Errors: Error 33-43: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 6-13: The function 'DateAdd' has some invalid arguments.
 
 //Empty string passed as Units parameter
 >> DateAdd(Date(2000,1,1),1, "")
-Errors: Error 26-28: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-29: The function 'DateAdd' has some invalid arguments.
+Errors: Error 26-28: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.
 
 >> DateAdd(Date(2000,1,1),1,Text(1/0))
-Errors: Error 25-34: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-35: The function 'DateAdd' has some invalid arguments.
+Errors: Error 25-34: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.6

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalMathFuncs_NumberIsFloatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalMathFuncs_NumberIsFloatDisabled.txt
@@ -355,13 +355,13 @@ Error({Kind:ErrorKind.Div0})
 // Decimal and Float functions
 
 >> Value( 1e100 )
-Errors: Error 7-12: Numeric value is too large.|Error 0-14: The function 'Value' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
+Errors: Error 7-12: Numeric value is too large.|Error 0-5: The function 'Value' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
 
 >> Decimal( 1e100 )
-Errors: Error 9-14: Numeric value is too large.|Error 0-16: The function 'Decimal' has some invalid arguments.|Error 9-14: Expected text or number. We expect text or a number at this point in the formula.
+Errors: Error 9-14: Numeric value is too large.|Error 0-7: The function 'Decimal' has some invalid arguments.|Error 9-14: Expected text or number. We expect text or a number at this point in the formula.
 
 >> Float( 1e100 )
-Errors: Error 7-12: Numeric value is too large.|Error 0-14: The function 'Float' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
+Errors: Error 7-12: Numeric value is too large.|Error 0-5: The function 'Float' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
 
 >> Value( "1e100" )
 Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalMathFuncs_NumberIsFloatDisabled_DVDecimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalMathFuncs_NumberIsFloatDisabled_DVDecimal.txt
@@ -396,13 +396,13 @@ Error({Kind:ErrorKind.Div0})
 // Decimal and Float functions
 
 >> Value( 1e100 )
-Errors: Error 7-12: Numeric value is too large.|Error 0-14: The function 'Value' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
+Errors: Error 7-12: Numeric value is too large.|Error 0-5: The function 'Value' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
 
 >> Decimal( 1e100 )
-Errors: Error 9-14: Numeric value is too large.|Error 0-16: The function 'Decimal' has some invalid arguments.|Error 9-14: Expected text or number. We expect text or a number at this point in the formula.
+Errors: Error 9-14: Numeric value is too large.|Error 0-7: The function 'Decimal' has some invalid arguments.|Error 9-14: Expected text or number. We expect text or a number at this point in the formula.
 
 >> Float( 1e100 )
-Errors: Error 7-12: Numeric value is too large.|Error 0-14: The function 'Float' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
+Errors: Error 7-12: Numeric value is too large.|Error 0-5: The function 'Float' has some invalid arguments.|Error 7-12: Expected text or number. We expect text or a number at this point in the formula.
 
 >> Value( "1e100" )
 Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalNonMathFuncs.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalNonMathFuncs.txt
@@ -209,7 +209,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 "12345-6789"
 
 >> Text( "123456789", "00000-0000" )
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 19-31: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 19-31: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // strings should pass straight through
 
@@ -220,10 +220,10 @@ Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 19-3
 "1234567890123456789012345678912345"
 
 >> Text( ".1234567890123456789012345678912345", "0.0000000000000000000000000000000e00" )
-Errors: Error 0-85: The function 'Text' has some invalid arguments.|Warning 45-83: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 45-83: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text( ".1234567890123456789012345678912345", "00.0000000000000000000000000000000000%" )
-Errors: Error 0-87: The function 'Text' has some invalid arguments.|Warning 45-85: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 45-85: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text( ParseJSON("1.234567890123456789012345678"), "0.000000000000e00" )
 "1.234567890123e00"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalNonMathFuncs_DVDecimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DecimalNonMathFuncs_DVDecimal.txt
@@ -234,7 +234,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 "12345-6789"
 
 >> Text( "123456789", "00000-0000" )
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 19-31: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 19-31: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // strings should pass straight through, second argument no longer allowed
 
@@ -245,10 +245,10 @@ Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 19-3
 "1234567890123456789012345678912345"
 
 >> Text( ".1234567890123456789012345678912345", "0.0000000000000000000000000000000e00" )
-Errors: Error 0-85: The function 'Text' has some invalid arguments.|Warning 45-83: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 45-83: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text( ".1234567890123456789012345678912345", "00.0000000000000000000000000000000000%" )
-Errors: Error 0-87: The function 'Text' has some invalid arguments.|Warning 45-85: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 45-85: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text( ParseJSON("1.234567890123456789012345678"), "0.000000000000e00" )
 "1.234567890123e00"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Distinct_V1Compat.txt
@@ -2,8 +2,8 @@
 
 // Untyped blanks are not allowed in the argument that defines the row scope
 >> Distinct(Blank(), true)
-Errors: Error 9-16: Invalid argument type.|Error 0-23: The function 'Distinct' has some invalid arguments.
+Errors: Error 9-16: Invalid argument type.|Error 0-8: The function 'Distinct' has some invalid arguments.
 
 // Untyped blanks are not allowed in the argument that defines the row scope
 >> Distinct(Error("error"), true)
-Errors: Error 9-23: Invalid argument type.|Error 0-30: The function 'Distinct' has some invalid arguments.
+Errors: Error 9-23: Invalid argument type.|Error 0-8: The function 'Distinct' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DropColumns_SupportColumnNamesAsIdentifiers.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DropColumns_SupportColumnNamesAsIdentifiers.txt
@@ -45,11 +45,11 @@ Table({a:1,b:2},{a:3,b:4})
 Table({a:8,b:2},{a:64,b:4})
 
 >> DropColumns(Table({a:1,b:2},{a:3,b:4}), a, a)
-Errors: Error 43-44: The specified column 'a' does not exist. The column with the most similar name is 'b'.|Error 0-45: The function 'DropColumns' has some invalid arguments.
+Errors: Error 43-44: The specified column 'a' does not exist. The column with the most similar name is 'b'.|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 // Record
 >> DropColumns({a:1,b:2}, a, a)
-Errors: Error 26-27: The specified column 'a' does not exist. The column with the most similar name is 'b'.|Error 0-28: The function 'DropColumns' has some invalid arguments.
+Errors: Error 26-27: The specified column 'a' does not exist. The column with the most similar name is 'b'.|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 >> Last(DropColumns(Table({a:1,b:2},{a:3,b:4}), b)).a
 3
@@ -58,15 +58,15 @@ Errors: Error 26-27: The specified column 'a' does not exist. The column with th
 Table({},{},{})
 
 >> DropColumns([1, 2], 3)
-Errors: Error 20-21: Expected identifier name|Error 0-22: The function 'DropColumns' has some invalid arguments.
+Errors: Error 20-21: Expected identifier name|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 // Record
 >> DropColumns({Value:1}, 3)
-Errors: Error 23-24: Expected identifier name|Error 0-25: The function 'DropColumns' has some invalid arguments.
+Errors: Error 23-24: Expected identifier name|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 >> DropColumns([1, 2], z)
-Errors: Error 20-21: The specified column 'z' does not exist.|Error 0-22: The function 'DropColumns' has some invalid arguments.
+Errors: Error 20-21: The specified column 'z' does not exist.|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 // Record
 >> DropColumns({Value:1}, z)
-Errors: Error 23-24: The specified column 'z' does not exist.|Error 0-25: The function 'DropColumns' has some invalid arguments.
+Errors: Error 23-24: The specified column 'z' does not exist.|Error 0-11: The function 'DropColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DropColumns_SupportColumnNamesAsIdentifiersDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/DropColumns_SupportColumnNamesAsIdentifiersDisabled.txt
@@ -13,7 +13,7 @@ Table({},{})
 Table({},{})
 
 >> DropColumns(Table({a:1,b:2},{a:3,b:4}), "a", "a")
-Errors: Error 45-48: The specified column 'a' does not exist. The column with the most similar name is 'b'.|Error 0-49: The function 'DropColumns' has some invalid arguments.
+Errors: Error 45-48: The specified column 'a' does not exist. The column with the most similar name is 'b'.|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 >> Last(DropColumns(Table({a:1,b:2},{a:3,b:4}), "b")).a
 3
@@ -22,7 +22,7 @@ Errors: Error 45-48: The specified column 'a' does not exist. The column with th
 Table({},{},{})
 
 >> DropColumns([1, 2, 3], 5)
-Errors: Error 23-24: Argument '5' is invalid, expected a text literal.|Error 0-25: The function 'DropColumns' has some invalid arguments.
+Errors: Error 23-24: Argument '5' is invalid, expected a text literal.|Error 0-11: The function 'DropColumns' has some invalid arguments.
 
 >> DropColumns([1, 2, 3], "")
-Errors: Error 23-25: Argument '' is not a valid identifier.|Error 0-26: The function 'DropColumns' has some invalid arguments.
+Errors: Error 23-25: Argument '' is not a valid identifier.|Error 0-11: The function 'DropColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterFunctions_V1Compat.txt
@@ -2,4 +2,4 @@
 
 // Untyped blanks are not allowed in the argument that defines the row scope
 >> Filter(Blank(), Blank())
-Errors: Error 7-14: Invalid argument type.|Error 0-24: The function 'Filter' has some invalid arguments.
+Errors: Error 7-14: Invalid argument type.|Error 0-6: The function 'Filter' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterLookUp_TwoArg_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FilterLookUp_TwoArg_V1Compat.txt
@@ -5,10 +5,10 @@ Table({Value:2},{Value:3})
 
 // Allowed in Canvas today, but disallowed in Power Fx 1.0, use And instead (see next test)
 >> Filter([1,2,3], Value > 1, Value > 2)
-Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument.|Error 0-37: The function 'Filter' has some invalid arguments.
+Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument.|Error 0-6: The function 'Filter' has some invalid arguments.
 
 >> Filter([1,2,3], Value > 1, Value > 2, Value > 3)
-Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument.|Error 0-48: The function 'Filter' has some invalid arguments.
+Errors: Error 33-34: Use the And operator to combine multiple predicates into the second argument.|Error 0-6: The function 'Filter' has some invalid arguments.
 
 >> Filter([1,2,3], Value > 1 And Value > 2)
 Table({Value:3})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FirstLast.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FirstLast.txt
@@ -38,7 +38,7 @@ Blank()
 Blank()
 
 >> First({a:1,b:2})
-Errors: Error 0-16: The function 'First' has some invalid arguments.|Error 6-15: Invalid argument type (Record). Expecting a Table value instead.
+Errors: Error 0-5: The function 'First' has some invalid arguments.|Error 6-15: Invalid argument type (Record). Expecting a Table value instead.
 
 >> Last([1, 2, 3, 4, 5])
 {Value:5}
@@ -80,4 +80,4 @@ Blank()
 Blank()
 
 >> Last({a:1,b:2})
-Errors: Error 0-15: The function 'Last' has some invalid arguments.|Error 5-14: Invalid argument type (Record). Expecting a Table value instead.
+Errors: Error 0-4: The function 'Last' has some invalid arguments.|Error 5-14: Invalid argument type (Record). Expecting a Table value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FirstLastN_RequiredSecondArgument.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/FirstLastN_RequiredSecondArgument.txt
@@ -3,15 +3,15 @@
 // ######### FirstN ##########
 
 >> FirstN([1, 2, 3, 4, 5])
-Errors: Error 0-23: The function 'FirstN' has some invalid arguments.|Error 0-23: Invalid number of arguments: received 1, expected 2.
+Errors: Error 0-6: The function 'FirstN' has some invalid arguments.|Error 0-23: Invalid number of arguments: received 1, expected 2.
 
 >> FirstN(Blank())
-Errors: Error 0-15: The function 'FirstN' has some invalid arguments.|Error 0-15: Invalid number of arguments: received 1, expected 2.
+Errors: Error 0-6: The function 'FirstN' has some invalid arguments.|Error 0-15: Invalid number of arguments: received 1, expected 2.
 
 // ######### LastN ##########
 
 >> LastN([1, 2, 3, 4, 5])
-Errors: Error 0-22: The function 'LastN' has some invalid arguments.|Error 0-22: Invalid number of arguments: received 1, expected 2.
+Errors: Error 0-5: The function 'LastN' has some invalid arguments.|Error 0-22: Invalid number of arguments: received 1, expected 2.
 
 >> LastN(Blank())
-Errors: Error 0-14: The function 'LastN' has some invalid arguments.|Error 0-14: Invalid number of arguments: received 1, expected 2.
+Errors: Error 0-5: The function 'LastN' has some invalid arguments.|Error 0-14: Invalid number of arguments: received 1, expected 2.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Hex2Dec.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Hex2Dec.txt
@@ -99,7 +99,7 @@ Table({Value:1},{Value:16},{Value:256})
 Table({Value:10},{Value:16},{Value:11})
 
 >> Hex2Dec(Table({a:[1]},{a:[2]}))
-Errors: Error 0-31: The function 'Hex2Dec' has some invalid arguments.|Error 8-30: Invalid schema, expected a column of Text values for 'a'.
+Errors: Error 0-7: The function 'Hex2Dec' has some invalid arguments.|Error 8-30: Invalid schema, expected a column of Text values for 'a'.
 
 >> Hex2Dec(Table({a:{b:1}},{a:{b:2}}))
-Errors: Error 0-35: The function 'Hex2Dec' has some invalid arguments.|Error 8-34: Invalid schema, expected a column of Text values for 'a'.
+Errors: Error 0-7: The function 'Hex2Dec' has some invalid arguments.|Error 8-34: Invalid schema, expected a column of Text values for 'a'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Hex2Dec.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Hex2Dec.txt
@@ -90,7 +90,7 @@ Table({Value:10})
 Table({Value:10},{Value:18},{Value:65535})
 
 >> Hex2Dec(Table({a:"A",b:"B"}))
-Errors: Error 0-29: The function 'Hex2Dec' has some invalid arguments.|Error 8-28: Invalid schema, expected a one-column table.
+Errors: Error 0-7: The function 'Hex2Dec' has some invalid arguments.|Error 8-28: Invalid schema, expected a one-column table.
 
 >> Hex2Dec(Table({a:1},{a:10},{a:100}))
 Table({Value:1},{Value:16},{Value:256})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If.txt
@@ -64,10 +64,10 @@ If(true, {test:1}, "Void value (result of the expression can't be used).")
 If(true, {test:1}, "Void value (result of the expression can't be used).")
 
 >> If(true, 1, x)
-Errors: Error 12-13: Name isn't valid. 'x' isn't recognized.|Error 0-14: The function 'If' has some invalid arguments.
+Errors: Error 12-13: Name isn't valid. 'x' isn't recognized.|Error 0-2: The function 'If' has some invalid arguments.
 
 >> If(true, x, 1)
-Errors: Error 9-10: Name isn't valid. 'x' isn't recognized.|Error 0-14: The function 'If' has some invalid arguments.
+Errors: Error 9-10: Name isn't valid. 'x' isn't recognized.|Error 0-2: The function 'If' has some invalid arguments.
 
 // ************************************** FIRST CONDITION TRUE CASES **************************************
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/IfError_V1Compat.txt
@@ -23,10 +23,10 @@ Error({Kind:ErrorKind.Div0})
 If(true, {test:1}, "Void value (result of the expression can't be used).")
 
 >> IfError(1, a)
-Errors: Error 11-12: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
+Errors: Error 11-12: Name isn't valid. 'a' isn't recognized.|Error 0-7: The function 'IfError' has some invalid arguments.
 
 >> IfError(a, 1)
-Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-13: The function 'IfError' has some invalid arguments.
+Errors: Error 8-9: Name isn't valid. 'a' isn't recognized.|Error 0-7: The function 'IfError' has some invalid arguments.
 
 >> IfError( If(true, 1, {a:1}), 1, 2 )
 2

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -33,7 +33,7 @@ Blank()
 Error({Kind:ErrorKind.Div0})
 
 >> If(1<0, "abc", If(1<0, {x:3}, 1), 1>0, 2)
-Errors: Error 15-32: Invalid argument type (Void). Expecting a Boolean value instead.|Error 0-41: The function 'If' has some invalid arguments.
+Errors: Error 15-32: Invalid argument type (Void). Expecting a Boolean value instead.|Error 0-2: The function 'If' has some invalid arguments.
 
 >> If(1<0, {x:3}, 1/0)
 Error({Kind:ErrorKind.Div0})
@@ -55,13 +55,13 @@ true
 
 // result of If can't be used.
 >> IsBlankOrError( If(1<0, If(false, {x:3}, 1/0)) )
-Errors: Error 0-48: The function 'IsBlankOrError' has some invalid arguments.
+Errors: Error 0-14: The function 'IsBlankOrError' has some invalid arguments.
 
 >> IsBlankOrError( If(false, { a: 1 }, 2 ) )
-Errors: Error 0-41: The function 'IsBlankOrError' has some invalid arguments.|Error 16-39: Invalid argument type.
+Errors: Error 0-14: The function 'IsBlankOrError' has some invalid arguments.|Error 16-39: Invalid argument type.
 
 >> IsNumeric( If(false, { a: 1 }, 2 ) )
-Errors: Error 11-34: Invalid argument type.|Error 0-36: The function 'IsNumeric' has some invalid arguments.
+Errors: Error 11-34: Invalid argument type.|Error 0-9: The function 'IsNumeric' has some invalid arguments.
 
 >> If( true, With({a:1},Switch(a, 1, { prop:"complex" }, "scalar")) )
 If(true, {test:1}, "Void value (result of the expression can't be used).")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Len.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Len.txt
@@ -68,6 +68,6 @@ Error({Kind:ErrorKind.Div0})
 29
 
 >> Len([])
-Errors: Error 0-7: The function 'Len' has some invalid arguments.|Error 4-6: Invalid schema, expected a one-column table.
+Errors: Error 0-3: The function 'Len' has some invalid arguments.|Error 4-6: Invalid schema, expected a one-column table.
 
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup.txt
@@ -112,7 +112,7 @@ Error({Kind:ErrorKind.Div0})
 Errors: Error 7-11: Invalid argument type.
 
 >> LookUp([1, 2, 3], "string")
-Errors: Error 18-26: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-27: The function 'LookUp' has some invalid arguments.
+Errors: Error 18-26: Expected boolean. We expect a boolean (true/false) at this point in the formula.|Error 0-6: The function 'LookUp' has some invalid arguments.
 
 >> LookUp([1, 2, 3] As X, Value > 2)
 Errors: Error 23-28: Name isn't valid. 'Value' isn't recognized.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Lookup_V1Compat.txt
@@ -2,9 +2,9 @@
 
 // Untyped blanks are not allowed in the argument that defines the row scope
 >> LookUp(Blank(), Blank())
-Errors: Error 7-14: Invalid argument type.|Error 0-24: The function 'LookUp' has some invalid arguments.
+Errors: Error 7-14: Invalid argument type.|Error 0-6: The function 'LookUp' has some invalid arguments.
 
 
 // Untyped blanks are not allowed in the argument that defines the row scope
 >> LookUp(Blank(), Blank(), "constant")
-Errors: Error 7-14: Invalid argument type.|Error 0-36: The function 'LookUp' has some invalid arguments.
+Errors: Error 7-14: Invalid argument type.|Error 0-6: The function 'LookUp' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Match.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Match.txt
@@ -85,16 +85,16 @@ Blank()
 Blank()
 
 >> Match(Blank(), Blank())
-Errors: Error 15-22: Regular expressions must be constant values.|Error 0-23: The function 'Match' has some invalid arguments.
+Errors: Error 15-22: Regular expressions must be constant values.|Error 0-5: The function 'Match' has some invalid arguments.
 
 >> Match("28", 28)
-Errors: Error 12-14: Regular expressions must be constant values.|Error 0-15: The function 'Match' has some invalid arguments.
+Errors: Error 12-14: Regular expressions must be constant values.|Error 0-5: The function 'Match' has some invalid arguments.
 
 >> Match(1/0, "Hi")
 Error({Kind:ErrorKind.Div0})
 
 >> Match("Hello", Right("llo", 3)).FullMatch
-Errors: Error 15-30: Regular expressions must be constant values.|Error 0-31: The function 'Match' has some invalid arguments.|Error 31-41: Name isn't valid. 'FullMatch' isn't recognized.
+Errors: Error 15-30: Regular expressions must be constant values.|Error 0-5: The function 'Match' has some invalid arguments.|Error 31-41: Name isn't valid. 'FullMatch' isn't recognized.
 
 >> Match("(555) 123-4567", "^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$")
 {FullMatch:"(555) 123-4567",StartMatch:1,SubMatches:Table()}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MatchAll.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MatchAll.txt
@@ -25,7 +25,7 @@ Table({FullMatch:"Joe 164",StartMatch:1,SubMatches:Table({Value:"Joe"},{Value:"1
 Table()
 
 >> MatchAll(Blank(), Blank())
-Errors: Error 18-25: Regular expressions must be constant values.|Error 0-26: The function 'MatchAll' has some invalid arguments.
+Errors: Error 18-25: Regular expressions must be constant values.|Error 0-8: The function 'MatchAll' has some invalid arguments.
 
 >> MatchAll(1/0, "Hi")
 Error({Kind:ErrorKind.Div0})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMax.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/MinMax.txt
@@ -290,10 +290,10 @@ Errors: Error 4-9: Expected number. We expect a number at this point in the form
 Errors: Error 4-9: Expected number. We expect a number at this point in the formula.|Error 11-16: Expected number. We expect a number at this point in the formula.|Error 18-23: Expected number. We expect a number at this point in the formula.
 
 >> Min([1,2,3], [1])
-Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-17: The function 'Min' has some invalid arguments.
+Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-3: The function 'Min' has some invalid arguments.
 
 >> Max([1,2,3], [1])
-Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-17: The function 'Max' has some invalid arguments.
+Errors: Error 13-16: Expected number. We expect a number at this point in the formula.|Error 0-3: The function 'Max' has some invalid arguments.
 
 >> Max(Table({a:1},Blank(),{a:3}), If(IsBlank(ThisRecord),100,a))
 100

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Mod_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Mod_Float.txt
@@ -32,4 +32,4 @@
 -5.8180083079168396E-201
 
 >> Mod(1E+400, 3)
-Errors: Error 4-10: Numeric value is too large.|Error 4-10: Invalid argument type (Error). Expecting a Number value instead.|Error 0-14: The function 'Mod' has some invalid arguments.
+Errors: Error 4-10: Numeric value is too large.|Error 4-10: Invalid argument type (Error). Expecting a Number value instead.|Error 0-3: The function 'Mod' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Unary_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Unary_Decimal.txt
@@ -278,13 +278,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 true
 
 >> Not(Date(2000,1,1))
-Errors: Error 4-18: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-19: The function 'Not' has some invalid arguments.
+Errors: Error 4-18: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-3: The function 'Not' has some invalid arguments.
 
 >> Not(DateTime(2000,1,1,12,0,0))
-Errors: Error 4-29: Invalid argument type (DateTime). Expecting a Boolean value instead.|Error 0-30: The function 'Not' has some invalid arguments.
+Errors: Error 4-29: Invalid argument type (DateTime). Expecting a Boolean value instead.|Error 0-3: The function 'Not' has some invalid arguments.
 
 >> Not(Time(12,0,0))
-Errors: Error 4-16: Invalid argument type (Time). Expecting a Boolean value instead.|Error 0-17: The function 'Not' has some invalid arguments.
+Errors: Error 4-16: Invalid argument type (Time). Expecting a Boolean value instead.|Error 0-3: The function 'Not' has some invalid arguments.
 
 >> Not(Decimal("2.000000000000000000000002"))
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Unary_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/OpMatrix_Unary_Float.txt
@@ -257,13 +257,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 true
 
 >> Not(Date(2000,1,1))
-Errors: Error 4-18: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-19: The function 'Not' has some invalid arguments.
+Errors: Error 4-18: Invalid argument type (Date). Expecting a Boolean value instead.|Error 0-3: The function 'Not' has some invalid arguments.
 
 >> Not(DateTime(2000,1,1,12,0,0))
-Errors: Error 4-29: Invalid argument type (DateTime). Expecting a Boolean value instead.|Error 0-30: The function 'Not' has some invalid arguments.
+Errors: Error 4-29: Invalid argument type (DateTime). Expecting a Boolean value instead.|Error 0-3: The function 'Not' has some invalid arguments.
 
 >> Not(Time(12,0,0))
-Errors: Error 4-16: Invalid argument type (Time). Expecting a Boolean value instead.|Error 0-17: The function 'Not' has some invalid arguments.
+Errors: Error 4-16: Invalid argument type (Time). Expecting a Boolean value instead.|Error 0-3: The function 'Not' has some invalid arguments.
 
 >> Not(ParseJSON("2"))
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson.txt
@@ -184,7 +184,7 @@ Table({Value:1},{Value:1},{Value:3},{Value:0})
 Table({Value:1},{Value:2},{Value:3})
 
 >> ForAll(ParseJSON("[1,2,3]"), ThisItem)
-Errors: Error 29-37: Name isn't valid. 'ThisItem' isn't recognized.|Error 0-38: The function 'ForAll' has some invalid arguments.
+Errors: Error 29-37: Name isn't valid. 'ThisItem' isn't recognized.|Error 0-6: The function 'ForAll' has some invalid arguments.
 
 >> ParseJSON("5") + ParseJSON("5")
 10

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -28,11 +28,11 @@ GUID("5cc45615-f759-4a53-b225-d3a2497f60ad")
 "08:03:05"
 
 >> Sum(ParseJSON("[1,2,3]"), Blank())
-Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-34: The function 'Sum' has some invalid arguments.
+Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-3: The function 'Sum' has some invalid arguments.
 
 // Arity error code path for Sum
 >> Sum(ParseJSON("[1,2,3]"))
-Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-25: The function 'Sum' has some invalid arguments.
+Errors: Error 4-24: Untyped objects cannot be used as the first argument to functions which support record scopes.|Error 0-3: The function 'Sum' has some invalid arguments.
 
 // Scalar version of Sum
 >> Sum([ParseJSON("1"), ParseJSON("2"), ParseJSON("3")], Value)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ParseJson_Coercions.txt
@@ -39,7 +39,7 @@ Errors: Error 4-24: Untyped objects cannot be used as the first argument to func
 6
 
 >> Filter(ParseJSON("[1,2,3]"), true)
-Errors: Error 7-27: Invalid argument type.|Error 0-34: The function 'Filter' has some invalid arguments.
+Errors: Error 7-27: Invalid argument type.|Error 0-6: The function 'Filter' has some invalid arguments.
 
 // Comparison tests
 >> Abs(5) = Abs(ParseJSON("5"))

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -33,7 +33,7 @@ Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
 
 >> Patch(t1, r1, {Field5:"Field5"});
    t1
-Errors: Error 14-31: The specified column 'Field5' does not exist.|Error 0-32: The function 'Patch' has some invalid arguments.
+Errors: Error 14-31: The specified column 'Field5' does not exist.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 // This test would fail in PA.
 >> Patch(t1, r1, {Field2:"Venus"})
@@ -61,7 +61,7 @@ Blank()
 Table({Field1:10,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
 >> Patch(t1, 0, 0)
-Errors: Error 10-11: Invalid argument type (Decimal). Expecting a Record value instead.|Error 13-14: Invalid argument type (Decimal). Expecting a Record value instead.|Error 10-11: Cannot use a non-record value in this context.|Error 13-14: Cannot use a non-record value in this context.|Error 0-15: The function 'Patch' has some invalid arguments.
+Errors: Error 10-11: Invalid argument type (Decimal). Expecting a Record value instead.|Error 13-14: Invalid argument type (Decimal). Expecting a Record value instead.|Error 10-11: Cannot use a non-record value in this context.|Error 13-14: Cannot use a non-record value in this context.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 // Display names
 >> Patch(t1, First(t1), {DisplayNameField2:"Saturn"});
@@ -90,10 +90,10 @@ Table({Field1:0,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 
 >> Patch(t1, First(t1), {DisplayNameField5:"Pandora"});
    First(t1)
-Errors: Error 21-50: The specified column 'DisplayNameField5' does not exist. The column with the most similar name is 'DisplayNameField1'.|Error 0-51: The function 'Patch' has some invalid arguments.
+Errors: Error 21-50: The specified column 'DisplayNameField5' does not exist. The column with the most similar name is 'DisplayNameField1'.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch(t1, First(Filter(t1, Field2="earth")), {Field3: "2022-11-14 7:22:06 pm"})
-Errors: Error 45-78: The type of this argument 'Field3' does not match the expected type 'DateTime'. Found type 'Text'.|Error 0-79: The function 'Patch' has some invalid arguments.
+Errors: Error 45-78: The type of this argument 'Field3' does not match the expected type 'DateTime'. Found type 'Text'.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch(t1,LookUp(t1,DisplayNameField2="earth"),{Field1:100,Field4:false});t1
 Table({Field1:100,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:false})
@@ -118,7 +118,7 @@ Table({Field1:100,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:false}
 Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 0-51: The function 'Patch' has some invalid arguments.
 
 >> Patch(Foo, Bar, {DisplayNameField2:"jupter"})
-Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 11-14: Name isn't valid. 'Bar' isn't recognized.|Error 0-45: The function 'Patch' has some invalid arguments.
+Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 11-14: Name isn't valid. 'Bar' isn't recognized.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Set(t_an_bs, [{a:1, b:"a"}, {a:2, b:Blank()}]); Patch(t_an_bs, Last(t_an_bs), {a:3, b:"c"}); t_an_bs
 Table({a:1,b:"a"},{a:3,b:"c"})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch.txt
@@ -115,7 +115,7 @@ Table({Field1:100,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:false}
 {Field1:6,Field2:"phobos",Field3:DateTime(2033,1,1,0,0,0,0),Field4:false}
 
 >> Patch(Foo, First(t1), {DisplayNameField2:"jupter"})
-Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 0-51: The function 'Patch' has some invalid arguments.
+Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch(Foo, Bar, {DisplayNameField2:"jupter"})
 Errors: Error 6-9: Name isn't valid. 'Foo' isn't recognized.|Error 11-14: Name isn't valid. 'Bar' isn't recognized.|Error 0-5: The function 'Patch' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1Compat.txt
@@ -2,28 +2,28 @@
 #SETUP: EnableExpressionChaining,MutationFunctionsTestSetup
 
 >> Patch([1,2], {Value:1}, If(false, {x:1, Value:2}, {Value:11, z:2}))
-Errors: Error 24-66: The specified column 'x' does not exist.|Error 6-11: The value passed to the 'Patch' function cannot be changed.|Error 0-67: The function 'Patch' has some invalid arguments.
+Errors: Error 24-66: The specified column 'x' does not exist.|Error 6-11: The value passed to the 'Patch' function cannot be changed.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  {Value:11})
-Errors: Error 13-54: The specified column 'x' does not exist.|Error 6-11: The value passed to the 'Patch' function cannot be changed.|Error 0-68: The function 'Patch' has some invalid arguments.
+Errors: Error 13-54: The specified column 'x' does not exist.|Error 6-11: The value passed to the 'Patch' function cannot be changed.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch([1,2], If(false, {x:1, Value:2}, {Value:1, z:2}),  If(false, {x:1, Value:2}, {Value:11, z:2}))
-Errors: Error 13-54: The specified column 'x' does not exist.|Error 57-99: The specified column 'x' does not exist.|Error 6-11: The value passed to the 'Patch' function cannot be changed.|Error 0-100: The function 'Patch' has some invalid arguments.
+Errors: Error 13-54: The specified column 'x' does not exist.|Error 57-99: The specified column 'x' does not exist.|Error 6-11: The value passed to the 'Patch' function cannot be changed.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch(Table({Value:1}, If(false, {x:1, Value:2}, {Value:2, z:2}), {Value:3}), {Value:2}, {Value:11})
 Errors: Error 6-76: The value passed to the 'Patch' function cannot be changed.
 
 >> Collect(t_empty, {Value:1}); Collect(t_empty, {Value:2}); Patch(t_empty, {Value:1}, If(false, {x:1, Value:2}, {Value:11, z:2}))
-Errors: Error 84-126: The specified column 'x' does not exist.|Error 58-127: The function 'Patch' has some invalid arguments.
+Errors: Error 84-126: The specified column 'x' does not exist.|Error 58-63: The function 'Patch' has some invalid arguments.
 
 >> Collect(t_empty, {Value:1}); Collect(t_empty, {Value:2}); Patch(t_empty, If(false, {x:1, Value:2}, {Value:1, z:2}),  {Value:11})
-Errors: Error 73-114: The specified column 'x' does not exist.|Error 58-128: The function 'Patch' has some invalid arguments.
+Errors: Error 73-114: The specified column 'x' does not exist.|Error 58-63: The function 'Patch' has some invalid arguments.
 
 >> Collect(t_empty, {Value:1}); Collect(t_empty, {Value:2}); Patch(t_empty, If(false, {x:1, Value:2}, {Value:1, z:2}),  If(false, {x:1, Value:2}, {Value:11, z:2}))
-Errors: Error 73-114: The specified column 'x' does not exist.|Error 117-159: The specified column 'x' does not exist.|Error 58-160: The function 'Patch' has some invalid arguments.
+Errors: Error 73-114: The specified column 'x' does not exist.|Error 117-159: The specified column 'x' does not exist.|Error 58-63: The function 'Patch' has some invalid arguments.
 
 >> Collect(t_empty, {Value:1}); Collect(t_empty, If(false, {x:1, Value:2}, {Value:2, z:2})); Collect(t_empty, {Value:3}); Patch(t_empty, {Value:2}, {Value:11})
-Errors: Error 46-87: The specified column 'x' does not exist.|Error 29-88: The function 'Collect' has some invalid arguments.
+Errors: Error 46-87: The specified column 'x' does not exist.|Error 29-36: The function 'Collect' has some invalid arguments.
 
 // field22 is missing
 >> Patch(

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Patch_V1CompatDisabled.txt
@@ -32,7 +32,7 @@
        {field1:3, field2:{field21:"moon",field22:"phobos"}}),
      {field2:{field21:"moon"}},
      {field1:7})
-Errors: Error 151-176: Invalid argument type. Expecting a Record value, but of a different schema.|Error 151-176: Missing column. Your formula is missing a column 'field22' with a type of 'Text'.|Error 0-195: The function 'Patch' has some invalid arguments.
+Errors: Error 151-176: Invalid argument type. Expecting a Record value, but of a different schema.|Error 151-176: Missing column. Your formula is missing a column 'field22' with a type of 'Text'.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> Patch(
      Table(
@@ -40,4 +40,4 @@ Errors: Error 151-176: Invalid argument type. Expecting a Record value, but of a
        {Planet:"Saturn",Properties:{Color:"red-brown",Size:"huge",Weight:99999,Moon:{Name:"Phobos", Color:"yellow"}}}),
     {Properties:{Moon:{Name:"Phobos"}}},
     {Planet:"Jupter"})
-Errors: Error 258-293: Invalid argument type. Expecting a Record value, but of a different schema.|Error 258-293: Missing column. Your formula is missing a column 'Color' with a type of 'Text'.|Error 0-318: The function 'Patch' has some invalid arguments.
+Errors: Error 258-293: Invalid argument type. Expecting a Record value, but of a different schema.|Error 258-293: Missing column. Your formula is missing a column 'Color' with a type of 'Text'.|Error 0-5: The function 'Patch' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
@@ -95,16 +95,16 @@ Error({Kind:ErrorKind.NotFound})
 
 // Wrong arguments
 >> Remove(t1, r1,"Al");
-Errors: Error 14-18: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-19: The function 'Remove' has some invalid arguments.
+Errors: Error 14-18: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, r1,"");
-Errors: Error 14-16: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-17: The function 'Remove' has some invalid arguments.
+Errors: Error 14-16: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, r1, r1, r1, r1, r1, r1, "Al");
-Errors: Error 35-39: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-40: The function 'Remove' has some invalid arguments.
+Errors: Error 35-39: If provided, last argument must be 'RemoveFlags.All'. Is there a typo?|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, "All");
-Errors: Error 11-16: Invalid argument type (Text). Expecting a Record value instead.|Error 11-16: Cannot use a non-record value in this context.|Error 0-17: The function 'Remove' has some invalid arguments.
+Errors: Error 11-16: Invalid argument type (Text). Expecting a Record value instead.|Error 11-16: Cannot use a non-record value in this context.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Collect(t1, r2);
   Collect(t1, {Field1:3,Field2:"earth",Field3:DateTime(2030,2,1,0,0,0,0),Field4:true});

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Remove.txt
@@ -54,16 +54,16 @@ Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{F
 Table({Field1:2,Field2:{Field2_1:221,Field2_2:"2_2",Field2_3:{Field2_3_1:2231,Field2_3_2:"common"}},Field3:false},{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_3:{Field2_3_1:3231,Field2_3_2:"common"}},Field3:true})
 
 >> Remove(t2, {Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231}},Field3:false}); t2
-Errors: Error 11-98: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-98: Missing column. Your formula is missing a column 'DisplayNameField2_3.DisplayNameField2_3_2' with a type of 'Text'.|Error 0-99: The function 'Remove' has some invalid arguments.
+Errors: Error 11-98: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-98: Missing column. Your formula is missing a column 'DisplayNameField2_3.DisplayNameField2_3_2' with a type of 'Text'.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t2, {Field1:2,Field2:{Field2_1:221,Field2_3:{Field2_3_1:2231,Field2_3_2:"common"}},Field3:false}); t2
-Errors: Error 11-103: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-103: Missing column. Your formula is missing a column 'DisplayNameField2_2' with a type of 'Text'.|Error 0-104: The function 'Remove' has some invalid arguments.
+Errors: Error 11-103: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-103: Missing column. Your formula is missing a column 'DisplayNameField2_2' with a type of 'Text'.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t2, {Field2:{Field2_1:321, Field2_2:"Moon"}}); t2
-Errors: Error 11-51: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-51: Missing column. Your formula is missing a column 'DisplayNameField2_3' with a type of 'Record'.|Error 0-52: The function 'Remove' has some invalid arguments.
+Errors: Error 11-51: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-51: Missing column. Your formula is missing a column 'DisplayNameField2_3' with a type of 'Record'.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t2, {Field2:{Field2_3:{Field2_3_1:3231}}}) ; t2
-Errors: Error 11-48: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-48: Missing column. Your formula is missing a column 'DisplayNameField2_1' with a type of 'Decimal'.|Error 0-49: The function 'Remove' has some invalid arguments.
+Errors: Error 11-48: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-48: Missing column. Your formula is missing a column 'DisplayNameField2_1' with a type of 'Decimal'.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t2, {Field2:{Field2_1:321,Field2_2:"2_2",Field2_3:{Field2_3_1:3231,Field2_3_2:"common"}}}); t2
 Error({Kind:ErrorKind.NotFound})
@@ -79,16 +79,16 @@ Error({Kind:ErrorKind.NotFound})
 
 
 >> Remove(t2, {Field2:{Field2_3:{Field2_3_2:"common"}}}, "All")
-Errors: Error 11-52: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-52: Missing column. Your formula is missing a column 'DisplayNameField2_1' with a type of 'Decimal'.|Error 0-60: The function 'Remove' has some invalid arguments.
+Errors: Error 11-52: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-52: Missing column. Your formula is missing a column 'DisplayNameField2_1' with a type of 'Decimal'.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t2, {Field1:5}, "All")
 Error({Kind:ErrorKind.NotFound})
 
 >> Remove(t2, {Field2:{Field2_1:321}});t2
-Errors: Error 11-34: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-34: Missing column. Your formula is missing a column 'DisplayNameField2_2' with a type of 'Text'.|Error 0-35: The function 'Remove' has some invalid arguments.
+Errors: Error 11-34: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-34: Missing column. Your formula is missing a column 'DisplayNameField2_2' with a type of 'Text'.|Error 0-6: The function 'Remove' has some invalid arguments.
    
 >> Remove(t2, {Field2:{Field2_3:{Field2_3_1:3231}}});t2
-Errors: Error 11-48: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-48: Missing column. Your formula is missing a column 'DisplayNameField2_1' with a type of 'Decimal'.|Error 0-49: The function 'Remove' has some invalid arguments.
+Errors: Error 11-48: Invalid argument type. Expecting a Record value, but of a different schema.|Error 11-48: Missing column. Your formula is missing a column 'DisplayNameField2_1' with a type of 'Decimal'.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t2, {Field2:{Field2_1:321,Field2_2:"2_2",Field2_3:{Field2_3_1:5555,Field2_3_2:"common"}}}, "All");t2
 Error({Kind:ErrorKind.NotFound})
@@ -128,10 +128,10 @@ Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{F
 Table({Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false},{Field1:3,Field2:"earth",Field3:DateTime(2030,2,1,0,0,0,0),Field4:true},{Field1:4,Field2:"earth",Field3:DateTime(2040,2,1,0,0,0,0),Field4:false})
 
 >> Remove(Foo, {Field1:5}, "All")
-Errors: Error 7-10: Name isn't valid. 'Foo' isn't recognized.|Error 12-22: The specified column 'Field1' does not exist.|Error 0-30: The function 'Remove' has some invalid arguments.
+Errors: Error 7-10: Name isn't valid. 'Foo' isn't recognized.|Error 12-22: The specified column 'Field1' does not exist.|Error 0-6: The function 'Remove' has some invalid arguments.
    
 >> Remove(Foo, Bar)
-Errors: Error 7-10: Name isn't valid. 'Foo' isn't recognized.|Error 12-15: Name isn't valid. 'Bar' isn't recognized.|Error 0-16: The function 'Remove' has some invalid arguments.
+Errors: Error 7-10: Name isn't valid. 'Foo' isn't recognized.|Error 12-15: Name isn't valid. 'Bar' isn't recognized.|Error 0-6: The function 'Remove' has some invalid arguments.
 
 >> Remove(t1, {Field1:2,Field2:"not in the table",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
 Error({Kind:ErrorKind.NotFound})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RenameColumns_SupportColumnNamesAsIdentifiers.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RenameColumns_SupportColumnNamesAsIdentifiers.txt
@@ -60,18 +60,18 @@ Table({a:1,b:2},{a:3,b:4})
 {a:1,b:2}
 
 >> RenameColumns(Table({a:1,b:2},{a:3,b:4}), a, b)
-Errors: Error 45-46: A column named 'b' already exists.|Error 0-47: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 45-46: A column named 'b' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({a:1,b:2}, a, b)
-Errors: Error 28-29: A column named 'b' already exists.|Error 0-30: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 28-29: A column named 'b' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 >> RenameColumns(Table({a:1,b:2},{a:3,b:4}), a, c, b, c)
-Errors: Error 51-52: A column named 'c' already exists.|Error 0-53: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 51-52: A column named 'c' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({a:1,b:2}, a, c, b, c)
-Errors: Error 34-35: A column named 'c' already exists.|Error 0-36: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 34-35: A column named 'c' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 >> Last(RenameColumns(Table({a:1,b:2},{a:3,b:4}), b, c)).c
 4
@@ -87,15 +87,15 @@ Errors: Error 0-51: Invalid number of arguments: received 4, expected an odd num
 Errors: Error 0-34: Invalid number of arguments: received 4, expected an odd number.
 
 >> RenameColumns([1, 2], 3, 4)
-Errors: Error 22-23: Expected identifier name|Error 0-27: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 22-23: Expected identifier name|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({Value:1}, 3, 4)
-Errors: Error 25-26: Expected identifier name|Error 0-30: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 25-26: Expected identifier name|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 >> RenameColumns([1, 2], z, y)
-Errors: Error 22-23: The specified column 'z' does not exist.|Error 0-27: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 22-23: The specified column 'z' does not exist.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({Value:1}, z, y)
-Errors: Error 25-26: The specified column 'z' does not exist.|Error 0-30: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 25-26: The specified column 'z' does not exist.|Error 0-13: The function 'RenameColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RenameColumns_SupportColumnNamesAsIdentifiersDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/RenameColumns_SupportColumnNamesAsIdentifiersDisabled.txt
@@ -60,18 +60,18 @@ Table({a:1,b:2},{a:3,b:4})
 {a:1,b:2}
 
 >> RenameColumns(Table({a:1,b:2},{a:3,b:4}), "a", "c", "b", "c")
-Errors: Error 57-60: A column named 'c' already exists.|Error 0-61: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 57-60: A column named 'c' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({a:1,b:2}, "a", "c", "b", "c")
-Errors: Error 40-43: A column named 'c' already exists.|Error 0-44: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 40-43: A column named 'c' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 >> RenameColumns(Table({a:1,b:2},{a:3,b:4}), "a", "b")
-Errors: Error 47-50: A column named 'b' already exists.|Error 0-51: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 47-50: A column named 'b' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({a:1,b:2}, "a", "b")
-Errors: Error 30-33: A column named 'b' already exists.|Error 0-34: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 30-33: A column named 'b' already exists.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 >> Last(RenameColumns(Table({a:1,b:2},{a:3,b:4}), "b", "c")).c
 4
@@ -87,15 +87,15 @@ Errors: Errors: Error 0-57: Invalid number of arguments: received 4, expected an
 Errors: Error 0-40: Invalid number of arguments: received 4, expected an odd number.
 
 >> RenameColumns([1, 2], 3, 4)
-Errors: Error 22-23: Argument '3' is invalid, expected a text literal.|Error 0-27: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 22-23: Argument '3' is invalid, expected a text literal.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({Value:1}, 3, 4)
-Errors: Error 25-26: Argument '3' is invalid, expected a text literal.|Error 0-30: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 25-26: Argument '3' is invalid, expected a text literal.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 >> RenameColumns([1, 2], "z", "y")
-Errors: Error 22-25: The specified column 'z' does not exist.|Error 0-31: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 22-25: The specified column 'z' does not exist.|Error 0-13: The function 'RenameColumns' has some invalid arguments.
 
 // Record
 >> RenameColumns({Value:1}, "z", "y")
-Errors: Error 25-28: The specified column 'z' does not exist.|Error 0-34: The function 'RenameColumns' has some invalid arguments.
+Errors: Error 25-28: The specified column 'z' does not exist.|Error 0-13: The function 'RenameColumns' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ShowColumns.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ShowColumns.txt
@@ -35,11 +35,11 @@ Table({a:1,c:1},{a:3,c:27})
 Table({a:1,b:1},{a:3,b:27})
 
 >> ShowColumns(Table({a:1,b:2},{a:3,b:4}), a, c)
-Errors: Error 43-44: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-45: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 43-44: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 // Record
 >> ShowColumns({a:1,b:2}, a, c)
-Errors: Error 26-27: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-28: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 26-27: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 >> Last(ShowColumns(Table({a:1,b:2},{a:3,b:4}), b)).b
 4
@@ -55,18 +55,18 @@ Table({Value:1},{Value:2},{Value:3})
 {Value:3}
 
 >> ShowColumns([1, 2], 3)
-Errors: Error 20-21: Expected identifier name|Error 0-22: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 20-21: Expected identifier name|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 // Record
 >> ShowColumns({Value:1}, 3)
-Errors: Error 23-24: Expected identifier name|Error 0-25: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 23-24: Expected identifier name|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 >> ShowColumns([1, 2], z)
-Errors: Error 20-21: The specified column 'z' does not exist.|Error 0-22: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 20-21: The specified column 'z' does not exist.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 // Record
 >> ShowColumns({Value:1}, z)
-Errors: Error 23-24: The specified column 'z' does not exist.|Error 0-25: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 23-24: The specified column 'z' does not exist.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 >> ShowColumns([{a:1,b:2},{a:1/0,b:4},{a:5,b:6}],a)
 Table({a:1},{a:Error({Kind:ErrorKind.Div0})},{a:5})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ShowColumns_SupportColumnNamesAsIdentifiersDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/ShowColumns_SupportColumnNamesAsIdentifiersDisabled.txt
@@ -35,11 +35,11 @@ Table({a:1,c:1},{a:3,c:27})
 Table({a:1,b:1},{a:3,b:27})
 
 >> ShowColumns(Table({a:1,b:2},{a:3,b:4}), "a", "c")
-Errors: Error 45-48: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-49: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 45-48: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 // Record
 >> ShowColumns({a:1,b:2}, "a", "c")
-Errors: Error 28-31: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-32: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 28-31: The specified column 'c' does not exist. The column with the most similar name is 'a'.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 >> Last(ShowColumns(Table({a:1,b:2},{a:3,b:4}), "b")).b
 4
@@ -55,11 +55,11 @@ Table({Value:1},{Value:2},{Value:3})
 {Value:3}
 
 >> ShowColumns([1, 2], "z")
-Errors: Error 20-23: The specified column 'z' does not exist.|Error 0-24: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 20-23: The specified column 'z' does not exist.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 // Record
 >> ShowColumns({Value:1}, "z")
-Errors: Error 23-26: The specified column 'z' does not exist.|Error 0-27: The function 'ShowColumns' has some invalid arguments.
+Errors: Error 23-26: The specified column 'z' does not exist.|Error 0-11: The function 'ShowColumns' has some invalid arguments.
 
 >> ShowColumns([{a:1,b:2},{a:1/0,b:4},{a:5,b:6}],"a")
 Table({a:1},{a:Error({Kind:ErrorKind.Div0})},{a:5})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Shuffle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Shuffle.txt
@@ -29,4 +29,4 @@ Blank()
 Table()
 
 >> Shuffle({a:1,b:2})
-Errors: Error 8-17: Invalid argument type (Record). Expecting a Table value instead.|Error 0-18: The function 'Shuffle' has some invalid arguments.
+Errors: Error 8-17: Invalid argument type (Record). Expecting a Table value instead.|Error 0-7: The function 'Shuffle' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/SqrtT.txt
@@ -4,7 +4,7 @@
 Table({Value:1},{Value:23},{Value:12},{Value:18})
 
 >> Sqrt([])
-Errors: Error 0-8: The function 'Sqrt' has some invalid arguments.|Error 5-7: Invalid schema, expected a one-column table.
+Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 5-7: Invalid schema, expected a one-column table.
 
 >> Sqrt([9, 1444])
 Table({Value:3},{Value:38})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnums.txt
@@ -45,7 +45,7 @@ Errors: Error 45-46: Incompatible types for comparison. These types can't be com
 
 // Functions can enforce expecting an enum type
 >> DateAdd(Date(2011,1,15), 100000000, "milliseconds")
-Errors: Error 36-50: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-51: The function 'DateAdd' has some invalid arguments.
+Errors: Error 36-50: Invalid argument type (Text). Expecting a Enum (TimeUnit) value instead.|Error 0-7: The function 'DateAdd' has some invalid arguments.
 
 >> DateAdd(Date(2011,1,15), 100000000, TimeUnit.Milliseconds)
 Date(2011,1,16)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Table.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Table.txt
@@ -33,11 +33,11 @@ Table({c:"Hello",d:{x:"World"}},{c:"PowerFx",d:{x:"Cool"}})
 
 // Invalid input - trying to coerce guid and datetime 
 >> Table([{a:Date(2024,1,1)}], [{a:GUID("some-guid-value-1234")}]) 
-Errors: Error 0-63: The function 'Table' has some invalid arguments.|Error 28-62: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
+Errors: Error 0-5: The function 'Table' has some invalid arguments.|Error 28-62: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
 
 // Table type with incompatible schema
 >> Table([1, 2], If(1<0, Table({Value:{a:2}})))
-Errors: Error 0-44: The function 'Table' has some invalid arguments.|Error 14-43: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
+Errors: Error 0-5: The function 'Table' has some invalid arguments.|Error 14-43: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
 
 // No arg
 >> Table()
@@ -86,7 +86,7 @@ Table({Value:"everything"},{Value:"42"})
 Table({a:1},Error({Kind:ErrorKind.Div0}),{a:3},{a:4})
 
 >> Table([{a:1}], 1/0, {a:3}, [{a:4}])
-Errors: Error 0-35: The function 'Table' has some invalid arguments.|Error 16-17: Only record or table values can be used in this context.
+Errors: Error 0-5: The function 'Table' has some invalid arguments.|Error 16-17: Only record or table values can be used in this context.
 
 // The second argument is a record, no ambiguity
 >> Table([{a:1}], If(1/0<2,{a:2}), {a:3}, [{a:4}])
@@ -105,7 +105,7 @@ Table({a:{b:{c:"Hello"}},d:Blank()},{a:{b:{c:"World"}},d:{f:Table({Value:1},{Val
 
 // Mixing nested record and nested table inside a record - same column - type error
 >> Table({a: {b: {c: "Hello"}}}, [{a: Table({e: 1}, {e: 2}, {e:5}, {f:[1, 2, 3, 4]})}])
-Errors: Error 0-84: The function 'Table' has some invalid arguments.|Error 30-83: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
+Errors: Error 0-5: The function 'Table' has some invalid arguments.|Error 30-83: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
 
 // Does not modify existing behavior of Inline value tables
 >> [[1, 2, 3], [4, 5, 6]]

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableCoercion.txt
@@ -29,7 +29,7 @@ Table({a:1},{a:1},{a:1})
 Table({a:1},{a:44986},{a:1})
 
 >> Table({a:0,b:Date(2023,3,1)}, {a:Date(2023,3,1),b:GUID("5cc45615-f759-4a53-b225-d3a2497f60ad")})
-Errors: Error 0-96: The function 'Table' has some invalid arguments.
+Errors: Error 0-5: The function 'Table' has some invalid arguments.
 
 >> Table({A:{x:{d1:1,d2:3},y:3}},{A:{x:{d1:"1",d2:4},y:3}})
 Table({A:{x:{d1:1,d2:3},y:3}},{A:{x:{d1:1,d2:4},y:3}})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableCoercion_StronglyTypedEnum.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/TableCoercion_StronglyTypedEnum.txt
@@ -10,4 +10,4 @@ Errors: Error 17-19: Incompatible type. The item you are trying to put into a ta
 
 // Table type enum (Table function), cannot have numbers
 >> Table({a:ErrorKind.Div0}, {a:12})
-Errors: Error 0-33: The function 'Table' has some invalid arguments.|Error 26-32: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.
+Errors: Error 0-5: The function 'Table' has some invalid arguments.|Error 26-32: Incompatible type. The item you are trying to put into a table has a type that is not compatible with the table.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat.txt
@@ -30,10 +30,10 @@
 "{$-fr-FR}  1.235"
 
 >> Text(1234.5678,"abc[$-en-US]0 # # # !!!", "en-US")
-Errors: Error 0-50: The function 'Text' has some invalid arguments.|Warning 15-40: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-40: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "mnk  [$-fr-FR] # ##0,00"   , "vi-VI")
-Errors: Error 0-54: The function 'Text' has some invalid arguments.|Warning 16-41: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-41: Incorrect format specifier for 'Text'.
 
 // Basic usage
 >> Text(ParseJSON("""\u202F"""), "##")
@@ -554,14 +554,14 @@ Table({Value:"08:03:05"},{Value:"00:00:00"})
 
 // Format has mixed datetime and number
 >> Text(1234567.1234567, "\m\mm # ddd yyy")
-Errors: Error 0-40: The function 'Text' has some invalid arguments.|Warning 22-39: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-39: Incorrect format specifier for 'Text'.
 
 // Literal characters conflicting with date/time format specifiers.
 >> Text(72, "# y")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
 
 >> Text(72, "# m")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
 
 // Sections.  Three sections are supported, for positive, negative, and zero.
 >> Text(1234567.1234567, "##;(##);ZZZ")
@@ -590,22 +590,22 @@ Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14
 
 // Excel supports a fourth section that is a string, for the case where the input is text.  We are strongly typed so less ipmortant.  We will error for now.
 >> Text(1234567.1234567, "##;(##);ZZZ;AAA")
-Errors: Error 0-40: The function 'Text' has some invalid arguments.|Warning 22-39: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-39: Incorrect format specifier for 'Text'.
 
 >> Text(-1234567.1234567, "##;(##);ZZZ;AAA")
-Errors: Error 0-41: The function 'Text' has some invalid arguments.|Warning 23-40: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 23-40: Incorrect format specifier for 'Text'.
 
 >> Text(0, "##;(##);ZZZ;AAA")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 8-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-25: Incorrect format specifier for 'Text'.
 
 >> Text(1, "##;(##);ZZZ;""AAA """)
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 8-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-30: Incorrect format specifier for 'Text'.
 
 >> Text(-1, "##;(##);ZZZ;""AAA """)
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 9-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-31: Incorrect format specifier for 'Text'.
 
 >> Text(0, "##;(##);ZZZ;""AAA """)
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 8-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-30: Incorrect format specifier for 'Text'.
 
 // If only two sections, first format used for Zero.
 >> Text(0, "00.00;(00.00)")
@@ -619,15 +619,15 @@ Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 8-30
 
 // Excel: "€ 1,234,567.1235"
 >> Text(1234567.1234567, "[$€-de-DE] #,####.0000")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
 
 // Excel: "$ 1,234,567.1235"
 >> Text(1234567.1234567, "[$$-de-DE] #,####.0000")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
 
 // Excel: "€€€€ 1,234,567.1235"
 >> Text(1234567.1234567, "[$€€€€-de-DE] #,####.0000")
-Errors: Error 0-50: The function 'Text' has some invalid arguments.|Warning 22-49: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-49: Incorrect format specifier for 'Text'.
 
 // Sections can be skipped.
 >> Text(1234567.1234567, ";(##)")
@@ -764,130 +764,130 @@ Error({Kind:ErrorKind.Div0})
 // Color specifications, ignored by Excel's Text function, but supported for cell formatting.  We should error for now.
 // Excel: "$1.00"
 >> Text(1, "$#,##0.00;[Red]($#,##0.00)")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
 
 // Excel: "($1.00)"
 >> Text(-1, "$#,##0.00;[Red]($#,##0.00)")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 9-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-37: Incorrect format specifier for 'Text'.
 
 // Excel: "$0.00"
 >> Text(0, "$#,##0.00;[Red]($#,##0.00)")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
 
 // Excel: "5"
 >> Text(5, "[Blue][<10]General;[Red][>=10]General")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 8-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-47: Incorrect format specifier for 'Text'.
 
 // Excel: "15"
 >> Text(15, "[Blue][<10]General;[Red][>=10]General")
-Errors: Error 0-49: The function 'Text' has some invalid arguments.|Warning 9-48: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-48: Incorrect format specifier for 'Text'.
 
 // Excel: "5"
 >> Text(5, "[Blue][<10]#;[Red][>=10](#)")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 8-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-37: Incorrect format specifier for 'Text'.
 
 // Excel: "(15)"
 >> Text(15, "[Blue][<10]#;[Red][>=10](#)")
-Errors: Error 0-39: The function 'Text' has some invalid arguments.|Warning 9-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-38: Incorrect format specifier for 'Text'.
 
 // Excel: "25.00"
 >> Text(25, "[Blue][>10]0.00;[Red][>5]0.0000")
-Errors: Error 0-43: The function 'Text' has some invalid arguments.|Warning 9-42: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-42: Incorrect format specifier for 'Text'.
 
 // Excel: "7.0000"
 >> Text(7, "[Blue][>10]0.00;[Red][>5]0.0000")
-Errors: Error 0-42: The function 'Text' has some invalid arguments.|Warning 8-41: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-41: Incorrect format specifier for 'Text'.
 
 // Value not hit by either condition
 >> Text(3, "[Blue][>10]0.00;[Red][>5]0.0000")
-Errors: Error 0-42: The function 'Text' has some invalid arguments.|Warning 8-41: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-41: Incorrect format specifier for 'Text'.
 
 // Excel: "3.0000"
 >> Text(3, "[Blue][>10]0.00;[Red]0.0000")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 8-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-37: Incorrect format specifier for 'Text'.
 
 // More than two conditions not suported by Excel
 >> Text(3, "[Blue][>10]0.00;[Red][>5]0.0000;[Yellow][>0]0000.0")
-Errors: Error 0-61: The function 'Text' has some invalid arguments.|Warning 8-60: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-60: Incorrect format specifier for 'Text'.
 
 // Excel: "0000.0"
 >> Text(0, "[Blue][>10]0.00;[Red][>5]0.0000;[Yellow]0000.0")
-Errors: Error 0-57: The function 'Text' has some invalid arguments.|Warning 8-56: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-56: Incorrect format specifier for 'Text'.
 
 // Excel: "10.00"
 >> Text(10, "[Blue][=10]0.00;[Red][=5]0.0000;12")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 9-45: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-45: Incorrect format specifier for 'Text'.
 
 // Excel: "5.0000"
 >> Text(5, "[Blue][=10]0.00;[Red][=5]0.0000;12")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
 
 // Excel: "12"
 >> Text(3, "[Blue][=10]0.00;[Red][=5]0.0000;12")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
 
 // Excel: "12"
 >> Text(0, "[Blue][=10]0.00;[Red][=5]0.0000;12")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
 
 // Excel: "7.00"
 >> Text(7, "[Blue][<>10]0.00;[Red][<>5]0.0000;12")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 8-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-46: Incorrect format specifier for 'Text'.
 
 // Excel: "10.0000"
 >> Text(10, "[Blue][<>10]0.00;[Red][<>5]0.0000;12")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 9-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-47: Incorrect format specifier for 'Text'.
 
 // Excel: "GBP 1,234,567.123"
 >> Text(1234567.1234567, "[$GBP] #,###.000")
-Errors: Error 0-41: The function 'Text' has some invalid arguments.|Warning 22-40: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-40: Incorrect format specifier for 'Text'.
 
 // Excel: "GBP 3"
 >> Text(3, "[$GBP-000000] #")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 8-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-25: Incorrect format specifier for 'Text'.
 
 // Excel: "GBP"
 >> Text(3, "[$GBP-809]")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 8-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-20: Incorrect format specifier for 'Text'.
 
 >> Text(45, "###: number of foos")
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 9-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-30: Incorrect format specifier for 'Text'.
 
 >> Text(45, "000: number of foos")
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 9-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-30: Incorrect format specifier for 'Text'.
 
 // Excel: #VALUE!
 >> Text(1E+23, "General ###")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 12-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-25: Incorrect format specifier for 'Text'.
 
 // Can't mix time parts and numbers
 >> Text(1.010101, "hh:00")
-Errors: Error 0-23: The function 'Text' has some invalid arguments.|Warning 15-22: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-22: Incorrect format specifier for 'Text'.
 
 >> Text(1.010101, "hh:mm:00")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 15-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-25: Incorrect format specifier for 'Text'.
 
 >> Text(1.010101, "00:mm:ss")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 15-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-25: Incorrect format specifier for 'Text'.
 
 // Excel: "00.00"
 >> Text(0, "[ss].00")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: "28020.00"
 >> Text(0.324305555555556, "[ss].00")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 24-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 24-33: Incorrect format specifier for 'Text'.
 
 // Excel: "87272.73"
 >> Text(1.010101, "[ss].00")
-Errors: Error 0-25: The function 'Text' has some invalid arguments.|Warning 15-24: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-24: Incorrect format specifier for 'Text'.
 
 // Can't mix date parts and numbers
 >> Text(3, "m/2001")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 8-16: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-16: Incorrect format specifier for 'Text'.
 
 >> Text(3, "2001/y")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 8-16: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-16: Incorrect format specifier for 'Text'.
 
 // Percent signs.  Multiplies the number by 100 before displaying and can be stacked.
 >> Text(0.244740088392962, "0%")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat_PowerFxV1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat_PowerFxV1Compat.txt
@@ -2,215 +2,215 @@
 
 // Block language code
 >> Text(1234.5678, "$-fr-FR] # ##0,00", "vi-VI")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.89, "[$-fr-FR]# ###,## €", Blank())
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.89, "[$-fr-FR]# ###,## €", "fr-FR")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
 
 >> Text(1234567,89; "[$-fr-FR]# ###,## €")
 
-Errors: Error 15-16: Expected operator. We expect an operator such as +, *, or & at this point in the formula.|Error 0-39: The function 'Text' has some invalid arguments.
+Errors: Error 15-16: Expected operator. We expect an operator such as +, *, or & at this point in the formula.|Error 0-4: The function 'Text' has some invalid arguments.
 
 // Color
 >> Text(Color.Red, "###")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(Color.Red, "@")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 16-19: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-19: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(Color.Red, "@ @")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(Color.Red, "#/4")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(Color.Red, "Foo @")
-Errors: Error 0-24: The function 'Text' has some invalid arguments.|Warning 16-23: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-23: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(Color.Red, "Foo ####")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 16-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Not support format string for non numeric/datetime/date/time
 >> Text("123.456", "###")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("123.456", "@")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 16-19: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-19: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("123.456", "@ @")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("123.456", "#/4")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-21: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("123.456", "Foo @")
-Errors: Error 0-24: The function 'Text' has some invalid arguments.|Warning 16-23: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-23: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("123.456", "Foo ####")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 16-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("bsdf", "###")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("bsdf", "@")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 13-16: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-16: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("bsdf", "@ @")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("bsdf", "#/4")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("bsdf", "Foo @")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 13-20: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-20: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(true, "#")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 11-14: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-14: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(true, "###")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 11-16: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-16: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(false, "0")
-Errors: Error 0-16: The function 'Text' has some invalid arguments.|Warning 12-15: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-15: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(false, "0000")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 12-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("abc", "0.00")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 12-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "b")
-Errors: Error 0-51: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "d", "vi-Vn")
-Errors: Error 0-60: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "p", "vi-Vn")
-Errors: Error 0-60: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "n", "vi-Vn")
-Errors: Error 0-60: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "b", "vi-Vn")
-Errors: Error 0-60: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 47-50: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("", "0,00.0")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 9-17: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-17: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("", "####.#")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 9-17: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-17: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("Hello", If(1 < 0, "d", Blank()))
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 14-37: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-37: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("Hello", If(1 < 0, "d", ""))
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 14-32: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-32: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("Hello", If(1 > 0, "d", ""))
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 14-32: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-32: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(If(1<0,false), "0.00")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 20-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 20-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(If(1<0,"test",Blank()), "####")
-Errors: Error 0-36: The function 'Text' has some invalid arguments.|Warning 29-35: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 29-35: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(If(1 < 0, false), "mmm ddd yyy")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 23-36: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 23-36: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(Boolean("True"), "", "vi-Vn")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-24: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-24: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(GUID("0f8fad5bd9cb469fa16570867728950e"), "", "vi-Vn")
-Errors: Error 0-59: The function 'Text' has some invalid arguments.|Warning 47-49: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 47-49: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Block bad language code
 // If have empty language code, throw error
 >> Text(1234.5678,"[$-]")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
 
 // If not closed by a ']', throw error
 >> Text(1234.5678,"[$-a")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
 
 // If not closed by a ']', throw error
 >> Text(1234.5678, "[$-en-US#,##0.00", "en-US")
-Errors: Error 0-44: The function 'Text' has some invalid arguments.|Warning 16-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-]fr-FR # ##0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 // End with e or e+ in numeric or datetime format is invalid
 >> Text(1234567.1234567, "0.00e+")
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 22-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-30: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00e")
-Errors: Error 0-30: The function 'Text' has some invalid arguments.|Warning 22-29: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-29: Incorrect format specifier for 'Text'.
 
 >> Text("ss", "true")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 11-17: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-17: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("ss", "false")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text(1234567.1234567, "\""#\""\")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(123.456, "\m\m\m\-ddd\-yyy\")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 14-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, """""""#")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, """\""""#")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "dddd, mmm "" dd, yyy") 
-Errors: Error 0-63: The function 'Text' has some invalid arguments.|Warning 40-62: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-62: Incorrect format specifier for 'Text'.
 
 >> Text(30470, "DDDD, MMM "" DD, YYY") 
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 12-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-34: Incorrect format specifier for 'Text'.
 
 // Format does not have close double quote
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ([""][^""]*[""]) dd yyyy") 
-Errors: Error 0-73: The function 'Text' has some invalid arguments.|Warning 42-72: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 42-72: Incorrect format specifier for 'Text'.
 
 >> Text(30470, "mmm ([""][^""]*[""]) dd yyyy") 
-Errors: Error 0-43: The function 'Text' has some invalid arguments.|Warning 12-42: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-42: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""])"" dd yyyy") 
-Errors: Error 0-77: The function 'Text' has some invalid arguments.|Warning 42-76: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 42-76: Incorrect format specifier for 'Text'.
 
 >> Text(30470, "mmm ""([""][^""]*[""])"" dd yyyy") 
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 12-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-46: Incorrect format specifier for 'Text'.
 
 >> Text(Date(1983, 6, 3), "dddd, mmm "" dd, yyy") 
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 23-45: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 23-45: Incorrect format specifier for 'Text'.
 
 // Block locale until we will support for datetime as well
 >> Text(1234.5678, "[$-fr-FR]# ##0,00", "en-US")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR]# ##0,00", "vi-VI")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-en-US]#,##0.00", "en-US")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-pt-BR]#.##0,00", "en-US")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-pt-BR]#.##0,00", "fr-FR")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-en-US]#,##0.00", "pt-BR")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678,"[$-en-US]0 # # # !!!", "en-US")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 15-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-37: Incorrect format specifier for 'Text'.
 
 // The thousands separator in the fi-FI locale is the no-break space (U+00A0)
 >> Text(12345.6789, $"[$-fi-FI]#{Char(160)}##0.00", "en-US")
@@ -224,518 +224,518 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> Text(1234.5678, "[$-en-US]", "en-US")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 16-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-27: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR]", "fr-FR")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 16-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-27: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR]", "en-US")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 16-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-27: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-  fr-FR  ]# ##0,00", "vi-VI")
-Errors: Error 0-49: The function 'Text' has some invalid arguments.|Warning 16-39: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-39: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR  ]# ##0,00", "vi-VI")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-  fr-FR]# ##0,00", "vi-VI")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR][# ##0,00]", "vi-VI")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "$-fr-FR][ # ##0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "$[-fr-FR] # ##0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR][$-fr-FR# ##0,00]", "vi-VI")
-Errors: Error 0-54: The function 'Text' has some invalid arguments.|Warning 16-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-44: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "]$-fr-FR[ # ##0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$ # ##0,00", "vi-VI")
-Errors: Error 0-39: The function 'Text' has some invalid arguments.|Warning 16-29: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-29: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$] # ##0,00", "vi-VI")
-Errors: Error 0-40: The function 'Text' has some invalid arguments.|Warning 16-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-30: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "][-$ # ##0,00", "vi-VI")
-Errors: Error 0-41: The function 'Text' has some invalid arguments.|Warning 16-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-31: Incorrect format specifier for 'Text'.
 
 // If does not have valid language code, throw error
 >> Text(1234.5678, "[$-a]0,0", "en-US")
-Errors: Error 0-36: The function 'Text' has some invalid arguments.|Warning 16-26: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-26: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr - FR]# ##0,00", "vi-VI")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR #] ##0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR # ##0,00]", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR,en-US] # ##0,00", "vi-VI")
-Errors: Error 0-52: The function 'Text' has some invalid arguments.|Warning 16-42: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-42: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR # ##]0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 // Format contains block characters
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 123), "mmm ""([""][^""]*[""]) dd yyyy")
-Errors: Error 0-75: The function 'Text' has some invalid arguments.|Warning 42-74: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 42-74: Incorrect format specifier for 'Text'.
 
 >> Text(30470, "mmm ""([""][^""]*[""]) dd yyyy") 
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 12-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-44: Incorrect format specifier for 'Text'.
 
 >> Text(123456789, "???????????????????")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-37: Incorrect format specifier for 'Text'.
 
 // Fractions with forward slash.  We should reserve the slash character for now and produce an error.
 // Excel: "5/4"
 >> Text(1.25, "#/#")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 11-16: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-16: Incorrect format specifier for 'Text'.
 
 // Excel: "1 1/4"
 >> Text(1.25, "# #/#")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "1 1/2"
 >> Text(1.5, "# #/##")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 10-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 10-18: Incorrect format specifier for 'Text'.
 
 // Excel: "32 1/800"
 >> Text(32.00125, "# #/#####")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 15-26: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-26: Incorrect format specifier for 'Text'.
 
 // Excel: "3/5"
 >> Text(0.59375, "0/0")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 14-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-19: Incorrect format specifier for 'Text'.
 
 // Excel: "19/32"
 >> Text(0.59375, "00/00")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 14-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-21: Incorrect format specifier for 'Text'.
 
 // Excel: "19/32"
 >> Text(0.59375, "0/#0")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 14-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-20: Incorrect format specifier for 'Text'.
 
 // Excel: "1/8"
 >> Text(0.125, "0/0")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 12-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-17: Incorrect format specifier for 'Text'.
 
 // Excel: "01/08"
 >> Text(0.125, "00/00")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 12-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-19: Incorrect format specifier for 'Text'.
 
 // Excel: "1/8"
 >> Text(0.125, "0/#0")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 12-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4 1/3"
 >> Text(4.34, "# ?/?")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "1/3"
 >> Text(0.34, "# ?/?")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4 17/50"
 >> Text(4.34, "# ??/??")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
 
 // Excel: "4  17/50", note extra space
 >> Text(4.34, "# ???/???")
-Errors: Error 0-23: The function 'Text' has some invalid arguments.|Warning 11-22: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-22: Incorrect format specifier for 'Text'.
 
 // Excel: "4 1/2"
 >> Text(4.34, "# ?/2")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4 1/4"
 >> Text(4.34, "# ?/4")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4  5/16", note extra space
 >> Text(4.34, "# ??/16")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
 
 // Excel: "4 3/10"
 >> Text(4.34, "# ?/10")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 11-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-19: Incorrect format specifier for 'Text'.
 
 // Excel: "4 34/100"
 >> Text(4.34, "# ?/100")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
 
 // Excel: "4 1/3"
 >> Text(4.34, "# #/#")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "1/3"
 >> Text(0.34, "# #/#")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4 17/50"
 >> Text(4.34, "# ##/##")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
 
 // Excel: "4 17/50"
 >> Text(4.34, "# ###/###")
-Errors: Error 0-23: The function 'Text' has some invalid arguments.|Warning 11-22: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-22: Incorrect format specifier for 'Text'.
 
 // Excel: "4 1/2"
 >> Text(4.34, "# #/2")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4 1/4"
 >> Text(4.34, "# #/4")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-18: Incorrect format specifier for 'Text'.
 
 // Excel: "4 5/16"
 >> Text(4.34, "# ##/16")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
 
 // Excel: "4 3/10"
 >> Text(4.34, "# #/10")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 11-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-19: Incorrect format specifier for 'Text'.
 
 // Excel: "4 34/100"
 >> Text(4.34, "# #/100")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-20: Incorrect format specifier for 'Text'.
 
 // Excel: "1/1"
 >> Text(1, "0/0")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "1/1"
 >> Text(1, "#/#")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "1/1"
 >> Text(1, "?/?")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "  1/1  "
 >> Text(1, "???/???")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: "1/1"
 >> Text(1, "###/###")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: "001/001"
 >> Text(1, "000/000")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: "494/4"
 >> Text(123.456, "#/4")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 14-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-19: Incorrect format specifier for 'Text'.
 
 // block conditional sections.
 // Excel: "(123) 456-7898"
 >> Text(1234567898, "[<=9999999]###-####;(###) ###-####")
-Errors: Error 0-54: The function 'Text' has some invalid arguments.|Warning 17-53: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-53: Incorrect format specifier for 'Text'.
 
 // Excel: "123-4567"
 >> Text(1234567, "[<=9999999]###-####;(###) ###-####")
-Errors: Error 0-51: The function 'Text' has some invalid arguments.|Warning 14-50: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-50: Incorrect format specifier for 'Text'.
 
 // Indent with _(and _) around cell contents. Excel Text function replaces with a space. We should repalce with a space in time, error for now.
 // Excel: " 3"
 >> Text(3, "_(#")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: " 3 "
 >> Text(3, "_(#_)")
-Errors: Error 0-16: The function 'Text' has some invalid arguments.|Warning 8-15: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-15: Incorrect format specifier for 'Text'.
 
 // Excel: "3 "
 >> Text(3, "#_)")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "   3"
 >> Text(3, "_(_(_(#")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: "   3   "
 >> Text(3, "_(_(_(#_)_)_)")
-Errors: Error 0-24: The function 'Text' has some invalid arguments.|Warning 8-23: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-23: Incorrect format specifier for 'Text'.
 
 // Excel: "3   "
 >> Text(3, "#_)_)_)")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: " 3 "
 >> Text(3, "_-#_-")
-Errors: Error 0-16: The function 'Text' has some invalid arguments.|Warning 8-15: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-15: Incorrect format specifier for 'Text'.
 
 // Excel: " $1.00* "
 >> Text(1, "_($* #,##0.00""*""_);_($* (#,##0.00);_($* ""-""??_);_(@_)")
-Errors: Error 0-68: The function 'Text' has some invalid arguments.|Warning 8-67: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-67: Incorrect format specifier for 'Text'.
 
 // Excel: " $(1.00)"
 >> Text(-1, "_($* #,##0.00""*""_);_($* (#,##0.00);_($* ""-""??_);_(@_)")
-Errors: Error 0-69: The function 'Text' has some invalid arguments.|Warning 9-68: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-68: Incorrect format specifier for 'Text'.
 
 // Excel: " $-   "
 >> Text(0, "_($* #,##0.00""*""_);_($* (#,##0.00);_($* ""-""??_);_(@_)")
-Errors: Error 0-68: The function 'Text' has some invalid arguments.|Warning 8-67: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-67: Incorrect format specifier for 'Text'.
 
 // Excel: " asdf "
 >> Text("asdf", "_($* #,##0.00""*""_);_($* (#,##0.00);_($* ""-""??_);_(@_)")
-Errors: Error 0-73: The function 'Text' has some invalid arguments.|Warning 13-72: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-72: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Asterisk is used for alignment in cell formatting, repeating character after the *. Ignored by Excel text function. We should ignore long term, error for now.
 // Excel: "$ 1.00"
 >> Text(1, "$ * 0.00")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 8-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-18: Incorrect format specifier for 'Text'.
 
 // Excel: "-$ 1.00"
 >> Text(-1, "$ * 0.00")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 9-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-19: Incorrect format specifier for 'Text'.
 
 // Excel: "$ 0.00"
 >> Text(0, "$ * 0.00")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 8-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-18: Incorrect format specifier for 'Text'.
 
 // Excel: "3"
 >> Text(3, "#,###* ; -#,###* ; 0* ;* @")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
 
 // Excel: " -3"
 >> Text(-3, "#,###* ; -#,###* ; 0* ;* @")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 9-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-37: Incorrect format specifier for 'Text'.
 
 // Excel: " 0"
 >> Text(0, "#,###* ; -#,###* ; 0* ;* @")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-36: Incorrect format specifier for 'Text'.
 
 // Excel: "asdf"
 >> Text("asdf", "#,###* ; -#,###* ; 0* ;* @")
-Errors: Error 0-42: The function 'Text' has some invalid arguments.|Warning 13-41: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-41: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Excel: "1"
 >> Text(1, "*0#")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "1"
 >> Text(1, "#*=")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "1"
 >> Text(1, "*(#")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 // Excel: "$ 1,234,567"
 >> Text(1234567.1234567, "$ * #,##0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 // * by itself is an error, it needs a character to either side
 >> Text(1234567.1234567, "*")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
 
 // Excel: ""
 >> Text(1234567.1234567, "*=")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 22-26: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-26: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "=*")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 22-26: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-26: Incorrect format specifier for 'Text'.
 
 >> Text("asdf", "##;(##);ZZZ;""AAA """)
-Errors: Error 0-36: The function 'Text' has some invalid arguments.|Warning 13-35: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-35: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("asdf", "##;(##);ZZZ;""AAA ""@")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 13-36: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-36: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 >> Text("asdf", "##;(##);ZZZ")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 13-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-26: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Output localization. We will cover this with the third argumnet for now.
 // Excel: "1,234,567.1235"
 >> Text(1234567.1234567, "[$-en-US]#,####.0000")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 22-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-44: Incorrect format specifier for 'Text'.
 
 // Excel: "$ 1,234,567.1235"
 >> Text(1234567.1234567, "[$-en-US]$ #,####.0000")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
 
 // Excel: "$ 1,234,567.1235"
 >> Text(1234567.1234567, "[$-fr-FR]$ #,####.0000")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
 
 // Excel: "$ 1,234,567.1235"
 >> Text(1234567.1234567, "[$-de-DE]$ #,####.0000")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
 
 // Excel: "€ 1,234,567.1235"
 >> Text(1234567.1234567, "[$€-fr-FR] #,####.0000")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-46: Incorrect format specifier for 'Text'.
 
 // Excel: " 3"
 >> Text(3, "[$-000000] #")
-Errors: Error 0-23: The function 'Text' has some invalid arguments.|Warning 8-22: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-22: Incorrect format specifier for 'Text'.
 
 // Excel: "$$$$ 1,234,567.1235"
 >> Text(1234567.1234567, "[$$$$-en-US]$ #,####.0000")
-Errors: Error 0-50: The function 'Text' has some invalid arguments.|Warning 22-49: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-49: Incorrect format specifier for 'Text'.
 
 // Colon, interpreted as a time seperator, not allowed between numbers
 >> Text(2, ":#:")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 >> Text(2, "#:#")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 >> Text(2, "?:?")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 >> Text(2, "z:0")
-Errors: Error 0-14: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-13: Incorrect format specifier for 'Text'.
 
 >> Text(45, "foo: ####")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 9-20: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-20: Incorrect format specifier for 'Text'.
 
 >> Text(45, "foo: 000")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 9-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-19: Incorrect format specifier for 'Text'.
 
 >> Text(2, "0:""#""0")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 8-18: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-18: Incorrect format specifier for 'Text'.
 
 // Block General (case insensitive) and @ - Reserved word for "default" formatting
 // Excel: "1234567.123"
 >> Text(1234567.1234567, "General")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 // Excel: "1234567.123"
 >> Text(1234567.1234567, "general")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 // Excel: "1234567.123"
 >> Text(1234567.1234567, "gEnErAl")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 // Excel: ""
 >> Text(1234567.1234567, "g")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
 
 // Excel: ""
 >> Text(1234567.1234567, "G")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
 
 // Excel: "Foo asdf"
 >> Text("asdf", "Foo @")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 13-20: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-20: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Excel: #VALUE!
 >> Text(1E+23, "@ ###")
-Errors: Error 0-20: The function 'Text' has some invalid arguments.|Warning 12-19: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 12-19: Incorrect format specifier for 'Text'.
 
 // Excel: #VALUE!
 >> Text("asdf", "@ ###")
-Errors: Error 0-21: The function 'Text' has some invalid arguments.|Warning 13-20: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-20: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Excel: "asdf"
 >> Text("asdf", "@")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 13-16: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-16: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Excel: "asdf asdf"
 >> Text("asdf", "@ @")
-Errors: Error 0-19: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-18: The second argument of the 'Text' function is only supported for numeric and date/time values.
 
 // Elapsed time
 // Excel: "0:00"
 >> Text(0, "[h]:mm")
-Errors: Error 0-17: The function 'Text' has some invalid arguments.|Warning 8-16: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-16: Incorrect format specifier for 'Text'.
 
 // Excel: "00:00"
 >> Text(0, "[mm]:ss")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-17: Incorrect format specifier for 'Text'.
 
 // Excel: "7:47"
 >> Text(0.324305555555556, "[h]:mm")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 24-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 24-32: Incorrect format specifier for 'Text'.
 
 // Excel: "467:00"
 >> Text(0.324305555555556, "[mm]:ss")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 24-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 24-33: Incorrect format specifier for 'Text'.
 
 // Excel: "24:14"
 >> Text(1.010101, "[h]:mm")
-Errors: Error 0-24: The function 'Text' has some invalid arguments.|Warning 15-23: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-23: Incorrect format specifier for 'Text'.
 
 // Excel: "1454:33"
 >> Text(1.010101, "[mm]:ss")
-Errors: Error 0-25: The function 'Text' has some invalid arguments.|Warning 15-24: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-24: Incorrect format specifier for 'Text'.
 
 // Excel: "Jan Tuesday 1900 "
 >> Text(3, "[$-en-US]mmm dddd yyyy ")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 8-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-33: Incorrect format specifier for 'Text'.
 
 // Excel: "janv. mardi 1900 "
 >> Text(3, "[$-fr-FR]mmm dddd yyyy ")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 8-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-33: Incorrect format specifier for 'Text'.
 
 >> Text(3, "/m")
-Errors: Error 0-13: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.
 
 // Excel: "0003.0"
 >> Text(3, "[Blue][>10]0.00;[Yellow][>0]0000.0")
-Errors: Error 0-45: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-44: Incorrect format specifier for 'Text'.
 
 // Expanding elapsed time to include days
 // Excel: #VALUE!, Desired: 32.07:47:00.00
 >> Text(32.324305555, "[d].hh:mm:ss.00")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 19-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 19-36: Incorrect format specifier for 'Text'.
 
 // Not allow the last character is opening quote (missing close quote).
 >> Text(123.456, "0.0""")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 14-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-21: Incorrect format specifier for 'Text'.
 
 >> Text(123.456, "mmm ddd yyy""")
-Errors: Error 0-30: The function 'Text' has some invalid arguments.|Warning 14-29: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-29: Incorrect format specifier for 'Text'.
 
 >> Text(123.456, "@")
-Errors: Error 0-18: The function 'Text' has some invalid arguments.|Warning 14-17: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-17: Incorrect format specifier for 'Text'.
 
 >> Text(12.34567,"Foo @")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 14-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-21: Incorrect format specifier for 'Text'.
 
 // C# supports E without a '+' or '-' after it.  Consitent with Excel, we do not.
 >> Text(1234567.123,"0.00E+")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 17-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-25: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.123,"0.00E")
-Errors: Error 0-25: The function 'Text' has some invalid arguments.|Warning 17-24: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-24: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.123,"0.00e+")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 17-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-25: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.123,"0.00e")
-Errors: Error 0-25: The function 'Text' has some invalid arguments.|Warning 17-24: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-24: Incorrect format specifier for 'Text'.
 
 // Excel treats "e" as an era.  We shouldn't assume that an "e" by itself is scientific notation.
 >> Text(1234567.1234567, "e")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "E")
-Errors: Error 0-26: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-25: Incorrect format specifier for 'Text'.
 
 // Reserved [@...] notation
 >> Text(1234567.123,"[@-en-US]#,###.0000")
-Errors: Error 0-39: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.123,"[@-fr-Fr]#.###,0000")
-Errors: Error 0-39: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-38: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.123,"[@]#,###.0000")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 17-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.123,"[@]#.###,0000")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 17-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 17-32: Incorrect format specifier for 'Text'.
 
 // Literal characters conflicting with date/time format specifiers.
 >> Text(72, "# \m")
@@ -745,10 +745,10 @@ Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 17-3
 "72 y"
 
 >> Text(72, "# y")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
 
 >> Text(72, "# m")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
 
 // Scaling factor.  Each comma on the end divides the number by 1,000.
 >> Text(1234567891234, "0,0,,,""dollar""\z\M")
@@ -789,138 +789,138 @@ Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14
 
 // 5 digit month not supported yet
 >> Text(70.125, "MMMMM DD YYY")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "mmmmm dd yyy")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "MMMMM DDD YYY")
-Errors: Error 0-29: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "mmmmm ddd yyy")
-Errors: Error 0-29: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "MMMMM DDD YY")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "mmmmm ddd yy")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "MMMMM DDD YYYY")
-Errors: Error 0-30: The function 'Text' has some invalid arguments.|Warning 13-29: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-29: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "mmmmm ddd yyyy")
-Errors: Error 0-30: The function 'Text' has some invalid arguments.|Warning 13-29: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-29: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "MMMMM DDDD YYYY")
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 13-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-30: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "mmmmm dddd yyyy")
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 13-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-30: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "MMMMM D YYYY")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(70.125, "mmmmm d yyyy")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(68.125, "MMMMM D YYYY")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(68.125, "mmmmm d yyyy")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(68.125, "MMMMMM D YYYY")
-Errors: Error 0-29: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
 
 >> Text(68.125, "mmmmmm d yyyy")
-Errors: Error 0-29: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-28: Incorrect format specifier for 'Text'.
 
 >> Text(68.125, "mMmMmmMM d yyyy")
-Errors: Error 0-31: The function 'Text' has some invalid arguments.|Warning 13-30: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-30: Incorrect format specifier for 'Text'.
 
 >> Text(68.125, "MMMmm d yyyy")
-Errors: Error 0-28: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-27: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, MMMMM dd, yyyy hh:mm:ss")
-Errors: Error 0-71: The function 'Text' has some invalid arguments.|Warning 39-70: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-70: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, MMMM dd, yyyy hh:mmmmm:ss")
-Errors: Error 0-73: The function 'Text' has some invalid arguments.|Warning 39-72: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-72: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"yyyy-mmmmm-dd hh:mm:ss")
-Errors: Error 0-64: The function 'Text' has some invalid arguments.|Warning 39-63: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-63: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"yyyy-mmmm-dd hh:mmmmmm:ss")
-Errors: Error 0-67: The function 'Text' has some invalid arguments.|Warning 39-66: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-66: Incorrect format specifier for 'Text'.
 
 // Lowercase am/pm and a/p are not supported, C# has no lowercase representation
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/p")
-Errors: Error 0-47: The function 'Text' has some invalid arguments.|Warning 40-46: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-46: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/p")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 40-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-47: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "h:mm a/p")
-Errors: Error 0-51: The function 'Text' has some invalid arguments.|Warning 40-50: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-50: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "H:MM a/p")
-Errors: Error 0-51: The function 'Text' has some invalid arguments.|Warning 40-50: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-50: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/p")
-Errors: Error 0-52: The function 'Text' has some invalid arguments.|Warning 40-51: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-51: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "HH:MM a/p")
-Errors: Error 0-52: The function 'Text' has some invalid arguments.|Warning 40-51: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-51: Incorrect format specifier for 'Text'.
 
 >> Text(70.82430555555555555555555,"h:mm:ss a/p")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 32-45: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-45: Incorrect format specifier for 'Text'.
 
 >> Text(70.32430555555555555555555,"h:mm:ss a/p")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 32-45: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-45: Incorrect format specifier for 'Text'.
 
 >> Text(70.82430555555555555555555,"h:mm:ss am/pm")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
 
 >> Text(70.32430555555555555555555,"h:mm:ss am/pm")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
 
 >> Text(70.32430555555555555555555,"h:mm:ss Am/Pm")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
 
 >> Text(70.32430555555555555555555,"h:mm:ss aM/pM")
-Errors: Error 0-48: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
 
 >> Text(70.32430555555555555555555,"h:mm:ss a/p", "vi-VN")
-Errors: Error 0-55: The function 'Text' has some invalid arguments.|Warning 32-45: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-45: Incorrect format specifier for 'Text'.
 
 >> Text(70.32430555555555555555555,"h:mm:ss am/pm", "vi-VN")
-Errors: Error 0-57: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 32-47: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "ha/putc")
-Errors: Error 0-50: The function 'Text' has some invalid arguments.|Warning 40-49: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-49: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hha/putc")
-Errors: Error 0-51: The function 'Text' has some invalid arguments.|Warning 40-50: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-50: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0), "hh:mm a/putc")
-Errors: Error 0-55: The function 'Text' has some invalid arguments.|Warning 40-54: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 40-54: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, mmmm dd, yyyy hh:mm:ss a/p")
-Errors: Error 0-74: The function 'Text' has some invalid arguments.|Warning 39-73: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-73: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, mmmm dd, yyyy hh:mm:ss am/pm")
-Errors: Error 0-76: The function 'Text' has some invalid arguments.|Warning 39-75: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-75: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, mmmm dd, yyyy hh:mm:ss aM/pM")
-Errors: Error 0-76: The function 'Text' has some invalid arguments.|Warning 39-75: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-75: Incorrect format specifier for 'Text'.
 
 >> Text(DateTime(1983, 6, 3, 2, 53, 9, 0),"dddd, mmmm dd, yyyy hh:mm:ss Am/Pm")
-Errors: Error 0-76: The function 'Text' has some invalid arguments.|Warning 39-75: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 39-75: Incorrect format specifier for 'Text'.
 
 >> Text(1, 
   "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm")
-Errors: Error 0-124: The function 'Text' has some invalid arguments.|Warning 11-123: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 11-123: Incorrect format specifier for 'Text'.
 
 // DateTimeFormat Enum
 >> Text(DateTimeValue(Blank()), DateTimeFormat.LongDate)
@@ -1036,175 +1036,175 @@ true
 
 // Block exponential notation with decimals, escaping character and scaling modifier
 >> Text(1234567.1234567, "0.00E+0.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000E+0.000")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#E+#.00")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0E+#.0")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0E+0.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#E+#.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00E-0.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000E-0.000")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#E-#.00")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0E-#.0")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0E-0.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#E-#.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00e+0.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000e+0.000")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#e+#.00")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0e+#.0")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0e+0.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#e+#.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00e-0.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000e-0.000")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#e-#.00")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0e-#.0")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0e-0.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#e-#.00")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00E+0\.0")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000E+0\.000")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#E+#\.00")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0E+#\.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0E+0\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#E+#\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00E-0\.0")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000E-0\.000")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#E-#\.00")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0E-#\.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0E-0\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#E-#\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00e+0\.0")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000e+0\.000")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#e+#\.00")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0e+#\.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0e+0\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#e+#\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00e-0\.0")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000e-0\.000")
-Errors: Error 0-38: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-37: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#e-#\.00")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0e-#\.0")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0e-0\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#e-#\.00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00e-0\k0")
-Errors: Error 0-35: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000e-0""k""000")
-Errors: Error 0-41: The function 'Text' has some invalid arguments.|Warning 22-40: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-40: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0e-0\k00")
-Errors: Error 0-33: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-32: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#e-#""k""00")
-Errors: Error 0-36: The function 'Text' has some invalid arguments.|Warning 22-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-35: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.00E+00%")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.000E+0000%")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#.#E+#00%")
-Errors: Error 0-34: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-33: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0.0E+#%")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "0E+000%")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#E+#00%")
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-31: Incorrect format specifier for 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat_PowerFxV1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_ExcelCompat_PowerFxV1CompatDisabled.txt
@@ -4,7 +4,7 @@
 >> Text(1234.5678, "$-fr-FR] # ##0,00", "vi-VI")
 Error({Kind:ErrorKind.InvalidArgument})
 
->> Text(1234567.89, "[$-fr-FR]# ###,## €", "fr-FR")
+>> Text(1234567.89, "[$-fr-FR]# ###,## ï¿½", "fr-FR")
 Error({Kind:ErrorKind.InvalidArgument})
 
 // Not support format string for non numeric/datetime/date/time
@@ -480,10 +480,10 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> Text("asdf", "##;(##);ZZZ;""AAA """)
-Errors: Error 0-36: The function 'Text' has some invalid arguments.|Warning 13-35: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-35: Incorrect format specifier for 'Text'.
 
 >> Text("asdf", "##;(##);ZZZ;""AAA ""@")
-Errors: Error 0-37: The function 'Text' has some invalid arguments.|Warning 13-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 13-36: Incorrect format specifier for 'Text'.
 
 >> Text("asdf", "##;(##);ZZZ")
 Error({Kind:ErrorKind.InvalidArgument})
@@ -505,8 +505,8 @@ Error({Kind:ErrorKind.InvalidArgument})
 >> Text(1234567.1234567, "[$-de-DE]$ #,####.0000")
 Error({Kind:ErrorKind.InvalidArgument})
 
-// Excel: "€ 1,234,567.1235"
->> Text(1234567.1234567, "[$€-fr-FR] #,####.0000")
+// Excel: "ï¿½ 1,234,567.1235"
+>> Text(1234567.1234567, "[$ï¿½-fr-FR] #,####.0000")
 Error({Kind:ErrorKind.InvalidArgument})
 
 // Excel: " 3"
@@ -669,53 +669,53 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 // Literal characters conflicting with date/time format specifiers.
 >> Text(72, "# \m")
-Errors: Error 0-16: The function 'Text' has some invalid arguments.|Warning 9-15: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-15: Incorrect format specifier for 'Text'.
 
 >> Text(72, "# \y")
-Errors: Error 0-16: The function 'Text' has some invalid arguments.|Warning 9-15: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-15: Incorrect format specifier for 'Text'.
 
 >> Text(72, "# y")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
 
 >> Text(72, "# m")
-Errors: Error 0-15: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 9-14: Incorrect format specifier for 'Text'.
 
 // Scaling factor.  Each comma on the end divides the number by 1,000.
 >> Text(1234567891234, "0,0,,,""dollar""\z\M")
-Errors: Error 0-43: The function 'Text' has some invalid arguments.|Warning 20-42: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 20-42: Incorrect format specifier for 'Text'.
 
 >> Text(1234567891234, "0,0,""dollar"",\z,\M")
-Errors: Error 0-43: The function 'Text' has some invalid arguments.|Warning 20-42: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 20-42: Incorrect format specifier for 'Text'.
 
 >> Text(1234567891234, "0,0,""dollar"",\z,z""P""\M")
-Errors: Error 0-49: The function 'Text' has some invalid arguments.|Warning 20-48: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 20-48: Incorrect format specifier for 'Text'.
 
 >> Text(1234567891234, "\K#\M,,,z'""TH""")
-Errors: Error 0-39: The function 'Text' has some invalid arguments.|Warning 20-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 20-38: Incorrect format specifier for 'Text'.
 
 >> Text(1234567891234, "\K#\M,,z'""TH"",")
-Errors: Error 0-39: The function 'Text' has some invalid arguments.|Warning 20-38: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 20-38: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.##################,,,z'\k\m")
-Errors: Error 0-56: The function 'Text' has some invalid arguments.|Warning 22-55: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-55: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.###,###,###,###,###,###,,,z'\k\m")
-Errors: Error 0-61: The function 'Text' has some invalid arguments.|Warning 22-60: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-60: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.##################,,,z'\k\m""am""")
-Errors: Error 0-62: The function 'Text' has some invalid arguments.|Warning 22-61: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-61: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.##################,,,z'\k\m\d\y""am""")
-Errors: Error 0-66: The function 'Text' has some invalid arguments.|Warning 22-65: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-65: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.##################,z'\k\m,\d\y,""am"",")
-Errors: Error 0-67: The function 'Text' has some invalid arguments.|Warning 22-66: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-66: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.###############,###,z'\k\m,\d\y,""am"",")
-Errors: Error 0-68: The function 'Text' has some invalid arguments.|Warning 22-67: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-67: Incorrect format specifier for 'Text'.
 
 >> Text(1234567.1234567, "#,#.###,###,###,###,###,###,z'\k\m,\d\y,""am"",")
-Errors: Error 0-72: The function 'Text' has some invalid arguments.|Warning 22-71: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 22-71: Incorrect format specifier for 'Text'.
 
 // 5 digit month not supported yet
 >> Text(70.125, "MMMMM DD YYY")

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format.txt
@@ -395,7 +395,7 @@
 "1983-06-03 00:28:07.500"
 
 >> Text(1, "00.00 dd-mm-yyyy")
-Errors: Error 0-27: The function 'Text' has some invalid arguments.|Warning 8-26: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-26: Incorrect format specifier for 'Text'.
 
 >> Text(Time(2, 53, 9, 3), "mm:ss.00") 
 "53:09.00"

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format_PowerFxV1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Text_Format_PowerFxV1Compat.txt
@@ -1,25 +1,25 @@
 #SETUP: PowerFxV1CompatibilityRules
 
 >> Text(123.466, "[$-en-US]$#0.0M") 
-Errors: Error 0-32: The function 'Text' has some invalid arguments.|Warning 14-31: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 14-31: Incorrect format specifier for 'Text'.
 
 >> Text(1, "M#")
-Errors: Error 0-13: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 8-12: Incorrect format specifier for 'Text'.
 
 // If have empty language code, throw error
 >> Text(1234.5678,"[$-]")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
 
 // If not closed by a ']', throw error
 >> Text(1234.5678,"[$-a")
-Errors: Error 0-22: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 15-21: Incorrect format specifier for 'Text'.
 
 // If not closed by a ']', throw error
 >> Text(1234.5678, "[$-en-US#,##0.00", "en-US")
-Errors: Error 0-44: The function 'Text' has some invalid arguments.|Warning 16-34: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-34: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-]fr-FR # ##0,00", "vi-VI")
-Errors: Error 0-46: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-36: Incorrect format specifier for 'Text'.
 
 >> Text(1234.5678, "[$-fr-FR][$-en-US] # ##0,00", "vi-VI")
-Errors: Error 0-55: The function 'Text' has some invalid arguments.|Warning 16-45: Incorrect format specifier for 'Text'.
+Errors: Error 0-4: The function 'Text' has some invalid arguments.|Warning 16-45: Incorrect format specifier for 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Trace.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Trace.txt
@@ -37,7 +37,7 @@ Errors: Error 72-116: The 'trace_options' parameter to the Trace function must b
 Error({Kind:ErrorKind.Div0})
 
 >> Trace("test2", TraceSeverity.Critical, Float(1/0), TraceOptions.None) ; traceRecord;
-Errors: Error 39-49: Invalid argument type (Number). Expecting a Record value instead.|Error 0-69: The function 'Trace' has some invalid arguments.
+Errors: Error 39-49: Invalid argument type (Number). Expecting a Record value instead.|Error 0-5: The function 'Trace' has some invalid arguments.
 
 >> Trace(Blank(), TraceSeverity.Critical, Blank(), TraceOptions.None) ; traceRecord;
 {customRecord:"{}",message:"",severity:-1}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Trace_StronglyTypedBuiltinEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Trace_StronglyTypedBuiltinEnums.txt
@@ -13,7 +13,7 @@
 {customRecord:"{f1:Decimal(1),f2:""test""}",message:"test1",severity:1}
 
 >> Trace("test1", Float(1/0), {f1: Float(1), f2: "test"}, "1") ; traceRecord;
-Errors: Error 15-25: Invalid argument type (Number). Expecting a Enum (TraceSeverity) value instead.|Error 55-58: Invalid argument type (Text). Expecting a Enum (TraceOptions) value instead.|Error 0-59: The function 'Trace' has some invalid arguments.
+Errors: Error 15-25: Invalid argument type (Number). Expecting a Enum (TraceSeverity) value instead.|Error 55-58: Invalid argument type (Text). Expecting a Enum (TraceOptions) value instead.|Error 0-5: The function 'Trace' has some invalid arguments.
 
 >> Trace("test1", Decimal(1), {f1: Float(1), f2: "test"}, "1") ; traceRecord;
-Errors: Error 15-25: Invalid argument type (Decimal). Expecting a Enum (TraceSeverity) value instead.|Error 55-58: Invalid argument type (Text). Expecting a Enum (TraceOptions) value instead.|Error 0-59: The function 'Trace' has some invalid arguments.
+Errors: Error 15-25: Invalid argument type (Decimal). Expecting a Enum (TraceSeverity) value instead.|Error 55-58: Invalid argument type (Text). Expecting a Enum (TraceOptions) value instead.|Error 0-5: The function 'Trace' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/switch.txt
@@ -305,7 +305,7 @@ DateTime(2001,4,1,10,0,0,0)
 
 // Result of switch can't be consumed.
 >> Abs(Switch(1, 1, -2, {x:4}))
-Errors: Error 0-28: The function 'Abs' has some invalid arguments.|Error 4-27: Invalid argument type (Void). Expecting a Decimal value instead.
+Errors: Error 0-3: The function 'Abs' has some invalid arguments.|Error 4-27: Invalid argument type (Void). Expecting a Decimal value instead.
 
 // Expression generating void value can be used inside of the switch. If(1<0, 1, {x:1}) => void value
 >> Switch(1, 1, 2, If(1<0, 1, {x:4}))
@@ -320,7 +320,7 @@ Error({Kind:ErrorKind.Div0})
 If(true, {test:1}, "Void value (result of the expression can't be used).")
 
 >> Switch("a", "a", 2, {x:4}, 3)
-Errors: Error 20-25: Invalid argument type (Record). Expecting a Text value instead.|Error 0-29: The function 'Switch' has some invalid arguments.
+Errors: Error 20-25: Invalid argument type (Record). Expecting a Text value instead.|Error 0-6: The function 'Switch' has some invalid arguments.
 
 >> Switch(1, 2, 2, 3, b)
-Errors: Error 19-20: Name isn't valid. 'b' isn't recognized.|Error 0-21: The function 'Switch' has some invalid arguments.
+Errors: Error 19-20: Name isn't valid. 'b' isn't recognized.|Error 0-6: The function 'Switch' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/ClearCollect.txt
@@ -41,19 +41,19 @@ Errors: Error 0-24: Invalid number of arguments: received 3, expected 2.
 Errors: Error 0-30: Invalid number of arguments: received 3, expected 2.
 
 >> ClearCollect(t1, "x")
-Errors: Error 17-20: Invalid argument type (Text). Expecting a Record value instead.|Error 17-20: Invalid argument type. Cannot use Text values in this context.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-20: Invalid argument type (Text). Expecting a Record value instead.|Error 17-20: Invalid argument type. Cannot use Text values in this context.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(t1, 1)
-Errors: Error 17-18: Invalid argument type (Decimal). Expecting a Record value instead.|Error 17-18: Invalid argument type. Cannot use Decimal values in this context.|Error 0-19: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-18: Invalid argument type (Decimal). Expecting a Record value instead.|Error 17-18: Invalid argument type. Cannot use Decimal values in this context.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(t1, Float(1))
-Errors: Error 17-25: Invalid argument type (Number). Expecting a Record value instead.|Error 17-25: Invalid argument type. Cannot use Number values in this context.|Error 0-26: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-25: Invalid argument type (Number). Expecting a Record value instead.|Error 17-25: Invalid argument type. Cannot use Number values in this context.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(t1, true)
-Errors: Error 17-21: Invalid argument type (Boolean). Expecting a Record value instead.|Error 17-21: Invalid argument type. Cannot use Boolean values in this context.|Error 0-22: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-21: Invalid argument type (Boolean). Expecting a Record value instead.|Error 17-21: Invalid argument type. Cannot use Boolean values in this context.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Table({name: "VC"}), {surname: "textInput1"})
-Errors: Error 34-57: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 13-32: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-58: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 34-57: The specified column 'surname' does not exist. The column with the most similar name is 'name'.|Error 13-32: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> Set(temp2, [{name:"hello"}])
 Table({name:"hello"})
@@ -62,31 +62,31 @@ Table({name:"hello"})
 Errors: Error 13-29: The value passed to the 'ClearCollect' function cannot be changed.
 
 >> ClearCollect(Foo,r1)
-Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-19: The specified column 'a' does not exist.|Error 0-20: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-19: The specified column 'a' does not exist.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Foo,Bar)
-Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-20: Name isn't valid. 'Bar' isn't recognized.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 13-16: Name isn't valid. 'Foo' isn't recognized.|Error 17-20: Name isn't valid. 'Bar' isn't recognized.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(1/0,Foo)
-Errors: Error 17-20: Name isn't valid. 'Foo' isn't recognized.|Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 14-15: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-21: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 17-20: Name isn't valid. 'Foo' isn't recognized.|Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 14-15: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Float(1)/0,Foo)
-Errors: Error 24-27: Name isn't valid. 'Foo' isn't recognized.|Error 21-22: Invalid argument type (Number). Expecting a Table value instead.|Error 21-22: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-28: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 24-27: Name isn't valid. 'Foo' isn't recognized.|Error 21-22: Invalid argument type (Number). Expecting a Table value instead.|Error 21-22: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Error({Kind:ErrorKind.Custom}), r1)
-Errors: Error 45-47: The specified column 'a' does not exist.|Error 13-43: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-48: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 45-47: The specified column 'a' does not exist.|Error 13-43: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Error({Kind:ErrorKind.Custom}), Error({Kind:ErrorKind.Div0}))
 Errors: Error 13-43: The value passed to the 'ClearCollect' function cannot be changed.
 
 >> ClearCollect(Blank(), r1)
-Errors: Error 22-24: The specified column 'a' does not exist.|Error 13-20: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-25: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 22-24: The specified column 'a' does not exist.|Error 13-20: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(Blank(), Blank())
 Errors: Error 13-20: The value passed to the 'ClearCollect' function cannot be changed.
 
 >> ClearCollect("", "")
-Errors: Error 13-15: Invalid argument type (Text). Expecting a Table value instead.|Error 17-19: Invalid argument type (Text). Expecting a Record value instead.|Error 17-19: Invalid argument type. Cannot use Text values in this context.|Error 13-15: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-20: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 13-15: Invalid argument type (Text). Expecting a Table value instead.|Error 17-19: Invalid argument type (Text). Expecting a Record value instead.|Error 17-19: Invalid argument type. Cannot use Text values in this context.|Error 13-15: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.
 
 >> ClearCollect(If(false,Blank()),r1)
-Errors: Error 31-33: The specified column 'a' does not exist.|Error 13-30: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-34: The function 'ClearCollect' has some invalid arguments.
+Errors: Error 31-33: The specified column 'a' does not exist.|Error 13-30: The value passed to the 'ClearCollect' function cannot be changed.|Error 0-12: The function 'ClearCollect' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
@@ -49,7 +49,7 @@ Blank()
 Table({Value:1},{Value:2},{Value:3})
 
 >> Collect(temp1,{Value:"200"}).Value
-Errors: Error 14-27: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-28: The function 'Collect' has some invalid arguments.|Error 28-34: Name isn't valid. 'Value' isn't recognized.
+Errors: Error 14-27: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-7: The function 'Collect' has some invalid arguments.|Error 28-34: Name isn't valid. 'Value' isn't recognized.
 
 >> Collect( temp1, { Value:"11"+0 } )
 {Value:11}

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Collect.txt
@@ -34,7 +34,7 @@ Table({Value:1},{Value:2},{Value:3},{Value:99},{Value:88},{Value:77},{Value:77},
 Errors: Error 8-15: The value passed to the 'Collect' function cannot be changed.
 
 >> Collect([1,2,3],{Value:Date(2023,3,1)})
-#SKIP Issue 1205 expecting no error.  Old error: Errors: Error 16-38: Incompatible type. The 'Value' column in the data source you’re updating expects a 'Decimal' type and you’re using a 'Date' type.|Error 0-39: The function 'Collect' has some invalid arguments.
+#SKIP Issue 1205 expecting no error.  Old error: Errors: Error 16-38: Incompatible type. The 'Value' column in the data source you’re updating expects a 'Decimal' type and you’re using a 'Date' type.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Collect(Table({x:1,y:2}), {x: 3}).y 
 Errors: Error 8-24: The value passed to the 'Collect' function cannot be changed.
@@ -58,13 +58,13 @@ Errors: Error 14-27: The type of this argument 'Value' does not match the expect
 Table({Value:1},{Value:2},{Value:3})
 
 >> Collect( temp1, {Value:"200"}); temp1
-Errors: Error 16-29: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-30: The function 'Collect' has some invalid arguments.
+Errors: Error 16-29: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-7: The function 'Collect' has some invalid arguments.
 
 >> Set(temp1, [1,2,3]) // Reset temp1 again
 Table({Value:1},{Value:2},{Value:3})
 
 >> Collect(temp1,{Value:"run time error"}).Value
-Errors: Error 14-38: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-39: The function 'Collect' has some invalid arguments.|Error 39-45: Name isn't valid. 'Value' isn't recognized.
+Errors: Error 14-38: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-7: The function 'Collect' has some invalid arguments.|Error 39-45: Name isn't valid. 'Value' isn't recognized.
 
 >> Set(partialT1, Table({a:1,b:1},{a:2,b:2}))
 Table({a:1,b:1},{a:2,b:2})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Patch_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/MutationScripts/Patch_V1Compat.txt
@@ -37,13 +37,13 @@ Table({b:true,d:1,t:"hi"},{b:false,d:2,t:"back"},{b:Blank(),d:3,t:"cycle"})
 Table({b:true,d:1,t:"hi"},{b:Blank(),d:12,t:"different"},{b:Blank(),d:3,t:"cycle"})
 
 >> Patch( y, Index(y,2), {b:1,d:"23",t:DateTime(2002,2,2,2,2,2)})
-Errors: Error 22-61: The type of this argument 'd' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-62: The function 'Patch' has some invalid arguments.
+Errors: Error 22-61: The type of this argument 'd' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> 5;y
 Table({b:true,d:1,t:"hi"},{b:Blank(),d:12,t:"different"},{b:Blank(),d:3,t:"cycle"})
 
 >> Patch( y, Index(y,3), {b:"0",d:true,t:GUID("1d9ec9bf-3b8b-4ff3-bac4-c2a723a0f49c")} )
-Errors: Error 22-83: The type of this argument 'b' does not match the expected type 'Boolean'. Found type 'Text'.|Error 0-85: The function 'Patch' has some invalid arguments.
+Errors: Error 22-83: The type of this argument 'b' does not match the expected type 'Boolean'. Found type 'Text'.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 // should not have been changed from the previous patch
 >> 6;y
@@ -80,7 +80,7 @@ Error({Kind:ErrorKind.NotFound})
 Table({Value:1},{Value:88},{Value:3})
 
 >> Patch(x.t, {Value:88}, {Value:"77"})
-Errors: Error 23-35: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-36: The function 'Patch' has some invalid arguments.
+Errors: Error 23-35: The type of this argument 'Value' does not match the expected type 'Decimal'. Found type 'Text'.|Error 0-5: The function 'Patch' has some invalid arguments.
 
 >> 4;x.t
 Table({Value:1},{Value:88},{Value:3})


### PR DESCRIPTION
Moves the error span for "some invalid arguments" to just the head of the call node, so it doesn't hide/distract from other more specific errors in the formula bar