### PR TITLE
Ensure AssociatedDataSources is nonnull even for DType.Invalid

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -210,6 +210,7 @@ namespace Microsoft.PowerFx.Core.Types
         // Constructor for the single invalid DType sentinel value.
         private DType()
         {
+            AssociatedDataSources = new HashSet<IExternalTabularDataSource>();
         }
 
         internal DType(DKind kind)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TypeSystemTests/DTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TypeSystemTests/DTypeTests.cs
@@ -233,6 +233,40 @@ namespace Microsoft.PowerFx.Tests
         }
 
         [Fact]
+        public void TestAllAssociatedDataSourcesNonNull()
+        {
+            Assert.NotNull(DType.Unknown.AssociatedDataSources);
+            Assert.NotNull(DType.Error.AssociatedDataSources);
+            Assert.NotNull(DType.Number.AssociatedDataSources);
+            Assert.NotNull(DType.Boolean.AssociatedDataSources);
+            Assert.NotNull(DType.String.AssociatedDataSources);
+            Assert.NotNull(DType.Hyperlink.AssociatedDataSources);
+            Assert.NotNull(DType.Image.AssociatedDataSources);
+            Assert.NotNull(DType.PenImage.AssociatedDataSources);
+            Assert.NotNull(DType.Media.AssociatedDataSources);
+            Assert.NotNull(DType.Guid.AssociatedDataSources);
+            Assert.NotNull(DType.Blob.AssociatedDataSources);
+            Assert.NotNull(DType.Color.AssociatedDataSources);
+            Assert.NotNull(DType.Currency.AssociatedDataSources);
+            Assert.NotNull(DType.Decimal.AssociatedDataSources);
+            Assert.NotNull(DType.DateTime.AssociatedDataSources);
+            Assert.NotNull(DType.EmptyRecord.AssociatedDataSources);
+            Assert.NotNull(DType.EmptyTable.AssociatedDataSources);
+            Assert.NotNull(DType.EmptyEnum.AssociatedDataSources);
+            Assert.NotNull(AttachmentTableType.AssociatedDataSources);
+            Assert.NotNull(AttachmentRecordType.AssociatedDataSources);
+            Assert.NotNull(OptionSetType.AssociatedDataSources);
+            Assert.NotNull(MultiSelectOptionSetType.AssociatedDataSources);
+            Assert.NotNull(DType.Date.AssociatedDataSources);
+            Assert.NotNull(DType.Time.AssociatedDataSources);
+            Assert.NotNull(DType.Polymorphic.AssociatedDataSources);
+            Assert.NotNull(DType.NamedValue.AssociatedDataSources);
+            Assert.NotNull(DType.Deferred.AssociatedDataSources);
+            Assert.NotNull(DType.Void.AssociatedDataSources);
+            Assert.NotNull(DType.Invalid.AssociatedDataSources);
+        }
+
+        [Fact]
         public void ErrorIsSupertypeOfAll()
         {
             foreach (var dType in _dTypes)


### PR DESCRIPTION
Fixes a longstanding intermmitent Arg Null Exception we've seen, when DType.Invalid leaks into the system. 