### PR TITLE
Fix incorrect warnings from Table function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -8,7 +8,6 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
-using Microsoft.PowerFx.Core.Functions.FunctionArgValidators;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -115,11 +115,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (var i = 0; i < argTypes.Length; i++)
             {
-                var ads = argTypes[i].AssociatedDataSources?.FirstOrDefault();
-
-                var isDelegable = ArgValidators.DelegatableDataSourceInfoValidator.TryGetValidValue(args[i], binding, out _);
-
-                if (argTypes[i].IsTableNonObjNull && ads is IExternalTabularDataSource)
+                // show warning when the node is pageable as data would be truncated at this point
+                if (argTypes[i].IsTableNonObjNull && binding.IsPageable(args[i]))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Warning, args[i], TexlStrings.ErrTruncatedArgWarning, args[i].ToString(), Name);
                     continue;

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (var i = 0; i < argTypes.Length; i++)
             {
-                // show warning when the node is pageable as data would be truncated at this point
+                // show warning when the node is pageable as data could be truncated at this point
                 if (argTypes[i].IsTableNonObjNull && binding.IsPageable(args[i]))
                 {
                     errors.EnsureError(DocumentErrorSeverity.Warning, args[i], TexlStrings.ErrTruncatedArgWarning, args[i].ToString(), Name);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Table.cs
@@ -8,6 +8,7 @@ using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Functions.FunctionArgValidators;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
@@ -115,6 +116,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             for (var i = 0; i < argTypes.Length; i++)
             {
                 var ads = argTypes[i].AssociatedDataSources?.FirstOrDefault();
+
+                var isDelegable = ArgValidators.DelegatableDataSourceInfoValidator.TryGetValidValue(args[i], binding, out _);
 
                 if (argTypes[i].IsTableNonObjNull && ads is IExternalTabularDataSource)
                 {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/Helpers/TestTabularDataSource.cs
@@ -205,7 +205,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         public DType Type { get; }
 
-        public bool IsPageable => false;
+        public virtual bool IsPageable => false;
 
         public virtual TabularDataQueryOptions QueryOptions => _tabularDataQueryOptions;
 
@@ -290,17 +290,21 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
     {
         private readonly TabularDataQueryOptions _queryOptions;
         private readonly IDelegationMetadata _delegationMetadata;
+        private readonly bool _isPageable;
 
-        internal TestDelegableDataSource(string name, DType schema, IDelegationMetadata delegationMetadata)
+        internal TestDelegableDataSource(string name, DType schema, IDelegationMetadata delegationMetadata, bool isPageable = false)
             : base(name, schema)
         {
             _queryOptions = new TabularDataQueryOptions(this);
             _delegationMetadata = delegationMetadata;
+            _isPageable = isPageable;
         }
 
         public override bool IsSelectable => true;
 
         public override bool IsDelegatable => true;
+
+        public override bool IsPageable => _isPageable;
 
         public override bool CanIncludeSelect(string selectColumnName)
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -4198,7 +4198,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Table([], Table([], Search(DS, \"Foo\", Name)))", "*[Id:n, Name:s, Age:n]", 1)]
         [InlineData("Table(Search(DS, \"Foo\", Name), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 1)]
 
-        // existing warning due to sqrt should propogate, no new warnigns on table
+        // existing warning due to sqrt should propagate, no new warnigns on table
         [InlineData("Table(Filter(DS, Sqrt(Age) > 5), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 1)]
         public void TexlFunctionTypeSemanticsTable_PageableInputs(string script, string expectedSchema, int errorCount)
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -2479,16 +2479,29 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Table(First(DS))", "*[Id:n, Name:s, Age:n]")]
         [InlineData("Table(First(DS), Last(DS))", "*[Id:n, Name:s, Age:n]")]
         [InlineData("Table(Last(DS), {count: CountRows(DS)})", "*[Id:n, Name:s, Age:n, count:n]")]
+        [InlineData("With({majors: Filter(DS, Age >= 18)},Table(majors,{Id:0, Name: \"Other\", Age:100}))", "*[Id:n, Name:s, Age:n]")]
         public void TexlFunctionTypeSemanticsTable(string script, string expectedType)
         {
-            var symbol = new SymbolTable();
+            var symbol = new DelegatableSymbolTable();
             symbol.AddVariable("T1", new TableType(TestUtils.DT("*[a:n, b:n, c:n]")));
             symbol.AddVariable("T2", new TableType(TestUtils.DT("*[a:n, b:b, c:s]")));
             symbol.AddVariable("T3", new TableType(TestUtils.DT("*[d:n]")));
             symbol.AddVariable("T4", new TableType(TestUtils.DT("*[a:s]")));
 
             var dataSourceSchema = TestUtils.DT("*[Id:n, Name:s, Age:n]");
-            symbol.AddEntity(new TestDataSource("DS", dataSourceSchema));
+            symbol.AddEntity(new TestDelegableDataSource(
+                    "DS",
+                    dataSourceSchema,
+                    new TestDelegationMetadata(
+                        new DelegationCapability(DelegationCapability.Filter | DelegationCapability.Count),
+                        dataSourceSchema,
+                        new FilterOpMetadata(
+                            dataSourceSchema,
+                            new Dictionary<DPath, DelegationCapability>(),
+                            new Dictionary<DPath, DelegationCapability>(),
+                            new DelegationCapability(DelegationCapability.Equal | DelegationCapability.GreaterThanOrEqual),
+                            null)),
+                    true));
 
             Assert.True(DType.TryParse(expectedType, out DType type));
             Assert.True(type.IsValid);
@@ -4180,29 +4193,34 @@ namespace Microsoft.PowerFx.Core.Tests
         [Theory]
         [InlineData("Table(DS, Blank())", "*[Id:n, Name:s, Age:n]", 1)]
         [InlineData("Table(DS, T1)", "*[Id:n, Name:s, Age:n, a:n, b:s]", 1)]
-        [InlineData("Table(DS, Filter(DS, \"Foo\" in Name))", "*[Id:n, Name:s, Age:n]", 2)]
-        [InlineData("Table([], Table(DS, []))", "*[Id:n, Name:s, Age:n]", 2)]
-        [InlineData("Table([], Table([], Search(DS, \"Foo\", Name)))", "*[Id:n, Name:s, Age:n]", 2)]
-        [InlineData("Table([], FirstN(DS, 5))", "*[Id:n, Name:s, Age:n]", 1)]
-        [InlineData("Table(Search(DS, \"Foo\", Name), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 2)]
-        [InlineData("Table(Filter(DS, Sqrt(Age) > 5), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 2)]
-        public void TexlFunctionTypeSemanticsTable_Delegation(string script, string expectedSchema, int errorCount)
-        {
-            var schema = TestUtils.DT("*[Id:n, Name:s, Age:n]");
+        [InlineData("Table(DS, Filter(DS, Name = \"Foo\"))", "*[Id:n, Name:s, Age:n]", 2)]
+        [InlineData("Table([], Table(DS, []))", "*[Id:n, Name:s, Age:n]", 1)]
+        [InlineData("Table([], Table([], Search(DS, \"Foo\", Name)))", "*[Id:n, Name:s, Age:n]", 1)]
+        [InlineData("Table(Search(DS, \"Foo\", Name), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 1)]
 
-            var symbol = new SymbolTable();
+        // existing warning due to sqrt should propogate, no new warnigns on table
+        [InlineData("Table(Filter(DS, Sqrt(Age) > 5), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 1)]
+        public void TexlFunctionTypeSemanticsTable_PageableInputs(string script, string expectedSchema, int errorCount)
+        {
+            var dataSourceSchema = TestUtils.DT("*[Id:n, Name:s, Age:n]");
+
+            var symbol = new DelegatableSymbolTable();
             symbol.AddEntity(new TestDelegableDataSource(
                     "DS",
-                    schema,
+                    dataSourceSchema,
                     new TestDelegationMetadata(
                         DelegationCapability.Filter,
-                        schema,
+                        dataSourceSchema,
                         new FilterOpMetadata(
-                            schema,
+                            dataSourceSchema,
                             new Dictionary<DPath, DelegationCapability>(),
-                            new Dictionary<DPath, DelegationCapability>(),
-                            new DelegationCapability(DelegationCapability.Equal | DelegationCapability.StartsWith),
-                            null))));
+                            new Dictionary<DPath, DelegationCapability>
+                            {
+                                { DPath.Root.Append(new DName("Name")), new DelegationCapability(DelegationCapability.Filter | DelegationCapability.Contains) }
+                            },
+                            new DelegationCapability(DelegationCapability.Equal),
+                            null)),
+                    true));
 
             symbol.AddVariable("T1", new TableType(TestUtils.DT("*[a:n, b:s]")));
 
@@ -4311,6 +4329,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var opts = new ParserOptions() { NumberIsFloat = numberIsFloat };
             var result = engine.Check(script, opts);
             Assert.Equal(expectedType, result.Binding.ResultType);
+            Assert.False(result.Binding.ErrorContainer.HasErrors());
             Assert.True(result.IsSuccess);
         }
     }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -4188,10 +4188,22 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Table(Filter(DS, Sqrt(Age) > 5), FirstN(LastN(DS, 10), 5))", "*[Id:n, Name:s, Age:n]", 2)]
         public void TexlFunctionTypeSemanticsTable_Delegation(string script, string expectedSchema, int errorCount)
         {
-            var dataSourceSchema = TestUtils.DT("*[Id:n, Name:s, Age:n]");
+            var schema = TestUtils.DT("*[Id:n, Name:s, Age:n]");
 
             var symbol = new SymbolTable();
-            symbol.AddEntity(new TestDataSource("DS", dataSourceSchema));
+            symbol.AddEntity(new TestDelegableDataSource(
+                    "DS",
+                    schema,
+                    new TestDelegationMetadata(
+                        DelegationCapability.Filter,
+                        schema,
+                        new FilterOpMetadata(
+                            schema,
+                            new Dictionary<DPath, DelegationCapability>(),
+                            new Dictionary<DPath, DelegationCapability>(),
+                            new DelegationCapability(DelegationCapability.Equal | DelegationCapability.StartsWith),
+                            null))));
+
             symbol.AddVariable("T1", new TableType(TestUtils.DT("*[a:n, b:s]")));
 
             TestBindingWarning(


### PR DESCRIPTION
Table function gives incorrect warnings in cases like

```
With({majors: Filter(DS, Age >= 18)},Table(majors,{Id:0, Name: \"Other\", Age:100}))
```

this PR addresses this issue.

