### PR TITLE
Remove Obsolete Warnings from LSP to not break dataverse tests proj build

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -73,7 +73,13 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 
         private readonly IHostTaskExecutor _hostTaskExecutor;
 
-        [Obsolete("Use the constructor with ILanguageServerOperationHandlerFactory")]
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LanguageServer"/> class.
+        /// Note: Avoid using this constructor. It is only for backward compatibility.
+        /// </summary>
+        /// <param name="sendToClient"></param>
+        /// <param name="scopeFactory"></param>
+        /// <param name="logger"></param>
         public LanguageServer(SendToClient sendToClient, IPowerFxScopeFactory scopeFactory, Action<string> logger = null)
         {
             Contracts.AssertValue(sendToClient);
@@ -212,7 +218,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         /// Note: Do not use this overload. Move to using OnDataReceivedAsync overloads.
         /// Note: This only exists for backward compatibility and runs synchronously which could affect performance.
         /// </summary>
-        [Obsolete("Use OnDataReceivedAsync Overloads", false)]
         public void OnDataReceived(string jsonRpcPayload)
         {
             Contracts.AssertValue(jsonRpcPayload);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/TestLanguageServer.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/TestLanguageServer.cs
@@ -13,9 +13,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
     public class TestLanguageServer : LanguageServer
     {
         public TestLanguageServer(ITestOutputHelper output, SendToClient sendToClient, IPowerFxScopeFactory scopeFactory, INLHandlerFactory nlHandlerFactory = null)
-#pragma warning disable CS0618 // Type or member is obsolete
             : base(sendToClient, scopeFactory, (string s) => output.WriteLine(s))
-#pragma warning restore CS0618 // Type or member is obsolete
         {            
             NLHandlerFactory = nlHandlerFactory;
         }
@@ -32,9 +30,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         // And suppresses the call at one place only
         public new void OnDataReceived(string jsonRpcPayload)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             base.OnDataReceived(jsonRpcPayload);
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
@gregli-msft Noticed that adding obsolete on Language Server old ctor and old onDataReceived caused compiler errors/warnings in Dataverse tests projects. Removing these warnings if dataverse doesn't want to suppress it,