### PR TITLE
Avoid nullref in ErrorContainer

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
@@ -88,7 +88,9 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
 
             foreach (var err in _errors)
             {
-                if (err.Node.InTree(rootNode) && err.Severity >= severity)
+                if (err.Severity >= severity &&
+                    ((err.Node?.InTree(rootNode) ?? false) || 
+                    (err.Node == null && err.TextSpan.Min >= rootNode.GetTextSpan().Min && err.TextSpan.Lim <= rootNode.GetTextSpan().Lim)))
                 {
                     return true;
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/ErrorContainers/ErrorContainer.cs
@@ -88,9 +88,12 @@ namespace Microsoft.PowerFx.Core.App.ErrorContainers
 
             foreach (var err in _errors)
             {
+                Span nodeSpan;
                 if (err.Severity >= severity &&
                     ((err.Node?.InTree(rootNode) ?? false) || 
-                    (err.Node == null && err.TextSpan.Min >= rootNode.GetTextSpan().Min && err.TextSpan.Lim <= rootNode.GetTextSpan().Lim)))
+                    (err.Node == null && 
+                        ((nodeSpan = rootNode.GetTextSpan()) != null) &&
+                        err.TextSpan.Min >= nodeSpan.Min && err.TextSpan.Lim <= nodeSpan.Lim)))
                 {
                     return true;
                 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/BinderTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/BinderTests.cs
@@ -147,5 +147,21 @@ namespace Microsoft.PowerFx.Core.Tests
             var aNode = valueANode.ChildNodes[0];
             Assert.False(binding.IsMutable(aNode));
         }
+
+        [Fact]
+        public void TestHasErrorsInTreeCallNode()
+        {
+            var config = new PowerFxConfig();
+            var engine = new Engine(config);
+            config.SymbolTable.AddVariable("tableVar", new TableType(TestUtils.DT("*[Value:n]")));
+
+            // Function with wrong number of arguments, first error will be a token not a node error
+            var checkResult = engine.Check("FirstN([1, 2, 3, 4, 5])");
+            Assert.False(checkResult.IsSuccess);
+
+            var binding = checkResult.Binding;
+
+            Assert.True(binding.ErrorContainer.HasErrorsInTree(binding.Top));
+        }
     }
 }


### PR DESCRIPTION
This fixes a nullref that's always been possible in ErrorContainer.HaserrorsInTree Following #2284 it was more common that errors had only a token and not a node. This wasn't handled in this function. 