### PR TITLE
Adds a way Hosts can add error without extending Engine.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -94,7 +94,9 @@ namespace Microsoft.PowerFx
         /// <summary>
         /// List of error processor that will add host specific custom errors at the end of the check.
         /// </summary>
-        internal readonly IList<IPostCheckErrorHandler> PostCheckErrorHandlers = new List<IPostCheckErrorHandler>();
+        private readonly IList<IPostCheckErrorHandler> _postCheckErrorHandlers = new List<IPostCheckErrorHandler>();
+
+        public IList<IPostCheckErrorHandler> PostCheckErrorHandlers => _postCheckErrorHandlers;
         
         /// <summary>
         /// Get all functions from the config and symbol tables. 
@@ -273,9 +275,9 @@ namespace Microsoft.PowerFx
         protected virtual IEnumerable<ExpressionError> PostCheck(CheckResult check)
         {
             var hostErrors = new List<ExpressionError>();
-            foreach (var postCheckErrorHandler in PostCheckErrorHandlers)
+            foreach (var postCheckErrorHandler in _postCheckErrorHandlers)
             {
-                hostErrors.AddRange(postCheckErrorHandler.Process(check.Binding.Top));
+                hostErrors.AddRange(postCheckErrorHandler.Process(check));
             }
 
             return hostErrors;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -92,6 +92,11 @@ namespace Microsoft.PowerFx
         internal readonly List<Core.IR.IRTransform> IRTransformList = new List<Core.IR.IRTransform>();
         
         /// <summary>
+        /// List of error processor that will add host specific custom errors at the end of the check.
+        /// </summary>
+        internal readonly IList<IPostCheckErrorHandler> PostCheckErrorHandlers = new List<IPostCheckErrorHandler>();
+        
+        /// <summary>
         /// Get all functions from the config and symbol tables. 
         /// </summary>        
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -267,7 +272,13 @@ namespace Microsoft.PowerFx
         // Called after check result, can inject additional errors or constraints. 
         protected virtual IEnumerable<ExpressionError> PostCheck(CheckResult check)
         {
-            return Enumerable.Empty<ExpressionError>();
+            var hostErrors = new List<ExpressionError>();
+            foreach (var postCheckErrorHandler in PostCheckErrorHandlers)
+            {
+                hostErrors.AddRange(postCheckErrorHandler.Process(check.Binding.Top));
+            }
+
+            return hostErrors;
         }
 
         internal IEnumerable<ExpressionError> InvokePostCheck(CheckResult check)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/PostCheckErrorHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/PostCheckErrorHandler.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerFx
+{
+    public interface IPostCheckErrorHandler
+    {
+        public IEnumerable<ExpressionError> Process(TexlNode root);
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/PostCheckErrorHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/PostCheckErrorHandler.cs
@@ -8,6 +8,6 @@ namespace Microsoft.PowerFx
 {
     public interface IPostCheckErrorHandler
     {
-        public IEnumerable<ExpressionError> Process(TexlNode root);
+        public IEnumerable<ExpressionError> Process(CheckResult check);
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/EngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/EngineTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.PowerFx.Syntax;
+using Xunit;
+
+namespace Microsoft.PowerFx.Core.Tests
+{
+    public class EngineTests
+    {
+        [Fact]
+        public void AddPostCheckErrors()
+        {
+            var expr = "User()";
+            var engine = new Engine();
+            engine.PostCheckErrorHandlers.Add(new TestPostCheckErrorHandler());
+
+            var check = engine.Check(expr);
+            Assert.Contains(check.Errors, error => error.Message == "User function is not Supported, instead use the User object (Ie User, but without parenthesis).");
+        }
+
+        private class TestPostCheckErrorHandler : IPostCheckErrorHandler
+        {
+            public IEnumerable<ExpressionError> Process(TexlNode root)
+            {
+                var visitor = new ErrorVisitor();
+                root.Accept(visitor);
+                return visitor.Errors;
+            }
+        }
+
+        private class ErrorVisitor : TexlVisitor
+        {
+            private readonly IList<ExpressionError> _errors = new List<ExpressionError>();
+
+            public IEnumerable<ExpressionError> Errors => _errors;
+
+            public override void PostVisit(StrInterpNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(DottedNameNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(UnaryOpNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(BinaryOpNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(VariadicOpNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(CallNode node)
+            {
+                if (node.Head.Name == "User")
+                {
+                    _errors.Add(new ExpressionError()
+                    {
+                        Message = "User function is not Supported, instead use the User object (Ie User, but without parenthesis).",
+                        Span = node.GetTextSpan()
+                    });
+                }
+            }
+
+            public override void PostVisit(ListNode node)
+            {
+                return;
+            }
+
+            public override void PostVisit(RecordNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(TableNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void PostVisit(AsNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(ErrorNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(BlankNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(BoolLitNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(StrLitNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(NumLitNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(DecLitNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(FirstNameNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(ParentNode node)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Visit(SelfNode node)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests/EngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/EngineTests.cs
@@ -23,10 +23,10 @@ namespace Microsoft.PowerFx.Core.Tests
 
         private class TestPostCheckErrorHandler : IPostCheckErrorHandler
         {
-            public IEnumerable<ExpressionError> Process(TexlNode root)
+            public IEnumerable<ExpressionError> Process(CheckResult check)
             {
                 var visitor = new ErrorVisitor();
-                root.Accept(visitor);
+                check.ApplyParse().Root.Accept(visitor);
                 return visitor.Errors;
             }
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/PublicSurfaceTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.OptionSet",
                 "Microsoft.PowerFx.ParseResult",
                 "Microsoft.PowerFx.ParserOptions",
+                "Microsoft.PowerFx.IPostCheckErrorHandler",
 
                 "Microsoft.PowerFx.EngineDocumentation",
 


### PR DESCRIPTION
Hosts can now add custom host specific authoring error without extending the Engine class.