### PR TITLE
Retire ProcessUserdefinitions

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests/AttributeParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/AttributeParserTests.cs
@@ -17,12 +17,11 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestNamedFormulaAttributes()
         {
-            UserDefinitions.ProcessUserDefinitions(
+            var result = UserDefinitions.Parse(
             @"
                 [SomeName Ident]
                 Foo = 123;
-            ", _parseOptions,
-            out var result);
+            ", _parseOptions);
 
             Assert.False(result.HasErrors);
 
@@ -34,12 +33,11 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestNFAttributeSingleKeyAnd()
         {
-            UserDefinitions.ProcessUserDefinitions(
+            var result = UserDefinitions.Parse(
             @"
                 [Partial And]
                 Foo = 123;
-            ", _parseOptions,
-            out var result);
+            ", _parseOptions);
 
             Assert.False(result.HasErrors);
 
@@ -59,14 +57,13 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Table", "Table")]
         public void TestNFAttributeOperationsCombined(string op, string combinedFunctionName)
         {
-            UserDefinitions.ProcessUserDefinitions(
+            var result = UserDefinitions.Parse(
             $@"
                 [Partial {op}]
                 Foo = false;
                 [Partial {op}]
                 Foo = true;
-            ", _parseOptions,
-            out var result);
+            ", _parseOptions);
 
             Assert.False(result.HasErrors);
 
@@ -85,14 +82,13 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestNFAttributeOperationInvalid()
         {
-            UserDefinitions.ProcessUserDefinitions(
+            var result = UserDefinitions.Parse(
             $@"
                 [Partial Unknown]
                 Foo = false;
                 [Partial Unknown]
                 Foo = true;
-            ", _parseOptions,
-            out var result);
+            ", _parseOptions);
 
             Assert.True(result.HasErrors);
 
@@ -103,7 +99,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestMultipleNamedFormulaAttributes()
         {
-            UserDefinitions.ProcessUserDefinitions(
+            var result = UserDefinitions.Parse(
             @"
                 [SomeName Ident]
                 Foo = 123;
@@ -113,8 +109,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
                 [SomeName2 Ident2]
                 Foo2 = 123;
-            ", _parseOptions,
-            out var result);
+            ", _parseOptions);
 
             Assert.False(result.HasErrors);
 
@@ -138,7 +133,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestErrorNamedFormulaAttributes()
         {
-            UserDefinitions.ProcessUserDefinitions(
+            var result = UserDefinitions.Parse(
             @"
                 [SomeNa.me Iden()t]
                 Foo = 123;
@@ -148,8 +143,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
                 [SomeName2 Ident2]
                 Foo2 = 123;
-            ", _parseOptions,
-            out var result);
+            ", _parseOptions);
 
             Assert.True(result.HasErrors);
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -829,7 +829,7 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.False(parseResult.HasErrors);
         }
 
-        internal void TestFormulasParseError(string script)
+        private ParseUserDefinitionResult TestFormulasParseError(string script)
         {
             var parserOptions = new ParserOptions()
             {
@@ -837,6 +837,8 @@ namespace Microsoft.PowerFx.Core.Tests
             };
             var parseResult = UserDefinitions.Parse(script, parserOptions);
             Assert.True(parseResult.HasErrors);
+
+            return parseResult;
         }
 
         [Theory]
@@ -860,12 +862,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("a = 10; b = 30; c = in'valid ; d = (10; e = 42;", "e")]
         public void TestFormulaParseRestart(string script, string key)
         {
-            var parserOptions = new ParserOptions()
-            {
-                AllowsSideEffects = false
-            };
-            var parseResult = UserDefinitions.Parse(script, parserOptions);
-            Assert.True(parseResult.HasErrors);
+            var parseResult = TestFormulasParseError(script);
 
             // Parser restarted, and found 'c' correctly
             Assert.Contains(parseResult.NamedFormulas, kvp => kvp.Ident.Name.ToString() == key);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/UserDefinedTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/UserDefinedTests.cs
@@ -3,6 +3,8 @@
 
 using System.Globalization;
 using System.Linq;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Syntax;
 using Microsoft.PowerFx.Types;
 using Xunit;
@@ -39,9 +41,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 AllowsSideEffects = true,
                 Culture = CultureInfo.InvariantCulture
             };
-            UserDefinitions.ProcessUserDefinitions(script, options, out var result);
+            var parseResult = UserDefinitions.Parse(script, options);
+            var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out var errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.False(result.HasErrors);
+            Assert.False(errors.Any());
         }
 
         [Theory]
@@ -54,9 +58,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 AllowsSideEffects = true,
                 Culture = CultureInfo.InvariantCulture
             };
-            UserDefinitions.ProcessUserDefinitions(script, options, out var result);
+            var parseResult = UserDefinitions.Parse(script, options);
+            var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out var errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.False(result.HasErrors);
+            Assert.False(errors.Any());
         }
 
         [Theory]
@@ -68,9 +74,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 AllowsSideEffects = true,
                 Culture = CultureInfo.InvariantCulture
             };
-            UserDefinitions.ProcessUserDefinitions(script, options, out var result);
+            var parseResult = UserDefinitions.Parse(script, options);
+            var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out var errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.True(result.HasErrors);
+            Assert.True(errors.Any());
         }
 
         [Theory]
@@ -83,11 +91,13 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 AllowsSideEffects = true,
                 Culture = CultureInfo.InvariantCulture
             };
-            UserDefinitions.ProcessUserDefinitions(script, options, out var result);
+            var parseResult = UserDefinitions.Parse(script, options);
+            var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out var errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.True(result.HasErrors);
-            Assert.Equal(udfCount, result.UDFs.Count());
-            Assert.Equal(nfCount, result.NamedFormulas.Count());
+            Assert.True(errors.Any());
+            Assert.Equal(udfCount, udfs.Count());
+            Assert.Equal(nfCount, parseResult.NamedFormulas.Count());
         }
 
         [Theory]
@@ -99,18 +109,23 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 AllowsSideEffects = false,
                 Culture = CultureInfo.InvariantCulture
             };
-            UserDefinitions.ProcessUserDefinitions(script, options, out var result);
 
-            Assert.True(result.HasErrors);
+            var parseResult = UserDefinitions.Parse(script, options);
+            var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out var errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
+
+            Assert.True(errors.Any());
 
             options = new ParserOptions()
             {
                 AllowsSideEffects = true,
                 Culture = CultureInfo.InvariantCulture
             };
-            UserDefinitions.ProcessUserDefinitions(script, options, out result);
+            parseResult = UserDefinitions.Parse(script, options);
+            udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), out errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.False(result.HasErrors);
+            Assert.False(errors.Any());
         }
     }
 }


### PR DESCRIPTION
Step 2 of allowing user defined types effort .

Retires `UserDefinitions.ProcessUserdefinitions` as it creates a tight coupling between Parse and processing of all different kinds of Userdefinitions. 

We and our tests assume that client uses this method for processing, hence fixing all the tests as we will not use this moving forward.

Moving `AllowAttributes` transformation to `Parse` as it is a transformation of `ParseResult` and returns a `ParseResult` . Ideally this could be a transformation on NamedFormula `ParseResult` .

This will be followed with  

1. Introduce NamedTypes, LookupType in INameResolver but support only Primitives. Remove PrimitiveTypeSymbolTable usage , Require INameResolver to create UDFs.
2. Introduce parsing and adding user defined NamedTypes.
3. Optimize type graph to update incremental.