### PR TITLE
Propagate display names with ShowColumns

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowDropColumnsBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowDropColumnsBase.cs
@@ -103,6 +103,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 _isShowColumns
                 ? (isRecord ? DType.EmptyRecord : DType.EmptyTable)
                 : returnType;
+            Dictionary<DName, DName> newDisplayNameMapping = null;
+            if (_isShowColumns && returnType.DisplayNameProvider != null)
+            {
+                newDisplayNameMapping = new Dictionary<DName, DName>();
+            }
 
             var count = args.Length;
             for (var i = 1; i < count; i++)
@@ -136,6 +141,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     // Make a note of which columns are being kept.
                     Contracts.Assert(columnType.IsValid);
                     colsToKeep = colsToKeep.Add(columnName, columnType);
+                    if (newDisplayNameMapping != null && returnType.DisplayNameProvider.TryGetDisplayName(columnName, out var displayName))
+                    {
+                        newDisplayNameMapping.Add(columnName, displayName);
+                    }
                 }
                 else
                 {
@@ -155,6 +164,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
 
             returnType = colsToKeep;
+            if (newDisplayNameMapping != null)
+            {
+                var newDisplayNameProvider = DisplayNameProvider.New(newDisplayNameMapping);
+                returnType = DType.AttachOrDisableDisplayNameProvider(returnType, newDisplayNameProvider);
+            }
 
             return fArgsValid;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowDropColumnsBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/ShowDropColumnsBase.cs
@@ -104,7 +104,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 ? (isRecord ? DType.EmptyRecord : DType.EmptyTable)
                 : returnType;
             Dictionary<DName, DName> newDisplayNameMapping = null;
-            if (_isShowColumns && returnType.DisplayNameProvider != null)
+
+            // With Power Fx 1.0, we will propagate the display names to the new result type.
+            // We will not change the pre-v1 logic as it may break some corner scenarios.
+            if (_isShowColumns && context.Features.PowerFxV1CompatibilityRules && returnType.DisplayNameProvider != null)
             {
                 newDisplayNameMapping = new Dictionary<DName, DName>();
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -275,13 +275,7 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.True(result.IsSuccess);
         }
 
-        [Theory]
-        [InlineData("ForAll( ShowColumns( MyTable, 'Display Name 2' ), { a: 'Display Name 2' } )", "*[a:n]")]
-        [InlineData("ForAll( ShowColumns( MyTable, 'Display Name 1', 'Display Name 2' ), { a: 'Display Name 1', b: 'Display Name 2' } )", "*[a:s,b:n]")]
-        [InlineData("ForAll( ShowColumns( MyTable, LogicalName2 ), { a: 'Display Name 2' } )", "*[a:n]")]
-        [InlineData("ForAll( ShowColumns( MyTable, LogicalName2 ), { a: 'LogicalName2' } )", "*[a:n]")]
-        [InlineData("ForAll( ShowColumns( MyTable, LogicalName1, 'Display Name 2' ), { a: 'Display Name 1', b: LogicalName2 } )", "*[a:s,b:n]")]
-        public void TexlFunctionTypeSemanticsShowColumns_DisplayNames(string expression, string expectedType)
+        private static TableType CreateTableTypeWithDisplayNames()
         {
             var myTableType = DType.EmptyTable
                 .Add(new DName("LogicalName1"), DType.String)
@@ -294,11 +288,39 @@ namespace Microsoft.PowerFx.Core.Tests
             });
 
             var myTableTypeWithDisplayNames = DType.AttachOrDisableDisplayNameProvider(myTableType, myDisplayNameProvider);
+            return new TableType(myTableTypeWithDisplayNames);
+        }
 
+        [Theory]
+        [InlineData("ForAll( ShowColumns( MyTable, 'Display Name 2' ), { a: 'Display Name 2' } )", "*[a:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, 'Display Name 1', 'Display Name 2' ), { a: 'Display Name 1', b: 'Display Name 2' } )", "*[a:s,b:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, LogicalName2 ), { a: 'Display Name 2' } )", "*[a:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, LogicalName2 ), { a: 'LogicalName2' } )", "*[a:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, LogicalName1, 'Display Name 2' ), { a: 'Display Name 1', b: LogicalName2 } )", "*[a:s,b:n]")]
+        public void TexlFunctionTypeSemanticsShowColumns_DisplayNames(string expression, string expectedType)
+        {
             var symbol = new SymbolTable();
-            symbol.AddVariable("MyTable", new TableType(myTableTypeWithDisplayNames));
+            symbol.AddVariable("MyTable", CreateTableTypeWithDisplayNames());
 
             var engine = new Engine(new PowerFxConfig(Features.PowerFxV1) { SymbolTable = symbol });
+            var result = engine.Check(expression);
+
+            Assert.True(DType.TryParse(expectedType, out var expectedDType));
+            Assert.Equal(expectedDType, result.Binding.ResultType);
+            Assert.True(result.IsSuccess);
+        }
+
+        [Theory]
+        [InlineData(
+            "With({'Display Name 2':false}, ForAll(ShowColumns(MyTable, 'Display Name 1', 'Display Name 2'), { a:LogicalName1, b:'Display Name 2' }))",
+            "*[a:s,b:b]")]
+        public void TexlFunctionTypeSemanticsShowColumns_DisplayNamesNotPropagatedPrePFxV1(string expression, string expectedType)
+        {
+            var symbol = new SymbolTable();
+            symbol.AddVariable("MyTable", CreateTableTypeWithDisplayNames());
+
+            var features = new Features(Features.PowerFxV1) { PowerFxV1CompatibilityRules = false };
+            var engine = new Engine(new PowerFxConfig(features) { SymbolTable = symbol });
             var result = engine.Check(expression);
 
             Assert.True(DType.TryParse(expectedType, out var expectedDType));

--- a/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/TexlTests.cs
@@ -276,6 +276,37 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
+        [InlineData("ForAll( ShowColumns( MyTable, 'Display Name 2' ), { a: 'Display Name 2' } )", "*[a:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, 'Display Name 1', 'Display Name 2' ), { a: 'Display Name 1', b: 'Display Name 2' } )", "*[a:s,b:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, LogicalName2 ), { a: 'Display Name 2' } )", "*[a:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, LogicalName2 ), { a: 'LogicalName2' } )", "*[a:n]")]
+        [InlineData("ForAll( ShowColumns( MyTable, LogicalName1, 'Display Name 2' ), { a: 'Display Name 1', b: LogicalName2 } )", "*[a:s,b:n]")]
+        public void TexlFunctionTypeSemanticsShowColumns_DisplayNames(string expression, string expectedType)
+        {
+            var myTableType = DType.EmptyTable
+                .Add(new DName("LogicalName1"), DType.String)
+                .Add(new DName("LogicalName2"), DType.Number);
+
+            var myDisplayNameProvider = DisplayNameProvider.New(new Dictionary<DName, DName>
+            {
+                { new DName("LogicalName1"), new DName("Display Name 1") },
+                { new DName("LogicalName2"), new DName("Display Name 2") },
+            });
+
+            var myTableTypeWithDisplayNames = DType.AttachOrDisableDisplayNameProvider(myTableType, myDisplayNameProvider);
+
+            var symbol = new SymbolTable();
+            symbol.AddVariable("MyTable", new TableType(myTableTypeWithDisplayNames));
+
+            var engine = new Engine(new PowerFxConfig(Features.PowerFxV1) { SymbolTable = symbol });
+            var result = engine.Check(expression);
+
+            Assert.True(DType.TryParse(expectedType, out var expectedDType));
+            Assert.Equal(expectedDType, result.Binding.ResultType);
+            Assert.True(result.IsSuccess);
+        }
+
+        [Theory]
         [InlineData("ShowColumns([{A:\"hello\",B:1}], \"A\")", "*[A:s]")]
         [InlineData("ShowColumns([{A:\"hello\",B:1}], \"B\")", "*[B:n]")]
         [InlineData("ShowColumns([{A:\"hello\",B:1}], \"A\", \"B\")", "*[A:s,B:n]")]


### PR DESCRIPTION
Now that ShowColumns can be used with display names, we should propagate the name mapping so that its output also has both logical and display names.