### PR TITLE
Removed resource that should not be translated

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -304,7 +304,7 @@ namespace Microsoft.PowerFx.Core.Functions
                 // The invariant name is used to form a URL. It cannot contain spaces and other
                 // funky characters. We have tests that enforce this constraint. If we ever need
                 // such characters (#, &, %, ?), they need to be encoded here, e.g. %20, etc.
-                StringResources.Get("FunctionReference_Link") + char.ToLowerInvariant(LocaleInvariantName.First());
+                "https://go.microsoft.com/fwlink/?LinkId=722347#" + char.ToLowerInvariant(LocaleInvariantName.First());
 
         /// <summary>
         /// Might need to reset if Function is variadic function.

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -2506,10 +2506,6 @@
     <value>Component</value>
     <comment>Function category name - function defined in components within the environment where it is running.</comment>
   </data>
-  <data name="FunctionReference_Link" xml:space="preserve">
-    <value>https://go.microsoft.com/fwlink/?LinkId=722347#</value>
-    <comment>{StringContains=LCID}</comment>
-  </data>
   <data name="InvalidXml_ElementMissingAttribute_ElemName_AttrName" xml:space="preserve">
     <value>The element '{0}' is missing attribute '{1}'.</value>
     <comment>Invalid xml error message.</comment>


### PR DESCRIPTION
We have a string that is a fwlink redirector in our localized resources. Fwlinks should not be translated (it redirects to the user locale, based on the browser's language), so this change removes it.