### PR TITLE
Fix connector function when returning a blob

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -859,6 +859,11 @@ namespace Microsoft.PowerFx.Connectors
                 }
             }
 
+            if (ReturnParameterType.FormulaType is BlobType bt && result is StringValue str)
+            {
+                result = FormulaValue.NewBlob(str.Value, ReturnParameterType.Schema.Format == "byte");
+            }
+
             return result;
         }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/BaseConnectorTest.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/BaseConnectorTest.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -124,6 +125,14 @@ namespace Microsoft.PowerFx.Connectors.Tests
             else if (expectedResult.StartsWith("RECORD"))
             {
                 Assert.IsAssignableFrom<RecordValue>(fv);
+            }
+            else if (expectedResult.StartsWith("BLOBSTR"))
+            {
+                Assert.IsAssignableFrom<BlobValue>(fv);
+
+                BlobValue bv = (BlobValue)fv;
+                string blobStr = await bv.GetAsStringAsync(Encoding.UTF8, CancellationToken.None).ConfigureAwait(false);
+                Assert.StartsWith(expectedResult.Substring(8), blobStr);
             }
             else if (expectedResult.StartsWith("BLOB"))
             {

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/Microsoft.PowerFx.Connectors.Tests.csproj
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/Microsoft.PowerFx.Connectors.Tests.csproj
@@ -32,7 +32,8 @@
     <EmbeddedResource Include="Responses\*.json" />
     <EmbeddedResource Include="Responses\*.jsonSet" />
     <EmbeddedResource Include="Responses\*.png" />
-    <EmbeddedResource Include="Responses\*.txt" />        
+    <EmbeddedResource Include="Responses\*.txt" />
+    <EmbeddedResource Include="Responses\*.raw" />
     <EmbeddedResource Include="Swagger\*.json" />
   </ItemGroup>
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/O365OutlookTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/O365OutlookTests.cs
@@ -556,14 +556,14 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
         [InlineData(
             @"Office365Outlook.ExportEmail(""AAMkADZiMmZiZGEwLTIyZDYtNDA3ZC1hZjJkLTljYjgxNjQ5YjFkNwBGAAAAAAC1gTSkmbm5QLpPwj9qarJqBwDr1A2S1MsmTIW9552ybeHbAAAAAAEMAADr1A2S1MsmTIW9552ybeHbAABwN-WMAAA="")",
-            "STARTSWITH:Received: from LV3P223MB0915.NAMP223.PROD.OUTLOOK.COM (2603:10b6:408:1dd::10)",
+            "BLOBSTR:Received: from LV3P223MB0915.NAMP223.PROD.OUTLOOK.COM (2603:10b6:408:1dd::10)",
             "GET:/apim/office365/3ea3b1e7f28d4c54a23a4dcbcae7de69/codeless/api/beta/me/messages/AAMkADZiMmZiZGEwLTIyZDYtNDA3ZC1hZjJkLTljYjgxNjQ5YjFkNwBGAAAAAAC1gTSkmbm5QLpPwj9qarJqBwDr1A2S1MsmTIW9552ybeHbAAAAAAEMAADr1A2S1MsmTIW9552ybeHbAABwN-WMAAA%3d/$value",
             "",
             "Response_O365Outlook_ExportEmail.eml")]
 
         [InlineData(
             @"Office365Outlook.ExportEmailV2(""AAMkADZiMmZiZGEwLTIyZDYtNDA3ZC1hZjJkLTljYjgxNjQ5YjFkNwBGAAAAAAC1gTSkmbm5QLpPwj9qarJqBwDr1A2S1MsmTIW9552ybeHbAAAAAAEMAADr1A2S1MsmTIW9552ybeHbAABwN-WMAAA="")",
-            "STARTSWITH:Received: from LV3P223MB0915.NAMP223.PROD.OUTLOOK.COM (2603:10b6:408:1dd::10)",
+            "BLOBSTR:Received: from LV3P223MB0915.NAMP223.PROD.OUTLOOK.COM (2603:10b6:408:1dd::10)",
             "GET:/apim/office365/3ea3b1e7f28d4c54a23a4dcbcae7de69/codeless/beta/me/messages/AAMkADZiMmZiZGEwLTIyZDYtNDA3ZC1hZjJkLTljYjgxNjQ5YjFkNwBGAAAAAAC1gTSkmbm5QLpPwj9qarJqBwDr1A2S1MsmTIW9552ybeHbAAAAAAEMAADr1A2S1MsmTIW9552ybeHbAABwN-WMAAA%3d/$value",
             "",
             "Response_O365Outlook_ExportEmail.eml")]

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests/Responses/AzureBlobStorage_GetFileContentV2.raw
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests/Responses/AzureBlobStorage_GetFileContentV2.raw
@@ -1,0 +1,1 @@
+TEST FILE


### PR DESCRIPTION
When a connector function was supposed to return a BlobValue, we were returning a string instead.