### PR TITLE
Fix UDF with invalid body to be ParseInvalid

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -412,7 +412,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                         var bodyParseValid = _errors?.Count == errorCount;
 
-                        udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken, returnType.As<IdentToken>(), new HashSet<UDFArg>(args), result, isImperative: isImperative, parserOptions.NumberIsFloat, isValid: true));
+                        udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken, returnType.As<IdentToken>(), new HashSet<UDFArg>(args), result, isImperative: isImperative, parserOptions.NumberIsFloat, isValid: bodyParseValid));
                     }
                     else
                     {

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -377,7 +377,7 @@ namespace Microsoft.PowerFx.Core.Parser
                         ParseTrivia();
                         _flagsMode.Push(parserOptions.AllowsSideEffects ? Flags.EnableExpressionChaining : Flags.None);
 
-                        var errorCount = _errors.Count;
+                        var errorCount = _errors?.Count;
 
                         var exp_result = ParseExpr(Precedence.None);
                         _flagsMode.Pop();
@@ -387,7 +387,7 @@ namespace Microsoft.PowerFx.Core.Parser
                             break;
                         }
 
-                        var bodyParseValid = _errors.Count == errorCount;
+                        var bodyParseValid = _errors?.Count == errorCount;
 
                         udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken,  returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, _hasSemicolon, parserOptions.NumberIsFloat, isValid: bodyParseValid));
                     }
@@ -398,7 +398,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                         var isImperative = _curs.TidCur == TokKind.CurlyOpen && parserOptions.AllowsSideEffects;
 
-                        var errorCount = _errors.Count;
+                        var errorCount = _errors?.Count;
                         
                         var result = isImperative ? ParseUDFBody() : ParseExpr(Precedence.None);
                         ParseTrivia();
@@ -410,7 +410,7 @@ namespace Microsoft.PowerFx.Core.Parser
                             break;
                         }
 
-                        var bodyParseValid = _errors.Count == errorCount;
+                        var bodyParseValid = _errors?.Count == errorCount;
 
                         udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken, returnType.As<IdentToken>(), new HashSet<UDFArg>(args), result, isImperative: isImperative, parserOptions.NumberIsFloat, isValid: true));
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -376,6 +376,9 @@ namespace Microsoft.PowerFx.Core.Parser
                         _hasSemicolon = false;
                         ParseTrivia();
                         _flagsMode.Push(parserOptions.AllowsSideEffects ? Flags.EnableExpressionChaining : Flags.None);
+
+                        var errorCount = _errors.Count;
+
                         var exp_result = ParseExpr(Precedence.None);
                         _flagsMode.Pop();
                         ParseTrivia();
@@ -384,7 +387,9 @@ namespace Microsoft.PowerFx.Core.Parser
                             break;
                         }
 
-                        udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken,  returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, _hasSemicolon, parserOptions.NumberIsFloat, isValid: true));
+                        var bodyParseValid = _errors.Count == errorCount;
+
+                        udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken,  returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, _hasSemicolon, parserOptions.NumberIsFloat, isValid: bodyParseValid));
                     }
                     else if (_curs.TidCur == TokKind.Equ)
                     {
@@ -393,6 +398,8 @@ namespace Microsoft.PowerFx.Core.Parser
 
                         var isImperative = _curs.TidCur == TokKind.CurlyOpen && parserOptions.AllowsSideEffects;
 
+                        var errorCount = _errors.Count;
+                        
                         var result = isImperative ? ParseUDFBody() : ParseExpr(Precedence.None);
                         ParseTrivia();
 
@@ -402,6 +409,8 @@ namespace Microsoft.PowerFx.Core.Parser
                             CreateError(_curs.TokCur, TexlStrings.ErrNamedFormula_MissingSemicolon);
                             break;
                         }
+
+                        var bodyParseValid = _errors.Count == errorCount;
 
                         udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken, returnType.As<IdentToken>(), new HashSet<UDFArg>(args), result, isImperative: isImperative, parserOptions.NumberIsFloat, isValid: true));
                     }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -936,5 +936,24 @@ namespace Microsoft.PowerFx.Core.Tests
                 i++;
             }
         }
+
+        [Theory]
+        [InlineData("SomeFunc(): Number = ({x:5, y5);", 1, 0, true)]
+        [InlineData("Add(x: Number, y:Number): Number = ;", 1, 0, true)]
+        [InlineData("Valid(x: Number): Number = x; Invalid(x: Text): Text = {;};", 2, 1, true)]
+        [InlineData("Invalid(x: Text): Text = ({); A(): Text = \"Hello\";", 2, 1, true)]
+        public void TestUDFInvalidBody(string script, int udfCount, int validUdfCount, bool expectErrors)
+        {
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = true
+            };
+
+            var parseResult = UserDefinitions.Parse(script, parserOptions);
+
+            Assert.Equal(udfCount, parseResult.UDFs.Count());
+            Assert.Equal(validUdfCount, parseResult.UDFs.Where(udf => udf.IsParseValid).Count());
+            Assert.Equal(expectErrors, parseResult.HasErrors);
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ParseTests.cs
@@ -883,19 +883,19 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("a = 10; b = in'valid ; c = 20;", 0, 3, true)]
-        [InlineData("a = 10; b = in(valid ; c = 20;", 0, 3, true)]
-        [InlineData("a = 10; b = in)valid ; c = 20;", 0, 3, true)]
-        [InlineData("a = 10; b = in{valid ; c = 20;", 0, 3, true)]
-        [InlineData("a = 10; b = in}valid ; c = 20;", 0, 3, true)]
-        [InlineData("Foo(x: Number): Number = Abs(x);", 1, 0, false)]
-        [InlineData("x = 1; Foo(x: Number): Number = Abs(x); y = 2;", 1, 2, false)]
-        [InlineData("Add(x: Number, y:Number): Number = x + y; Foo(x: Number): Number = Abs(x); y = 2;", 2, 1, false)]
-        [InlineData("Add(x: Number, y:Number): Number = x + y;;; Foo(x: Number): Number = Abs(x); y = 2;", 2, 1, true)]
-        [InlineData(@"F2(b: Text): Text  = ""Test"";", 1, 0, false)]
-        [InlineData(@"F2(b: Text): Text  = ""Test;", 0, 0, true)]
-        [InlineData("Add(x: Number, y:Number): Number = (x + y;;; Foo(x: Number): Number = Abs(x); y = 2;", 2, 1, true)]
-        public void TestUDFNamedFormulaCountsRestart(string script, int udfCount, int namedFormulaCount, bool expectErrors)
+        [InlineData("a = 10; b = in'valid ; c = 20;", 0, 0, 3, true)]
+        [InlineData("a = 10; b = in(valid ; c = 20;", 0, 0, 3, true)]
+        [InlineData("a = 10; b = in)valid ; c = 20;", 0, 0, 3, true)]
+        [InlineData("a = 10; b = in{valid ; c = 20;", 0, 0, 3, true)]
+        [InlineData("a = 10; b = in}valid ; c = 20;", 0, 0, 3, true)]
+        [InlineData("Foo(x: Number): Number = Abs(x);", 1, 1, 0, false)]
+        [InlineData("x = 1; Foo(x: Number): Number = Abs(x); y = 2;", 1, 1, 2, false)]
+        [InlineData("Add(x: Number, y:Number): Number = x + y; Foo(x: Number): Number = Abs(x); y = 2;", 2, 2, 1, false)]
+        [InlineData("Add(x: Number, y:Number): Number = x + y;;; Foo(x: Number): Number = Abs(x); y = 2;", 2, 2, 1, true)]
+        [InlineData(@"F2(b: Text): Text  = ""Test"";", 1, 1, 0, false)]
+        [InlineData(@"F2(b: Text): Text  = ""Test;", 0, 0, 0, true)]
+        [InlineData("Add(x: Number, y:Number): Number = (x + y;;; Foo(x: Number): Number = Abs(x); y = 2;", 2, 1, 1, true)]
+        public void TestUDFNamedFormulaCountsRestart(string script, int udfCount, int validUdfCount, int namedFormulaCount, bool expectErrors)
         {
             var parserOptions = new ParserOptions()
             {
@@ -906,7 +906,8 @@ namespace Microsoft.PowerFx.Core.Tests
             var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.Equal(udfCount, udfs.Count());
+            Assert.Equal(udfCount, parseResult.UDFs.Count());
+            Assert.Equal(validUdfCount, udfs.Count());
             Assert.Equal(namedFormulaCount, parseResult.NamedFormulas.Count());
             Assert.Equal(expectErrors, errors.Any());
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/UserDefinedFunctionTests.cs
@@ -478,12 +478,12 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
-        [InlineData("x = $\"{\"}\";", 1, 0)]
-        [InlineData("x = First([$\"{ {a:1,b:2,c:3}.a }]).Value;", 1, 0)]
-        [InlineData("x = $\"{\"1$\"}.{\"}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1)]
-        [InlineData("x = $\"{$\"{$\"{$\"{.12e4}\"}}\"}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1)]
-        [InlineData("x = $\"{$\"{$\"{$\"{.12e4}\"}\"}\"}{$\"Another nested}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1)]
-        public void TestUDF(string formula, int nfCount, int udfCount)
+        [InlineData("x = $\"{\"}\";", 1, 0, 0)]
+        [InlineData("x = First([$\"{ {a:1,b:2,c:3}.a }]).Value;", 1, 0, 0)]
+        [InlineData("x = $\"{\"1$\"}.{\"}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1, 0)]
+        [InlineData("x = $\"{$\"{$\"{$\"{.12e4}\"}}\"}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1, 0)]
+        [InlineData("x = $\"{$\"{$\"{$\"{.12e4}\"}\"}\"}{$\"Another nested}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1, 0)]
+        public void TestUDF(string formula, int nfCount, int udfCount, int validUdfCount)
         {
             var parserOptions = new ParserOptions()
             {
@@ -495,7 +495,8 @@ namespace Microsoft.PowerFx.Core.Tests
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
             Assert.Equal(nfCount, parseResult.NamedFormulas.Count());
-            Assert.Equal(udfCount, udfs.Count());
+            Assert.Equal(udfCount, parseResult.UDFs.Count());
+            Assert.Equal(validUdfCount, udfs.Count());
             Assert.Contains(errors, e => e.MessageKey == "ErrBadToken");
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/UserDefinedTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/UserDefinedTests.cs
@@ -84,9 +84,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Theory]
-        [InlineData("test2(b: Boolean): Boolean = { Set(a, b); Collect(,) ;}; num = 3;", 1, 1)]
-        [InlineData("test2(b: Boolean): Boolean = { Set(a, b); Collect(,) ;};;;;;;;; num = 3;", 1, 1)]
-        public void InvalidUDFBodyTest2(string script, int udfCount, int nfCount)
+        [InlineData("test2(b: Boolean): Boolean = { Set(a, b); Collect(,) ;}; num = 3;", 1, 0, 1)]
+        [InlineData("test2(b: Boolean): Boolean = { Set(a, b); Collect(,) ;};;;;;;;; num = 3;", 1, 0, 1)]
+        public void InvalidUDFBodyTest2(string script, int udfCount, int validUdfCount, int nfCount)
         {
             var options = new ParserOptions()
             {
@@ -98,7 +98,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
             Assert.True(errors.Any());
-            Assert.Equal(udfCount, udfs.Count());
+            Assert.Equal(udfCount, parseResult.UDFs.Count());
+            Assert.Equal(validUdfCount, udfs.Count());
             Assert.Equal(nfCount, parseResult.NamedFormulas.Count());
         }
 


### PR DESCRIPTION
We considered UDF with parse failures in body to be parse valid UDFs which leads to issues when binding the body of UDFs with errors. 

In This PR we check if there are any new errors after parsing body and set parseValid appropriately.