### PR TITLE
Fix strongly typed option sets issues in Power Apps (#2382), t24051

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -807,7 +807,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue
                     && typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
                 {
-                    if (typeLeft.OptionSetInfo.CanCompareNumeric)
+                    if (!usePowerFxV1CompatibilityRules || typeLeft.OptionSetInfo.CanCompareNumeric)
                     {
                         return new BinderCheckTypeResult
                         {
@@ -830,9 +830,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // Comparing to backing type is permitted under a few circumstances
-                else if (typeLeft.Kind == DKind.OptionSetValue && typeLeft.OptionSetInfo.CanCompareNumeric &&
-                        (!usePowerFxV1CompatibilityRules || typeLeft.OptionSetInfo.CanCoerceFromBackingKind || typeLeft.OptionSetInfo.CanCoerceToBackingKind) &&
-                        (typeRight.Kind == DKind.Number || typeRight.Kind == DKind.Decimal))
+                else if (IsOptionSetComparableWithNumeric(typeLeft, typeRight, usePowerFxV1CompatibilityRules))
                 {
                     return new BinderCheckTypeResult
                     {
@@ -843,9 +841,7 @@ namespace Microsoft.PowerFx.Core.Binding
                         }
                     };
                 }
-                else if (typeRight.Kind == DKind.OptionSetValue && typeRight.OptionSetInfo.CanCompareNumeric &&
-                        (!usePowerFxV1CompatibilityRules || typeRight.OptionSetInfo.CanCoerceFromBackingKind || typeRight.OptionSetInfo.CanCoerceToBackingKind) &&
-                        (typeLeft.Kind == DKind.Number || typeLeft.Kind == DKind.Decimal))
+                else if (IsOptionSetComparableWithNumeric(typeRight, typeLeft, usePowerFxV1CompatibilityRules))
                 {
                     return new BinderCheckTypeResult
                     {
@@ -983,6 +979,15 @@ namespace Microsoft.PowerFx.Core.Binding
             }
 
             return new BinderCheckTypeResult() { Coercions = coercions };
+        }
+
+        private static bool IsOptionSetComparableWithNumeric(DType optionSet, DType numeric, bool usePowerFxV1CompatibilityRules)
+        {
+            return optionSet.Kind == DKind.OptionSetValue &&
+                   (numeric.Kind == DKind.Number || numeric.Kind == DKind.Decimal) &&
+                   (!usePowerFxV1CompatibilityRules ||
+                       (optionSet.OptionSetInfo.CanCompareNumeric &&
+                           (optionSet.OptionSetInfo.CanCoerceFromBackingKind || optionSet.OptionSetInfo.CanCoerceToBackingKind)));     
         }
 
         private static BinderCheckTypeResult CheckEqualArgTypesCore(IErrorContainer errorContainer, TexlNode left, TexlNode right, bool usePowerFxV1CompatibilityRules, DType typeLeft, DType typeRight, bool numberIsFloat)
@@ -1297,6 +1302,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     return new BinderCheckTypeResult() { Node = node, NodeType = DType.Boolean, Coercions = resLeftAnd.Coercions.Concat(resRightAnd.Coercions).ToList() };
 
                 case BinaryOp.Concat:
+                    // Behavior here should match that of the Concatenate function.
                     BinderCheckTypeResult resLeftConcat;
                     BinderCheckTypeResult resRightConcat;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -357,7 +357,7 @@ namespace Microsoft.PowerFx.Functions
                     BuiltinFunctionsCore.Concatenate.Name,
                     expandArguments: NoArgExpansion,
                     replaceBlankValues: ReplaceBlankWithEmptyString,
-                    checkRuntimeTypes: StringOrOptionSetBackedByString,
+                    checkRuntimeTypes: StringOrOptionSet,
                     checkRuntimeValues: DeferRuntimeValueChecking,
                     returnBehavior: ReturnBehavior.AlwaysEvaluateAndReturnResult,
                     targetFunction: Concatenate)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PowerFx.Functions
                         sb.Append(sv.Value);
                         break;
                     case OptionSetValue osv:
-                        sb.Append(osv.ExecutionValue);
+                        sb.Append(osv.ExecutionValue is string s ? s : osv.DisplayName);
                         break;
                     default:
                         return CommonErrors.RuntimeTypeMismatch(arg.IRContext);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/StandardErrorHandling.cs
@@ -767,6 +767,16 @@ namespace Microsoft.PowerFx.Functions
             return CommonErrors.RuntimeTypeMismatch(irContext);
         }
 
+        private static FormulaValue StringOrOptionSet(IRContext irContext, int index, FormulaValue arg)
+        {
+            if (arg is StringValue || arg is OptionSetValue)
+            {
+                return arg;
+            }
+
+            return CommonErrors.RuntimeTypeMismatch(irContext);
+        }
+
         private static FormulaValue StringOrBlankOrOptionSetBackedByString(IRContext irContext, int index, FormulaValue arg)
         {
             if (arg is BlankValue)

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums.txt
@@ -302,6 +302,39 @@ Errors: Error 11-19: Invalid argument type. Expecting one of the following: Deci
 >> StartOfWeek.Tuesday * 2
 Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
 
+>> StartOfWeek.Tuesday * StartOfWeek.Thursday
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 33-42: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday + 2
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Tuesday + StartOfWeek.Wednesday
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 33-43: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday - 2
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday - StartOfWeek.Thursday
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday * 2
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday / 2
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday / StartOfWeek.Thursday
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+
+>> StartOfWeek.Friday ^ 2
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+
+>> StartOfWeek.Friday ^ StartOfWeek.Thursday
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+
+>> StartOfWeek.Friday%
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Date, DateTime, DateTimeNoTimeZone, Time, Text, Boolean, UntypedObject.
+
 //===========================================================================================================
 //
 // 8. By default, Boolean operations between Boolean based enums is not supported, but can be overriden with CanCoerceToBackingKind
@@ -445,6 +478,9 @@ RGBA(26,29,33,1)
 >> ErrorKind.Unknown + 2
 14
 
+>> ErrorKind.Unknown - 2
+10
+
 >> ErrorKind.Unknown * 2
 24
 
@@ -453,6 +489,9 @@ RGBA(26,29,33,1)
 
 >> ErrorKind.Unknown ^ 2
 144
+
+>> ErrorKind.Unknown%
+0.12
 
 // Equals/not equals comparisons
 
@@ -498,8 +537,14 @@ Errors: Error 34-35: Invalid argument type (Text). Expecting a Enum (JSONFormat)
 >> JSON( [1,2,3], JSONFormat.IgnoreBinaryData & JSONFormat.FlattenValueTables )
 "[1,2,3]"
 
+>> JSON( [1,2,3], Concatenate( JSONFormat.IgnoreBinaryData, JSONFormat.FlattenValueTables ) )
+"[1,2,3]"
+
 >> JSON( [1,2,3], JSONFormat.IgnoreBinaryData & "_" )
 Errors: Error 43-44: Invalid argument type (Text). Expecting a Enum (JSONFormat) value instead.|Error 0-4: The function 'JSON' has some invalid arguments.
+
+>> JSON( [1,2,3], Concatenate( JSONFormat.IgnoreBinaryData, "_" ) )
+Errors: Error 15-62: Invalid argument type (Text). Expecting a Enum (JSONFormat) value instead.|Error 0-4: The function 'JSON' has some invalid arguments.
 
 >> JSON( [4,5,6], "_" )
 Errors: Error 15-18: Invalid argument type (Text). Expecting a Enum (JSONFormat) value instead.|Error 0-4: The function 'JSON' has some invalid arguments.
@@ -648,6 +693,15 @@ If(true, {test:1}, "Void value (result of the expression can't be used).")
 >> "Label:" & StartOfWeek.Sunday
 "Label:Sunday"
 
+>> Concatenate( "Label:", StartOfWeek.Sunday )
+"Label:Sunday"
+
+>> StartOfWeek.Sunday & "Evening"
+"SundayEvening"
+
+>> Concatenate( StartOfWeek.Sunday, "Evening" )
+"SundayEvening"
+
 >> Mid( StartOfWeek.Sunday, 2 )
 "unday"
 
@@ -675,11 +729,50 @@ Match.CalculatedOptionSetValue
 >> "Label:" & MatchOptions.IgnoreCase
 "Label:i"
 
+>> Concatenate( "Label:" & MatchOptions.IgnoreCase )
+"Label:i"
+
 >> Text( ErrorKind.FileNotFound )
 "FileNotFound"
 
 >> "Label:" & ErrorKind.FileNotFound
 "Label:FileNotFound"
+
+>> Concatenate( "Label:" & ErrorKind.FileNotFound )
+"Label:FileNotFound"
+
+>> Concat( ["String", StartOfWeek.Tuesday, ErrorKind.Div0, JSONFormat.FlattenValueTables], Value )
+"StringTuesdayDiv0_"
+
+>> Concat( [StartOfWeek.Tuesday, StartOfWeek.Friday], Value )
+"TuesdayFriday"
+
+>> true & StartOfWeek.Friday
+"trueFriday"
+
+>> 1 & StartOfWeek.Friday
+"1Friday"
+
+>> "hi" & StartOfWeek.Friday
+"hiFriday"
+
+>> StartOfWeek.Friday & true
+"Fridaytrue"
+
+>> StartOfWeek.Friday & 1
+"Friday1"
+
+>> StartOfWeek.Friday & "hi"
+"Fridayhi"
+
+>> Concatenate( true, StartOfWeek.Friday )
+"trueFriday"
+
+>> Concatenate( 1, StartOfWeek.Friday )
+"1Friday"
+
+>> Concatenate( "hi", StartOfWeek.Friday )
+"hiFriday"
 
 //===========================================================================================================
 //
@@ -718,6 +811,9 @@ true
 "Monday"
 
 >> "Severity: " & StartOfWeek.Monday
+"Severity: Monday"
+
+>> Concatenate( "Severity: ", StartOfWeek.Monday )
 "Severity: Monday"
 
 >> Len( StartOfWeek.Monday )
@@ -782,6 +878,9 @@ Errors: Error 19-21: Unable to compare values of type Enum (StartOfWeek).
 // Can't concatenate strongly typed (CanConcatenateStronglyTyped = false)
 
 >> StartOfWeek.Monday & StartOfWeek.Tuesday
+"MondayTuesday"
+
+>> Concatenate( StartOfWeek.Monday, StartOfWeek.Tuesday )
 "MondayTuesday"
 
 >> Weekday( Date(1980,1,1), StartOfWeek.Monday & StartOfWeek.Tuesday )
@@ -919,6 +1018,21 @@ true
 
 >> "Option: " & Color.Yellow
 "Option: Yellow"
+
+>> Concatenate( "Option: ", Color.Yellow )
+"Option: Yellow"
+
+>> Color.Yellow & " banana"
+"Yellow banana"
+
+>> Concatenate( Color.Yellow, " banana" )
+"Yellow banana"
+
+>> Color.Green & " bananas are riper than " & Color.Yellow & " bananas"
+"Green bananas are riper than Yellow bananas"
+
+>> Concatenate( Color.Green, " bananas are riper than ", Color.Yellow, " bananas" )
+"Green bananas are riper than Yellow bananas"
 
 >> Len( Color.Yellow )
 6

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
@@ -435,6 +435,9 @@ RGBA(26,29,33,1)
 >> ErrorKind.Unknown + 2
 14
 
+>> ErrorKind.Unknown - 2
+10
+
 >> ErrorKind.Unknown * 2
 24
 
@@ -488,7 +491,13 @@ Table({Value:1},{Value:2},{Value:3})
 >> JSON( [1,2,3], JSONFormat.IgnoreBinaryData & JSONFormat.FlattenValueTables )
 "[1,2,3]"
 
+>> JSON( [1,2,3], Concatenate( JSONFormat.IgnoreBinaryData, JSONFormat.FlattenValueTables ) )
+"[1,2,3]"
+
 >> JSON( [1,2,3], JSONFormat.IgnoreBinaryData & "_" )
+"[1,2,3]"
+
+>> JSON( [1,2,3], Concatenate( JSONFormat.IgnoreBinaryData, "_" ) )
 "[1,2,3]"
 
 >> JSON( [4,5,6], "_" )
@@ -640,6 +649,15 @@ true
 >> "Label:" & StartOfWeek.Sunday
 "Label:1"
 
+>> Concatenate( "Label:", StartOfWeek.Sunday )
+"Label:1"
+
+>> StartOfWeek.Sunday & "Evening"
+"1Evening"
+
+>> Concatenate( StartOfWeek.Sunday, "Evening" )
+"1Evening"
+
 >> Mid( StartOfWeek.Sunday, 2 )
 ""
 
@@ -667,12 +685,50 @@ true
 >> "Label:" & MatchOptions.IgnoreCase
 "Label:i"
 
+>> Concatenate( "Label:" & MatchOptions.IgnoreCase )
+"Label:i"
+
 >> Text( ErrorKind.FileNotFound )
 "17"
 
 >> "Label:" & ErrorKind.FileNotFound
 "Label:17"
 
+>> Concatenate( "Label:" & ErrorKind.FileNotFound )
+"Label:17"
+
+>> Concat( ["String", StartOfWeek.Tuesday, ErrorKind.Div0, JSONFormat.FlattenValueTables], Value )
+"String1213_"
+
+>> Concat( [StartOfWeek.Tuesday, StartOfWeek.Friday], Value )
+"1215"
+
+>> true & StartOfWeek.Friday
+"true15"
+
+>> 1 & StartOfWeek.Friday
+"115"
+
+>> "hi" & StartOfWeek.Friday
+"hi15"
+
+>> StartOfWeek.Friday & true
+"15true"
+
+>> StartOfWeek.Friday & 1
+"151"
+
+>> StartOfWeek.Friday & "hi"
+"15hi"
+
+>> Concatenate( true, StartOfWeek.Friday )
+"true15"
+
+>> Concatenate( 1, StartOfWeek.Friday )
+"115"
+
+>> Concatenate( "hi", StartOfWeek.Friday )
+"hi15"
 
 //===========================================================================================================
 //
@@ -708,6 +764,9 @@ true
 "2"
 
 >> "Severity: " & StartOfWeek.Monday
+"Severity: 2"
+
+>> Concatenate( "Severity: ", StartOfWeek.Monday )
 "Severity: 2"
 
 >> Len( StartOfWeek.Monday )
@@ -772,6 +831,9 @@ false
 // Can't concatenate strongly typed (CanConcatenateStronglyTyped = false)
 
 >> StartOfWeek.Monday & StartOfWeek.Tuesday
+"212"
+
+>> Concatenate( StartOfWeek.Monday, StartOfWeek.Tuesday )
 "212"
 
 >> Weekday( Date(1980,1,1), StartOfWeek.Monday & StartOfWeek.Tuesday )
@@ -912,6 +974,21 @@ Errors: Error 10-17: Invalid argument type (Color). Expecting a Text value inste
 
 >> Left( Color.Yellow, 4 )
 Errors: Error 0-4: The function 'Left' has some invalid arguments.|Error 11-18: Invalid argument type (Color). Expecting a Text value instead.
+
+>> Concatenate( "Option: ", Color.Yellow )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 30-37: Invalid argument type (Color). Expecting a Text value instead.
+
+>> Color.Yellow & " banana"
+Errors: Error 5-12: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> Concatenate( Color.Yellow, " banana" )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 18-25: Invalid argument type (Color). Expecting a Text value instead.
+
+>> Color.Green & " bananas are riper than " & Color.Yellow & " bananas"
+Errors: Error 5-11: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.|Error 48-55: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> Concatenate( Color.Green, " bananas are riper than ", Color.Yellow, " bananas" )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 18-24: Invalid argument type (Color). Expecting a Text value instead.|Error 59-66: Invalid argument type (Color). Expecting a Text value instead.
 
 // Standard error cases for color backed enums
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums.txt
@@ -410,6 +410,15 @@ false
 >> "Label:" & TestYesNo.No
 "Label:No"
 
+>> Concatenate( "Label:", TestYesNo.No )
+"Label:No"
+
+>> TestYesNo.No & "Way"
+"NoWay"
+
+>> Concatenate( TestYesNo.No, "Way" )
+"NoWay"
+
 >> Text( TestYeaNay.Nay )
 "Nay"
 
@@ -434,6 +443,21 @@ false
 >> "Label:" & TestBlueRamp.Blue50
 "Label:Blue50"
 
+>> Concatenate( "Label:", TestBlueRamp.Blue50 )
+"Label:Blue50"
+
+>> TestBlueRamp.Blue50 & " is the sky"
+"Blue50 is the sky"
+
+>> Concatenate( TestBlueRamp.Blue50, " is the sky")
+"Blue50 is the sky"
+
+>> "The sky is so very " & TestBlueRamp.Blue50 & " !!!"
+"The sky is so very Blue50 !!!"
+
+>> Concatenate( "The sky is so very ", TestBlueRamp.Blue50, " !!!")
+"The sky is so very Blue50 !!!"
+
 >> Mid( TestBlueRamp.Blue50, 2 )
 "lue50"
 
@@ -451,6 +475,60 @@ false
 
 >> Len( TestRedRamp.Red25 )
 5
+
+>> true & TestRedRamp.Red25
+"trueRed25"
+
+>> 1 & TestRedRamp.Red25
+"1Red25"
+
+>> "hi" & TestRedRamp.Red25
+"hiRed25"
+
+>> TestRedRamp.Red25 & true
+"Red25true"
+
+>> TestRedRamp.Red25 & 1
+"Red251"
+
+>> TestRedRamp.Red25 & "hi"
+"Red25hi"
+
+>> Concatenate( true, TestRedRamp.Red25 )
+"trueRed25"
+
+>> Concatenate( 1, TestRedRamp.Red25 )
+"1Red25"
+
+>> Concatenate( "hi", TestRedRamp.Red25 )
+"hiRed25"
+
+>> true & TestYeaNay.Yea
+"trueYea"
+
+>> 1 & TestYeaNay.Yea
+"1Yea"
+
+>> "hi" & TestYeaNay.Yea
+"hiYea"
+
+>> TestYeaNay.Yea & true
+"Yeatrue"
+
+>> TestYeaNay.Yea & 1
+"Yea1"
+
+>> TestYeaNay.Yea & "hi"
+"Yeahi"
+
+>> Concatenate( true, TestYeaNay.Yea )
+"trueYea"
+
+>> Concatenate( 1, TestYeaNay.Yea )
+"1Yea"
+
+>> Concatenate( "hi", TestYeaNay.Yea )
+"hiYea"
 
 //===========================================================================================================
 //

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums_PreV1.txt
@@ -408,6 +408,15 @@ false
 >> "Label:" & TestYesNo.No
 "Label:false"
 
+>> Concatenate( "Label:", TestYesNo.No )
+"Label:false"
+
+>> TestYesNo.No & "Way"
+"falseWay"
+
+>> Concatenate( TestYesNo.No, "Way" )
+"falseWay"
+
 >> Text( TestYeaNay.Nay )
 "false"
 
@@ -432,6 +441,21 @@ Errors: Error 0-4: The function 'Text' has some invalid arguments.|Error 18-25: 
 >> "Label:" & TestBlueRamp.Blue50
 Errors: Error 23-30: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
 
+>> Concatenate( "Label:", TestBlueRamp.Blue50 )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 35-42: Invalid argument type (Color). Expecting a Text value instead.
+
+>> TestBlueRamp.Blue50 & " is the sky"
+Errors: Error 12-19: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> Concatenate( TestBlueRamp.Blue50, " is the sky")
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 25-32: Invalid argument type (Color). Expecting a Text value instead.
+
+>> "The sky is so very " & TestBlueRamp.Blue50 & " !!!"
+Errors: Error 36-43: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> Concatenate( "The sky is so very ", TestBlueRamp.Blue50, " !!!")
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 48-55: Invalid argument type (Color). Expecting a Text value instead.
+
 >> Mid( TestBlueRamp.Blue50, 2 )
 Errors: Error 0-3: The function 'Mid' has some invalid arguments.|Error 17-24: Invalid argument type (Color). Expecting a Text value instead.
 
@@ -449,6 +473,60 @@ Errors: Error 0-3: The function 'Mid' has some invalid arguments.|Error 16-22: I
 
 >> Len( TestRedRamp.Red25 )
 Errors: Error 16-22: Invalid argument type (Color). Expecting a Text value instead.
+
+>> true & TestRedRamp.Red25
+Errors: Error 18-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> 1 & TestRedRamp.Red25
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> "hi" & TestRedRamp.Red25
+Errors: Error 18-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> TestRedRamp.Red25 & true
+Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> TestRedRamp.Red25 & 1
+Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> TestRedRamp.Red25 & "hi"
+Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+
+>> Concatenate( true, TestRedRamp.Red25 )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 30-36: Invalid argument type (Color). Expecting a Text value instead.
+
+>> Concatenate( 1, TestRedRamp.Red25 )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 27-33: Invalid argument type (Color). Expecting a Text value instead.
+
+>> Concatenate( "hi", TestRedRamp.Red25 )
+Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 30-36: Invalid argument type (Color). Expecting a Text value instead.
+
+>> true & TestYeaNay.Yea
+"truetrue"
+
+>> 1 & TestYeaNay.Yea
+"1true"
+
+>> "hi" & TestYeaNay.Yea
+"hitrue"
+
+>> TestYeaNay.Yea & true
+"truetrue"
+
+>> TestYeaNay.Yea & 1
+"true1"
+
+>> TestYeaNay.Yea & "hi"
+"truehi"
+
+>> Concatenate( true, TestYeaNay.Yea )
+"truetrue"
+
+>> Concatenate( 1, TestYeaNay.Yea )
+"1true"
+
+>> Concatenate( "hi", TestYeaNay.Yea )
+"hitrue"
 
 //===========================================================================================================
 //


### PR DESCRIPTION
Option sets coming from Dataverse that are backed by a number are not handled correctly in Power Apps, a pre-V1 host. An error is produced for comparisons where there was not one previously. A few checks for pre-V1 were missing:
- Concatenate function (but not the operator)
- Numerical comparisons between option sets

Updating the test suite revealed that the interpreter's implementation of Concatenate didn't properly account for non-string option sets, which has also been fixed.

One reason we didn't detect these problems earlier is that we use EnumSymbol as a proxy for OptionSet, which is usually pretty good, but in the comparison case it led tests to fail but the product to fail. There will be a separate task to expand OptionSet to support more data types and update the tests.