### PR TITLE
More improvements to strongly typed option sets

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -800,7 +800,7 @@ namespace Microsoft.PowerFx.Core.Binding
             var usePowerFxV1CompatibilityRules = features.PowerFxV1CompatibilityRules;
 
             // Special cases for comparing option set values
-            // Without StronglyTypedBuiltinEnums, option sets are convereted to their backing kind before getting here in Visitor.Visit(FirstNameNode)
+            // Without StronglyTypedBuiltinEnums, enums are convereted to their backing kind before getting here in Binder.cs, Visitor.Visit(FirstNameNode)
             if (typeLeft.Kind == DKind.OptionSetValue || typeRight.Kind == DKind.OptionSetValue)
             {
                 if (usePowerFxV1CompatibilityRules)

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -803,11 +803,36 @@ namespace Microsoft.PowerFx.Core.Binding
             // Without StronglyTypedBuiltinEnums, option sets are convereted to their backing kind before getting here in Visitor.Visit(FirstNameNode)
             if (typeLeft.Kind == DKind.OptionSetValue || typeRight.Kind == DKind.OptionSetValue)
             {
-                // Comparing values from two different option set values is not supported
-                if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue
-                    && typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                if (usePowerFxV1CompatibilityRules)
                 {
-                    if (!usePowerFxV1CompatibilityRules || typeLeft.OptionSetInfo.CanCompareNumeric)
+                    // Comparing values from two different option set values is not supported
+                    if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue
+                        && typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                    {
+                        if (!usePowerFxV1CompatibilityRules || typeLeft.OptionSetInfo.CanCompareNumeric)
+                        {
+                            return new BinderCheckTypeResult
+                            {
+                                Coercions = new[]
+                                {
+                                    new BinderCoercionResult { Node = left, CoercedType = DType.Number },
+                                    new BinderCoercionResult { Node = right, CoercedType = DType.Number }
+                                }
+                            };
+                        }
+                        else
+                        {
+                            errorContainer.EnsureError(
+                                DocumentErrorSeverity.Severe,
+                                left.Parent,
+                                TexlStrings.ErrUnOrderedTypeForComparison_Type,
+                                typeLeft.GetKindString());
+                            return new BinderCheckTypeResult();
+                        }
+                    }
+
+                    // Comparing to backing type is permitted under a few circumstances
+                    else if (IsOptionSetComparableWithNumeric(typeLeft, typeRight))
                     {
                         return new BinderCheckTypeResult
                         {
@@ -818,49 +843,98 @@ namespace Microsoft.PowerFx.Core.Binding
                             }
                         };
                     }
-                    else
+                    else if (IsOptionSetComparableWithNumeric(typeRight, typeLeft))
+                    {
+                        return new BinderCheckTypeResult
+                        {
+                            Coercions = new[]
+                            {
+                                new BinderCoercionResult { Node = left, CoercedType = DType.Number },
+                                new BinderCoercionResult { Node = right, CoercedType = DType.Number }
+                            }
+                        };
+                    }
+
+                    // otherwise, we have an illegal option set comparison
+                    errorContainer.EnsureError(
+                        DocumentErrorSeverity.Severe,
+                        left.Parent,
+                        TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
+                        typeLeft.GetKindString(),
+                        typeRight.GetKindString());
+                    return new BinderCheckTypeResult();
+                }
+                else
+                {
+                    // Option set must be numeric to compare. 
+                    if ((typeLeft.OptionSetInfo?.BackingKind ?? DKind.Number) != DKind.Number)
                     {
                         errorContainer.EnsureError(
                             DocumentErrorSeverity.Severe,
                             left.Parent,
                             TexlStrings.ErrUnOrderedTypeForComparison_Type,
                             typeLeft.GetKindString());
+
                         return new BinderCheckTypeResult();
                     }
-                }
-
-                // Comparing to backing type is permitted under a few circumstances
-                else if (IsOptionSetComparableWithNumeric(typeLeft, typeRight, usePowerFxV1CompatibilityRules))
-                {
-                    return new BinderCheckTypeResult
+                    else if ((typeRight.OptionSetInfo?.BackingKind ?? DKind.Number) != DKind.Number)
                     {
-                        Coercions = new[]
-                        {
-                            new BinderCoercionResult { Node = left, CoercedType = DType.Number },
-                            new BinderCoercionResult { Node = right, CoercedType = DType.Number }
-                        }
-                    };
-                }
-                else if (IsOptionSetComparableWithNumeric(typeRight, typeLeft, usePowerFxV1CompatibilityRules))
-                {
-                    return new BinderCheckTypeResult
-                    {
-                        Coercions = new[]
-                        {
-                            new BinderCoercionResult { Node = left, CoercedType = DType.Number },
-                            new BinderCoercionResult { Node = right, CoercedType = DType.Number }
-                        }
-                    };
-                }
+                        errorContainer.EnsureError(
+                            DocumentErrorSeverity.Severe,
+                            left.Parent,
+                            TexlStrings.ErrUnOrderedTypeForComparison_Type,
+                            typeRight.GetKindString());
 
-                // otherwise, we have an illegal option set comparison
-                errorContainer.EnsureError(
-                    DocumentErrorSeverity.Severe,
-                    left.Parent,
-                    TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
-                    typeLeft.GetKindString(),
-                    typeRight.GetKindString());
-                return new BinderCheckTypeResult();
+                        return new BinderCheckTypeResult();
+                    }
+
+                    // Mismatched option sets can't be compared
+                    if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue && !typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                    {
+                        errorContainer.EnsureError(
+                            DocumentErrorSeverity.Severe,
+                            left.Parent,
+                            TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
+                            typeLeft.GetKindString(),
+                            typeRight.GetKindString());
+
+                        return new BinderCheckTypeResult();
+                    }
+                    else if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue)
+                    {
+                        coercions.Add(new BinderCoercionResult() { Node = left, CoercedType = DType.Number });
+                        coercions.Add(new BinderCoercionResult() { Node = right, CoercedType = DType.Number });
+                    }
+                    else if (typeLeft.Kind == DKind.OptionSetValue)
+                    {
+                        // The other value (right in this case) needs to be a number or coerced to a number in order to compare
+                        var rightResult = CheckComparisonTypeOneOfCore(errorContainer, right, features, typeRight, DType.Number, DType.Decimal, DType.Date, DType.Time, DType.DateTime);
+                        coercions.AddRange(rightResult.Coercions);
+
+                        // CheckComparisonTypeOneOfCore above will validate that Decimal is OK, but will not coerce to a number
+                        if (!DType.Number.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                        {
+                            coercions.Add(new BinderCoercionResult() { Node = right, CoercedType = DType.Number });
+                        }
+
+                        // Comparing option sets to their backing kind is permitted, and coerces the option set to the backing kind. In this case, always number, checked above.
+                        coercions.Add(new BinderCoercionResult() { Node = left, CoercedType = DType.Number });
+                    }
+                    else if (typeRight.Kind == DKind.OptionSetValue)
+                    {
+                        var leftResult = CheckComparisonTypeOneOfCore(errorContainer, left, features, typeLeft, DType.Number, DType.Decimal, DType.Date, DType.Time, DType.DateTime);
+                        coercions.AddRange(leftResult.Coercions);
+
+                        if (!DType.Number.Accepts(typeLeft, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                        {
+                            coercions.Add(new BinderCoercionResult() { Node = left, CoercedType = DType.Number });
+                        }
+
+                        coercions.Add(new BinderCoercionResult() { Node = right, CoercedType = DType.Number });
+                    }
+
+                    return new BinderCheckTypeResult() { Coercions = coercions };
+                }
             }
 
             // Excel's type coercion for inequality operators is inconsistent / borderline wrong, so we can't
@@ -981,13 +1055,13 @@ namespace Microsoft.PowerFx.Core.Binding
             return new BinderCheckTypeResult() { Coercions = coercions };
         }
 
-        private static bool IsOptionSetComparableWithNumeric(DType optionSet, DType numeric, bool usePowerFxV1CompatibilityRules)
+        private static bool IsOptionSetComparableWithNumeric(DType optionSet, DType numeric)
         {
-            return optionSet.Kind == DKind.OptionSetValue &&
-                   (numeric.Kind == DKind.Number || numeric.Kind == DKind.Decimal) &&
-                   (!usePowerFxV1CompatibilityRules ||
-                       (optionSet.OptionSetInfo.CanCompareNumeric &&
-                           (optionSet.OptionSetInfo.CanCoerceFromBackingKind || optionSet.OptionSetInfo.CanCoerceToBackingKind)));     
+            return optionSet.Kind == DKind.OptionSetValue && optionSet.OptionSetInfo != null &&
+                   optionSet.OptionSetInfo.BackingKind == DKind.Number &&
+                   optionSet.OptionSetInfo.CanCompareNumeric &&
+                   (optionSet.OptionSetInfo.CanCoerceFromBackingKind || optionSet.OptionSetInfo.CanCoerceToBackingKind) &&
+                   (numeric.Kind == DKind.Number || numeric.Kind == DKind.Decimal || numeric.Kind == DKind.ObjNull);
         }
 
         private static BinderCheckTypeResult CheckEqualArgTypesCore(IErrorContainer errorContainer, TexlNode left, TexlNode right, bool usePowerFxV1CompatibilityRules, DType typeLeft, DType typeRight, bool numberIsFloat)
@@ -1024,21 +1098,19 @@ namespace Microsoft.PowerFx.Core.Binding
             // Special case for comparing option set values
             if (typeLeft.Kind == DKind.OptionSetValue || typeRight.Kind == DKind.OptionSetValue)
             {
-                // Comparing values from two different option set values is not supported
-                if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue)
+                if (usePowerFxV1CompatibilityRules)
                 {
-                    if (typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                    // Comparing values from two different option set values is not supported
+                    if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue)
                     {
-                        return new BinderCheckTypeResult();
+                        if (typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                        {
+                            return new BinderCheckTypeResult();
+                        }
                     }
-                }
 
-                // Comparing to backing type is permitted under a few circumstances
-                else if (typeLeft.Kind == DKind.OptionSetValue &&
-                        (!usePowerFxV1CompatibilityRules || typeLeft.OptionSetInfo.CanCoerceFromBackingKind || typeLeft.OptionSetInfo.CanCoerceToBackingKind))
-                {
-                    if (typeLeft.OptionSetInfo.BackingKind == typeRight.Kind ||
-                        (typeLeft.IsOptionSetBackedByNumber && typeRight.Kind == DKind.Decimal))
+                    // Comparing to backing type is permitted under a few circumstances
+                    else if (IsOptionSetEqualWithPrimitive(typeLeft, typeRight))
                     {
                         return new BinderCheckTypeResult
                         {
@@ -1049,12 +1121,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             }
                         };
                     }
-                }
-                else if (typeRight.Kind == DKind.OptionSetValue &&
-                        (!usePowerFxV1CompatibilityRules || typeRight.OptionSetInfo.CanCoerceFromBackingKind || typeRight.OptionSetInfo.CanCoerceToBackingKind))
-                {
-                    if (typeRight.OptionSetInfo.BackingKind == typeLeft.Kind ||
-                        (typeRight.IsOptionSetBackedByNumber && typeLeft.Kind == DKind.Decimal))
+                    else if (IsOptionSetEqualWithPrimitive(typeRight, typeLeft))
                     {
                         return new BinderCheckTypeResult
                         {
@@ -1065,16 +1132,58 @@ namespace Microsoft.PowerFx.Core.Binding
                             }
                         };
                     }
+
+                    // otherwise, we have an illegal option set comparison
+                    errorContainer.EnsureError(
+                        DocumentErrorSeverity.Severe,
+                        left.Parent,
+                        TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
+                        typeLeft.GetKindString(),
+                        typeRight.GetKindString());
+                    return new BinderCheckTypeResult();
                 }
-                
-                // otherwise, we have an illegal option set comparison
-                errorContainer.EnsureError(
-                    DocumentErrorSeverity.Severe,
-                    left.Parent,
-                    TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
-                    typeLeft.GetKindString(),
-                    typeRight.GetKindString());
-                return new BinderCheckTypeResult();
+                else
+                {
+                    // Special case for comparing option set values, it should produce an error when the base option sets are different
+                    if (typeLeft.Kind == DKind.OptionSetValue && typeRight.Kind == DKind.OptionSetValue && !typeLeft.Accepts(typeRight, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules))
+                    {
+                        errorContainer.EnsureError(
+                            DocumentErrorSeverity.Severe,
+                            left.Parent,
+                            TexlStrings.ErrIncompatibleTypesForEquality_Left_Right,
+                            typeLeft.GetKindString(),
+                            typeRight.GetKindString());
+
+                        return new BinderCheckTypeResult();
+                    }
+                    else if (typeLeft.Kind == DKind.OptionSetValue && typeLeft.OptionSetInfo?.BackingKind == typeRight.Kind)
+                    {
+                        // Comparing option sets to their backing kind is permitted, and coerces the option set to the backing kind
+                        Contracts.Assert(typeRight.Kind == DKind.String || typeRight.Kind == DKind.Number || typeRight.Kind == DKind.Boolean || typeRight.Kind == DKind.Color);
+
+                        return new BinderCheckTypeResult() { Coercions = new[] { new BinderCoercionResult() { Node = left, CoercedType = typeRight } } };
+                    }
+                    else if (typeRight.Kind == DKind.OptionSetValue && typeRight.OptionSetInfo?.BackingKind == typeLeft.Kind)
+                    {
+                        Contracts.Assert(typeLeft.Kind == DKind.String || typeLeft.Kind == DKind.Number || typeLeft.Kind == DKind.Boolean || typeLeft.Kind == DKind.Color);
+
+                        return new BinderCheckTypeResult() { Coercions = new[] { new BinderCoercionResult() { Node = right, CoercedType = typeLeft } } };
+                    }
+
+                    // Special case for comparing option set values backed by numbers with decimal values
+                    if ((typeLeft.Kind == DKind.OptionSetValue && typeLeft.OptionSetInfo?.BackingKind == DKind.Number && typeRight.Kind == DKind.Decimal) ||
+                        (typeRight.Kind == DKind.OptionSetValue && typeRight.OptionSetInfo?.BackingKind == DKind.Number && typeLeft.Kind == DKind.Decimal))
+                    {
+                        return new BinderCheckTypeResult
+                        {
+                            Coercions = new[]
+                            {
+                                new BinderCoercionResult { Node = left, CoercedType = DType.Number },
+                                new BinderCoercionResult { Node = right, CoercedType = DType.Number }
+                            }
+                        };
+                    }
+                }
             }
 
             // Special case for view values, it should produce an error when the base views are different
@@ -1208,6 +1317,15 @@ namespace Microsoft.PowerFx.Core.Binding
             }
 
             return new BinderCheckTypeResult();
+        }
+
+        private static bool IsOptionSetEqualWithPrimitive(DType optionSet, DType primitive)
+        {
+            return optionSet.Kind == DKind.OptionSetValue && optionSet.OptionSetInfo != null &&
+                   (primitive.Kind == DKind.ObjNull ||
+                       ((optionSet.OptionSetInfo.BackingKind == primitive.Kind ||
+                           (optionSet.OptionSetInfo.BackingKind == DKind.Number && primitive.Kind == DKind.Decimal)) &&
+                        (optionSet.OptionSetInfo.CanCoerceFromBackingKind || optionSet.OptionSetInfo.CanCoerceToBackingKind)));
         }
 
         // Return types from CheckUnaryOpCore:

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums.txt
@@ -29,15 +29,16 @@
 // Misc
 //   15. Since there is no longer an Accepts relationship between enums and their backing kinds, more likely to get Void results
 //   16. Everything coerces to string
+//   17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
 // 
 // Examples (examples for Boolean backed enums and other configurations are in StronglyTypedEnums_TestEnums)
-//   17. StartOfWeek - Standard number backed enum
-//   18. TimeUnit - Standard string backed enum
-//   19. MatchOptions - String backed enum with CanConcatenateStronglyTyped
-//   20. Color - Color backed enum with CoerceToBackingKind
-//   21. ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
-//   22. DateTimeFormat - String backed enum with CoerceFromBackingKind
-//   23. Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
+//   18. StartOfWeek - Standard number backed enum
+//   19. TimeUnit - Standard string backed enum
+//   20. MatchOptions - String backed enum with CanConcatenateStronglyTyped
+//   21. Color - Color backed enum with CoerceToBackingKind
+//   22. ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
+//   23. DateTimeFormat - String backed enum with CoerceFromBackingKind
+//   24. Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
 
 //============================================================================================================
 //
@@ -776,7 +777,62 @@ Match.CalculatedOptionSetValue
 
 //===========================================================================================================
 //
-// 17. Examples - StartOfWeek - Standard number backed enum
+// 17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
+//
+
+>> StartOfWeek.Monday < Blank()
+Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: Enum (StartOfWeek), ObjNull.
+
+>> StartOfWeek.Monday = Blank()
+false
+
+>> Blank() >= StartOfWeek.Monday
+Errors: Error 8-10: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (StartOfWeek).
+
+>> Blank() <> StartOfWeek.Monday
+true
+
+// ErrorKind works because of CanCompareNumeric
+
+>> ErrorKind.Network < Blank()
+false
+
+>> ErrorKind.Network = Blank()
+false
+
+>> Blank() >= ErrorKind.Network
+false
+
+>> Blank() <> ErrorKind.Network
+true
+
+>> Match.Letter < Blank()
+Errors: Error 13-14: Incompatible types for comparison. These types can't be compared: Enum (Match), ObjNull.
+
+>> Match.Letter = Blank()
+false
+
+>> Blank() >= Match.Letter
+Errors: Error 8-10: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (Match).
+
+>> Blank() <> Match.Letter
+true
+
+>> Color.Gray < Blank()
+Errors: Error 11-12: Incompatible types for comparison. These types can't be compared: Enum (Color), ObjNull.
+
+>> Color.Gray = Blank()
+false
+
+>> Blank() >= Color.Gray
+Errors: Error 8-10: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (Color).
+
+>> Blank() <> Color.Gray
+true
+
+//===========================================================================================================
+//
+// 18. Examples - StartOfWeek - Standard number backed enum
 //
 
 // Standard usage
@@ -888,7 +944,7 @@ Errors: Error 44-45: Invalid argument type (Text). Expecting a Enum (StartOfWeek
 
 //===========================================================================================================
 //
-// 18. Examples - TimeUnit - Standard string backed enum
+// 19. Examples - TimeUnit - Standard string backed enum
 //
 
 // Standard usage
@@ -991,7 +1047,7 @@ Errors: Error 43-44: Invalid argument type (Text). Expecting a Enum (TimeUnit) v
 
 //===========================================================================================================
 //
-// 20. Examples - Color - Color backed enum with CoerceToBackingKind
+// 21. Examples - Color - Color backed enum with CoerceToBackingKind
 //
 
 // Standard usage
@@ -1109,7 +1165,7 @@ Errors: Error 10-12: Incompatible types for comparison. These types can't be com
 
 //===========================================================================================================
 //
-// 21. Examples - ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
+// 22. Examples - ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
 //
 
 // Standard usage
@@ -1232,7 +1288,7 @@ false
 
 //===========================================================================================================
 //
-// 22. Examples - DateTimeFormat - String backed enum with CoerceFromBackingKind
+// 23. Examples - DateTimeFormat - String backed enum with CoerceFromBackingKind
 //
 
 // Standard usage
@@ -1346,7 +1402,7 @@ Errors: Error 24-26: Unable to compare values of type Enum (DateTimeFormat).
 
 //===========================================================================================================
 //
-// 23. Examples - Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
+// 24. Examples - Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
 //
 
 // Standard usage

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
@@ -31,15 +31,16 @@
 // Misc
 //   15. Since there is no longer an Accepts relationship between enums and their backing kinds, more likely to get Void results
 //   16. Everything coerces to string
+//   17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
 // 
 // Examples (examples for Boolean backed enums and other configurations are in StronglyTypedEnums_TestEnums)
-//   17. StartOfWeek - Standard number backed enum
-//   18. TimeUnit - Standard string backed enum
-//   19. MatchOptions - String backed enum with CanConcatenateStronglyTyped
-//   20. Color - Color backed enum with CoerceToBackingKind
-//   21. ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
-//   22. DateTimeFormat - String backed enum with CoerceFromBackingKind
-//   23. Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
+//   18. StartOfWeek - Standard number backed enum
+//   19. TimeUnit - Standard string backed enum
+//   20. MatchOptions - String backed enum with CanConcatenateStronglyTyped
+//   21. Color - Color backed enum with CoerceToBackingKind
+//   22. ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
+//   23. DateTimeFormat - String backed enum with CoerceFromBackingKind
+//   24. Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
 
 //============================================================================================================
 //
@@ -732,7 +733,62 @@ true
 
 //===========================================================================================================
 //
-// 17. Examples - StartOfWeek - Standard number backed enum
+// 17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
+//
+
+>> StartOfWeek.Monday < Blank()
+false
+
+>> StartOfWeek.Monday = Blank()
+false
+
+>> Blank() >= StartOfWeek.Monday
+false
+
+>> Blank() <> StartOfWeek.Monday
+true
+
+// ErrorKind works because of CanCompareNumeric
+
+>> ErrorKind.Network < Blank()
+false
+
+>> ErrorKind.Network = Blank()
+false
+
+>> Blank() >= ErrorKind.Network
+false
+
+>> Blank() <> ErrorKind.Network
+true
+
+>> Match.Letter < Blank()
+Errors: Error 5-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> Match.Letter = Blank()
+false
+
+>> Blank() >= Match.Letter
+Errors: Error 16-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> Blank() <> Match.Letter
+true
+
+>> Color.Gray < Blank()
+Errors: Error 5-10: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> Color.Gray = Blank()
+false
+
+>> Blank() >= Color.Gray
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> Blank() <> Color.Gray
+true
+
+//===========================================================================================================
+//
+// 18. Examples - StartOfWeek - Standard number backed enum
 //
 
 // Standard usage
@@ -841,7 +897,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 //===========================================================================================================
 //
-// 18. Examples - TimeUnit - Standard string backed enum
+// 19. Examples - TimeUnit - Standard string backed enum
 //
 
 // Standard usage
@@ -941,7 +997,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 //===========================================================================================================
 //
-// 20. Examples - Color - Color backed enum with CoerceToBackingKind
+// 21. Examples - Color - Color backed enum with CoerceToBackingKind
 //
 
 // Standard usage
@@ -1056,7 +1112,7 @@ Errors: Error 5-9: Invalid argument type. Expecting one of the following: Text, 
 
 //===========================================================================================================
 //
-// 21. Examples - ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
+// 22. Examples - ErrorKind - Number backed enum with CoerceToBackingKind and CanCompareNumeric
 //
 
 // Standard usage
@@ -1176,7 +1232,7 @@ false
 
 //===========================================================================================================
 //
-// 22. Examples - DateTimeFormat - String backed enum with CoerceFromBackingKind
+// 23. Examples - DateTimeFormat - String backed enum with CoerceFromBackingKind
 //
 
 // Standard usage
@@ -1287,7 +1343,7 @@ Errors: Error 14-23: Invalid argument type. Expecting one of the following: Numb
 
 //===========================================================================================================
 //
-// 23. Examples - Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
+// 24. Examples - Match - String backed enum with CoerceFromBackingKind and CanConcatenateStronglyTyped
 //
 
 // Standard usage

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums.txt
@@ -28,9 +28,10 @@
 // Misc
 //   15. Since there is no longer an Accepts relationship between enums and their backing kinds, more likely to get Void results
 //   16. Everything coerces to string
+//   17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
 //
 // Examples
-//   17. TestYesNo - Standard DV Boolean backed option set, with CoerceToBackingKind and CoerceFromBackingKind
+//   18. TestYesNo - Standard DV Boolean backed option set, with CoerceToBackingKind and CoerceFromBackingKind
 
 //============================================================================================================
 //
@@ -532,7 +533,126 @@ false
 
 //===========================================================================================================
 //
-// 17. Examples - TestYesNo - Standard DV Boolean backed option set, with CoerceToBackingKind and CoerceFromBackingKind
+// 17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
+//
+
+>> TestYesNo.Yes = Blank()
+false
+
+>> TestYesNo.No = Blank()
+false
+
+>> TestYesNo.Yes <> Blank()
+true
+
+>> TestYesNo.No <> Blank()
+true
+
+>> Blank() = TestYesNo.Yes
+false
+
+>> Blank() = TestYesNo.No 
+false
+
+>> Blank() <> TestYesNo.Yes
+true
+
+>> Blank() <> TestYesNo.No
+true
+
+>> TestYesNo.No >= Blank()
+Errors: Error 13-15: Incompatible types for comparison. These types can't be compared: Enum (TestYesNo), ObjNull.
+
+>> TestYesNo.No < Blank()
+Errors: Error 13-14: Incompatible types for comparison. These types can't be compared: Enum (TestYesNo), ObjNull.
+
+>> Blank() < TestYesNo.Yes
+Errors: Error 8-9: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (TestYesNo).
+
+>> Blank() <= TestYesNo.Yes
+Errors: Error 8-10: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (TestYesNo).
+
+>> TestNumberCompareNumeric.V2 < Blank()
+Errors: Error 28-29: Incompatible types for comparison. These types can't be compared: Enum (TestNumberCompareNumeric), ObjNull.
+
+>> TestNumberCompareNumeric.V2 <= Blank()
+Errors: Error 28-30: Incompatible types for comparison. These types can't be compared: Enum (TestNumberCompareNumeric), ObjNull.
+
+>> TestNumberCompareNumeric.V2 >= Blank()
+Errors: Error 28-30: Incompatible types for comparison. These types can't be compared: Enum (TestNumberCompareNumeric), ObjNull.
+
+>> TestNumberCompareNumeric.V2 > Blank()
+Errors: Error 28-29: Incompatible types for comparison. These types can't be compared: Enum (TestNumberCompareNumeric), ObjNull.
+
+>> TestNumberCompareNumeric.V2 = Blank()
+false
+
+>> TestNumberCompareNumeric.V2 <> Blank()
+true
+
+>> Blank() < TestNumberCompareNumeric.V2
+Errors: Error 8-9: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (TestNumberCompareNumeric).
+
+>> Blank() <= TestNumberCompareNumeric.V2
+Errors: Error 8-10: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (TestNumberCompareNumeric).
+
+>> Blank() >= TestNumberCompareNumeric.V2
+Errors: Error 8-10: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (TestNumberCompareNumeric).
+
+>> Blank() > TestNumberCompareNumeric.V2
+Errors: Error 8-9: Incompatible types for comparison. These types can't be compared: ObjNull, Enum (TestNumberCompareNumeric).
+
+>> Blank() = TestNumberCompareNumeric.V2
+false
+
+>> Blank() <> TestNumberCompareNumeric.V2
+true
+
+>> TestNumberCoerceTo.V > Blank()
+Errors: Error 21-22: Incompatible types for comparison. These types can't be compared: Enum (TestNumberCoerceTo), ObjNull.
+
+>> TestNumberCoerceTo.V = Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V < Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V <= Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V >= Blank()
+true
+
+>> TestNumberCompareNumericCoerceFrom.V > Blank()
+true
+
+>> TestNumberCompareNumericCoerceFrom.V = Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V <> Blank()
+true
+
+>> Blank() < TestNumberCompareNumericCoerceFrom.V
+true
+
+>> Blank() <= TestNumberCompareNumericCoerceFrom.V
+true
+
+>> Blank() >= TestNumberCompareNumericCoerceFrom.V
+false
+
+>> Blank() > TestNumberCompareNumericCoerceFrom.V
+false
+
+>> Blank() = TestNumberCompareNumericCoerceFrom.V
+false
+
+>> Blank() <> TestNumberCompareNumericCoerceFrom.V
+true
+
+//===========================================================================================================
+//
+// 18. Examples - TestYesNo - Standard DV Boolean backed option set, with CoerceToBackingKind and CoerceFromBackingKind
 //
 
 // Standard usage

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/StronglyTypedEnum_TestEnums_PreV1.txt
@@ -30,6 +30,7 @@
 // Misc
 //   15. Since there is no longer an Accepts relationship between enums and their backing kinds, more likely to get Void results
 //   16. Everything coerces to string
+//   17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
 
 //============================================================================================================
 //
@@ -530,7 +531,126 @@ Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error
 
 //===========================================================================================================
 //
-// 17. Examples - TestYesNo - Standard DV Boolean backed option set, with CoerceToBackingKind and CoerceFromBackingKind
+// 17. Everything equals compares to Blank() (ObjNull), can order compare with numbers and CanCompareNumerics set
+//
+
+>> TestYesNo.Yes = Blank()
+false
+
+>> TestYesNo.No = Blank()
+false
+
+>> TestYesNo.Yes <> Blank()
+true
+
+>> TestYesNo.No <> Blank()
+true
+
+>> Blank() = TestYesNo.Yes
+false
+
+>> Blank() = TestYesNo.No 
+false
+
+>> Blank() <> TestYesNo.Yes
+true
+
+>> Blank() <> TestYesNo.No
+true
+
+>> TestYesNo.No >= Blank()
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> TestYesNo.No < Blank()
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> Blank() < TestYesNo.Yes
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> Blank() <= TestYesNo.Yes
+Errors: Error 20-24: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+
+>> TestNumberCompareNumeric.V2 < Blank()
+false
+
+>> TestNumberCompareNumeric.V2 <= Blank()
+false
+
+>> TestNumberCompareNumeric.V2 >= Blank()
+true
+
+>> TestNumberCompareNumeric.V2 > Blank()
+true
+
+>> TestNumberCompareNumeric.V2 = Blank()
+false
+
+>> TestNumberCompareNumeric.V2 <> Blank()
+true
+
+>> Blank() < TestNumberCompareNumeric.V2
+true
+
+>> Blank() <= TestNumberCompareNumeric.V2
+true
+
+>> Blank() >= TestNumberCompareNumeric.V2
+false
+
+>> Blank() > TestNumberCompareNumeric.V2
+false
+
+>> Blank() = TestNumberCompareNumeric.V2
+false
+
+>> Blank() <> TestNumberCompareNumeric.V2
+true
+
+>> TestNumberCoerceTo.V > Blank()
+true
+
+>> TestNumberCoerceTo.V = Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V < Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V <= Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V >= Blank()
+true
+
+>> TestNumberCompareNumericCoerceFrom.V > Blank()
+true
+
+>> TestNumberCompareNumericCoerceFrom.V = Blank()
+false
+
+>> TestNumberCompareNumericCoerceFrom.V <> Blank()
+true
+
+>> Blank() < TestNumberCompareNumericCoerceFrom.V
+true
+
+>> Blank() <= TestNumberCompareNumericCoerceFrom.V
+true
+
+>> Blank() >= TestNumberCompareNumericCoerceFrom.V
+false
+
+>> Blank() > TestNumberCompareNumericCoerceFrom.V
+false
+
+>> Blank() = TestNumberCompareNumericCoerceFrom.V
+false
+
+>> Blank() <> TestNumberCompareNumericCoerceFrom.V
+true
+
+//===========================================================================================================
+//
+// 18. Examples - TestYesNo - Standard DV Boolean backed option set, with CoerceToBackingKind and CoerceFromBackingKind
 //
 
 // Standard usage


### PR DESCRIPTION
Addresses customer reported bug in pre-V1 where option set value = Blank() resulted in an error.  General remedy is to return the pre-V1 code to its original state and have a large if around V1 vs. pre-V1 code.  And more tests.