### PR TITLE
Update Invalid Use of Dot error

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3363,7 +3363,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 if (!leftType.IsControl && !leftType.IsAggregate && !leftType.IsEnum && !leftType.IsOptionSet && !leftType.IsView && !leftType.IsUntypedObject && !leftType.IsDeferred)
                 {
-                    SetDottedNameError(node, TexlStrings.ErrInvalidDot);
+                    SetDottedNameError(node, TexlStrings.ErrInvalidDot, leftType.GetKindString());
                     return;
                 }
 

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1863,8 +1863,8 @@
     <comment>Description of the third parameter to Sequence</comment>
   </data>
   <data name="ErrInvalidDot" xml:space="preserve">
-    <value>Invalid use of '.'</value>
-    <comment>Error Message.</comment>
+    <value>The '.' operator cannot be used on {0} values.</value>
+    <comment>Error Message. {Locked='.'}. Error that occurs when you use the `.` operator on a type that doesn't support it. {0} is populated by a type name (e.g. Number, Text, Boolean).</comment>
   </data>
   <data name="ErrUnknownFunction" xml:space="preserve">
     <value>'{0}' is an unknown or unsupported function.</value>

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns_SupportColumnNamesAsIdentifiers.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/AddColumns_SupportColumnNamesAsIdentifiers.txt
@@ -49,7 +49,7 @@ Table({a:1,b:1},{a:2,b:8})
 {a:2,b:8}
 
 >> AddColumns(Table({a: 1, b: {c: 3}}, {a: 2, b: {c: 4}}), b.d, a * a * a)
-Errors: Error 56-57: Name isn't valid. 'b' isn't recognized.|Error 57-59: Invalid use of '.'|Error 0-10: The function 'AddColumns' has some invalid arguments.
+Errors: Error 56-57: Name isn't valid. 'b' isn't recognized.|Error 57-59: The '.' operator cannot be used on Error values.|Error 0-10: The function 'AddColumns' has some invalid arguments.
 
 >> AddColumns(Table({a: 1, b: {c: 3}}, {a: 2, b: {c: 4}}), 'b.d', a * a * a)
 Table({a:1,b:{c:3},'b.d':1},{a:2,b:{c:4},'b.d':8})

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Record.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/Record.txt
@@ -24,7 +24,7 @@ true
 "abc"
 
 >> First([{a: 1}]).Value.a
-Errors: Error 15-21: Name isn't valid. 'Value' isn't recognized.|Error 21-23: Invalid use of '.'
+Errors: Error 15-21: Name isn't valid. 'Value' isn't recognized.|Error 21-23: The '.' operator cannot be used on Error values.
 
 >> First([ { Value : 10 } ]).Value
 10

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_Decimal.txt
@@ -5,3 +5,6 @@
 
 >> With( { x : 2e28 , y : 1.234e28}, x * y )
 Error({Kind:ErrorKind.Numeric})
+
+>> With ( { x : 3 }, x.y )
+Errors: Error 19-21: The '.' operator cannot be used on Decimal values.

--- a/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests/ExpressionTestCases/With_Float.txt
@@ -5,3 +5,6 @@
 
 >> With( { x : 1e306 }, Power( x, x/3 ) )
 Error({Kind:ErrorKind.Numeric})
+
+>> With ( { x : 3 }, x.y )
+Errors: Error 19-21: The '.' operator cannot be used on Number values.


### PR DESCRIPTION
Updates error to "The '.' operator cannot be used on <TypeName> values"

The error shows up in the case of
"the thing on the left of “.” is a number/string/other thing you can’t use “.” on ever, excluding polymorphic because it's weird"