### PR TITLE
Update resource strings per localization team feedback

### DIFF
--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1864,7 +1864,7 @@
   </data>
   <data name="ErrInvalidDot" xml:space="preserve">
     <value>The '.' operator cannot be used on {0} values.</value>
-    <comment>Error Message. {Locked="'.'"}. Error that occurs when you use the `.` operator on a type that doesn't support it. {0} is populated by a type name (e.g. Number, Text, Boolean).</comment>
+    <comment>Error Message. Error that occurs when you use the `.` operator on a type that doesn't support it. {0} is populated by a type name (e.g. Number, Text, Boolean). The operator (.) is not translated, should be the same character ('full stop', \u002E, decimal code 46) in all languages.</comment>
   </data>
   <data name="ErrUnknownFunction" xml:space="preserve">
     <value>'{0}' is an unknown or unsupported function.</value>


### PR DESCRIPTION
The localization team asked us to remove the locked directive for one resource, as it was having errors in a few languages.