### PR TITLE
Add Field to Nl2Fx and Fx2Nl Result Dtos to hold diagnostics info such as Model prompt

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/BaseNLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/BaseNLParams.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
     public class BaseNLParams
@@ -9,5 +11,16 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// Additional context for NL operation. Usually, a stringified JSON object.
         /// </summary>
         public string Context { get; set; } = null;
+    }
+
+    public class BaseNLResult
+    {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault | JsonIgnoreCondition.WhenWritingNull)]
+        public BaseNLDiagnosticInfo Diagnostics { get; set; } = null;
+    }
+
+    public class BaseNLDiagnosticInfo
+    {
+        public string ModelPrompt { get; set; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/BaseNLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/BaseNLParams.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
@@ -16,11 +17,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     public class BaseNLResult
     {
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault | JsonIgnoreCondition.WhenWritingNull)]
-        public BaseNLDiagnosticInfo Diagnostics { get; set; } = null;
-    }
-
-    public class BaseNLDiagnosticInfo
-    {
-        public string ModelPrompt { get; set; }
+        public string DiagnosticsJson { get; set; } = null;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     /// <summary>
     /// Response for a <see cref="CustomNL2FxParams"/> event.
     /// </summary>
-    public class CustomFx2NLResult
+    public class CustomFx2NLResult : BaseNLResult
     {
         /// <summary>
         /// A natural-language sentence explaining the incoming expression.

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomNL2FxParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomNL2FxParams.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     /// <summary>
     /// Response for a <see cref="CustomNL2FxParams"/> event.
     /// </summary>
-    public class CustomNL2FxResult
+    public class CustomNL2FxResult : BaseNLResult
     {
         /// <summary>
         /// Possible expression.

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
@@ -79,6 +79,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         public UsageHints UsageHints { get; set; }
 
         // we may add additional app context...
+        public bool IncludeModelLogs { get; set; } = false;
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
@@ -79,7 +79,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         public UsageHints UsageHints { get; set; }
 
         // we may add additional app context...
-        public bool IncludeModelLogs { get; set; } = false;
     }
 
     /// <summary>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
@@ -71,6 +71,8 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomGetCapabilitiesParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomGetCapabilitiesResult",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.BaseNLParams",
+                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.BaseNLResult",
+                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.BaseNLDiagnosticInfo",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomFx2NLParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomFx2NLResult",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomNL2FxParams",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests/LanguageServiceProtocol/PublicSurfaceTests.cs
@@ -72,7 +72,6 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomGetCapabilitiesResult",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.BaseNLParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.BaseNLResult",
-                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.BaseNLDiagnosticInfo",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomFx2NLParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomFx2NLResult",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.CustomNL2FxParams",


### PR DESCRIPTION
This pr simply adds a new field to capture diagnostics for fx2nl or nl2fx