### PR TITLE
Deep mutations of records, squashed

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -126,8 +126,14 @@ namespace Microsoft.PowerFx.Core.Functions
         /// </summary>
         public virtual bool HasPreciseErrors => false;
 
-        // Returns true if the function will mutate the value of argument 0, as is the case with Patch, Collect, Remove, etc.
-        public virtual bool MutatesArg0 => false;
+        /// <summary>
+        /// Returns true if the function will mutate the argument, as is the case of Patch, Collect, Remove, etc.
+        /// Set can also mutate, but needs to make a decision based on the argument's node.
+        /// This function covers both CanMutate and CanSetMutate scenarios which is checked in CheckTypes/CheckSemantics.
+        /// </summary>
+        /// <param name="argIndex">Index of the argument.</param>
+        /// <param name="arg">Argument at that index.</param>
+        public virtual bool MutatesArg(int argIndex, TexlNode arg) => false;
 
         public virtual RequiredDataSourcePermissions FunctionPermission => RequiredDataSourcePermissions.None;
 
@@ -239,6 +245,23 @@ namespace Microsoft.PowerFx.Core.Functions
         protected void ValidateArgumentIsMutable(TexlBinding binding, TexlNode arg, IErrorContainer errors)
         {
             if (binding.Features.PowerFxV1CompatibilityRules && !binding.IsMutable(arg))
+            {
+                errors.EnsureError(
+                    arg,
+                    new ErrorResourceKey("ErrorResource_MutationFunctionCannotBeUsedWithImmutableValue"),
+                    this.Name);
+            }
+        }
+
+        /// <summary>
+        /// Adds an error to the container if the given argument is immutable.
+        /// </summary>
+        /// <param name="binding"></param>
+        /// <param name="arg"></param>
+        /// <param name="errors"></param>
+        protected void ValidateArgumentIsSetMutable(TexlBinding binding, TexlNode arg, IErrorContainer errors)
+        {
+            if (binding.Features.PowerFxV1CompatibilityRules && !binding.IsSetMutable(arg))
             {
                 errors.EnsureError(
                     arg,

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -129,6 +129,8 @@ namespace Microsoft.PowerFx.Core.Functions
         /// <summary>
         /// Returns true if the function will mutate the argument, as is the case of Patch, Collect, Remove, etc.
         /// Set can also mutate, but needs to make a decision based on the argument's node.
+        /// For example, Set(x,{a:1}) is not a mutate and has a single FirstName node for the first argument, 
+        /// while Set(x.a,1) is a mutate and has a more complex node for the first argument.
         /// This function covers both CanMutate and CanSetMutate scenarios which is checked in CheckTypes/CheckSemantics.
         /// </summary>
         /// <param name="argIndex">Index of the argument.</param>

--- a/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/IR/IRTranslator.cs
@@ -352,7 +352,7 @@ namespace Microsoft.PowerFx.Core.IR
                 for (var i = 0; i < carg; ++i)
                 {
                     var arg = node.Args.Children[i];
-                    var argContext = i == 0 && func.MutatesArg0 ? new IRTranslatorContext(context, isMutation: true) : context;
+                    var argContext = func.MutatesArg(i, arg) ? new IRTranslatorContext(context, isMutation: true) : context;
 
                     var supportColumnNamesAsIdentifiers = _features.SupportColumnNamesAsIdentifiers;
                     if (supportColumnNamesAsIdentifiers && func.ParameterCanBeIdentifier(arg, i, context.Binding.Features))

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/DeferredSymbolTable.cs
@@ -145,7 +145,8 @@ namespace Microsoft.PowerFx
             var props = new SymbolProperties
             {
                  CanMutate = true,
-                 CanSet = false
+                 CanSet = false,
+                 CanSetMutate = false
             };
 
             var data = new NameSymbol(logical, props)

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolProperties.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolProperties.cs
@@ -17,13 +17,29 @@ namespace Microsoft.PowerFx
 {    
     public class SymbolProperties
     {
-        // Can this symbol be reassigned with a Set() function. 
+        // When a symbol table variable is created, these attributes can be specified.
+        // A host can override these settings as they see fit.
+        // 
+        // Examples by category:
+        //
+        //                               CanSet   CanMutate   CanSetMutate
+        // ================================================================
+        //  Data sources                  false     true         false
+        //  Scope variables               false     false        false
+        //  Global variables (1)          true      true         false
+        //  Low code plugin NewRecord     false     false        true
+        //  Low code plugin OldRecord     false     false        false
+        //
+        // (1) CanSetMutate for global variables is false by default today, but we may change this default in the future.
+
+        // Can this symbol be reassigned with a Set function. For example: Set( a, {b:3} )
         public bool CanSet { get; init; }
 
-        // Can this symbol be passed to Collect, Patch() for mutation 
+        // Can this symbol be passed to Collect, Patch, Remove, etc. for mutation. For example: Collect( t, {b:3} )
         // This only applies to symbols of a tabular type. 
         public bool CanMutate { get; init; }
 
-        // Is Copyable?
+        // Can this symbol be deep mutated with Set. For example: Set( a.b, 3 )
+        public bool CanSetMutate { get; init; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -101,7 +101,8 @@ namespace Microsoft.PowerFx
             var props = new SymbolProperties
             {
                 CanSet = mutable,
-                CanMutate = mutable
+                CanMutate = mutable,
+                CanSetMutate = false
             };
             return AddVariable(name, type, props, displayName);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTableOverRecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTableOverRecordType.cs
@@ -40,7 +40,8 @@ namespace Microsoft.PowerFx
                 var data = new NameSymbol(TexlBinding.ThisRecordDefaultName, new SymbolProperties
                 {
                      CanMutate = false,
-                     CanSet = false
+                     CanSet = false,
+                     CanSetMutate = false
                 })
                 {
                     Owner = this,
@@ -70,7 +71,8 @@ namespace Microsoft.PowerFx
             var data = new NameSymbol(TexlBinding.ThisRecordDefaultName, new SymbolProperties
             {
                 CanMutate = false,
-                CanSet = false
+                CanSet = false,
+                CanSetMutate = false
             })
             {
                 Owner = this,
@@ -224,7 +226,8 @@ namespace Microsoft.PowerFx
                     data = new NameSymbol(logicalName, new SymbolProperties
                     {
                         CanSet = _mutable,
-                        CanMutate = false
+                        CanMutate = false,
+                        CanSetMutate = false
                     })
                     {
                         Owner = this,

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
@@ -126,14 +126,8 @@ namespace Microsoft.PowerFx.Types
         protected override bool TryGetIndex(int index1, out DValue<RecordValue> record)
         {
             var index0 = index1 - 1;
-            if (_sourceIndex != null)
+            if (_sourceIndex != null && index0 >= 0 && index0 < _sourceCount.Count)
             {
-                if (index0 < 0 || index0 >= _sourceCount.Count)
-                {
-                    record = null;
-                    return false;
-                }
-
                 var item = _sourceIndex[index0];
                 record = Marshal(item);
                 return true;
@@ -142,6 +136,50 @@ namespace Microsoft.PowerFx.Types
             {
                 return base.TryGetIndex(index1, out record);
             }
+        }
+
+        protected override bool TryGetIndex(int index1, out DValue<RecordValue> record, bool mutationCopy)
+        {
+            if (!mutationCopy)
+            {
+                return TryGetIndex(index1, out record);
+            }
+            else
+            {
+                var index0 = index1 - 1;
+                if (_sourceIndex != null && _sourceMutableIndex != null && index0 >= 0 && index0 < _sourceCount.Count)
+                {
+                    RecordValue rec = Marshal(_sourceIndex[index0]).Value;
+                    RecordValue copyRecord = (RecordValue)rec.MaybeShallowCopy();
+                    _sourceMutableIndex[index0] = MarshalInverse(copyRecord);
+                    record = DValue<RecordValue>.Of(copyRecord);
+                    return true;
+                }
+                else
+                {
+                    return base.TryGetIndex(index1, out record, mutationCopy);
+                }
+            }
+        }
+
+        public override DValue<RecordValue> First(bool mutationCopy = false)
+        {
+            if (TryGetIndex(1, out var record, mutationCopy: mutationCopy))
+            {
+                return record;
+            }
+
+            return DValue<RecordValue>.Of(FormulaValue.NewBlank());
+        }
+
+        public override DValue<RecordValue> Last(bool mutationCopy = false)
+        {
+            if (TryGetIndex(Count(), out var record, mutationCopy: mutationCopy))
+            {
+                return record;
+            }
+
+            return DValue<RecordValue>.Of(FormulaValue.NewBlank());
         }
 
         public override async Task<DValue<BooleanValue>> RemoveAsync(IEnumerable<FormulaValue> recordsToRemove, bool all, CancellationToken cancellationToken)

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PowerFx.Types
                 return record;
             }
 
-            return DValue<RecordValue>.Of(ArgumentOutOfRange(IRContext));
+            return DValue<RecordValue>.Of(ArgumentOutOfRangeError(IRContext));
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Microsoft.PowerFx.Types
                 return record;
             }
 
-            return DValue<RecordValue>.Of(ArgumentOutOfRange(IRContext));
+            return DValue<RecordValue>.Of(ArgumentOutOfRangeError(IRContext));
         }
 
         // Index() does standard error messaging and then call TryGetIndex().
@@ -166,7 +166,7 @@ namespace Microsoft.PowerFx.Types
         {
             if (mutationCopy)
             {
-                return DValue<RecordValue>.Of(ImmutableTable(IRContext));
+                return DValue<RecordValue>.Of(ImmutableTableError(IRContext));
             }
 
             return Rows.FirstOrDefault() ?? DValue<RecordValue>.Of(FormulaValue.NewBlank());
@@ -181,13 +181,13 @@ namespace Microsoft.PowerFx.Types
         {
             if (mutationCopy)
             {
-                return DValue<RecordValue>.Of(ImmutableTable(IRContext));
+                return DValue<RecordValue>.Of(ImmutableTableError(IRContext));
             }
 
             return Rows.LastOrDefault() ?? DValue<RecordValue>.Of(FormulaValue.NewBlank());
         }
 
-        private static ErrorValue ImmutableTable(IRContext irContext)
+        private static ErrorValue ImmutableTableError(IRContext irContext)
         {
             return new ErrorValue(irContext, new ExpressionError()
             {
@@ -197,7 +197,7 @@ namespace Microsoft.PowerFx.Types
             });
         }
 
-        private static ErrorValue ArgumentOutOfRange(IRContext irContext)
+        private static ErrorValue ArgumentOutOfRangeError(IRContext irContext)
         {
             return new ErrorValue(irContext, new ExpressionError()
             {
@@ -207,7 +207,7 @@ namespace Microsoft.PowerFx.Types
             });
         }
 
-        private static ErrorValue NotImplemented(IRContext irContext, [CallerMemberName] string methodName = null)
+        private static ErrorValue NotImplementedError(IRContext irContext, [CallerMemberName] string methodName = null)
         {
             return new ErrorValue(irContext, new ExpressionError()
             {
@@ -223,17 +223,17 @@ namespace Microsoft.PowerFx.Types
         // Async because derived classes may back this with a network call. 
         public virtual async Task<DValue<RecordValue>> AppendAsync(RecordValue record, CancellationToken cancellationToken)
         {
-            return DValue<RecordValue>.Of(NotImplemented(IRContext));
+            return DValue<RecordValue>.Of(NotImplementedError(IRContext));
         }
 
         public virtual async Task<DValue<BooleanValue>> RemoveAsync(IEnumerable<FormulaValue> recordsToRemove, bool all, CancellationToken cancellationToken)
         {
-            return DValue<BooleanValue>.Of(NotImplemented(IRContext));
+            return DValue<BooleanValue>.Of(NotImplementedError(IRContext));
         }
 
         public virtual async Task<DValue<BooleanValue>> ClearAsync(CancellationToken cancellationToken)
         {
-            return DValue<BooleanValue>.Of(NotImplemented(IRContext));
+            return DValue<BooleanValue>.Of(NotImplementedError(IRContext));
         }
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace Microsoft.PowerFx.Types
         /// <returns></returns>
         protected virtual async Task<DValue<RecordValue>> PatchCoreAsync(RecordValue baseRecord, RecordValue changeRecord, CancellationToken cancellationToken)
         {
-            return DValue<RecordValue>.Of(NotImplemented(IRContext));
+            return DValue<RecordValue>.Of(NotImplementedError(IRContext));
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Clear.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Clear.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool SupportsParamCoercion => false;
 
-        public override bool MutatesArg0 => true;
+        public override bool MutatesArg(int argIndex, TexlNode arg) => argIndex == 0;
 
         public ClearFunction()
             : base("Clear", TexlStrings.AboutClear, FunctionCategories.Behavior, DType.Unknown, 0, 1, 1, DType.EmptyTable)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Patch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Patch.cs
@@ -283,7 +283,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         // Return true if this function affects datasource query options.
         public override bool AffectsDataSourceQueryOptions => true;
 
-        public override bool MutatesArg0 => true;
+        public override bool MutatesArg(int argIndex, TexlNode arg) => argIndex == 0;
 
         public override RequiredDataSourcePermissions FunctionPermission => RequiredDataSourcePermissions.Create | RequiredDataSourcePermissions.Update;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx
         }
 
         /// <summary>
-        /// Enable a Set() function which allows scripts to do <see cref="RecalcEngine.UpdateVariable(string, Types.FormulaValue)"/>.
+        /// Enable a Set() function which allows scripts to do <see cref="RecalcEngine.UpdateVariable(string, Types.FormulaValue, SymbolProperties)"/>.
         /// </summary>
         /// <param name="powerFxConfig"></param>
         public static void EnableSetFunction(this PowerFxConfig powerFxConfig)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -167,6 +167,22 @@ namespace Microsoft.PowerFx
 
             var newValue = await arg1.Accept(this, context).ConfigureAwait(false);
 
+            if (arg0.IRContext.IsMutation && arg0 is RecordFieldAccessNode rfan)
+            {
+                var arg0value = await rfan.From.Accept(this, context).ConfigureAwait(false);
+                
+                if (arg0value is RecordValue rv && arg0value is IMutationCopyField)
+                {
+                    ((IMutationCopyField)rv).ShallowCopyFieldInPlace(rfan.Field);
+                    rv.UpdateField(rfan.Field, newValue);
+                    return node.IRContext.ResultType._type.Kind == DKind.Boolean ? FormulaValue.New(true) : FormulaValue.NewVoid();
+                }
+                else
+                {
+                    return CommonErrors.UnreachableCodeError(node.IRContext);
+                }
+            }
+
             // Binder has already ensured this is a first name node as well as mutable symbol. 
             if (arg0 is ResolvedObjectNode obj)
             {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/CollectFunction.cs
@@ -59,7 +59,7 @@ namespace Microsoft.PowerFx.Interpreter
             return argNum >= 1;
         }
 
-        public override bool MutatesArg0 => true;
+        public override bool MutatesArg(int argIndex, TexlNode arg) => argIndex == 0;
 
         public override bool IsLazyEvalParam(TexlNode node, int index, Features features)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Mutation/RemoveFunction.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Functions
             return argNum >= 1;
         }
 
-        public override bool MutatesArg0 => true;
+        public override bool MutatesArg(int argIndex, TexlNode arg) => argIndex == 0;
 
         public override bool IsLazyEvalParam(TexlNode node, int index, Features features)
         {

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/SetFunction.cs
@@ -28,6 +28,9 @@ namespace Microsoft.PowerFx.Interpreter
         // Set() is a behavior function. 
         public override bool IsSelfContained => false;
 
+        // Set() of a simple identifier is not a mutation through a reference (a mutate), but rather changing the reference (a true set).
+        public override bool MutatesArg(int argIndex, TexlNode arg) => argIndex == 0 && arg.Kind != NodeKind.FirstName;
+
         public override IEnumerable<StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.SetArg1, TexlStrings.SetArg2 };
@@ -71,50 +74,56 @@ namespace Microsoft.PowerFx.Interpreter
             Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
 
             var arg0 = argTypes[0];
+            var arg1 = argTypes[1];
+
+            // Type check
+            if (!(arg0.Accepts(arg1, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: binding.Features.PowerFxV1CompatibilityRules) ||
+                 (arg0.IsNumeric && arg1.IsNumeric)))
+            {
+                errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrBadType_ExpectedType_ProvidedType, arg0.GetKindString(), arg1.GetKindString());
+                return;
+            }
+
+            if (arg1.AggregateHasExpandedType())
+            {
+                if (binding.Features.SkipExpandableSetSemantics)
+                {
+                    errors.EnsureError(DocumentErrorSeverity.Warning, args[1], WrnSetExpandableType);
+                    return;
+                }
+                else
+                {
+                    if (arg1.IsTable)
+                    {
+                        errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrSetVariableWithRelationshipNotAllowTable);
+                        return;
+                    }
+
+                    if (arg1.IsRecord)
+                    {
+                        errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrSetVariableWithRelationshipNotAllowRecord);
+                        return;
+                    }
+                }
+            }
 
             var firstName = args[0].AsFirstName();
 
             if (firstName != null)
             {
+                // Variable reference assignment, for example Set( x, 3 )
                 var info = binding.GetInfo(firstName);
                 if (info.Data is NameSymbol nameSymbol && nameSymbol.Props.CanSet)
                 {
-                    // We have a variable. type check
-                    var arg1 = argTypes[1];
-
-                    if (!(arg0.Accepts(arg1, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: binding.Features.PowerFxV1CompatibilityRules) ||
-                         (arg0.IsNumeric && arg1.IsNumeric)))
-                    {
-                        errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrBadType_ExpectedType_ProvidedType, arg0.GetKindString(), arg1.GetKindString());
-                        return;
-                    }
-
-                    if (arg1.AggregateHasExpandedType())
-                    {
-                        if (binding.Features.SkipExpandableSetSemantics)
-                        {
-                            errors.EnsureError(DocumentErrorSeverity.Warning, args[1], WrnSetExpandableType);
-                            return;
-                        }
-                        else
-                        {
-                            if (arg1.IsTable)
-                            {
-                                errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrSetVariableWithRelationshipNotAllowTable);
-                                return;
-                            }
-
-                            if (arg1.IsRecord)
-                            {
-                                errors.EnsureError(DocumentErrorSeverity.Critical, args[1], ErrSetVariableWithRelationshipNotAllowRecord);
-                                return;
-                            }
-                        }
-                    }
-
-                    // Success
+                    // We have a variable, success
                     return;
                 }
+            }
+            else if (binding.Features.PowerFxV1CompatibilityRules)
+            {
+                // Deep mutation, for example Set( x.a, 4 )
+                base.ValidateArgumentIsSetMutable(binding, args[0], errors);
+                return;
             }
 
             errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrNeedValidVariableName_Arg, Name, args[0]);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -128,11 +128,22 @@ namespace Microsoft.PowerFx
         }
 
         /// <summary>
-        /// Create or update a named variable to a value. 
+        /// Create or update a named variable to a value, with custom CanSet/Mutate attributes. 
         /// </summary>
         /// <param name="name">variable name. This can be used in other formulas.</param>
         /// <param name="value">constant value.</param>
         public void UpdateVariable(string name, FormulaValue value)
+        {
+            UpdateVariable(name, value, new SymbolProperties { CanMutate = true, CanSet = true });
+        }
+
+        /// <summary>
+        /// Create or update a named variable to a value, with custom CanSet/Mutate attributes. 
+        /// </summary>
+        /// <param name="name">variable name. This can be used in other formulas.</param>
+        /// <param name="value">constant value.</param>
+        /// <param name="newVarProps">symbol properties.</param>
+        public void UpdateVariable(string name, FormulaValue value, SymbolProperties newVarProps)
         {
             var x = value;
 
@@ -151,7 +162,12 @@ namespace Microsoft.PowerFx
             else
             {
                 // New
-                var slot = _symbolTable.AddVariable(name, value.Type, mutable: true);
+                if (newVarProps == null)
+                {
+                    newVarProps = new SymbolProperties { CanMutate = true, CanSet = true };
+                }
+
+                var slot = _symbolTable.AddVariable(name, value.Type, newVarProps);
 
                 Formulas[slot.SlotIndex] = RecalcFormulaInfo.NewVariable(slot, name, x.IRContext.ResultType);
                 _symbolValues.Set(slot, value);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerFx
         /// Create or update a named variable to a value, with custom CanSet/Mutate attributes. 
         /// </summary>
         /// <param name="name">variable name. This can be used in other formulas.</param>
-        /// <param name="value">constant value.</param>
+        /// <param name="value">constant value. The variable will take the type of this value on create.</param>
         public void UpdateVariable(string name, FormulaValue value)
         {
             UpdateVariable(name, value, new SymbolProperties { CanMutate = true, CanSet = true });
@@ -141,8 +141,8 @@ namespace Microsoft.PowerFx
         /// Create or update a named variable to a value, with custom CanSet/Mutate attributes. 
         /// </summary>
         /// <param name="name">variable name. This can be used in other formulas.</param>
-        /// <param name="value">constant value.</param>
-        /// <param name="newVarProps">symbol properties.</param>
+        /// <param name="value">constant value. The variable will take the type of this value on create.</param>
+        /// <param name="newVarProps">symbol properties. This is only used on the intiail create of the variable.</param>
         public void UpdateVariable(string name, FormulaValue value, SymbolProperties newVarProps)
         {
             var x = value;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerFx
         /// </summary>
         /// <param name="name">variable name. This can be used in other formulas.</param>
         /// <param name="value">constant value. The variable will take the type of this value on create.</param>
-        /// <param name="newVarProps">symbol properties. This is only used on the intiail create of the variable.</param>
+        /// <param name="newVarProps">symbol properties. This is only used on the initial create of the variable.</param>
         public void UpdateVariable(string name, FormulaValue value, SymbolProperties newVarProps)
         {
             var x = value;

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4102,7 +4102,7 @@
     <comment>{0} - Entity that is about to be created/renamed, {1} - Name of the entity, {2} - Type of entity that is already using the name.</comment>
   </data>
   <data name="ErrNeedValidVariableName_Arg" xml:space="preserve">
-    <value>The first argument of '{0}' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type '{1}'</value>
+    <value>'{1}' can't be modified with '{0}' or conflicts with the name of an existing scope variable, data source, or other object.</value>
     <comment>Error Message</comment>
   </data>
   <data name="AboutSet" xml:space="preserve">

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Clear_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Clear_V1Compat.txt
@@ -12,6 +12,12 @@ Errors: Error 6-7: Invalid argument type (Decimal). Expecting a Table value inst
 >> Clear(1/0)
 Errors: Error 7-8: Invalid argument type (Decimal). Expecting a Table value instead.|Error 0-5: The function 'Clear' has some invalid arguments.
 
+>> Clear(If(false,[1,2,3]))
+Errors: Error 6-23: The value passed to the 'Clear' function cannot be changed.
+
+>> Clear(If(false,[1,2,3],Error("bad table")))
+Errors: Error 6-42: The value passed to the 'Clear' function cannot be changed.
+
 >> IsError(Clear(1))
 Errors: Error 14-15: Invalid argument type (Decimal). Expecting a Table value instead.|Error 8-13: The function 'Clear' has some invalid arguments.
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/FileExpressionEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/FileExpressionEvaluationTests.cs
@@ -233,6 +233,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             testRunner.AddFile(TestRunner.ParseSetupString(setup), path);
 
+            if (testRunner.Tests.Count > 0 && testRunner.Tests[0].SetupHandlerName.Contains("MutationFunctionsTestSetup"))
+            {
+                ExpressionEvaluationTests.MutationFunctionsTestSetup(engine, false);
+            }
+
             var result = testRunner.RunTests();
 
             if (result.Fail > 0)

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/AutomatedLowCodePlugins.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/AutomatedLowCodePlugins.txt
@@ -35,7 +35,7 @@ Errors: Error 10-11: Incompatible types for comparison. These types can't be com
 {Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
 
 >> Set( NewRecord, OldRecord )
-Errors: Error 5-14: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'NewRecord'
+Errors: Error 5-14: 'NewRecord' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
 
 // OldRecord can't be mutated or set
 
@@ -46,7 +46,7 @@ Errors: Error 14-21: The value passed to the 'Set' function cannot be changed.
 Errors: Error 14-21: The value passed to the 'Set' function cannot be changed.
 
 >> Set( OldRecord, NewRecord )
-Errors: Error 5-14: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'OldRecord'
+Errors: Error 5-14: 'OldRecord' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
 
 // Copies of NewRecord and OldRecord can't be mutated (today, we may relax this limitation in the future)
 
@@ -71,7 +71,7 @@ Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
 {Field1:1,Field2:"saturn",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
 
 >> Set( DataSource, Table(First(DataSource)) )
-Errors: Error 5-15: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'DataSource'
+Errors: Error 5-15: 'DataSource' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
 
 >> Set( DataSource.Field2, [{Name:"saturn"}] )
 Errors: Error 15-22: Deprecated use of '.'. Please use the 'ShowColumns' function instead.
@@ -87,10 +87,10 @@ Errors: Error 22-29: The value passed to the 'Set' function cannot be changed.
 20
 
 >> With( NewRecord, Set( Field1, 2 ) )
-Errors: Error 22-28: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+Errors: Error 22-28: 'Field1' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
 
 >> With( NewRecord, Set( Field1, Field1 ) )
-Errors: Error 22-28: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+Errors: Error 22-28: 'Field1' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
 
 >> With( NewRecord, Set( NewRecord.Field1, 22 ) ); NewRecord
 {Field1:22,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
@@ -99,10 +99,10 @@ Errors: Error 22-28: The first argument of 'Set' should be a valid variable name
 Table({Value:22},{Value:22})
 
 >> ForAll( [NewRecord, NewRecord], Set( Field1, 2 ) )
-Errors: Error 37-43: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+Errors: Error 37-43: 'Field1' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
   
 >> ForAll( [NewRecord, NewRecord], Set( Field1, Field1 ) )
-Errors: Error 37-43: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+Errors: Error 37-43: 'Field1' can't be modified with 'Set' or conflicts with the name of an existing scope variable, data source, or other object.
 
 >> ForAll( [NewRecord, NewRecord], Set( ThisRecord.Field1, 3 ) )
 Errors: Error 47-54: The value passed to the 'Set' function cannot be changed.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/AutomatedLowCodePlugins.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/AutomatedLowCodePlugins.txt
@@ -1,0 +1,181 @@
+#SETUP: PowerFxV1CompatibilityRules,DecimalSupport,MutationFunctionsTestSetup
+
+>> NewRecord
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> OldRecord
+{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> NewRecord_SetEnabled_SetMutateEnabled
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+// Can compare fields, can't compare records
+
+>> NewRecord.Field1 = OldRecord.Field1
+false
+
+>> NewRecord.Field4 = Not( OldRecord.Field4 )
+true
+
+>> NewRecord = OldRecord; NewRecord // can't compare records, "; NewRecord" avoid the REPL from thinking it is named formula
+Errors: Error 10-11: Incompatible types for comparison. These types can't be compared: Record, Record.
+
+// NewRecord can be mutated but not set
+
+>> Set( NR, NewRecord )
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord.Field1, 20 ); NewRecord
+{Field1:20,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord.Field2, "venus"); NewRecord
+{Field1:20,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> NR // hasn't been modified from  on write
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord, OldRecord )
+Errors: Error 5-14: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'NewRecord'
+
+// OldRecord can't be mutated or set
+
+>> Set( OldRecord.Field1, 30 ); NewRecord
+Errors: Error 14-21: The value passed to the 'Set' function cannot be changed.
+
+>> Set( OldRecord.Field2, "mars"); NewRecord
+Errors: Error 14-21: The value passed to the 'Set' function cannot be changed.
+
+>> Set( OldRecord, NewRecord )
+Errors: Error 5-14: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'OldRecord'
+
+// Copies of NewRecord and OldRecord can't be mutated (today, we may relax this limitation in the future)
+
+>> Set( x, NewRecord )
+{Field1:20,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( x.Field1, 40 )
+Errors: Error 6-13: The value passed to the 'Set' function cannot be changed.
+
+>> Set( y, OldRecord )
+{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> Set( y.Field1, 50 )
+Errors: Error 6-13: The value passed to the 'Set' function cannot be changed.
+
+// Data source, can't use Set to mutate, Patch needs to be used
+
+>> DataSource
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Patch( DataSource, First(DataSource), {Field2: "saturn"} )
+{Field1:1,Field2:"saturn",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( DataSource, Table(First(DataSource)) )
+Errors: Error 5-15: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'DataSource'
+
+>> Set( DataSource.Field2, [{Name:"saturn"}] )
+Errors: Error 15-22: Deprecated use of '.'. Please use the 'ShowColumns' function instead.
+
+>> Set( First(DataSource).Field2, "saturn" )
+Errors: Error 22-29: The value passed to the 'Set' function cannot be changed.
+
+// USE IN SCOPE VARIABLES
+
+// Scope variables cannot be Set
+
+>> With( NewRecord, Field1 )
+20
+
+>> With( NewRecord, Set( Field1, 2 ) )
+Errors: Error 22-28: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+
+>> With( NewRecord, Set( Field1, Field1 ) )
+Errors: Error 22-28: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+
+>> With( NewRecord, Set( NewRecord.Field1, 22 ) ); NewRecord
+{Field1:22,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> ForAll( [NewRecord, NewRecord], Field1 )
+Table({Value:22},{Value:22})
+
+>> ForAll( [NewRecord, NewRecord], Set( Field1, 2 ) )
+Errors: Error 37-43: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+  
+>> ForAll( [NewRecord, NewRecord], Set( Field1, Field1 ) )
+Errors: Error 37-43: The first argument of 'Set' should be a valid variable name, and cannot conflict with any existing control, screen, collection, or data source names. Found type 'Field1'
+
+>> ForAll( [NewRecord, NewRecord], Set( ThisRecord.Field1, 3 ) )
+Errors: Error 47-54: The value passed to the 'Set' function cannot be changed.
+
+>> ForAll( [NewRecord, NewRecord], Set( NewRecord.Field1, 23 ) ); NewRecord
+{Field1:23,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+// The following three tests are effecitvely the same, with different levels of explicitness
+// In all three cases, we are reading the scope variable Field1 that was copied at the point With started and using that value throughout
+// The double additions don't matter since the source is always the same.
+>> With( NewRecord, Set( NewRecord.Field1, Field1+1); Set( NewRecord.Field1, Field1+1) ); NewRecord.Field1
+24
+
+>> With( NewRecord, Set( NewRecord.Field1, ThisRecord.Field1+1); Set( NewRecord.Field1, ThisRecord.Field1+1) ); NewRecord.Field1
+25
+
+>> With( NewRecord As ThisRecord, Set( NewRecord.Field1, ThisRecord.Field1+1); Set( NewRecord.Field1, ThisRecord.Field1+1) ); NewRecord.Field1
+26
+
+// In the future, we may allow variables to set mutate, which would use copy on write
+
+>> NewRecord // before NewRecord_SetEnabled_SetMutateEnabled changes
+{Field1:26,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord_SetEnabled_SetMutateEnabled, NewRecord )
+{Field1:26,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord_SetEnabled_SetMutateEnabled.Field2, "saturn" )
+If(true, {test:1}, "Void value (result of the expression can't be used).")
+
+>> Set( NewRecord_SetEnabled_SetMutateEnabled.Field3, DateTime(2024,3,1,0,0,0,0) )
+If(true, {test:1}, "Void value (result of the expression can't be used).")
+
+>> Set( NewRecord_SetEnabled_SetMutateEnabled.Field4, Blank() )
+If(true, {test:1}, "Void value (result of the expression can't be used).")
+
+>> NewRecord_SetEnabled_SetMutateEnabled // after mutations
+{Field1:26,Field2:"saturn",Field3:DateTime(2024,3,1,0,0,0,0),Field4:Blank()}
+
+>> NewRecord // unchanged (copy on write prevented it from being updated)
+{Field1:26,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( z, NewRecord ) 
+{Field1:26,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( z, Patch( NewRecord, { Field2: "neptune", Field3: DateTime(2024,4,1,0,0,0,0), Field4: false } ) )
+{Field1:26,Field2:"neptune",Field3:DateTime(2024,4,1,0,0,0,0),Field4:false}
+
+>> NewRecord // unchanged after z copy (not a mutation, not a copy on write)
+{Field1:26,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+// Check data type compatibility, should be the same as any other variable
+
+>> Set( NewRecord.Field1, Decimal(51) ); NewRecord
+{Field1:51,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord.Field1, Float(53) ); NewRecord
+{Field1:53,Field2:"venus",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( NewRecord.Field1, true ); NewRecord
+Errors: Error 23-27: Invalid argument type (Boolean). Expecting a Decimal value instead.
+
+>> Set( NewRecord.Field1, "53" ); NewRecord
+Errors: Error 23-27: Invalid argument type (Text). Expecting a Decimal value instead.
+
+>> Set( n, Decimal(100) )
+100
+
+>> Set( n, Float(101) )
+101
+
+>> Set( n, true )
+Errors: Error 8-12: Invalid argument type (Boolean). Expecting a Decimal value instead.
+
+>> Set( n, "102" )
+Errors: Error 8-13: Invalid argument type (Text). Expecting a Decimal value instead.

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/DeepMutation_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/DeepMutation_V1Compat.txt
@@ -410,3 +410,74 @@ Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value
 
 >> dbd // after dbd
 {d:Table({Value:1},{Value:2},{Value:3},{Value:11})}
+
+// REALLY DEEP MUTATIONS
+
+>> Set( deep, [[[[1,2,3],[4,5,6]]]] )
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> Set( deep_copy1, deep )
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> Patch( First(First(First(deep).Value).Value).Value, {Value:2}, {Value:99} )
+{Value:99}
+
+>> deep // after first update
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> deep_copy1
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> Set( deep_copy2, deep )
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> Patch( Last(Last(Last(deep).Value).Value).Value, {Value:6}, {Value:98} )
+{Value:98}
+
+>> deep // after last update
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:98})})})})
+
+>> deep_copy1 // unchanged
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> deep_copy2
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> Set( deep_copy3, deep )
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:98})})})})
+
+>> Patch( Index(Index(Index(deep,1).Value,1).Value,2).Value, {Value:4}, {Value:97} )
+{Value:97}
+
+>> deep // after index update
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:97},{Value:5},{Value:98})})})})
+
+>> deep_copy1 // still unchanged
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> deep_copy2 // unchanged
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:6})})})})
+
+>> deep_copy3
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:98})})})})
+
+>> Patch( Last(Index(First(deep_copy1).Value,1).Value).Value, {Value:5}, {Value:96} )
+{Value:96}
+
+>> deep_copy1 // local mod
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:2},{Value:3})},{Value:Table({Value:4},{Value:96},{Value:6})})})})
+
+>> Patch( Last(First(Index(deep_copy2,1).Value).Value).Value, {Value:4}, {Value:95} )
+{Value:95}
+
+>> deep_copy2 // local mod
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:95},{Value:5},{Value:6})})})})
+
+>> Patch( Index(First(First(deep_copy3).Value).Value,1).Value, {Value:1}, {Value:94} )
+{Value:94}
+
+>> deep_copy3 // local mod
+Table({Value:Table({Value:Table({Value:Table({Value:94},{Value:99},{Value:3})},{Value:Table({Value:4},{Value:5},{Value:98})})})})
+
+>> deep // unchanged after copy mutations
+Table({Value:Table({Value:Table({Value:Table({Value:1},{Value:99},{Value:3})},{Value:Table({Value:97},{Value:5},{Value:98})})})})

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/Set_DeepMutation_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/Set_DeepMutation_V1Compat.txt
@@ -1,0 +1,342 @@
+#SETUP: PowerFxV1CompatibilityRules,MutationFunctionsTestSetup
+
+// Newly declared vars are output as part of the testing infrastructure.  The Set function is actually returning Void.
+
+// BASICS by default, variables are mutable but not set mutable
+
+>> Set( x, {a:1} )
+{a:1}
+
+>> Set( x.a, 3 )
+Errors: Error 6-8: The value passed to the 'Set' function cannot be changed.
+
+>> Set( y, [1,2,3] )
+Table({Value:1},{Value:2},{Value:3})
+
+>> Set( First(y).Value, 4 )
+Errors: Error 13-19: The value passed to the 'Set' function cannot be changed.
+
+>> Patch( y, First(y), {Value:5})
+{Value:5}
+
+>> y
+Table({Value:5},{Value:2},{Value:3})
+
+// LITERALS can never be mutated
+
+>> Set( {a:1,b:2}.a, 3 )
+Errors: Error 14-16: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First([1,2,3]).Value, 4 )
+Errors: Error 19-25: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First(Table({a:1},{a:2},{a:3})).a, 5 )
+Errors: Error 36-38: The value passed to the 'Set' function cannot be changed.
+
+>> Patch( [1,2,3], {Value:1}, {Value:4} )
+Errors: Error 7-14: The value passed to the 'Patch' function cannot be changed.
+
+// SET MUTATION
+
+>> Set( r1_copy1, r1_SetMutateEnabled ); r1_copy1
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( r1_SetMutateEnabled.Field1, 25 ); r1_SetMutateEnabled
+{Field1:25,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> r1_copy1 // umodified due to copy on write
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( r1_copy2, r1_MutateEnabled_SetMutateEnabled ); r1_copy2
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( r1_MutateEnabled_SetMutateEnabled.Field1, 26 ); r1_MutateEnabled_SetMutateEnabled
+{Field1:26,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> r1_copy2 // umodified due to copy on write
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( r1_copy3, r1_MutateEnabled ); r1_copy3
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( r1_MutateEnabled.Field1, 27 ); r1_MutateEnabled_SetMutateEnabled
+Errors: Error 21-28: The value passed to the 'Set' function cannot be changed.
+
+>> r1_MutateEnabled // unmodified due to the error
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> r1_copy3 // umodified due to copy on write
+{Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Set( t1_copy1, t1_SetMutateEnabled ); t1_copy1
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Set( First(t1_SetMutateEnabled).Field1, 29 ); t1_SetMutateEnabled
+Table({Field1:29,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Set( t1_copy2, t1_MutateEnabled_SetMutateEnabled ); t1_copy2
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Set( First(t1_MutateEnabled_SetMutateEnabled).Field1, 28 ); t1_MutateEnabled_SetMutateEnabled
+Table({Field1:28,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Set( t1_copy3, t1_MutateEnabled ); t1_copy3
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Set( First(t1_MutateEnabled).Field1, 21 ); t1_MutateEnabled
+Errors: Error 28-35: The value passed to the 'Set' function cannot be changed.
+
+// PATCH/CLEAR/REMOVE/ETC MUTATION
+
+>> Patch( t1_SetMutateEnabled, First(t1_SetMutateEnabled), {Field2: "neptune"})
+Errors: Error 7-26: The value passed to the 'Patch' function cannot be changed.
+
+>> Collect( t1_SetMutateEnabled, r2 )
+Errors: Error 9-28: The value passed to the 'Collect' function cannot be changed.
+
+>> t1_SetMutateEnabled // so far
+Table({Field1:29,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> Patch( t1_MutateEnabled_SetMutateEnabled, First(t1_MutateEnabled_SetMutateEnabled), {Field2: "neptune"} )
+{Field1:28,Field2:"neptune",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Collect( t1_MutateEnabled_SetMutateEnabled, r2 )
+{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> t1_MutateEnabled_SetMutateEnabled
+Table({Field1:28,Field2:"neptune",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Patch( t1_MutateEnabled, First(t1_MutateEnabled), {Field2: "neptune"} )
+{Field1:1,Field2:"neptune",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true}
+
+>> Collect( t1_MutateEnabled, r2 )
+{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> t1_MutateEnabled
+Table({Field1:1,Field2:"neptune",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> t1_copy1 // umodified due to copy on write
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> t1_copy2 // umodified due to copy on write
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> t1_copy3 // umodified due to copy on write
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+// FUNCTIONS THAT PROPAGATE MUTABILITY
+
+>> Set( t1_copy4, t1_MutateEnabled_SetMutateEnabled )
+Table({Field1:28,Field2:"neptune",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Set( First(t1_MutateEnabled_SetMutateEnabled).Field3, DateTime(1999,1,1,0,0,0,0) ); t1_MutateEnabled_SetMutateEnabled
+Table({Field1:28,Field2:"neptune",Field3:DateTime(1999,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+>> Set( Last(t1_MutateEnabled_SetMutateEnabled).Field4, Blank() ); t1_MutateEnabled_SetMutateEnabled
+Table({Field1:28,Field2:"neptune",Field3:DateTime(1999,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:Blank()})
+
+>> Set( Index(t1_MutateEnabled_SetMutateEnabled,2).Field2, "mars" ); t1_MutateEnabled_SetMutateEnabled
+Table({Field1:28,Field2:"neptune",Field3:DateTime(1999,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"mars",Field3:DateTime(2022,2,1,0,0,0,0),Field4:Blank()})
+
+// FUNCTIONS THAT DON'T PROPAGATE MUTABILITY
+
+>> Set( Index(FirstN(t1_MutateEnabled_SetMutateEnabled,3),2).Field1, 6 )
+Errors: Error 57-64: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Index(LastN(t1_MutateEnabled_SetMutateEnabled,3),2).Field1, 6 )
+Errors: Error 56-63: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Index(Filter(t1_MutateEnabled_SetMutateEnabled,Field1>0),2).Field1, 6 )
+Errors: Error 64-71: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Index(Sort(t1_MutateEnabled_SetMutateEnabled,Field1),2).Field1, 6 )
+Errors: Error 60-67: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Index(SortByColumns(t1_MutateEnabled_SetMutateEnabled,Field1),2).Field1, 6 )
+Errors: Error 69-76: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First(FirstN(t1_MutateEnabled_SetMutateEnabled,3)).Field1, 6 )
+Errors: Error 55-62: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First(LastN(t1_MutateEnabled_SetMutateEnabled,3)).Field1, 6 )
+Errors: Error 54-61: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First(Filter(t1_MutateEnabled_SetMutateEnabled,Field1>0)).Field1, 6 )
+Errors: Error 62-69: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First(Sort(t1_MutateEnabled_SetMutateEnabled,Field1)).Field1, 6 )
+Errors: Error 58-65: The value passed to the 'Set' function cannot be changed.
+
+>> Set( First(SortByColumns(t1_MutateEnabled_SetMutateEnabled,Field1)).Field1, 6 )
+Errors: Error 67-74: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last(FirstN(t1_MutateEnabled_SetMutateEnabled,3)).Field1, 6 )
+Errors: Error 54-61: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last(LastN(t1_MutateEnabled_SetMutateEnabled,3)).Field1, 6 )
+Errors: Error 53-60: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last(Filter(t1_MutateEnabled_SetMutateEnabled,Field1>0)).Field1, 6 )
+Errors: Error 61-68: The value passed to the 'Set' function cannot be changed.
+
+>> Set( LookUp(t1_MutateEnabled_SetMutateEnabled,Field1>0).Field1, 6 )
+Errors: Error 55-62: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last(Sort(t1_MutateEnabled_SetMutateEnabled,Field1)).Field1, 6 )
+Errors: Error 57-64: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last(SortByColumns(t1_MutateEnabled_SetMutateEnabled,Field1)).Field1, 6 )
+Errors: Error 66-73: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last(Table(r1,r2)).Field1, 6 )
+Errors: Error 23-30: The value passed to the 'Set' function cannot be changed.
+
+>> Set( Last([r1,r2]).Field1, 6 )
+Errors: Error 18-25: The value passed to the 'Set' function cannot be changed.
+
+>> t1_MutateEnabled_SetMutateEnabled // all mods
+Table({Field1:28,Field2:"neptune",Field3:DateTime(1999,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"mars",Field3:DateTime(2022,2,1,0,0,0,0),Field4:Blank()})
+
+>> t1_copy2 // unchanged due to copy on write, recheck
+Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})
+
+>> t1_copy4 // unchanged due to copy on write
+Table({Field1:28,Field2:"neptune",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+
+// DEEP, DEEP RECORD MUTATION
+
+// rwr1_SetMutateEnabled
+
+>> Set( rwr1_copy1, rwr1_SetMutateEnabled )
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"common"}},Field3:false}
+
+>> Set( rwr1_SetMutateEnabled.Field2.Field2_3.Field2_3_2, "very common" ); rwr1_SetMutateEnabled
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"very common"}},Field3:false}
+
+>> Set( rwr1_copy2, rwr1_SetMutateEnabled )
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"very common"}},Field3:false}
+
+>> Set( rwr1_SetMutateEnabled.Field2.Field2_3.Field2_3_1, 2112 ); rwr1_SetMutateEnabled
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:2112,Field2_3_2:"very common"}},Field3:false}
+
+>> rwr1_copy1 // unchanged due to copy on write
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"common"}},Field3:false}
+
+>> rwr1_copy2 // unchanged due to copy on write
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"very common"}},Field3:false}
+
+// rwr1_MutateEnabled
+
+>> Set( rwr1_copy4, rwr1_MutateEnabled )
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"common"}},Field3:false}
+
+>> Set( rwr1_MutateEnabled.Field2.Field2_3.Field2_3_2, "very common" ); rwr1_MutateEnabled
+Errors: Error 39-50: The value passed to the 'Set' function cannot be changed.
+
+>> Set( rwr1_MutateEnabled.Field2.Field2_3.Field2_3_1, 2112 ); rwr1_MutateEnabled
+Errors: Error 39-50: The value passed to the 'Set' function cannot be changed.
+
+>> rwr1_copy4 // unchanged due to errors
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"common"}},Field3:false}
+
+// rwr1_MutateEnabled_SetMutateEnabled
+
+>> Set( rwr1_copy5, rwr1_MutateEnabled_SetMutateEnabled )
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"common"}},Field3:false}
+
+>> Set( rwr1_MutateEnabled_SetMutateEnabled.Field2.Field2_3.Field2_3_2, "super common" ); rwr1_MutateEnabled_SetMutateEnabled
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"super common"}},Field3:false}
+
+>> Set( rwr1_copy6, rwr1_MutateEnabled_SetMutateEnabled )
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"super common"}},Field3:false}
+
+>> Set( rwr1_MutateEnabled_SetMutateEnabled.Field2.Field2_3.Field2_3_1, 4224 ); rwr1_MutateEnabled_SetMutateEnabled
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:4224,Field2_3_2:"super common"}},Field3:false}
+
+>> rwr1_copy5 // unchanged due to copy on write
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"common"}},Field3:false}
+
+>> rwr1_copy6 // unchanged due to copy on write
+{Field1:1,Field2:{Field2_1:121,Field2_2:"2_2",Field2_3:{Field2_3_1:1231,Field2_3_2:"super common"}},Field3:false}
+
+// DEEP, DEEP RECORD MUTATION WITH TABLE
+
+// rwt1_MutateEnabled_SetMutateEnabled
+
+>> rwt1_MutateEnabled_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Set( rwt1_copy1, rwt1_MutateEnabled_SetMutateEnabled )
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Set( First(rwt1_MutateEnabled_SetMutateEnabled.Field2.Field2_4).Field2, "mercury" ); rwt1_MutateEnabled_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"mercury",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Collect( rwt1_MutateEnabled_SetMutateEnabled.Field2.Field2_4, r2 ); rwt1_MutateEnabled_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"mercury",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})}}
+
+>> Set( Last(rwt1_MutateEnabled_SetMutateEnabled.Field2.Field2_4).Field2, "jupiter" ); rwt1_MutateEnabled_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"mercury",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"jupiter",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})}}
+
+>> Patch( rwt1_MutateEnabled_SetMutateEnabled.Field2.Field2_4, LookUp(rwt1_MutateEnabled_SetMutateEnabled.Field2.Field2_4, Field2 = "jupiter"), { Field2: "stars" } )
+{Field1:2,Field2:"stars",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> rwt1_MutateEnabled_SetMutateEnabled // after changes
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"mercury",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"stars",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})}}
+
+>> rwt1_copy1
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+// rwt1_SetMutateEnabled
+
+>> rwt1_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Set( rwt1_copy2, rwt1_SetMutateEnabled )
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Set( First(rwt1_SetMutateEnabled.Field2.Field2_4).Field2, "mercury" ); rwt1_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"mercury",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Collect( rwt1_SetMutateEnabled.Field2.Field2_4, r2 ); rwt1_SetMutateEnabled
+Errors: Error 37-46: The value passed to the 'Collect' function cannot be changed.
+
+>> Set( Last(rwt1_SetMutateEnabled.Field2.Field2_4).Field2, "jupiter" ); rwt1_SetMutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"jupiter",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Patch( rwt1_SetMutateEnabled.Field2.Field2_4, LookUp(rwt1_SetMutateEnabled.Field2.Field2_4, Field2 = "jupiter"), { Field2: "stars" } )
+Errors: Error 35-44: The value passed to the 'Patch' function cannot be changed.
+
+>> rwt1_SetMutateEnabled // after changes
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"jupiter",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> rwt1_copy2
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+// rwt1_MutateEnabled
+
+>> rwt1_MutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Set( rwt1_copy3, rwt1_MutateEnabled )
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+>> Set( First(rwt1_MutateEnabled.Field2.Field2_4).Field2, "mercury" ); rwt1_MutateEnabled
+Errors: Error 46-53: The value passed to the 'Set' function cannot be changed.
+
+>> Collect( rwt1_MutateEnabled.Field2.Field2_4, r2 ); rwt1_MutateEnabled
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})}}
+
+>> Set( Last(rwt1_MutateEnabled.Field2.Field2_4).Field2, "jupiter" ); rwt1_MutateEnabled
+Errors: Error 45-52: The value passed to the 'Set' function cannot be changed.
+
+>> Patch( rwt1_MutateEnabled.Field2.Field2_4, LookUp(rwt1_MutateEnabled.Field2.Field2_4, Field2 = "moon"), { Field2: "stars" } )
+{Field1:2,Field2:"stars",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> rwt1_MutateEnabled // after changes
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true},{Field1:2,Field2:"stars",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})}}
+
+>> rwt1_copy3
+{Field1:3,Field2:{Field2_1:321,Field2_2:"2_2",Field2_4:Table({Field1:1,Field2:"earth",Field3:DateTime(2022,1,1,0,0,0,0),Field4:true})}}
+
+

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/PowerFxEvaluationTests.cs
@@ -11,10 +11,13 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.PowerFx.Core;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Functions;
 using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests;
+using Microsoft.PowerFx.Core.Tests.Helpers;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
@@ -590,7 +593,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             return null;
         }
 
-        private static void MutationFunctionsTestSetup(RecalcEngine engine, bool numberIsFloat)
+        internal static void MutationFunctionsTestSetup(RecalcEngine engine, bool numberIsFloat)
         {
             /*
              * Record r1 => {![Field1:n, Field2:s, Field3:d, Field4:b]}
@@ -654,6 +657,14 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     "DisplayNameField2_3")),
                 "DisplayNameField2"))
                 .Add(new NamedFormulaType("Field3", FormulaType.Boolean, "DisplayNameField3"));
+
+            var recordWithTableType = RecordType.Empty()
+                .Add(new NamedFormulaType("Field1", numberType, "DisplayNameField1"))
+                .Add(new NamedFormulaType("Field2", RecordType.Empty()
+                    .Add(new NamedFormulaType("Field2_1", numberType, "DisplayNameField2_1"))
+                    .Add(new NamedFormulaType("Field2_2", FormulaType.String, "DisplayNameField2_2"))
+                    .Add(new NamedFormulaType("Field2_4", FormulaValue.NewTable(r1.Type).Type, "DisplayNameField2_4")),
+                "DisplayNameField2"));
 #pragma warning restore SA1117 // Parameters should be on same line or separate lines
 
             var recordWithRecordFields1 = new List<NamedValue>()
@@ -704,9 +715,21 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 new NamedValue("Field3", FormulaValue.New(true))
             };
 
+            var recordWithTableFields1 = new List<NamedValue>()
+            {
+                new NamedValue("Field1", newNumber(3)),
+                new NamedValue("Field2", FormulaValue.NewRecordFromFields(new List<NamedValue>()
+                {
+                    new NamedValue("Field2_1", newNumber(321)),
+                    new NamedValue("Field2_2", FormulaValue.New("2_2")),
+                    new NamedValue("Field2_4", FormulaValue.NewTable(r1.Type, r1)),
+                }))
+            };
+
             var recordWithRecord1 = FormulaValue.NewRecordFromFields(recordWithRecordType, recordWithRecordFields1);
             var recordWithRecord2 = FormulaValue.NewRecordFromFields(recordWithRecordType, recordWithRecordFields2);
             var recordWithRecord3 = FormulaValue.NewRecordFromFields(recordWithRecordType, recordWithRecordFields3);
+            var recordWithTable1 = FormulaValue.NewRecordFromFields(recordWithTableType, recordWithTableFields1);
 
             var t2 = FormulaValue.NewTable(recordWithRecordType, new List<RecordValue>()
             {
@@ -728,6 +751,26 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             engine.UpdateVariable("rwr2", recordWithRecord2);
             engine.UpdateVariable("rwr3", recordWithRecord3);
             engine.UpdateVariable("r_empty", rEmpty);
+
+            // Low code plugin testing
+            engine.UpdateVariable("NewRecord", r1, new SymbolProperties { CanMutate = false, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("OldRecord", r2, new SymbolProperties { CanMutate = false, CanSet = false, CanSetMutate = false });
+            engine.UpdateVariable("DataSource", t1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = false });
+            engine.UpdateVariable("NewRecord_SetEnabled_SetMutateEnabled", r1, new SymbolProperties { CanMutate = false, CanSet = true, CanSetMutate = true });
+
+            // Set and Patch/Collect/Remove/etc deep mutation testing
+            engine.UpdateVariable("t1_SetMutateEnabled", t1, new SymbolProperties { CanMutate = false, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("t1_MutateEnabled_SetMutateEnabled", t1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("t1_MutateEnabled", t1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = false });
+            engine.UpdateVariable("r1_SetMutateEnabled", r1, new SymbolProperties { CanMutate = false, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("r1_MutateEnabled_SetMutateEnabled", r1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("r1_MutateEnabled", r1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = false });
+            engine.UpdateVariable("rwr1_SetMutateEnabled", recordWithRecord1, new SymbolProperties { CanMutate = false, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("rwr1_MutateEnabled_SetMutateEnabled", recordWithRecord1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("rwr1_MutateEnabled", recordWithRecord1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = false });
+            engine.UpdateVariable("rwt1_SetMutateEnabled", recordWithTable1, new SymbolProperties { CanMutate = false, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("rwt1_MutateEnabled_SetMutateEnabled", recordWithTable1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = true });
+            engine.UpdateVariable("rwt1_MutateEnabled", recordWithTable1, new SymbolProperties { CanMutate = true, CanSet = false, CanSetMutate = false });
 
             var valueTableType = TableType.Empty().Add("Value", numberType);
             var tEmpty = FormulaValue.NewTable(valueTableType.ToRecord());

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Scenarios/DataTableMarshallerProvider.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Scenarios/DataTableMarshallerProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerFx.Tests
             return recordType;
         }
 
-        protected override bool TryGetIndex(int index1, out DValue<RecordValue> record)
+        protected override bool TryGetIndex(int index1, out DValue<RecordValue> record, bool mutationCopy = false)
         {
             TryGetIndexNumberOfCalls++;
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/SetFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/SetFunctionTests.cs
@@ -130,6 +130,27 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Fact]
+        public void SetRecord_CanMutate()
+        {
+            var config = new PowerFxConfig();
+            config.EnableSetFunction();
+            var engine = new RecalcEngine(config);
+
+            var cache = new TypeMarshallerCache();
+            var obj = cache.Marshal(new { X = 10m, Y = 20m });
+
+            engine.UpdateVariable("obj", obj, new SymbolProperties { CanSet = true, CanSetMutate = true });
+
+            // Can update record
+            var r1 = engine.Eval("Set(obj, {X: 11, Y: 21}); obj.X", null, _opts);
+            Assert.Equal(11m, r1.ToObject());
+
+            // Can deep mutate record
+            var r2 = engine.Eval("Set(obj.X, 31); obj.X", null, _opts);
+            Assert.Equal(31m, r2.ToObject());
+        }
+
+        [Fact]
         public void SetRecordFloat()
         {
             var config = new PowerFxConfig();
@@ -146,8 +167,29 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             Assert.Equal(11.0, r1.ToObject());
 
             // But SetField fails 
-            var r2 = engine.Check("Set(obj.X, Float(31)); obj.X", null, _opts);
+            var r2 = engine.Check("Set(obj.X, 31); obj.X", null, _opts);
             Assert.False(r2.IsSuccess);
+        }
+
+        [Fact]
+        public void SetRecordFloat_SetMutate()
+        {
+            var config = new PowerFxConfig();
+            config.EnableSetFunction();
+            var engine = new RecalcEngine(config);
+
+            var cache = new TypeMarshallerCache();
+            var obj = cache.Marshal(new { X = 10f, Y = 20f });
+
+            engine.UpdateVariable("obj", obj, new SymbolProperties { CanSet = true, CanSetMutate = true });
+
+            // Can update record
+            var r1 = engine.Eval("Set(obj, {X: Float(11), Y: Float(21)}); obj.X", null, _opts);
+            Assert.Equal(11.0, r1.ToObject());
+
+            // Can deep mutate record
+            var r2 = engine.Eval("Set(obj.X, Float(31)); obj.X", null, _opts);
+            Assert.Equal(31.0, r2.ToObject());
         }
 
         // Test various failure cases 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/SymbolValueTests.cs
@@ -795,11 +795,15 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void MutationTests(bool canMutate, bool canSet)
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, true)]
+        [InlineData(true, true, false)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        public void MutationTests(bool canMutate, bool canSet, bool canSetMutate)
         {
             var recordType = RecordType.Empty().Add("Field1", FormulaType.Number);
             var tableType = recordType.ToTable();
@@ -808,7 +812,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             symbols.AddVariable("var", tableType, new SymbolProperties
             {
                  CanMutate = canMutate,
-                 CanSet = canSet
+                 CanSet = canSet,
+                 CanSetMutate = canSetMutate
             });
 
             var config = new PowerFxConfig();
@@ -823,9 +828,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             var checkSet = engine.Check("Set(var, Table({ Field1 : 123}))", opts, symbols);
             var checkMutate = engine.Check("Collect(var, { Field1 : 123})", opts, symbols);
+            var checkSetMutate = engine.Check("Set( First(var).Field1, 123 )", opts, symbols);
 
             Assert.Equal(canSet, checkSet.IsSuccess);
             Assert.Equal(canMutate, checkMutate.IsSuccess);
+            Assert.Equal(canSetMutate, checkSetMutate.IsSuccess);
         }
 
         // Get a convenient string representation of a SymbolValue

--- a/src/tests/Microsoft.PowerFx.TexlFunctionExporter.Shared/YamlTexlFunction.cs
+++ b/src/tests/Microsoft.PowerFx.TexlFunctionExporter.Shared/YamlTexlFunction.cs
@@ -104,7 +104,6 @@ namespace Microsoft.PowerFx.TexlFunctionExporter
             IsVariadicFunction = texlFunction.IsVariadicFunction;
             ManipulatesCollections = texlFunction.ManipulatesCollections;
             ModifiesValues = texlFunction.ModifiesValues;
-            MutatesArg0 = texlFunction.MutatesArg0;
             PropagatesMutability = texlFunction.PropagatesMutability;
             RequireAllParamColumns = texlFunction.RequireAllParamColumns;
             RequiresDataSourceScope = texlFunction.RequiresDataSourceScope;
@@ -167,7 +166,6 @@ namespace Microsoft.PowerFx.TexlFunctionExporter
         public bool IsVariadicFunction;
         public bool ManipulatesCollections;
         public bool ModifiesValues;
-        public bool MutatesArg0;
         public bool PropagatesMutability;
         public bool RequireAllParamColumns;
         public bool RequiresDataSourceScope;


### PR DESCRIPTION
Adds support for deep mutation through the Set function.  `Set( a, {b:1} )` doesn't change and will assign a reference to the record `{b:1}` to the variable `a`.  After `a` has been established, it now supports mutation through `Set( a.b, 2 )`.  This is an optional facility that is disabled by default and there are no semantic changes.  When creating variables the host has the option to enable this with `SymbolProperties.CanSetMutate`.

This also fixes two related bugs.  First, really deep mutations were not being properly copied on write, where `t` should be unaffected by the Patch https://github.com/microsoft/Power-Fx/issues/2450:
```
>> Set( deep, [[[[1,2,3],[4,5,6]]]] )
deep: [[[[1, 2, 3], [4, 5, 6]]]]

>> Set( t, deep )
t: [[[[1, 2, 3], [4, 5, 6]]]]

>> Patch( First(First(First(deep).Value).Value).Value, {Value:2}, {Value:99} )
{Value:99}

>> deep
[[[[1, 99, 3], [4, 5, 6]]]]

>> t
[[[[1, 99, 3], [4, 5, 6]]]]
```

And this should not return a casting error, instead returning Blank() https://github.com/microsoft/Power-Fx/issues/2451:
```
>> Patch(Blank(),Blank(),Blank())
Unable to cast object of type 'Microsoft.PowerFx.Types.BlankType' to type 'Microsoft.PowerFx.Types.RecordType'.
```

