### PR TITLE
Restore STJ nuget version to 6.0.8

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Microsoft.PowerFx.Connectors.csproj
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Microsoft.PowerFx.Connectors.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />   
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>

--- a/src/libraries/Microsoft.PowerFx.Json/Microsoft.PowerFx.Json.csproj
+++ b/src/libraries/Microsoft.PowerFx.Json/Microsoft.PowerFx.Json.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Microsoft.PowerFx.LanguageServerProtocol.csproj
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Microsoft.PowerFx.LanguageServerProtocol.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>

--- a/src/tests/.Net4.6.2/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
+++ b/src/tests/.Net4.6.2/Microsoft.PowerFx.Core.Tests/Microsoft.PowerFx.Core.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />    
     
     <!-- .Net 4.6.2 specific -->
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
#2442 bumped System.Text.Json nuget from to 6.0.9.  But not all consumers are updated. 

Restore back to 6.0.8