### PR TITLE
Better SymbolValue Helpers

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/DebugDump.cs
@@ -18,14 +18,14 @@ namespace Microsoft.PowerFx
     /// </summary>
     internal static class DebugDump
     {
-        public static string Dump(ReadOnlySymbolTable symbolTable)
+        public static string Dump(this ReadOnlySymbolTable symbolTable)
         {
             using var tw = new StringWriter();
             Dump(symbolTable, tw);
             return tw.ToString();
         }
 
-        public static void Dump(ReadOnlySymbolTable symbolTable, TextWriter tw, string indent = "")
+        public static void Dump(this ReadOnlySymbolTable symbolTable, TextWriter tw, string indent = "")
         {
             // These should also align with intellisense APIs. 
             tw.WriteLine($"{indent}SymbolTable '{symbolTable.DebugName()}', hash={symbolTable.VersionHash.GetHashCode()}");
@@ -67,17 +67,22 @@ namespace Microsoft.PowerFx
             tw.WriteLine();
         }
 
-        public static string Dump(ReadOnlySymbolValues symbolValues)
+        public static string Dump(this ReadOnlySymbolValues symbolValues)
         {
             using var tw = new StringWriter();
             Dump(symbolValues, tw);
             return tw.ToString();
         }
 
-        public static void Dump(ReadOnlySymbolValues symbolValues, TextWriter tw, string indent = "")
+        public static void Dump(this ReadOnlySymbolValues symbolValues, TextWriter tw, string indent = "")
         {
             tw.WriteLine($"{indent}SymbolValues '{symbolValues.DebugName}_{symbolValues.GetHashCode()}'");
             var symbolTable = symbolValues.SymbolTable;
+
+            if (symbolValues is ComposedReadOnlySymbolValues composed)
+            {
+                composed.DebugDumpChildren(tw, indent + "  ");
+            }
 
             var values = (IGlobalSymbolNameResolver)symbolTable;
             foreach (var kv in values.GlobalSymbols)
@@ -100,12 +105,12 @@ namespace Microsoft.PowerFx
             }
         }
 
-        public static string Dump(FormulaType type)
+        public static string Dump(this FormulaType type)
         {
             return type?.ToString();
         }
 
-        public static string Dump(FormulaValue value)
+        public static string Dump(this FormulaValue value)
         {
             var settings = new FormulaValueSerializerSettings
             {
@@ -116,25 +121,25 @@ namespace Microsoft.PowerFx
             return sb.ToString();
         }
 
-        public static string Dump(TexlNode parseNode)
+        public static string Dump(this TexlNode parseNode)
         {
             return TexlPretty.PrettyPrint(parseNode);
         }
 
-        internal static string Dump(IntermediateNode eval)
+        internal static string Dump(this IntermediateNode eval)
         {
             var str = eval?.ToString();
             return str;
         }
 
-        public static string Dump(CheckResult check)
+        public static string Dump(this CheckResult check)
         {
             using var tw = new StringWriter();
             Dump(check, tw);
             return tw.ToString();
         }
 
-        public static void Dump(CheckResult check, TextWriter tw, string indent = "")
+        public static void Dump(this CheckResult check, TextWriter tw, string indent = "")
         {
             tw.WriteLine($"{indent}CheckResult");
             tw.WriteLine();

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx
                 var st = kv.Key;
                 var sv = kv.Value;
 
-                tw.WriteLine($"{indent}{st.DebugName} --> {sv.DebugName}_{sv.GetHashCode()}");
+                tw.WriteLine($"{indent}{st.DebugName} --> {sv.DebugNameWithId}");
             }
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.PowerFx
                 else
                 {
                     // Bad - different instance with conflicting values.
-                    throw new InvalidOperationException($"SymbolTable {symTable.DebugName()} already has SymbolValues '{existing.DebugName}' associated with it. Can't add '{symValues.DebugName}'");
+                    throw new InvalidOperationException($"SymbolTable {symTable.DebugName()} already has SymbolValues '{existing.DebugNameWithId}' associated with it. Can't add '{symValues.DebugNameWithId}'");
                 }
             }
             else 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ComposedReadOnlySymbolValues.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.PowerFx.Core.Binding;
@@ -23,6 +24,18 @@ namespace Microsoft.PowerFx
         {
             _map = map;
             DebugName = symbolTable.DebugName;
+        }
+
+        // Helper for debugging.
+        internal void DebugDumpChildren(TextWriter tw, string indent = "")
+        {
+            foreach (var kv in _map)
+            {
+                var st = kv.Key;
+                var sv = kv.Value;
+
+                tw.WriteLine($"{indent}{st.DebugName} --> {sv.DebugName}_{sv.GetHashCode()}");
+            }
         }
 
         // Create SymbolValues to match the SymbolTable.
@@ -91,18 +104,24 @@ namespace Microsoft.PowerFx
         private static void Add(Dictionary<ReadOnlySymbolTable, ReadOnlySymbolValues> map, ReadOnlySymbolValues symValues)
         {
             var symTable = symValues.SymbolTable;
-            try
+
+            if (map.TryGetValue(symTable, out var existing))
             {
-                map.Add(symTable, symValues);
-            }
-            catch
-            {
-                // Give better error.
-                if (map.TryGetValue(symTable, out var existingSymValues))
+                if (object.ReferenceEquals(existing, symValues))
                 {
-                    throw new InvalidOperationException($"SymbolTable {symTable.DebugName()} already has SymbolValues '{existingSymValues.DebugName}' associated with it. Can't add '{symValues.DebugName}'");
+                    // Ok, same instance already added 
+                    return;
+                }
+                else
+                {
+                    // Bad - different instance with conflicting values.
+                    throw new InvalidOperationException($"SymbolTable {symTable.DebugName()} already has SymbolValues '{existing.DebugName}' associated with it. Can't add '{symValues.DebugName}'");
                 }
             }
+            else 
+            {                
+                map.Add(symTable, symValues);
+            }            
         }
 
         // Walk the symbolTable tree and for each node, create the corresponding symbol values. 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/ReadOnlySymbolValues.cs
@@ -13,13 +13,16 @@ namespace Microsoft.PowerFx
     /// Runtime values corresponding to static values described in a <see cref="SymbolTable"/>.
     /// See <see cref="SymbolValues"/> for a mutable derived class. 
     /// </summary>
-    [DebuggerDisplay("{this.GetType().Name}({DebugName})")]
+    [DebuggerDisplay("{this.GetType().Name}({DebugNameWithId})")]
     public abstract class ReadOnlySymbolValues
     {
         private readonly ReadOnlySymbolTable _symbolTable;
 
         // Helper in debugging. Useful when we have multiple symbol tables chained. 
         public string DebugName { get; init; } = "RuntimeValues";
+
+        // Include the hashcodfe as a unique id to tell difference between 2 symbol values that share same name. 
+        public string DebugNameWithId => $"{this.DebugName}_{this.GetHashCode()}";
 
         /// <summary>
         /// Get the symbol table that these values correspond to.

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -91,6 +91,29 @@ namespace Microsoft.PowerFx
 
             return expr;
         }
+
+        /// <summary>
+        /// Create SymbolValues that match against <see cref="CheckResult.Symbols"/>.
+        /// </summary>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public static ReadOnlySymbolValues CreateValues(this CheckResult check)
+        {
+            // We don't bother taking an existing symbolValues, since we're pulling everything from Check.
+
+            // This should match what we do in GetEvaluator().
+            ReadOnlySymbolValues globals = null;
+            if (check.Engine is RecalcEngine recalcEngine)
+            {
+                // Pull global values from the engine. 
+                globals = recalcEngine._symbolValues;                
+            }
+
+            ReadOnlySymbolTable st = check.Symbols;
+
+            var values = st.CreateValues(globals);
+            return values;
+        }
     }
 
     internal class ParsedExpression : IExpressionEvaluator

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/SymbolValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/SymbolValueTests.cs
@@ -883,10 +883,10 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var check = new CheckResult(engine).SetText("x").SetBindingInfo(sym1);
             check.ApplyBinding();
 
-            // Still does duplicate add....
-            //var symVals = check.Symbols.CreateValues(engine._symbolValues);
-
-            var symVals = sym1.CreateValues();
+            // Just doing this would fail because we miss the symbolValues on recalcEngine. 
+            // var symVals = sym1.CreateValues();
+            // Instead, do a CheckResult aware:
+            var symVals = check.CreateValues();            
 
             var ok = check.Symbols.TryLookupSlot("x", out var slot);
             Assert.True(ok);


### PR DESCRIPTION
Add helper for creating SymbolValues from CheckResults. 
This is tricky since it needs to include whatever symbolVAlues the checkresult already has. So Check.Symbols.CreateValues() may miss those and end up creating duplicate symbol values. 

Also add more tests 

