### PR TITLE
Revert comparison change in intellisense

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseSuggestionComparer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Intellisense/IntellisenseSuggestionComparer.cs
@@ -53,11 +53,12 @@ namespace Microsoft.PowerFx.Intellisense
 
             if (_culture == null)
             {
-                // Invariant culture implements different sort orders between .Net versions
-                return string.Compare(x.Text, y.Text, StringComparison.OrdinalIgnoreCase);             
+#pragma warning disable CA1310 // Specify StringComparison for correctness
+                return x.Text.CompareTo(y.Text);
+#pragma warning restore CA1310 // Specify StringComparison for correctness
             }
-            
-            return _culture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase).Compare(x.Text, y.Text);            
+
+            return _culture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase).Compare(x.Text, y.Text);
         }
 
         private bool IsExactMatch(string input, string match)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
@@ -340,7 +340,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [InlineData("Test|", "![Test1: s, Test2: n, Test3: h]", "Test1", "Test2", "Test3")]
         [InlineData("RecordName[|", "![RecordName: ![StringName: s, NumberName: n]]", "@NumberName", "@StringName")]
         [InlineData("RecordName[|", "![RecordName: ![]]")]
-        [InlineData("Test |", "![Test: s]", "&", "&&", "*", "+", "-", "/", "<", "<=", "<>", "=", ">", ">=", "And", "As", "exactin", "in", "Or", "^", "||")]
+        [InlineData("Test |", "![Test: s]", "-", "*", "/", "&", "&&", "^", "+", "<", "<=", "<>", "=", ">", ">=", "||", "And", "As", "exactin", "in", "Or")]
         [InlineData("Filter(Table, Table[|", "![Table: *[Column: s]]", "@Column")]
 
         // ErrorNodeSuggestionHandler

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/InterpreterSuggestTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/InterpreterSuggestTests.cs
@@ -285,8 +285,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             "RecordInputTest( {field1 : 2}, \"test\", { id: 1, name:\"test name\", |}")]
         [InlineData(
             "RecordInputTest( {field1 : 2}, \"test\", { id: 1, name: \"test\"}, {|",
-            "nested2:",
-            "nested:")]
+            "nested:",
+            "nested2:")]
 
         // nested record field.
         [InlineData(
@@ -319,8 +319,8 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         // table type arg.
         [InlineData(
             "RecordInputTest( {field1 : 5}, \"test\", { id: 1, name: \"test\"}, { nested2:{ id: 1, name: \"test\"} }, [{|",
-            "nested2:",
-            "nested:")]
+            "nested:",
+            "nested2:")]
 
         // table type arg with nested record field.
         [InlineData(


### PR DESCRIPTION
There was a recent change that updated the comparison for Intellisense suggestions. While the change looks good, it broke a test in Power Apps, so we're reverting it to unblock the integration, and later we can decide whether to reapply this change and update the test.