### PR TITLE
Collect fixes

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/InMemoryRecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/InMemoryRecordValue.cs
@@ -77,6 +77,14 @@ namespace Microsoft.PowerFx.Types
 
         public override async IAsyncEnumerable<NamedValue> GetOriginalFieldsAsync([EnumeratorCancellation] CancellationToken cancellationToken)
         {
+            foreach (var field in OriginalFields)
+            {
+                yield return field;
+            }
+        }
+
+        protected override IEnumerable<NamedValue> GetOriginalFieldsCore()
+        {
             foreach (var field in _fields)
             {
                 yield return new NamedValue(field.Key, field.Value);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/RecordValue.cs
@@ -49,6 +49,8 @@ namespace Microsoft.PowerFx.Types
         /// </summary>
         public IEnumerable<NamedValue> Fields => GetFields();
 
+        public IEnumerable<NamedValue> OriginalFields => GetOriginalFieldsCore();
+
         public virtual bool TryGetSpecialFieldName(SpecialFieldKind kind, out string fieldName)
         {
             fieldName = null;
@@ -98,6 +100,11 @@ namespace Microsoft.PowerFx.Types
                 Type.TryGetBackingDType(fieldName, out var backingDType);
                 yield return new NamedValue(fieldName, async () => GetField(fieldName), backingDType);
             }
+        }
+
+        protected virtual IEnumerable<NamedValue> GetOriginalFieldsCore()
+        {
+            yield return null;
         }
 
         public async IAsyncEnumerable<NamedValue> GetFieldsAsync([EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Collect.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Collect.cs
@@ -113,11 +113,10 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public virtual DType GetCollectedType(Features features, DType argType)
         {
             Contracts.Assert(argType.IsValid);
-
             return argType;
         }
 
-        private bool TryGetUnifiedCollectedTypeAllowTypeExpansion(TexlNode[] args, DType[] argTypes, IErrorContainer errors, Features features, out DType collectedType)
+        private bool TryGetUnifiedCollectedTypeAllowTypeExpansion(TexlNode[] args, DType[] argTypes, IErrorContainer errors, CheckTypesContext context, out DType collectedType)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -133,7 +132,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (int i = 1; i < argc; i++)
             {
-                DType argType = GetCollectedType(features, argTypes[i]);
+                DType argType = GetCollectedType(context.Features, argTypes[i]);
 
                 // The subsequent args should all be aggregates.
                 if (!argType.IsAggregate)
@@ -156,7 +155,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 else
                 {
                     bool fUnionError = false;
-                    itemType = DType.Union(ref fUnionError, itemType, argType, useLegacyDateTimeAccepts: true, features);
+                    itemType = DType.Union(ref fUnionError, itemType, argType, useLegacyDateTimeAccepts: true, context.Features);
                     if (fUnionError)
                     {
                         errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrIncompatibleTypes);
@@ -177,7 +176,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         }
 
         // Attempt to get the unified schema of the items being collected by an invocation.
-        private bool TryGetUnifiedCollectedTypeDontAllowTypeExpansion(TexlNode[] args, DType[] argTypes, IErrorContainer errors, Features features, out DType collectedType)
+        private bool TryGetUnifiedCollectedTypeDontAllowTypeExpansion(TexlNode[] args, DType[] argTypes, IErrorContainer errors, CheckTypesContext context, out DType collectedType, ref Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
         {
             Contracts.AssertValue(args);
             Contracts.AssertAllValues(args);
@@ -195,7 +194,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             for (var i = 1; i < argc; i++)
             {
-                DType argType = GetCollectedType(features, argTypes[i]);
+                DType argType = GetCollectedType(context.Features, argTypes[i]);
 
                 // The subsequent args should all be aggregates.
                 if (!argType.IsAggregate)
@@ -212,7 +211,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
 
                 // Checks if all record names exist against table type and if its possible to coerce.
-                bool checkAggregateNames = argType.CheckAggregateNames(datasourceType, args[i], errors, features, SupportsParamCoercion);
+                bool checkAggregateNames = argType.CheckAggregateNames(datasourceType, args[i], errors, context.Features, !context.AnalysisMode);
                 fValid = fValid && checkAggregateNames;
 
                 if (!itemType.IsValid)
@@ -222,12 +221,19 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 else
                 {
                     var fUnionError = false;
-                    itemType = DType.Union(ref fUnionError, itemType, argType, useLegacyDateTimeAccepts: true, features);
+
+                    itemType = DType.Union(ref fUnionError, itemType, argType, useLegacyDateTimeAccepts: true, context.Features);
                     if (fUnionError)
                     {
                         errors.EnsureError(DocumentErrorSeverity.Severe, args[i], TexlStrings.ErrIncompatibleTypes);
                         fValid = false;
                     }
+                }
+
+                // CheckAggregateNames should have already checked if there is any coercion error.
+                if (argType.TryGetCoercionSubType(datasourceType, out DType coercionType, out var coercionNeeded, context.Features) && coercionNeeded)
+                {
+                    CollectionUtils.Add(ref nodeToCoercedTypeMap, args[i], coercionType.ToRecord());
                 }
 
                 // We only support accessing entities in collections if the collection has only 1 argument that contributes to it's type
@@ -268,17 +274,19 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // document errors for invalid arguments such as unsupported aggregate types.
             if (context.AnalysisMode)
             {
-                fValid &= TryGetUnifiedCollectedTypeAllowTypeExpansion(args, argTypes, errors, context.Features, out collectedType);
+                fValid &= TryGetUnifiedCollectedTypeAllowTypeExpansion(args, argTypes, errors, context, out collectedType);
             }
             else
             {
-                fValid &= TryGetUnifiedCollectedTypeDontAllowTypeExpansion(args, argTypes, errors, context.Features, out collectedType);
+                fValid &= TryGetUnifiedCollectedTypeDontAllowTypeExpansion(args, argTypes, errors, context, out collectedType, ref nodeToCoercedTypeMap);
             }
 
             Contracts.Assert(collectedType.IsTable);
 
             bool fError = false;
-            returnType = DType.Union(ref fError, collectionType, collectedType, useLegacyDateTimeAccepts: true, context.Features);
+
+            returnType = DType.Union(ref fError, collectionType, collectedType, useLegacyDateTimeAccepts: context.AnalysisMode, context.Features, allowCoerce: !context.AnalysisMode);
+
             if (fError)
             {
                 fValid = false;

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMutation.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMutation.cs
@@ -332,7 +332,12 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
             else
             {
-                return CompileTimeTypeWrapperRecordValue.AdjustType(tableValue.Type.ToRecord(), (RecordValue)resultRows.First().ToFormulaValue());
+                if (resultRows.First().IsValue)
+                {
+                    return CompileTimeTypeWrapperRecordValue.AdjustType(tableValue.Type.ToRecord(), (RecordValue)resultRows.First().ToFormulaValue());
+                }
+                
+                return resultRows.First().ToFormulaValue();
             }
         }
     }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Collect_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Collect_V1Compat.txt
@@ -74,3 +74,9 @@ Errors: Error 12-15: Name isn't valid. 'Foo' isn't recognized.
 
 >> Collect(t1,{Price:200}).Price
 Errors: Error 0-7: The function 'Collect' has some invalid arguments.|Error 11-22: The specified column 'Price' does not exist.
+
+>> Collect(t1, {Field1:Date(2023,2,27),Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+{Field1:44984,Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false}
+
+>> Collect(t1, {Field1:"1",Field2:"moon",Field3:DateTime(2022,2,1,0,0,0,0),Field4:false})
+Errors: Errors: Error 0-7: The function 'Collect' has some invalid arguments.|Error 12-85: The type of this argument 'Field1' does not match the expected type 'Decimal'. Found type 'Text'.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/RecordValueTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/RecordValueTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Linq;
+using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Types;
+using Xunit;
+
+namespace Microsoft.PowerFx.Tests
+{
+    public sealed class RecordValueTests
+    {
+        [Fact]
+        public void GetOriginalFieldsTest()
+        {
+            var recordType = RecordType.Empty()
+                .Add("a", FormulaType.Decimal)
+                .Add("b", FormulaType.String);
+
+            var tableType = recordType
+                .Add("c", FormulaType.Boolean)
+                .ToTable();
+
+            var recordValue = new InMemoryRecordValue(
+                IRContext.NotInSource(recordType),
+                new NamedValue("a", FormulaValue.New(1)),
+                new NamedValue("b", FormulaValue.New("string")));
+
+            var wrapped = CompileTimeTypeWrapperRecordValue.AdjustType(tableType.ToRecord(), recordValue);
+
+            // OriginalFields will return hard fields from record type and not soft fields from table type.
+            Assert.Equal(2, wrapped.OriginalFields.Count());
+            Assert.Equal(3, wrapped.Fields.Count());
+        }
+    }
+}


### PR DESCRIPTION
This includes:
- Coercion fixes.
- Blank fields after adjusting the record/table type.
- Interpreter implementation was not handling Dataverse errors when appending.