### PR TITLE
Optimization for function sets 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerFx
 
                     if (_nameResolverFunctions == null)
                     {
-                        _nameResolverFunctions = new TexlFunctionSet(_symbolTables.Select(t => t.Functions).ToList());
+                        _nameResolverFunctions = TexlFunctionSet.Compose(_symbolTables.Select(t => t.Functions).ToList());
                         _cachedVersionHash = current;
                     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedSymbolTableCache.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedSymbolTableCache.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.PowerFx
+{
+    // This can cache the results of ReadOnlySymbolTable.Compose - and includes a safe 
+    // invalidation strategy. 
+    // Compose() is fast because it defers all work. But it will cache the results of that work,
+    // (notably compuing TexlFunctionSets), so caching Compose is important to reuse those
+    // other caches. 
+    internal class ComposedSymbolTableCache
+    {
+        // A cached value from ReadOnlySymbolTable.Compose
+        private ReadOnlySymbolTable _result;
+
+        // The symbol tables that were composed for _result.
+        private ReadOnlySymbolTable[] _list;
+
+        // Determine if the cache should be invalidated. 
+        // this will set _result to null to force a recompute.
+        private void MaybeInvalidateCache(ReadOnlySymbolTable[] tables)
+        {
+            // Check cache invalidation.
+            if (_list != null)
+            {
+                if (_list.Length != tables.Length)
+                {
+                    // Developer error - list that we cache on should be statically fixed. 
+                    throw new InvalidOperationException($"List should be fixed");
+                }
+                else
+                {
+                    // Check if any instances changed.
+                    // If it's the same symbol table instance, but the table has mutated, 
+                    // then ROST.compose will already that via the VersionHash.              
+                    for (int i = 0; i < tables.Length; i++)
+                    {
+                        if (!object.ReferenceEquals(_list[i], tables[i]))
+                        {
+                            _result = null;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        public ReadOnlySymbolTable GetComposedCached(params ReadOnlySymbolTable[] tables)
+        {
+            // This is a conceptually read-only operation, so it could be called on multiple threads. 
+            // CA2002 - Lock(this) is safe since it's a private object that doesn't cross AD boundaries.
+#pragma warning disable CA2002 // Do not lock on objects with weak identity
+            lock (this)
+            {
+                MaybeInvalidateCache(tables);
+
+                if (_result == null)
+                {
+                    var functionList = ReadOnlySymbolTable.Compose(tables);
+
+                    _list = tables;
+                    _result = functionList;
+                }
+
+                return _result;
+            }
+#pragma warning restore CA2002 // Do not lock on objects with weak identity
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedSymbolTableCache.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedSymbolTableCache.cs
@@ -18,6 +18,8 @@ namespace Microsoft.PowerFx
         // The symbol tables that were composed for _result.
         private ReadOnlySymbolTable[] _list;
 
+        private readonly object _lock = new object();
+
         // Determine if the cache should be invalidated. 
         // this will set _result to null to force a recompute.
         private void MaybeInvalidateCache(ReadOnlySymbolTable[] tables)
@@ -50,9 +52,7 @@ namespace Microsoft.PowerFx
         public ReadOnlySymbolTable GetComposedCached(params ReadOnlySymbolTable[] tables)
         {
             // This is a conceptually read-only operation, so it could be called on multiple threads. 
-            // CA2002 - Lock(this) is safe since it's a private object that doesn't cross AD boundaries.
-#pragma warning disable CA2002 // Do not lock on objects with weak identity
-            lock (this)
+            lock (_lock)
             {
                 MaybeInvalidateCache(tables);
 
@@ -66,7 +66,6 @@ namespace Microsoft.PowerFx
 
                 return _result;
             }
-#pragma warning restore CA2002 // Do not lock on objects with weak identity
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -163,6 +163,8 @@ namespace Microsoft.PowerFx
             symbols = ReadOnlySymbolTable.Compose(localSymbols, GetCombinedEngineSymbols());
             return symbols;
         }
+               
+        private readonly ComposedSymbolTableCache _functionListCache = new ComposedSymbolTableCache();
 
         /// <summary>
         /// Get a combined engine symbol table, including builtins and config. 
@@ -170,7 +172,12 @@ namespace Microsoft.PowerFx
         /// <returns></returns>
         public ReadOnlySymbolTable GetCombinedEngineSymbols()
         {
-            var symbols = ReadOnlySymbolTable.Compose(EngineSymbols, SupportedFunctions, Config.SymbolTable, PrimitiveTypes);
+            // Compose all the symbol tables most likely to have functions into a single 
+            // symbol table and then cache that. 
+            // That will cache unifying into a single TexlFunctionSet - which is the most expensive part. 
+            var functionList = _functionListCache.GetComposedCached(SupportedFunctions, Config.SymbolTable);
+
+            var symbols = ReadOnlySymbolTable.Compose(EngineSymbols, functionList, PrimitiveTypes);
 
             return symbols;
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FunctionTests.cs
@@ -319,10 +319,170 @@ namespace Microsoft.PowerFx.Core.Tests
             }
         }
 
+        [Fact]
+        public void Snapshot1()
+        {
+            var func1 = new TestTexlFunction("func1");
+            var func2 = new TestTexlFunction("func2");
+
+            var set1 = new TexlFunctionSet();
+            set1.Add(func1);
+
+            var set2 = new TexlFunctionSet(new TexlFunctionSet[] { set1 });
+
+            set1.Add(func2);
+
+            var has = set2.AnyWithName("func2");
+            Assert.False(has);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Snapshot2(bool notEmpty)
+        {
+            var func1 = new TestTexlFunction("func1");
+            var func2 = new TestTexlFunction("func2");
+
+            var set1 = new TexlFunctionSet();
+            if (notEmpty)
+            {
+                set1.Add(func1);
+            }
+
+            // $$$ We could repeat most tests above for composition! 
+            var set2 = Wrap(set1);
+
+            set1.Add(func2);
+
+            var has = set2.AnyWithName("func2");
+            Assert.False(has);
+        }
+
+        [Fact]
+        public void TestComposedEnums()
+        {
+            var set1 = new TexlFunctionSet();
+            var func1 = new TestTexlFunction("func1", requiredEnums: 1);
+            var func2 = new TestTexlFunction("func1", DType.Number, requiredEnums: 2);
+
+            set1.Add(func1);
+            Assert.Single(set1.Enums);
+
+            set1.Add(func2);
+            Assert.Equal(3, set1.Enums.Count());
+            Assert.Equal(2, set1.Enums.Distinct().Count());
+
+            var set2 = Wrap(set1);
+
+            Assert.Equal(3, set2.Enums.Count());
+            Assert.Equal(2, set2.Enums.Distinct().Count());
+        }
+
+        [Fact]
+        public void TestComposedNamespaces()
+        {
+            var func1 = new TestTexlFunction("NS1", "func1");
+            var func2 = new TestTexlFunction("NS2", "func1");
+
+            var set1 = new TexlFunctionSet();
+            set1.Add(func1);
+
+            var ns1 = GetNamespaces(set1);
+            Assert.Equal("NS1", ns1);
+
+            var set2 = Wrap(set1);
+
+            set1.Add(func2); // snapshot on old 
+
+            var ns2 = GetNamespaces(set2);
+            Assert.Equal("NS1", ns2);
+
+            set2.Add(func2);
+
+            ns2 = GetNamespaces(set2);
+            Assert.Equal("NS1,NS2", ns2);
+        }
+
+        [Fact]
+        public void TestComposedNamespaces1()
+        {
+            var func1 = new TestTexlFunction("NS1", "func1");
+            var func2 = new TestTexlFunction("NS1", "func2");
+
+            var set1 = new TexlFunctionSet();
+            set1.Add(func1);
+
+            var set2 = new TexlFunctionSet();
+            set2.Add(func2);
+
+            var set3 = Wrap(set1, set2);
+            var ns3 = GetNamespaces(set3);
+            Assert.Equal("NS1", ns3); // distinct
+        }
+
+        private static string GetNamespaces(TexlFunctionSet set)
+        {
+            var nsDpaths = set.Namespaces; 
+            string str = string.Join(",", nsDpaths.Select(x => x.ToString()).Order());
+            return str;            
+        }
+
+        // ctor will flatten via SelectMany 
+        [Fact]
+        public void Test2()
+        {
+            var func1 = new TestTexlFunction("func1");
+            var func2 = new TestTexlFunction("func2");
+
+            var set1 = new TexlFunctionSet();
+            set1.Add(func1);
+
+            var set2 = Wrap(set1);
+
+            set2.Add(func2);
+
+            var set3 = Wrap(set2);
+
+            string names = string.Join(",", set3.FunctionNames.Order());
+            Assert.Equal("func1,func2", names);
+        }
+
+        // ctor will flatten via SelectMany 
+        [Fact]
+        public void Triple()
+        {
+            var func1 = new TestTexlFunction("func1");
+            var func2 = new TestTexlFunction("func2");
+
+            var set1 = new TexlFunctionSet();
+            set1.Add(func1);
+
+            var set2 = Wrap(set1);
+
+            var set3 = Wrap(set2);
+
+            var count = set3.Count();
+            Assert.Equal(1, count);
+        }
+
+        private static TexlFunctionSet Wrap(params TexlFunctionSet[] sets)
+        {
+            // Current semantics are to take a snapshot of sets. 
+            // So if original set is modified, the returned snapshot is not affected.
+            return new TexlFunctionSet(sets);
+        }
+
         private class TestTexlFunction : TexlFunction
         {
             private readonly int _requiredEnums = 0;
-                
+
+            public TestTexlFunction(string @namespace, string name, DType type = null, int requiredEnums = 0)
+      : this(DPath.Root.Append(new DName(@namespace)), name, name, (string locale) => name, FunctionCategories.Text, type ?? DType.String, 0, 1, 1, type ?? DType.String)
+            {
+                _requiredEnums = requiredEnums;
+            }
+
             public TestTexlFunction(string name, DType type = null, int requiredEnums = 0, DPath? path = null)
                 : this(path ?? DPath.Root, name, name, (string locale) => name, FunctionCategories.Text, type ?? DType.String, 0, 1, 1, type ?? DType.String)
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FunctionTests.cs
@@ -424,7 +424,7 @@ namespace Microsoft.PowerFx.Core.Tests
         private static string GetNamespaces(TexlFunctionSet set)
         {
             var nsDpaths = set.Namespaces; 
-            string str = string.Join(",", nsDpaths.Select(x => x.ToString()).Order());
+            string str = string.Join(",", nsDpaths.Select(x => x.ToString()).OrderBy(x => x));
             return str;            
         }
 
@@ -444,7 +444,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
             var set3 = Wrap(set2);
 
-            string names = string.Join(",", set3.FunctionNames.Order());
+            string names = string.Join(",", set3.FunctionNames.OrderBy(x => x));
             Assert.Equal("func1,func2", names);
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/SymbolTableTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/SymbolTableTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 Assert.True(object.ReferenceEquals(c1, c1b));
             }
 
-            // Mutating an existing talbe is ok - ComposedSymbolTable will catch that
+            // Mutating an existing table is ok - ComposedSymbolTable will catch that
             {
                 table1.AddFunction(new BlankFunction());
                 var c1c = cache.GetComposedCached(table1, table2);
@@ -454,7 +454,15 @@ namespace Microsoft.PowerFx.Core.Tests
 
             var ok = c1.TryGetSymbolType("c1", out var type);
             Assert.True(ok);
-            Assert.Equal(FormulaType.String, type);            
+            Assert.Equal(FormulaType.String, type);
+
+            // Shorter args 
+            ComposedSymbolTableCache cache1arg = new ComposedSymbolTableCache();
+            cache1arg.GetComposedCached(nullTable);
+
+            // Shorter args 
+            ComposedSymbolTableCache cache0args = new ComposedSymbolTableCache();
+            cache0args.GetComposedCached();
         }
 
         // Type is wrong: https://github.com/microsoft/Power-Fx/issues/2342

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ThreadingTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ThreadingTests.cs
@@ -29,6 +29,8 @@ namespace Microsoft.PowerFx.Core.Tests
                 // Threading.InterlockedIncrement.
                 "VersionHash._hashStarter",
 
+                "TexlFunctionSet._empty", // points to an immutable object. 
+
                 // readonly arrays / dictionary - is there an IReadOnly type to changes these too instead? 
                 "ArgumentSuggestions._languageCodeSuggestions",
                 "BuiltinFunctionsCore._featureGateFunctions",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/ConfigTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/ConfigTests.cs
@@ -777,7 +777,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             // Switch default function set.
             // This removes Sum() and adds Func1(). 
-            var defaultFunctions = new SymbolTable();
+            var defaultFunctions = new SymbolTable { DebugName = "NewSet" };
             defaultFunctions.AddFunction(new Func1Function());
             engine.UpdateSupportedFunctions(defaultFunctions);
 
@@ -786,6 +786,23 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             result = engine.Check(expr2);
             Assert.True(result.IsSuccess);
+        }
+
+        // Verify we can mutate the config. 
+        [Fact]
+        public async Task DefaultFunctions2()
+        {
+            var config = new PowerFxConfig();
+            config.AddFunction(new Func1Function());
+            
+            var engine = new Engine(config);
+           
+            var result = engine.Check("Func1(3)"); // 6
+            Assert.True(result.IsSuccess);
+
+            config.AddFunction(new MultiplyFunction());
+            result = engine.Check("Multiply(4)"); // 8
+            Assert.True(result.IsSuccess);            
         }
 
         // Helper to set Engine.SupportedFunctions.

--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -103,90 +102,8 @@ namespace Microsoft.PowerFx
             return new RecalcEngine(config);
         }
 
-#pragma warning disable CA1303 // Do not pass literals as localized parameters
-        public static void Test2()
-        {
-            List<object> list = new List<object>();
-
-            Console.WriteLine($"Starting main-2...");
-
-            var start = GC.GetTotalMemory(false);
-
-            PowerFxConfig config = new PowerFxConfig();
-
-            config.EnableJsonFunctions();
-            Engine engine = new Engine(config);
-
-            var sw = Stopwatch.StartNew();
-
-            int numLoops = 10 * 1000;
-            for (int i = 0; i < numLoops; i++)
-            {
-                var record = RecordType.Empty().Add("a", FormulaType.String).Add("b", FormulaType.Decimal);
-                ReadOnlySymbolTable symbolTable = ReadOnlySymbolTable.NewFromRecord(record);
-
-                CheckResult checkResult = engine.Check("Abs(1)", new ParserOptions() { Culture = CultureInfo.InvariantCulture }, symbolTable);
-
-                list.Add(new { config, engine, symbolTable, checkResult });
-
-                checkResult.GetEvaluator().Eval();
-            }
-
-            var timeMS = sw.ElapsedMilliseconds;
-            var timeNanoSeconds = timeMS * 1000 * 1000;
-
-            var end = GC.GetTotalMemory(false);
-
-            var diff = end - start;
-
-            Console.WriteLine($"Pausing...: {start}, {end}");
-            Console.WriteLine($"{numLoops} loops");
-            Console.WriteLine($"{diff / 1000} kb");
-            Console.WriteLine($"{diff / numLoops / 1000} kb/loop");
-            Console.WriteLine($"{timeMS} total Ms");
-            Console.WriteLine($"{(double)timeMS / numLoops}  MS/loop");
-            Environment.Exit(1);
-        }
-
-        public static void Test()
-        {
-            List<object> list = new List<object>();
-
-            Console.WriteLine($"Starting...");
-
-            var start = GC.GetTotalMemory(false);
-
-            int numLoops = 10 * 1000;
-            for (int i = 0; i < numLoops; i++)
-            {
-                PowerFxConfig config = new PowerFxConfig();
-                config.EnableJsonFunctions();
-                Engine engine = new Engine(config);
-                var record = RecordType.Empty().Add("a", FormulaType.String).Add("b", FormulaType.Decimal);
-                ReadOnlySymbolTable symbolTable = ReadOnlySymbolTable.NewFromRecord(record);
-
-                CheckResult checkResult = engine.Check("Abs(1)", new ParserOptions() { Culture = CultureInfo.InvariantCulture }, symbolTable);
-
-                list.Add(new { config, engine, symbolTable, checkResult });
-
-                checkResult.GetEvaluator().Eval();
-            }
-
-            var end = GC.GetTotalMemory(false);
-
-            var diff = end - start;
-
-            Console.WriteLine($"Pausing...: {start}, {end}");
-            Console.WriteLine($"{numLoops} loops");
-            Console.WriteLine($"{diff / 1000} kb");
-            Console.WriteLine($"{diff / numLoops / 1000} kb/loop");
-            Console.ReadLine();
-        }
-
         public static void Main()
         {
-            Test2();
-
             var enabled = new StringBuilder();
 
             Console.InputEncoding = System.Text.Encoding.UTF8;


### PR DESCRIPTION
Optimize the pattern where:
- a host calls eval many times in a loop. 
- but using the same function set in all cases, as determined by just PowerFxConfig (with some enables).

This PR is an optimization and there shouldn't be any functional changes. However - we should review some of the behavior around TexlFunctionSet to enable us to pursue more comprehensive optimizations. 

Today, every call to Check() will compute the function set - which involves merging the function set from builtin functions plus the extra ones that were enabled.  This is expensive because TexlFunctionSet will "flatten" and copy all the functions into a single list. (Contrast to how we compose SymbolTables - which is entirely deferred). 

The optimization is to allow composing that once and caching it. But also to be sure we have correct invalidation strategy if anything changes. Added lots more tests as I discovered interesting corner cases. 

This makes the benchmark use 1/10 the working set and run 3x faster. 

