### PR TITLE
Collect check semantics PA change

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Collect.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Collect.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             MutationUtils.CheckSemantics(binding, this, args, argTypes, errors);
 
-            if (binding.Features.PowerFxV1CompatibilityRules)
+            if (!binding.CheckTypesContext.AnalysisMode)
             {
                 MutationUtils.CheckForReadOnlyFields(argTypes[0], args.Skip(1).ToArray(), argTypes.Skip(1).ToArray(), errors);
             }


### PR DESCRIPTION
PR https://github.com/microsoft/Power-Fx/pull/1964 checks for read-only fields. Changing the condition to run this check since PA deals with read-only fields differently.