### PR TITLE
Revert/Change TexlFunction flag name restricting use inside UDF

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -201,8 +201,8 @@ namespace Microsoft.PowerFx.Core.Functions
         // Return true if UDFs cannot override this function name.
         public virtual bool IsRestrictedUDFName => false;
 
-        // Return true if this function is associated with a specific screen.
-        public virtual bool CreatesImplicitScreenDependency => false;
+        // Return true if this function is not allowed inside a user defined function.
+        public virtual bool IsRestrictedInsideUdfBody => false;
 
         // Return true if this function affects scope variable ("app scope variable or component scope variable").
         public virtual bool AffectsScopeVariable => false;


### PR DESCRIPTION
`CreatesImplicitScreenDependency` is a PowerApps specific behavior to InvokeControl functions and doesn't need to be in this class here. We can drive IsRestrictedInsideUdfBody from that flag in PowerApps.