### PR TITLE
Fix imperative UDF throwing error without closing semicolon

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -384,6 +384,8 @@ namespace Microsoft.PowerFx.Core.Parser
                     ParseTrivia();
                     if (_curs.TidCur == TokKind.CurlyOpen)
                     {
+                        var isImperative = _curs.TidCur == TokKind.CurlyOpen && parserOptions.AllowsSideEffects;
+
                         _curs.TokMove();
                         _hasSemicolon = false;
                         ParseTrivia();
@@ -397,13 +399,13 @@ namespace Microsoft.PowerFx.Core.Parser
                         if (TokEat(TokKind.CurlyClose) == null)
                         {
                             // Add incomplete UDF as they are needed for intellisense
-                            udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken, returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, _hasSemicolon, parserOptions.NumberIsFloat, isValid: false));
+                            udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken, returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, isImperative: isImperative, parserOptions.NumberIsFloat, isValid: false));
                             break;
                         }
 
                         var bodyParseValid = _errors?.Count == errorCount;
 
-                        udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken,  returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, _hasSemicolon, parserOptions.NumberIsFloat, isValid: bodyParseValid));
+                        udfs.Add(new UDF(thisIdentifier.As<IdentToken>(), colonToken,  returnType.As<IdentToken>(), new HashSet<UDFArg>(args), exp_result, isImperative: isImperative, parserOptions.NumberIsFloat, isValid: bodyParseValid));
                     }
                     else if (_curs.TidCur == TokKind.Equ)
                     {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -576,5 +576,24 @@ namespace Microsoft.PowerFx.Core.Tests
                 }
             }
         }
+
+        [Theory]
+        [InlineData("func():Void { Set(x, 123) };")]
+        [InlineData("func():Void { Set(x, 123); Set(y, 123) };")]
+        [InlineData("func():Void = { Set(x, 123) };")]
+        [InlineData("func():Void = { Set(x, 123); Set(y, 123) };")]
+        public void TestImperativeUDFParseWithoutSemicolon(string script)
+        {
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = true,
+            };
+
+            var parseResult = UserDefinitions.Parse(script, parserOptions);
+            var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
+            errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
+
+            Assert.True(errors.Count() == 0);
+        }
     }
 }


### PR DESCRIPTION
`Function():Void { Set(a, 1) }` should now be valid