### PR TITLE
Add Nullcheck to GetInfo result in TryGetEntityInfo

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -759,7 +759,8 @@ namespace Microsoft.PowerFx.Core.Binding
             // It is possible for function to be null here if it referred to
             // a service function from a service we are in the process of
             // deregistering.
-            return GetInfo(callNode)?.VerifyValue()?.Function?.TryGetEntityInfo(node, this, out info) ?? false;
+            // GetInfo on a callNode may return null hence need null conditional operator and it short circuits if null.
+            return GetInfo(callNode)?.VerifyValue().Function?.TryGetEntityInfo(node, this, out info) ?? false;
         }
 
         internal IExternalRule Rule { get; }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -759,7 +759,7 @@ namespace Microsoft.PowerFx.Core.Binding
             // It is possible for function to be null here if it referred to
             // a service function from a service we are in the process of
             // deregistering.
-            return GetInfo(callNode).VerifyValue().Function?.TryGetEntityInfo(node, this, out info) ?? false;
+            return GetInfo(callNode)?.VerifyValue()?.Function?.TryGetEntityInfo(node, this, out info) ?? false;
         }
 
         internal IExternalRule Rule { get; }


### PR DESCRIPTION
Getinfo may return null to certain callNodes and hence it is creating NullReferenceException consistently as a noise. this PR fixes that issue.