### PR TITLE
Add lexer method to strip comments in a script

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using Microsoft.PowerFx.Core.Localization;
@@ -466,6 +467,32 @@ namespace Microsoft.PowerFx.Syntax
                     var newString = shouldNotTrim ? tokenString : tokenString.Trim();
 
                     stringBuilder.Append(newString);
+                }
+            }
+
+            var result = stringBuilder.ToString();
+            return result;
+        }
+
+        /// <summary>
+        /// Strips comments from the given script.
+        /// </summary>
+        /// <param name="script">The script from which comments should be removed.</param>
+        /// <param name="flags">Flags to tokenize the given script.</param>
+        /// <returns>A string containing the script without any comments.</returns>
+        public string StripCommentsFromScript(string script, Flags flags = Flags.None)
+        {
+            Contracts.AssertValue(script);
+
+            var tokens = GetTokens(script, flags);
+
+            var stringBuilder = new StringBuilder();
+
+            foreach (var token in tokens)
+            {
+                if (token.Kind != TokKind.Comment)
+                {
+                    stringBuilder.Append(token.Span.GetFragment(script));
                 }
             }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/LexerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/LexerTests.cs
@@ -718,5 +718,25 @@ namespace Microsoft.PowerFx.Core.Tests
             ITokenTextSpan tokenTextSpan = token;
             Assert.True(tokenTextSpan.CanBeHidden);
         }
+
+        [Theory]
+
+        // script with inline comment
+        [InlineData("// Textify number 42\r\nText(42)", "Text(42)")]
+
+        // script with inline comment and white spaces
+        [InlineData("Text( 42)  // SomeComment", "Text( 42)  ")]
+
+        // script with block comment before expression
+        [InlineData("/* This is a block comment */ \r\n Text(42)", " Text(42)")]
+
+        // script with block comments and inline comments in chained expression
+        [InlineData("/* This is a block comment */Text(42);/* Another comment */Set(y, 5);\r\n//comment ", " Text(42);Set(y, 5)\r\n")]
+        public void StripCommentsTest(string script, string expectedScript)
+        {
+            var scriptWithoutComments = TexlLexer.InvariantLexer.StripCommentsFromScript(script);
+
+            Assert.Equal(expectedScript, scriptWithoutComments);
+        }
     }
 }


### PR DESCRIPTION
Add a utility method to remove any comments from a given script. 
