### PR TITLE
Ensure proper spans on lexer errors with surrogate characters

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Lexer/TexlLexer.cs
@@ -1774,8 +1774,17 @@ namespace Microsoft.PowerFx.Syntax
                 if (CurrentChar > 255)
                 {
                     var position = CurrentPos;
-                    var unexpectedChar = Convert.ToUInt16(CurrentChar).ToString("X4", CultureInfo.InvariantCulture);
+                    var initialChar = CurrentChar;
+                    var unexpectedChar = Convert.ToUInt16(initialChar).ToString("X4", CultureInfo.InvariantCulture);
                     NextChar();
+                    if (char.IsHighSurrogate(initialChar) && char.IsLowSurrogate(CurrentChar))
+                    {
+                        // combine the two surrogates
+                        var unicodePoint = char.ConvertToUtf32(initialChar, CurrentChar);
+                        unexpectedChar = unicodePoint.ToString("X8", CultureInfo.InvariantCulture);
+                        NextChar();
+                    }
+
                     return new ErrorToken(GetTextSpan(), TexlStrings.UnexpectedCharacterToken, string.Concat("U+", unexpectedChar), position);
                 }
                 else

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("\"Newline  \n characters   \r   galore  \u00085\"")]
         [InlineData("\"And \u2028    some   \u2029   more!\"")]
         [InlineData("\"Other supported ones:  \t\b\v\f\0\'     \"")]
-        [InlineData("\"Some unicode characters: 🍰 ❤️ 💩 🤞🏽\"")]
+        [InlineData("\"Some unicode characters: 🍰 ❤ 💩 🤞🏽\"")]
         public void TexlParseStringLiteralsWithEscapableCharacters(string script)
         {
             TestRoundtrip(script);
@@ -335,7 +335,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("'A                                           A'")]
         [InlineData("'A                                           123'")]
         [InlineData("'🍰'")]
-        [InlineData("'🙋🏽‍ 😂 😞 🤞🏽'")]
+        [InlineData("'🙋🏽 😂 😞 🤞🏽'")]
 
         // Identifiers with bangs (e.g. qualified entity names)
         [InlineData("A!B")]
@@ -364,8 +364,8 @@ namespace Microsoft.PowerFx.Core.Tests
 
         [Theory]
         [InlineData("=", 0, 1)]
-        [InlineData("💩", 0, 2)] // It's a surrogate character pair, spawns 2 characters
-        [InlineData("a💩", 1, 3)] // Second character is a surrogate pair, spawns 2 characters
+        [InlineData("💩", 0, 2)] // It's a surrogate character pair, spans 2 characters
+        [InlineData("a💩", 1, 3)] // Second character is a surrogate pair, spans 2 characters
         public void TestParseIdentifiersThatNeedEscaping(string identifier, int expectedErrorSpanMin, int expectedErrorSpanMax)
         {
             var expression = $"Set({identifier}, 1)";

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -151,6 +151,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("\"Newline  \n characters   \r   galore  \u00085\"")]
         [InlineData("\"And \u2028    some   \u2029   more!\"")]
         [InlineData("\"Other supported ones:  \t\b\v\f\0\'     \"")]
+        [InlineData("\"Some unicode characters: 🍰 ❤️ 💩 🤞🏽\"")]
         public void TexlParseStringLiteralsWithEscapableCharacters(string script)
         {
             TestRoundtrip(script);
@@ -333,6 +334,8 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("'A                                           _'")]
         [InlineData("'A                                           A'")]
         [InlineData("'A                                           123'")]
+        [InlineData("'🍰'")]
+        [InlineData("'🙋🏽‍ 😂 😞 🤞🏽'")]
 
         // Identifiers with bangs (e.g. qualified entity names)
         [InlineData("A!B")]
@@ -357,6 +360,26 @@ namespace Microsoft.PowerFx.Core.Tests
         public void TexlParseIdentifiers(string script)
         {
             TestRoundtrip(script);
+        }
+
+        [Theory]
+        [InlineData("=", 0, 1)]
+        [InlineData("💩", 0, 2)] // It's a surrogate character pair, spawns 2 characters
+        [InlineData("a💩", 1, 3)] // Second character is a surrogate pair, spawns 2 characters
+        public void TestParseIdentifiersThatNeedEscaping(string identifier, int expectedErrorSpanMin, int expectedErrorSpanMax)
+        {
+            var expression = $"Set({identifier}, 1)";
+            expectedErrorSpanMax += "Set(".Length;
+            expectedErrorSpanMin += "Set(".Length;
+            var result = TexlParser.ParseScript(expression, flags: TexlParser.Flags.None);
+            var node = result.Root;
+
+            Assert.NotNull(node);
+            Assert.True(result.HasError, result.ParseErrorText);
+            var firstError = result.Errors.First();
+
+            Assert.Equal(expectedErrorSpanMin, firstError.Span.Min);
+            Assert.Equal(expectedErrorSpanMax, firstError.Span.Lim);
         }
 
         [Theory]


### PR DESCRIPTION
The lexer doesn't return the proper span for errors with surrogate characters (e.g., `Set(🍰, 1)`). This fixes it.