### PR TITLE
Fix RecordAndTableDTypeTests inconsistency between Debug and DebugAll

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,10 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
+
   <Target Name="DisableAnalyzers" BeforeTargets="CoreCompile"
           Condition="('$(Configuration)-$(TURN_OFF_STYLECOP_DEBUG)' == 'Debug-True') Or ('$(Configuration)-$(TURN_OFF_STYLECOP_DEBUG)' == 'Debug462-True') Or ('$(Configuration)-$(TURN_OFF_STYLECOP_DEBUG)' == 'Debug70-True') Or ('$(Configuration)-$(TURN_OFF_STYLECOP_DEBUG)' == 'DebugAll-True')">
     <ItemGroup>

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1365,8 +1365,7 @@ namespace Microsoft.PowerFx.Core.Types
             {
                 fullType = LazyTypeProvider.GetExpandedType(IsTable);
             }
-
-            Contracts.Assert(!TypeTree.Contains(name));
+            
             var tree = TypeTree.SetItem(name, type);
             var newType = new DType(Kind, tree, AssociatedDataSources, DisplayNameProvider);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1365,7 +1365,8 @@ namespace Microsoft.PowerFx.Core.Types
             {
                 fullType = LazyTypeProvider.GetExpandedType(IsTable);
             }
-            
+
+            Contracts.Assert(!TypeTree.Contains(name));
             var tree = TypeTree.SetItem(name, type);
             var newType = new DType(Kind, tree, AssociatedDataSources, DisplayNameProvider);
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/SafeDTypeToStringTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/SafeDTypeToStringTests.cs
@@ -116,13 +116,6 @@ namespace Microsoft.PowerFx.Connector.Tests
 
             Assert.Equal("*[field1:n, field2:n, field3:n]", type2.ToAnonymousString());
 
-            type2 = DType.CreateRecord(type1.GetNames(DPath.Root).ToArray());
-
-            // This will change the type of the existing B field
-            type2 = type2.Add(new DName("B"), DType.String);
-
-            Assert.Equal("![field1:n, field2:s, field3:n]", type2.ToAnonymousString());
-
             type2 = DType.EmptyTable
                 .Add(new DName("B"), DType.Number)
                 .Add(new DName("C"), DType.Number)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/SafeDTypeToStringTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/SafeDTypeToStringTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PowerFx.Connector.Tests
             Assert.Equal("*[field1:n, field2:n, field3:n]", type2.ToAnonymousString());
 
             type2 = DType.CreateRecord(type1.GetNames(DPath.Root).ToArray());
-            
+
             // This will change the type of the existing B field
             type2 = type2.Add(new DName("B"), DType.String);
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/SafeDTypeToStringTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/SafeDTypeToStringTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerFx.Connector.Tests
 
         [Fact]
         public void RecordAndTableDTypeTests()
-        {            
+        {
             var type1 = DType.CreateTable(
                 new TypedName(DType.Number, new DName("A")),
                 new TypedName(DType.Number, new DName("B")),
@@ -104,7 +104,7 @@ namespace Microsoft.PowerFx.Connector.Tests
 
             Assert.Equal("*[field1:n, field2:n, field3:n]", type1.ToAnonymousString());
             Assert.Equal("![field1:n, field2:n, field3:n]", type1.ToRecord().ToAnonymousString());
-            Assert.Equal("![field1:n, field2:n, field3:n]", type1.ToRecord().ToRecord().ToAnonymousString());            
+            Assert.Equal("![field1:n, field2:n, field3:n]", type1.ToRecord().ToRecord().ToAnonymousString());
 
             var type2 = DType.CreateTable(
                 new List<TypedName>()
@@ -117,10 +117,13 @@ namespace Microsoft.PowerFx.Connector.Tests
             Assert.Equal("*[field1:n, field2:n, field3:n]", type2.ToAnonymousString());
 
             type2 = DType.CreateRecord(type1.GetNames(DPath.Root).ToArray());
+            
+            // This will change the type of the existing B field
             type2 = type2.Add(new DName("B"), DType.String);
+
             Assert.Equal("![field1:n, field2:s, field3:n]", type2.ToAnonymousString());
 
-            type2 = DType.EmptyTable                
+            type2 = DType.EmptyTable
                 .Add(new DName("B"), DType.Number)
                 .Add(new DName("C"), DType.Number)
                 .Add(new DName("D"), DType.Boolean)
@@ -245,22 +248,22 @@ namespace Microsoft.PowerFx.Connector.Tests
 
             // Output should be *[A:n,B:s,C:*[D:n]]
             var superType = DType.Supertype(type3, type4, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules);
-            Assert.Equal("*[field1:n, field2:s, field3:*[field1:n]]", superType.ToAnonymousString());            
+            Assert.Equal("*[field1:n, field2:s, field3:*[field1:n]]", superType.ToAnonymousString());
             superType = DType.Supertype(type4, type3, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules);
-            Assert.Equal("*[field1:n, field2:s, field3:*[field1:n]]", superType.ToAnonymousString());            
+            Assert.Equal("*[field1:n, field2:s, field3:*[field1:n]]", superType.ToAnonymousString());
 
             // Output should be *[A:n,B:s,D:n]
             superType = DType.Supertype(type1, type2, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules);
-            Assert.Equal("*[field1:n, field2:s, field3:n]", superType.ToAnonymousString());            
+            Assert.Equal("*[field1:n, field2:s, field3:n]", superType.ToAnonymousString());
             superType = DType.Supertype(type2, type1, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules);
-            Assert.Equal("*[field1:n, field2:s, field3:n]", superType.ToAnonymousString());            
+            Assert.Equal("*[field1:n, field2:s, field3:n]", superType.ToAnonymousString());
 
             // Table with null value
             // Output should be *[A:n,B:s,C:b,D:n]
             superType = DType.Supertype(type1, type2s, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules);
-            Assert.Equal("*[field1:n, field2:s, field3:b, field4:n]", superType.ToAnonymousString());            
+            Assert.Equal("*[field1:n, field2:s, field3:b, field4:n]", superType.ToAnonymousString());
             superType = DType.Supertype(type2s, type1, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: usePowerFxV1CompatibilityRules);
-            Assert.Equal("*[field1:n, field2:s, field3:b, field4:n]", superType.ToAnonymousString());            
+            Assert.Equal("*[field1:n, field2:s, field3:b, field4:n]", superType.ToAnonymousString());
 
             // Table with null value
             // Output should be *[A:n,B:s,C:*[D:n,F:d]]


### PR DESCRIPTION
Fix RecordAndTableDTypeTests inconsistency
Fixed "#if DEBUG" conditions which were false when Debug462/70/All is used
Fix DType.Add behavior which is different between Debug (exception) and Release (no exception) when we want to change the field type in a record/table type.