### PR TITLE
Added another property on interface IExternalNamedFormula to detect reference to views in NF expressions.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalNamedFormula.cs
@@ -12,5 +12,7 @@ namespace Microsoft.PowerFx.Core.Entities
         bool TryGetExternalDataSource(out IExternalDataSource dataSource);
 
         bool IsConstant { get; }
+
+        bool ContainsReferenceToView { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/ViewFinderVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/ViewFinderVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
@@ -35,6 +36,11 @@ namespace Microsoft.PowerFx.Core.Texl
 
         public override void Visit(FirstNameNode node)
         {
+            var info = _txb.GetInfo(node);
+            if (info != null && info.Data is IExternalNamedFormula namedRule && namedRule.ContainsReferenceToView)
+            {
+                ContainsView = true;
+            }
         }
 
         public override void PostVisit(CallNode node)


### PR DESCRIPTION
Currently the logic to detect use of dataverse views in an expression doesn't work well when expression is abstracted under named formula.
For example,
T = Filter(Monthses, 'Monthses (Views)'.MyView);

Label1.Text = CountRows(T);

CountRows(T) is not detected currently as non-delegated expression as a result. This change fixes that. Unit test will be added on PAClient side for this where all of the delegation tests currently are.