### PR TITLE
Culture support for in operator and Sort function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/StringValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/StringValue.cs
@@ -36,11 +36,6 @@ namespace Microsoft.PowerFx.Types
             visitor.Visit(this);
         }
 
-        internal StringValue ToLower()
-        {
-            return new StringValue(IRContext.NotInSource(FormulaType.String), Value.ToLowerInvariant());
-        }
-
         public override void ToExpression(StringBuilder sb, FormulaValueSerializerSettings settings)
         {
             sb.Append($"\"{CharacterUtils.ExcelEscapeString(Value)}\"");

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryOperators.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryOperators.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.PowerFx.Core.IR;
@@ -720,9 +721,9 @@ namespace Microsoft.PowerFx.Functions
         }
 
         // See in_SS in JScript membershipReplacementFunctions
-        public static Func<IRContext, FormulaValue[], FormulaValue> StringInOperator(bool exact)
+        public static Func<IServiceProvider, IRContext, FormulaValue[], FormulaValue> StringInOperator(bool exact)
         {
-            return (irContext, args) =>
+            return (services, irContext, args) =>
             {
                 var left = args[0];
                 var right = args[1];
@@ -739,22 +740,24 @@ namespace Microsoft.PowerFx.Functions
                 var leftStr = (StringValue)left;
                 var rightStr = (StringValue)right;
 
-                return new BooleanValue(irContext, rightStr.Value.IndexOf(leftStr.Value, exact ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) >= 0);
+                return new BooleanValue(irContext, services.GetService<CultureInfo>().CompareInfo.IndexOf(rightStr.Value, leftStr.Value, exact ? CompareOptions.Ordinal : CompareOptions.IgnoreCase) >= 0);
             };
         }
 
         // Left is a scalar. Right is a single-column table.
         // See in_ST()
-        public static Func<IRContext, FormulaValue[], FormulaValue> InScalarTableOperator(bool exact)
+        public static Func<IServiceProvider, IRContext, FormulaValue[], FormulaValue> InScalarTableOperator(bool exact)
         {
-            return (irContext, args) =>
+            return (services, irContext, args) =>
             {
                 var left = args[0];
                 var right = args[1];
 
+                var cultureInfo = services.GetService<CultureInfo>();
+
                 if (!exact && left is StringValue strLhs)
                 {
-                    left = strLhs.ToLower();
+                    left = new StringValue(IRContext.NotInSource(FormulaType.String), cultureInfo.TextInfo.ToLower(strLhs.Value));
                 }
 
                 var source = (TableValue)right;
@@ -767,7 +770,7 @@ namespace Microsoft.PowerFx.Functions
 
                         if (!exact && rhs is StringValue strRhs)
                         {
-                            rhs = strRhs.ToLower();
+                            rhs = new StringValue(IRContext.NotInSource(FormulaType.String), cultureInfo.TextInfo.ToLower(strRhs.Value));
                         }
 
                         if (RuntimeHelpers.AreEqual(left, rhs))

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryTable.cs
@@ -652,31 +652,31 @@ namespace Microsoft.PowerFx.Functions
 
             if (allNumbers)
             {
-                return SortValueType<NumberValue, double>(pairs, irContext, compareToResultModifier);
+                return SortValueType<NumberValue, double>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allDecimals)
             {
-                return SortValueType<DecimalValue, decimal>(pairs, irContext, compareToResultModifier);
+                return SortValueType<DecimalValue, decimal>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allStrings)
             {
-                return SortValueType<StringValue, string>(pairs, irContext, compareToResultModifier);
+                return SortValueType<StringValue, string>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allBooleans)
             {
-                return SortValueType<BooleanValue, bool>(pairs, irContext, compareToResultModifier);
+                return SortValueType<BooleanValue, bool>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allDatetimes)
             {
-                return SortValueType<DateTimeValue, DateTime>(pairs, irContext, compareToResultModifier);
+                return SortValueType<DateTimeValue, DateTime>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allDates)
             {
-                return SortValueType<DateValue, DateTime>(pairs, irContext, compareToResultModifier);
+                return SortValueType<DateValue, DateTime>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allTimes)
             {
-                return SortValueType<TimeValue, TimeSpan>(pairs, irContext, compareToResultModifier);
+                return SortValueType<TimeValue, TimeSpan>(pairs, runner, irContext, compareToResultModifier);
             }
             else if (allOptionSets)
             {
@@ -1103,7 +1103,7 @@ namespace Microsoft.PowerFx.Functions
             return new InMemoryTableValue(irContext, result);
         }
 
-        private static FormulaValue SortValueType<TPFxPrimitive, TDotNetPrimitive>(List<(DValue<RecordValue> row, FormulaValue sortValue)> pairs, IRContext irContext, int compareToResultModifier)
+        private static FormulaValue SortValueType<TPFxPrimitive, TDotNetPrimitive>(List<(DValue<RecordValue> row, FormulaValue sortValue)> pairs, EvalVisitor runner, IRContext irContext, int compareToResultModifier)
             where TPFxPrimitive : PrimitiveValue<TDotNetPrimitive>
             where TDotNetPrimitive : IComparable<TDotNetPrimitive>
         {
@@ -1120,7 +1120,15 @@ namespace Microsoft.PowerFx.Functions
 
                 var n1 = a.sortValue as TPFxPrimitive;
                 var n2 = b.sortValue as TPFxPrimitive;
-                return n1.Value.CompareTo(n2.Value) * compareToResultModifier;
+                CultureInfo culture;
+                if (n1.Value is string n1s && n2.Value is string n2s && (culture = runner.GetService<CultureInfo>()) != null)
+                {
+                    return culture.CompareInfo.Compare(n1s, n2s) * compareToResultModifier;
+                }
+                else
+                {
+                    return n1.Value.CompareTo(n2.Value) * compareToResultModifier;
+                }
             });
 
             return new InMemoryTableValue(irContext, pairs.Select(pair => pair.row));

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Culture_en-US.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Culture_en-US.txt
@@ -1,0 +1,178 @@
+﻿#SETUP: RegEx,CultureInfo("en-US"),PowerFxV1CompatibilityRules,ConsistentOneColumnTableResult
+
+// Four types of letter I
+//        Dotted     Dotless
+// Upper  İ U+0130   I U+0049
+// Lower  i U+0069   ı U+0131
+
+>> Language()
+"en-US"
+
+>> "İ" = UniChar( Hex2Dec( "0130") )
+true
+
+>> "ı" = UniChar( Hex2Dec( "0131" ) )
+true
+
+// UPPER, LOWER, PROPER
+
+>> Upper( "i" )
+"I"
+
+>> Lower( "I" )
+"i"
+
+>> Upper( "i" ) = "I"
+true
+
+>> Lower( "I" ) = "i"
+true
+
+>> Lower( "quit" ) = Lower( "QUIT" )
+true
+
+>> Lower( "quit" ) = Lower( "QUİT" )
+true
+
+>> Lower( "quıt" ) = Lower( "QUIT" )
+false
+
+>> Upper( "quit" ) = Upper( "QUIT" )
+true
+
+>> Proper( "Iabc" )
+"Iabc"
+
+>> Proper( "iabc" )
+"Iabc"
+
+// VALUE, DECIMAL, FLOAT
+
+>> Value( "123,456" )
+123456
+
+>> Value( "123,456", "tr-TR" )
+123.456
+
+>> Decimal( "123,456" )
+123456
+
+>> Decimal( "123,456", "tr-TR" )
+123.456
+
+>> Float( "123,456" )
+123456
+
+>> Float( "123,456", "tr-TR" )
+123.456
+
+// TEXT
+
+>> Text( DateTime(2010,1,1,14,0,0,0), "mmm ddd yyyy AM/PM" )
+"Jan Fri 2010 PM"
+
+>> Text( DateTime(2020,1,1,2,0,0,0), "mmmm dddd yyyy AM/PM" )
+"January Wednesday 2020 AM"
+
+>> Text( 123456789, "#,###.00" )
+"123,456,789.00"
+
+>> Text( 123456789, "#.###,00" )
+"123456789.00000"
+
+// IN AND EXACTIN
+
+>> "i" in "SIGH"
+true
+
+>> "I" in "sigh"
+true
+
+>> "i" exactin "SIGH"
+false
+
+>> "I" exactin "sigh"
+false
+
+>> "I" exactin "SIGH"
+true
+
+>> "i" exactin "sigh"
+true
+
+>> "sIGh" in ["sigh","bcde"]
+true
+
+>> "siGh" in ["SIGH","bcde"]
+true
+
+>> "sIGH" in ["sigh","bcde"]
+true
+
+>> "siGH" in ["bcde","sIgh"]
+true
+
+>> "SIgh" in ["bcde","sigh"]
+true
+
+// SORT
+// Relative order of i, I, ı, İ are different between en-US and tr-TR
+
+>> Sort( [ "Z", "İ", "z", "I", "J", "j", "ı", "a", "h", "i", "A", "H"], Value )
+Table({Value:"a"},{Value:"A"},{Value:"h"},{Value:"H"},{Value:"i"},{Value:"I"},{Value:"İ"},{Value:"ı"},{Value:"j"},{Value:"J"},{Value:"z"},{Value:"Z"})
+
+>> SortByColumns( [ "Z", "İ", "z", "I", "J", "j", "ı", "a", "h", "i", "A", "H"], "Value" )
+Table({Value:"a"},{Value:"A"},{Value:"h"},{Value:"H"},{Value:"i"},{Value:"I"},{Value:"İ"},{Value:"ı"},{Value:"j"},{Value:"J"},{Value:"z"},{Value:"Z"})
+
+>> Concat( Sort( Split( "j J k K l L m M n N o O p P r R s S t T u U v V y Y z Z Ç ç Ş ş Ü ü Ö ö İ ı Ğ ğ a A b B c C d D e E f F g G h H i I", " " ), Value ), Value, " " )
+"a A b B c C ç Ç d D e E f F g G ğ Ğ h H i I İ ı j J k K l L m M n N o O ö Ö p P r R s S ş Ş t T u U ü Ü v V y Y z Z"
+
+>> Concat( SortByColumns( Split( "d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V y Y z Z Ç ç Ş ş Ü ü Ö ö İ ı Ğ ğ a A b B c C", " " ), "Value" ), Value, " " )
+"a A b B c C ç Ç d D e E f F g G ğ Ğ h H i I İ ı j J k K l L m M n N o O ö Ö p P r R s S ş Ş t T u U ü Ü v V y Y z Z"
+
+// REGULAR EXPRESSIONS
+// Always uses invariant even though tr-TR is set, subject of https://github.com/microsoft/Power-Fx/issues/2538
+
+// Results when using C#                                  // Invariant   tr-TR    en-US
+
+>> IsMatch( "İ", "i", MatchOptions.IgnoreCase )           // false       TRUE     TRUE
+false
+
+>> IsMatch( "i", "İ", MatchOptions.IgnoreCase )           // false       TRUE     TRUE
+false
+
+>> IsMatch( "ı", "I", MatchOptions.IgnoreCase )           // false       TRUE     false
+false
+
+>> IsMatch( "I", "ı", MatchOptions.IgnoreCase )           // false       TRUE     false
+false
+
+>> IsMatch( "İ", "I", MatchOptions.IgnoreCase )           // false       false    TRUE
+false
+
+>> IsMatch( "I", "İ", MatchOptions.IgnoreCase )           // false       false    TRUE
+false
+
+>> IsMatch( "ı", "i", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> IsMatch( "i", "ı", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> IsMatch( "i", "I", MatchOptions.IgnoreCase )           // TRUE        false    TRUE
+true
+
+>> IsMatch( "I", "i", MatchOptions.IgnoreCase )           // TRUE        false    TRUE
+true
+
+>> IsMatch( "ı", "İ", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> IsMatch( "İ", "ı", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> Match( "hiIıİİıIhi", "\u0130+" )
+{FullMatch:"İİ",StartMatch:5,SubMatches:Table()}
+
+>> IsMatch( "Sıgh", "\u0131", MatchOptions.Contains )
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Culture_tr-TR.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Culture_tr-TR.txt
@@ -1,0 +1,207 @@
+﻿#SETUP: RegEx,CultureInfo("tr-TR"),PowerFxV1CompatibilityRules,ConsistentOneColumnTableResult
+
+// Four types of letter I
+//        Dotted     Dotless
+// Upper  İ U+0130   I U+0049
+// Lower  i U+0069   ı U+0131
+
+>> Language()
+"tr-TR"
+
+>> "İ" = UniChar( Hex2Dec( "0130") )
+true
+
+>> "ı" = UniChar( Hex2Dec( "0131" ) )
+true
+
+// UPPER, LOWER, PROPER
+
+>> Upper( "i" )
+"İ"
+
+>> Lower( "I" )
+"ı"
+
+>> Upper( "ı" )
+"I"
+
+>> Lower( "İ" )
+"i"
+
+>> Upper( "i" ) = UniChar( Hex2Dec( "0130") )
+true
+
+>> Lower( "I" ) = UniChar( Hex2Dec( "0131") )
+true
+
+>> Upper( "i" ) = "I"
+false
+
+>> Lower( "I" ) = "i"
+false
+
+>> Lower( "quit" ) = Lower( "QUIT" )
+false
+
+>> Lower( "quit" ) = Lower( "QUİT" )
+true
+
+>> Lower( "quıt" ) = Lower( "QUIT" )
+true
+
+>> Upper( "quit" ) = Upper( "QUIT" )
+false
+
+>> Upper( "quit" ) = Upper( "QUİT" )
+true
+
+>> Upper( "quıt" ) = Upper( "QUIT" )
+true
+
+>> Proper( "Iabc" )
+"Iabc"
+
+>> Proper( "iabc" )
+"İabc"
+
+>> Proper( "İabc" )
+"İabc"
+
+>> Proper( "ıabc" )
+"Iabc"
+
+// VALUE, DECIMAL, FLOAT
+
+>> Value( "123,456" )
+123.456
+
+>> Value( "123,456", "en-US" )
+123456
+
+>> Decimal( "123,456" )
+123.456
+
+>> Decimal( "123,456", "en-US" )
+123456
+
+>> Float( "123,456" )
+123.456
+
+>> Float( "123,456", "en-US" )
+123456
+
+// TEXT
+
+>> Text( DateTime(2010,1,1,14,0,0,0), "mmm ddd yyyy AM/PM" )
+"Oca Cum 2010 ÖS"
+
+>> Text( DateTime(2020,1,1,2,0,0,0), "mmmm dddd yyyy AM/PM" )
+"Ocak Çarşamba 2020 ÖÖ"
+
+>> Text( 123456789, "#,###.00" )
+"123456789,00000"
+
+>> Text( 123456789, "#.###,00" )
+"123.456.789,00"
+
+// IN AND EXACTIN
+
+>> "ı" in "SIGH"
+true
+
+>> "İ" in "sigh"
+true
+
+>> "ı" in "SİGH"
+false
+
+>> "İ" in "sıgh"
+false
+
+>> "ı" exactin "SIGH"
+false
+
+>> "İ" exactin "sigh"
+false
+
+>> "ı" exactin "SİGH"
+false
+
+>> "İ" exactin "sıgh"
+false
+
+>> "sİGh" in ["sigh","bcde"]
+true
+
+>> "siGh" in ["SİGH","bcde"]
+true
+
+>> "sIGH" in ["sigh","bcde"]
+false
+
+>> "sıGH" in ["bcde","sIgh"]
+true
+
+>> "SIgh" in ["bcde","sıgh"]
+true
+
+// SORT
+
+>> Sort( [ "Z", "İ", "z", "I", "J", "j", "ı", "a", "h", "i", "A", "H"], Value )
+Table({Value:"a"},{Value:"A"},{Value:"h"},{Value:"H"},{Value:"ı"},{Value:"I"},{Value:"i"},{Value:"İ"},{Value:"j"},{Value:"J"},{Value:"z"},{Value:"Z"})
+
+>> SortByColumns( [ "Z", "İ", "z", "I", "J", "j", "ı", "a", "h", "i", "A", "H"], "Value" )
+Table({Value:"a"},{Value:"A"},{Value:"h"},{Value:"H"},{Value:"ı"},{Value:"I"},{Value:"i"},{Value:"İ"},{Value:"j"},{Value:"J"},{Value:"z"},{Value:"Z"})
+
+>> Concat( Sort( Split( "j J k K l L m M n N o O p P r R s S t T u U v V y Y z Z Ç ç Ş ş Ü ü Ö ö İ ı Ğ ğ a A b B c C d D e E f F g G h H i I", " " ), Value ), Value, " " )
+"a A b B c C ç Ç d D e E f F g G ğ Ğ h H ı I i İ j J k K l L m M n N o O ö Ö p P r R s S ş Ş t T u U ü Ü v V y Y z Z"
+
+>> Concat( SortByColumns( Split( "d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V y Y z Z Ç ç Ş ş Ü ü Ö ö İ ı Ğ ğ a A b B c C", " " ), "Value" ), Value, " " )
+"a A b B c C ç Ç d D e E f F g G ğ Ğ h H ı I i İ j J k K l L m M n N o O ö Ö p P r R s S ş Ş t T u U ü Ü v V y Y z Z"
+
+// REGULAR EXPRESSIONS
+// Always uses invariant even though tr-TR is set, subject of https://github.com/microsoft/Power-Fx/issues/2538
+
+// Results when using C#                                  // Invariant   tr-TR    en-US
+
+>> IsMatch( "İ", "i", MatchOptions.IgnoreCase )           // false       TRUE     TRUE
+false
+
+>> IsMatch( "i", "İ", MatchOptions.IgnoreCase )           // false       TRUE     TRUE
+false
+
+>> IsMatch( "ı", "I", MatchOptions.IgnoreCase )           // false       TRUE     false
+false
+
+>> IsMatch( "I", "ı", MatchOptions.IgnoreCase )           // false       TRUE     false
+false
+
+>> IsMatch( "İ", "I", MatchOptions.IgnoreCase )           // false       false    TRUE
+false
+
+>> IsMatch( "I", "İ", MatchOptions.IgnoreCase )           // false       false    TRUE
+false
+
+>> IsMatch( "ı", "i", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> IsMatch( "i", "ı", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> IsMatch( "i", "I", MatchOptions.IgnoreCase )           // TRUE        false    TRUE
+true
+
+>> IsMatch( "I", "i", MatchOptions.IgnoreCase )           // TRUE        false    TRUE
+true
+
+>> IsMatch( "ı", "İ", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> IsMatch( "İ", "ı", MatchOptions.IgnoreCase )           // false       false    false
+false
+
+>> Match( "hiIıİİıIhi", "\u0130+" )
+{FullMatch:"İİ",StartMatch:5,SubMatches:Table()}
+
+>> IsMatch( "Sıgh", "\u0131", MatchOptions.Contains )
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestHelpers/TestRunner.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestHelpers/TestRunner.cs
@@ -102,6 +102,7 @@ namespace Microsoft.PowerFx.Core.Tests
             possible.Add("RegEx");
             possible.Add("TimeZoneInfo");
             possible.Add("TraceSetup");
+            possible.Add("CultureInfo");
 
             foreach (Match match in Regex.Matches(setup, @"(disable:)?(([\w]+|//)(\([^\)]*\))?)"))
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TestRunnerTests/InternalSetup.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TestRunnerTests/InternalSetup.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -19,6 +20,8 @@ namespace Microsoft.PowerFx.Core.Tests
         internal Features Features { get; set; }
 
         internal TimeZoneInfo TimeZoneInfo { get; set; }
+
+        internal CultureInfo CultureInfo { get; set; }
 
         /// <summary>
         /// By default, we run expressions with a memory governor to enforce a limited amount of memory. 
@@ -104,6 +107,23 @@ namespace Microsoft.PowerFx.Core.Tests
 
                         // This call will throw if the Id in invalid
                         iSetup.TimeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(tz);
+                        parts.Remove(part);
+                    }
+                    else
+                    {
+                        throw new ArgumentException("Invalid TimeZoneInfo setup!");
+                    }
+                }
+                else if (part.StartsWith("CultureInfo", StringComparison.OrdinalIgnoreCase))
+                {
+                    var m = new Regex(@"CultureInfo\(""(?<culture>[^)]+)""\)", RegexOptions.IgnoreCase).Match(part);
+
+                    if (m.Success)
+                    {
+                        var culture = m.Groups["culture"].Value;
+
+                        // This call will throw if the Language tag in invalid
+                        iSetup.CultureInfo = new CultureInfo(culture);
                         parts.Remove(part);
                     }
                     else

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/AsyncVerify.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/AsyncVerify.cs
@@ -83,6 +83,11 @@ namespace Microsoft.PowerFx.Tests
                 rtConfig.AddService(setup.TimeZoneInfo);
             }
 
+            if (setup.CultureInfo != null)
+            {
+                rtConfig.AddService(setup.CultureInfo);
+            }
+
             var task = engine.EvalAsync(expr, CancellationToken.None, options: setup.Flags.ToParserOptions(new CultureInfo("en-US")), runtimeConfig: rtConfig);
 
             var i = 0;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/PowerFxEvaluationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/PowerFxEvaluationTests.cs
@@ -958,6 +958,11 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     runtimeConfig.AddService(iSetup.TimeZoneInfo);
                 }
 
+                if (iSetup.CultureInfo != null)
+                {
+                    runtimeConfig.AddService(iSetup.CultureInfo);
+                }
+
                 if (engine.TryGetByName("traceRecord", out _))
                 {
                     var traceRecord = engine.GetValue("traceRecord");

--- a/src/tools/Repl/Program.cs
+++ b/src/tools/Repl/Program.cs
@@ -44,6 +44,8 @@ namespace Microsoft.PowerFx
 
         private static StandardFormatter _standardFormatter;
 
+        private static CultureInfo _cultureInfo = CultureInfo.CurrentCulture;
+
         private static bool _reset;
 
         private static RecalcEngine ReplRecalcEngine()
@@ -90,6 +92,7 @@ namespace Microsoft.PowerFx
             config.AddFunction(new Option2Function());
             config.AddFunction(new Run1Function());
             config.AddFunction(new Run2Function());
+            config.AddFunction(new Language1Function());
 
             var optionsSet = new OptionSet("Options", DisplayNameUtility.MakeUnique(options));
 
@@ -131,6 +134,10 @@ namespace Microsoft.PowerFx
                 _standardFormatter = new StandardFormatter();
                 this.ValueFormatter = _standardFormatter;
                 this.HelpProvider = new MyHelpProvider();
+
+                var bsp = new BasicServiceProvider();
+                bsp.AddService(_cultureInfo);
+                this.InnerServices = bsp;
 
                 this.AllowSetDefinitions = true;
                 this.EnableSampleUserObject();
@@ -407,6 +414,26 @@ namespace Microsoft.PowerFx
             }
         }
 
+        // set the language
+        private class Language1Function : ReflectionFunction
+        {
+            public Language1Function()
+                : base("Language", FormulaType.Void, new[] { FormulaType.String })
+            {
+            }
+
+            public FormulaValue Execute(StringValue lang)
+            {
+                var cultureInfo = new CultureInfo(lang.Value);
+
+                _cultureInfo = cultureInfo;
+
+                _reset = true;
+
+                return FormulaValue.NewVoid();
+            }
+        }
+
         private class MyHelpProvider : HelpProvider
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -477,6 +504,8 @@ Records and Tables can be arbitrarily nested.
 Use Option( Options.FormatTable, false ) to disable table formatting.
 Use Option() to see the list of all options with their current value.
 Use Help( ""Options"" ) for more information.
+
+Use Language( ""en-US"" ) to set culture info.
 
 Once a formula is defined or a variable's type is defined, it cannot be changed.
 Use Reset() to clear all formulas and variables.


### PR DESCRIPTION
The `in` operator and `Sort` function were not culturally aware, resulting in incorrect results for Turkish and other I'm sure other languages.  

The `Lower`, `Upper`, `Proper`, and `SortByColumns` functions are already culturally aware.  

Our regular expression functions are not culturally aware, but that is an interesting design choice that is the subject of https://github.com/microsoft/Power-Fx/issues/2538.

For testing, this PR adds the ability to change the culture in this local REPL only, with a `Language` function overload that takes a language tag as the first argument.  Also added is a `#SETUP` handler to specify the culture for a .txt test file.