### PR TITLE
Adding optional range param to custom fx2nl param

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -21,6 +21,11 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// Existing Power Fx Expression.
         /// </summary>
         public string Expression { get; set; }
+
+        /// <summary>
+        /// Optional range of the expression in the document.
+        /// </summary>
+        public Range Range { get; set; } = null;
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,9 +24,10 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         public string Expression { get; set; }
 
         /// <summary>
-        /// Optional range of the expression.
+        /// Optional range within <see cref="Expression"></see> to explain.
+        /// If missing, then explain the whole expression.
         /// </summary>
-        public Range Range { get; set; } = null;
+        public Range Range { get; set; }
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         public string Expression { get; set; }
 
         /// <summary>
-        /// Optional range of the expression in the document.
+        /// Optional range of the expression.
         /// </summary>
         public Range Range { get; set; } = null;
     }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -26,8 +26,9 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// <summary>
         /// Optional range within <see cref="Expression"></see> to explain.
         /// If missing, then explain the whole expression.
+        /// Eg: [0,0,0,6] >> start line 0, start character 0, end line 0, end character 6.
         /// </summary>
-        public Range Range { get; set; }
+        public uint[] Range { get; set; }
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// <summary>
         /// Optional range within <see cref="Expression"></see> to explain.
         /// If missing, then explain the whole expression.
-        /// Eg: {1,6} >> 1d starting index is 1 and ending index is 6.
+        /// Eg: zero-based offsets {1,6} >> 1d starting index is 1 and ending index is 6.
         /// </summary>
         public ScalarRange Range { get; set; }
     }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/CustomFx2NLParams.cs
@@ -26,9 +26,9 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
         /// <summary>
         /// Optional range within <see cref="Expression"></see> to explain.
         /// If missing, then explain the whole expression.
-        /// Eg: [0,0,0,6] >> start line 0, start character 0, end line 0, end character 6.
+        /// Eg: {1,6} >> 1d starting index is 1 and ending index is 6.
         /// </summary>
-        public uint[] Range { get; set; }
+        public ScalarRange Range { get; set; }
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ScalarRange.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ScalarRange.cs
@@ -7,16 +7,16 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
     {
         public bool IsValid()
         {
-            return Start <= End;
+            return Start >= 0 && End >= 0 && Start <= End;
         }
 
         /// <summary>
-        /// The range's start position.
+        /// Zero-based offset, the range's start position.
         /// </summary>
         public int Start { get; set; }
 
         /// <summary>
-        /// The range's end position.
+        /// Zero-based offset, the range's end position.
         /// </summary>
         public int End { get; set; }
     }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ScalarRange.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ScalarRange.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
+{
+    public class ScalarRange
+    {
+        public ScalarRange(int start, int end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public bool IsValid()
+        {
+            return Start <= End;
+        }
+
+        /// <summary>
+        /// The range's start position.
+        /// </summary>
+        public int Start { get; set; }
+
+        /// <summary>
+        /// The range's end position.
+        /// </summary>
+        public int End { get; set; }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ScalarRange.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Protocol/ScalarRange.cs
@@ -5,12 +5,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Protocol
 {
     public class ScalarRange
     {
-        public ScalarRange(int start, int end)
-        {
-            Start = start;
-            End = end;
-        }
-
         public bool IsValid()
         {
             return Start <= End;

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/LegacyLanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/LegacyLanguageServerTests.cs
@@ -1648,6 +1648,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
                         Version = 1
                     },
                     Expression = "Score > 3",
+                    Range = range,
                     Context = context
                 }
             });

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/LegacyLanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/LegacyLanguageServerTests.cs
@@ -1632,7 +1632,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
         }
 
         private static string FX2NlMessageJson(string documentUri, string context = null)
-        { 
+        {
             return JsonSerializer.Serialize(new
             {
                 jsonrpc = "2.0",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/LegacyLanguageServerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/LegacyLanguageServerTests.cs
@@ -33,7 +33,6 @@ using Microsoft.PowerFx.Types;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.PowerFx.Tests.BindingEngineTests;
-using Range = Microsoft.PowerFx.LanguageServerProtocol.Protocol.Range;
 
 namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol.Tests
 {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/PublicSurfaceTests.cs
@@ -91,6 +91,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.PublishExpressionTypeParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.PublishTokensParams",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.Range",
+                "Microsoft.PowerFx.LanguageServerProtocol.Protocol.ScalarRange",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.SignatureHelp",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.SignatureHelpContext",
                 "Microsoft.PowerFx.LanguageServerProtocol.Protocol.SignatureHelpParams",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
@@ -204,42 +204,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             Assert.NotEmpty(TestServer.UnhandledExceptions);
         }
 
-        [Fact]
-        public async Task TestFx2NLWithRequestParamRange()
-        {
-            // Arrange
-            var documentUri = "powerfx://app?context=1";
-            var expectedExpr = "sentence";
-
-            var engine = new Engine();
-            var symbols = new SymbolTable();
-            symbols.AddVariable("Score", FormulaType.Number);
-            var scope = engine.CreateEditorScope(symbols: symbols);
-            var scopeFactory = new TestPowerFxScopeFactory((string documentUri) => scope);
-            Init(new InitParams(scopeFactory: scopeFactory));
-            var handler = CreateAndConfigureFx2NlHandler();
-            handler.Delay = true;
-            handler.Expected = expectedExpr;
-            handler.SupportsParameterHints = false;
-
-            // Optional request param Range field is set
-            Range range = new Range()
-            {
-                Start = new Position() { Line = 0, Character = 0 },
-                End = new Position() { Line = 0, Character = 5 }
-            };
-
-            // Act
-            var payload = Fx2NlMessageJson(documentUri, null, range);
-            var rawResponse = await TestServer.OnDataReceivedAsync(payload.payload);
-            var response = AssertAndGetResponsePayload<CustomFx2NLResult>(rawResponse, payload.id);
-
-            // Assert
-            // result has expected concat with symbols. 
-            Assert.Equal("Score > 3: True: sentence", response.Explanation);
-        }
-
-        private static (string payload, string id) Fx2NlMessageJson(string documentUri, string context = null, Range range = null)
+        private static (string payload, string id) Fx2NlMessageJson(string documentUri, string context = null)
         {
             var fx2NlParams = new CustomFx2NLParams()
             {
@@ -250,7 +215,6 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                     Version = 1
                 },
                 Expression = "Score > 3",
-                Range = range,
                 Context = context
             };
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
@@ -10,7 +10,6 @@ using Microsoft.PowerFx.LanguageServerProtocol.Handlers;
 using Microsoft.PowerFx.LanguageServerProtocol.Protocol;
 using Microsoft.PowerFx.Types;
 using Xunit;
-using Range = Microsoft.PowerFx.LanguageServerProtocol.Protocol.Range;
 
 namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
@@ -10,6 +10,7 @@ using Microsoft.PowerFx.LanguageServerProtocol.Handlers;
 using Microsoft.PowerFx.LanguageServerProtocol.Protocol;
 using Microsoft.PowerFx.Types;
 using Xunit;
+using Range = Microsoft.PowerFx.LanguageServerProtocol.Protocol.Range;
 
 namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 {
@@ -203,7 +204,42 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             Assert.NotEmpty(TestServer.UnhandledExceptions);
         }
 
-        private static (string payload, string id) Fx2NlMessageJson(string documentUri, string context = null)
+        [Fact]
+        public async Task TestFx2NLWithRequestParamRange()
+        {
+            // Arrange
+            var documentUri = "powerfx://app?context=1";
+            var expectedExpr = "sentence";
+
+            var engine = new Engine();
+            var symbols = new SymbolTable();
+            symbols.AddVariable("Score", FormulaType.Number);
+            var scope = engine.CreateEditorScope(symbols: symbols);
+            var scopeFactory = new TestPowerFxScopeFactory((string documentUri) => scope);
+            Init(new InitParams(scopeFactory: scopeFactory));
+            var handler = CreateAndConfigureFx2NlHandler();
+            handler.Delay = true;
+            handler.Expected = expectedExpr;
+            handler.SupportsParameterHints = false;
+
+            // Optional request param Range field is set
+            Range range = new Range()
+            {
+                Start = new Position() { Line = 0, Character = 0 },
+                End = new Position() { Line = 0, Character = 5 }
+            };
+
+            // Act
+            var payload = Fx2NlMessageJson(documentUri, null, range);
+            var rawResponse = await TestServer.OnDataReceivedAsync(payload.payload);
+            var response = AssertAndGetResponsePayload<CustomFx2NLResult>(rawResponse, payload.id);
+
+            // Assert
+            // result has expected concat with symbols. 
+            Assert.Equal("Score > 3: True: sentence", response.Explanation);
+        }
+
+        private static (string payload, string id) Fx2NlMessageJson(string documentUri, string context = null, Range range = null)
         {
             var fx2NlParams = new CustomFx2NLParams()
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
@@ -250,6 +250,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                     Version = 1
                 },
                 Expression = "Score > 3",
+                Range = range,
                 Context = context
             };
 


### PR DESCRIPTION
Update the expected params for Fx2Nl (CustomFx2NLParams) with an optional range field.
This will be used and passed down for the explain this partial formula explanation.