### PR TITLE
Fix 2523 - Improve Json deserialization errors and be more permisive

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -861,10 +861,10 @@ namespace Microsoft.PowerFx.Connectors
         {
             ExpressionError er = null;
 
-            if (result is ErrorValue ev && (er = ev.Errors.FirstOrDefault(e => e.Kind == ErrorKind.Network)) != null)
+            if (result is ErrorValue ev && (er = ev.Errors.FirstOrDefault(e => e.Kind == ErrorKind.Network || e.Kind == ErrorKind.InvalidJson)) != null)
             {
                 runtimeContext.ExecutionLogger?.LogError($"{this.LogFunction(nameof(PostProcessResultAsync))}, ErrorValue is returned with {er.Message}");
-                result = FormulaValue.NewError(new ExpressionError() { Kind = er.Kind, Severity = er.Severity, Message = $"{DPath.Root.Append(new DName(Namespace)).ToDottedSyntax()}.{Name} failed: {er.Message}" }, ev.Type);
+                result = FormulaValue.NewError(new ExpressionError() { Kind = er.Kind, Severity = er.Severity, Span = er.Span, Message = $"{DPath.Root.Append(new DName(Namespace)).ToDottedSyntax()}.{Name} failed: {er.Message}" }, ev.Type); 
             }
 
             if (IsPageable && result is RecordValue rv)

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -864,7 +864,10 @@ namespace Microsoft.PowerFx.Connectors
             if (result is ErrorValue ev && (er = ev.Errors.FirstOrDefault(e => e.Kind == ErrorKind.Network || e.Kind == ErrorKind.InvalidJson)) != null)
             {
                 runtimeContext.ExecutionLogger?.LogError($"{this.LogFunction(nameof(PostProcessResultAsync))}, ErrorValue is returned with {er.Message}");
-                result = FormulaValue.NewError(new ExpressionError() { Kind = er.Kind, Severity = er.Severity, Span = er.Span, Message = $"{DPath.Root.Append(new DName(Namespace)).ToDottedSyntax()}.{Name} failed: {er.Message}" }, ev.Type); 
+                ExpressionError newError = er is HttpExpressionError her
+                    ? new HttpExpressionError(her.StatusCode) { Kind = er.Kind, Severity = er.Severity, Message = $"{DPath.Root.Append(new DName(Namespace)).ToDottedSyntax()}.{Name} failed: {er.Message}" }
+                    : new ExpressionError() { Kind = er.Kind, Severity = er.Severity, Message = $"{DPath.Root.Append(new DName(Namespace)).ToDottedSyntax()}.{Name} failed: {er.Message}" };
+                result = FormulaValue.NewError(newError, ev.Type); 
             }
 
             if (IsPageable && result is RecordValue rv)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
@@ -459,11 +459,10 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             return FormulaValue.NewError(
-                    new ExpressionError()
+                    new HttpExpressionError(statusCode)
                     {
                         Kind = ErrorKind.Network,
                         Severity = ErrorSeverity.Critical,
-                        Span = new Syntax.Span(statusCode, statusCode), // Return HTTP Status code in Span
                         Message = $"The server returned an HTTP error with code {statusCode}{reasonPhrase}. Response: {text}"
                     },
                     _function.ReturnType);

--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
@@ -463,6 +463,7 @@ namespace Microsoft.PowerFx.Connectors
                     {
                         Kind = ErrorKind.Network,
                         Severity = ErrorSeverity.Critical,
+                        Span = new Syntax.Span(statusCode, statusCode), // Return HTTP Status code in Span
                         Message = $"The server returned an HTTP error with code {statusCode}{reasonPhrase}. Response: {text}"
                     },
                     _function.ReturnType);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerFx
         NotApplicable = 27,
         Timeout = 28,
         ServiceUnavailable = 29,
+        InvalidJson = 30,
         Custom = 1000,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/HttpExpressionError.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/HttpExpressionError.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Types;
+
+namespace Microsoft.PowerFx
+{
+    /// <summary>
+    /// Error message. This could be a compile time error from parsing or binding, 
+    /// or it could be a runtime error wrapped in a <see cref="ErrorValue"/>.
+    /// </summary>
+    public class HttpExpressionError : ExpressionError
+    {
+        public int StatusCode { get; }
+
+        public HttpExpressionError(int statusCode)
+            : base()
+        {
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/BuiltInEnums.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/BuiltInEnums.cs
@@ -154,6 +154,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                 { "NotApplicable", 27 },
                 { "Timeout", 28 },
                 { "ServiceUnavailable", 29 },
+                { "InvalidJson", 30 },
                 { "Custom", 1000 },
             },
             canCompareNumeric: true,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2560,6 +2560,9 @@ namespace Microsoft.PowerFx.Functions
                 case ErrorKind.ServiceUnavailable:
                     // Default message that is shown to users when they execute an operation requires a online service connection that is not available
                     return "Online service connection not available";
+                case ErrorKind.InvalidJson:
+                    // Default message that is shown to users when they receive a Json result that is invalid 
+                    return "Invalid Json format";
                 case ErrorKind.Custom:
                     // Default message that is shown to users when they create an error with a custom kind
                     return "Custom error";

--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerFx.Types
                 {
                     Message = $"{je.GetType().Name} {je.Message}",
                     Span = new Syntax.Span(0, 0),
-                    Kind = ErrorKind.Network
+                    Kind = ErrorKind.InvalidJson
                 });
             }
             catch (PowerFxJsonException pfxje)
@@ -53,7 +53,7 @@ namespace Microsoft.PowerFx.Types
                 {
                     Message = $"{pfxje.GetType().Name} {pfxje.Message}",
                     Span = new Syntax.Span(0, 0),
-                    Kind = ErrorKind.Network
+                    Kind = ErrorKind.InvalidJson
                 });
             }
         }

--- a/src/libraries/Microsoft.PowerFx.Json/PowerFxJsonException.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/PowerFxJsonException.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Net;
+using System.Runtime.Serialization;
+
+namespace Microsoft.PowerFx
+{
+    [Serializable]
+    internal class PowerFxJsonException : Exception
+    {
+        public PowerFxJsonException()
+        {
+        }
+
+        public PowerFxJsonException(string message)
+            : base(message)
+        {
+        }
+
+        public PowerFxJsonException(string message, string name)
+            : base($"{message}{(string.IsNullOrEmpty(name) ? string.Empty : $", in {name}")}")
+        {
+        }
+
+        public PowerFxJsonException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        protected PowerFxJsonException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Json/PowerFxJsonException.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/PowerFxJsonException.cs
@@ -19,8 +19,8 @@ namespace Microsoft.PowerFx
         {
         }
 
-        public PowerFxJsonException(string message, string name)
-            : base($"{message}{(string.IsNullOrEmpty(name) ? string.Empty : $", in {name}")}")
+        public PowerFxJsonException(string message, string path)
+            : base($"{message}{(string.IsNullOrEmpty(path) ? string.Empty : $", in {path}")}")
         {
         }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
@@ -53,6 +53,11 @@
     <None Include="$(MSBuildThisFileDirectory)Owl.NoAlpha.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service For Language v2.1_Invalid Response.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service For Language v2.1_Invalid Response 2.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service For Language v2.1_Invalid Response 3.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service For Language v2.1_Invalid Response 4.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service For Language v2.1_Invalid Response 5.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service for Language v2.1_Response.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Azure Cognitive Service for Language_Response.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\AzureBlobStorage_GetFileContentV2.raw" />

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -610,6 +610,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
 
             ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
+            Assert.Equal(ErrorKind.InvalidJson, ev.Errors.First().Kind);
             Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting Table but received a Number, in result/prediction/intents", ev.Errors.First().Message);
         }
 
@@ -674,6 +675,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
 
             ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
+            Assert.Equal(ErrorKind.InvalidJson, ev.Errors.First().Kind);
             Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting String but received a Table with 2 elements, in result/prediction/entities/category", ev.Errors.First().Message);
         }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -610,7 +610,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
 
             ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
-            Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting Table but reveived a Number, in result/prediction/intents", ev.Errors.First().Message);
+            Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting Table but received a Number, in result/prediction/intents", ev.Errors.First().Message);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -521,6 +521,194 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.Equal("{\"resolutionKind\":\"DateTimeResolution\",\"value\":\"2023-02-25\"}", visitor2.Result);
         }
 
+        [Fact]
+        public async Task ACSL_InvokeFunction_v21_WithInvalidResponse()
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\Azure Cognitive Service for Language v2.1.json", _output);
+            OpenApiDocument apiDoc = testConnector._apiDocument;
+            ConsoleLogger logger = new ConsoleLogger(_output);
+
+            PowerFxConfig pfxConfig = new PowerFxConfig(Features.PowerFxV1);
+            using var httpClient = new HttpClient(testConnector);
+
+            // 'intents' is a record instead of being a table
+            // Expecting Table but received a Record, in result/prediction/intents
+            testConnector.SetResponseFromFile(@"Responses\Azure Cognitive Service For Language v2.1_Invalid Response.json");
+
+            var xx = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList();
+            ConnectorFunction function = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList()[11];
+            Assert.Equal("ConversationAnalysisAnalyzeConversationConversation", function.Name);
+            Assert.Equal("![kind:s, result:![detectedLanguage:s, prediction:![entities:*[category:s, confidenceScore:w, extraInformation:O, length:w, multipleResolutions:b, offset:w, resolutions:O, text:s, topResolution:O], intents:*[category:s, confidenceScore:w], projectKind:s, topIntent:s], query:s]]", function.ReturnType.ToStringWithDisplayNames());
+
+            RecalcEngine engine = new RecalcEngine(pfxConfig);
+
+            string analysisInput = @"{ conversationItem: { modality: ""text"", language: ""en-us"", text: ""Book me a flight for Munich"" } }";
+            string parameters = @"{ deploymentName: ""deploy1"", projectName: ""project1"", verbose: true, stringIndexType: ""TextElement_V8"" }";
+            FormulaValue analysisInputParam = engine.Eval(analysisInput);
+            FormulaValue parametersParam = engine.Eval(parameters);
+            FormulaValue kind = FormulaValue.New("Conversation");
+
+            using PowerPlatformConnectorClient client = new PowerPlatformConnectorClient("https://lucgen-apim.azure-api.net", "aaa373836ffd4915bf6eefd63d164adc" /* environment Id */, "16e7c181-2f8d-4cae-b1f0-179c5c4e4d8b" /* connectionId */, () => "No Auth", httpClient) { SessionId = "a41bd03b-6c3c-4509-a844-e8c51b61f878", };
+            BaseRuntimeConnectorContext context = new TestConnectorRuntimeContext("ACSL", client, console: _output);
+
+            FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
+
+            Assert.NotNull(httpResult);
+            Assert.True(httpResult is RecordValue);
+
+            RecordValue httpResultValue = (RecordValue)httpResult;
+            RecordValue resultValue = (RecordValue)httpResultValue.GetField("result");
+            RecordValue predictionValue = (RecordValue)resultValue.GetField("prediction");
+            TableValue entitiesValue = (TableValue)predictionValue.GetField("entities");
+            IEnumerable<DValue<RecordValue>> rows = entitiesValue.Rows;
+
+            // Get second entity
+            RecordValue entityValue2 = rows.Skip(1).First().Value;
+            FormulaValue resolutionsValue = entityValue2.GetField("resolutions");
+
+            Assert.True(resolutionsValue is UntypedObjectValue);
+            UOValueVisitor visitor1 = new UOValueVisitor();
+            resolutionsValue.Visit(visitor1);
+
+            Assert.Equal("[\"{\\\"resolutionKind\\\":\\\"DateTimeResolution\\\",\\\"value\\\":\\\"2023-02-25\\\"}\"]", visitor1.Result);
+
+            FormulaValue topResolutionValue1 = entityValue2.GetField("topResolution");
+            Assert.True(topResolutionValue1 is UntypedObjectValue);
+
+            UOValueVisitor visitor2 = new UOValueVisitor();
+            topResolutionValue1.Visit(visitor2);
+
+            Assert.Equal("{\"resolutionKind\":\"DateTimeResolution\",\"value\":\"2023-02-25\"}", visitor2.Result);
+        }
+
+        [Fact]
+        public async Task ACSL_InvokeFunction_v21_WithInvalidResponse2()
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\Azure Cognitive Service for Language v2.1.json", _output);
+            OpenApiDocument apiDoc = testConnector._apiDocument;
+            ConsoleLogger logger = new ConsoleLogger(_output);
+
+            PowerFxConfig pfxConfig = new PowerFxConfig(Features.PowerFxV1);
+            using var httpClient = new HttpClient(testConnector);
+
+            // "intents": 99
+            testConnector.SetResponseFromFile(@"Responses\Azure Cognitive Service For Language v2.1_Invalid Response 2.json");
+
+            var xx = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList();
+            ConnectorFunction function = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList()[11];            
+            RecalcEngine engine = new RecalcEngine(pfxConfig);
+
+            string analysisInput = @"{ conversationItem: { modality: ""text"", language: ""en-us"", text: ""Book me a flight for Munich"" } }";
+            string parameters = @"{ deploymentName: ""deploy1"", projectName: ""project1"", verbose: true, stringIndexType: ""TextElement_V8"" }";
+            FormulaValue analysisInputParam = engine.Eval(analysisInput);
+            FormulaValue parametersParam = engine.Eval(parameters);
+            FormulaValue kind = FormulaValue.New("Conversation");
+
+            using PowerPlatformConnectorClient client = new PowerPlatformConnectorClient("https://lucgen-apim.azure-api.net", "aaa373836ffd4915bf6eefd63d164adc" /* environment Id */, "16e7c181-2f8d-4cae-b1f0-179c5c4e4d8b" /* connectionId */, () => "No Auth", httpClient) { SessionId = "a41bd03b-6c3c-4509-a844-e8c51b61f878", };
+            BaseRuntimeConnectorContext context = new TestConnectorRuntimeContext("ACSL", client, console: _output);
+
+            FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
+
+            ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
+            Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting Table but reveived a Number, in result/prediction/intents", ev.Errors.First().Message);
+        }
+
+        [Fact]
+        public async Task ACSL_InvokeFunction_v21_WithInvalidResponse3()
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\Azure Cognitive Service for Language v2.1.json", _output);
+            OpenApiDocument apiDoc = testConnector._apiDocument;
+            ConsoleLogger logger = new ConsoleLogger(_output);
+
+            PowerFxConfig pfxConfig = new PowerFxConfig(Features.PowerFxV1);
+            using var httpClient = new HttpClient(testConnector);
+
+            // "category" is an 1-element array instead of a string
+            testConnector.SetResponseFromFile(@"Responses\Azure Cognitive Service For Language v2.1_Invalid Response 3.json");
+
+            var xx = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList();
+            ConnectorFunction function = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList()[11];
+            RecalcEngine engine = new RecalcEngine(pfxConfig);
+
+            string analysisInput = @"{ conversationItem: { modality: ""text"", language: ""en-us"", text: ""Book me a flight for Munich"" } }";
+            string parameters = @"{ deploymentName: ""deploy1"", projectName: ""project1"", verbose: true, stringIndexType: ""TextElement_V8"" }";
+            FormulaValue analysisInputParam = engine.Eval(analysisInput);
+            FormulaValue parametersParam = engine.Eval(parameters);
+            FormulaValue kind = FormulaValue.New("Conversation");
+
+            using PowerPlatformConnectorClient client = new PowerPlatformConnectorClient("https://lucgen-apim.azure-api.net", "aaa373836ffd4915bf6eefd63d164adc" /* environment Id */, "16e7c181-2f8d-4cae-b1f0-179c5c4e4d8b" /* connectionId */, () => "No Auth", httpClient) { SessionId = "a41bd03b-6c3c-4509-a844-e8c51b61f878", };
+            BaseRuntimeConnectorContext context = new TestConnectorRuntimeContext("ACSL", client, console: _output);
+
+            FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
+
+            // valid result
+            Assert.IsAssignableFrom<RecordValue>(httpResult); 
+        }
+
+        [Fact]
+        public async Task ACSL_InvokeFunction_v21_WithInvalidResponse4()
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\Azure Cognitive Service for Language v2.1.json", _output);
+            OpenApiDocument apiDoc = testConnector._apiDocument;
+            ConsoleLogger logger = new ConsoleLogger(_output);
+
+            PowerFxConfig pfxConfig = new PowerFxConfig(Features.PowerFxV1);
+            using var httpClient = new HttpClient(testConnector);
+
+            // "category" is an 2-element array instead of a string
+            testConnector.SetResponseFromFile(@"Responses\Azure Cognitive Service For Language v2.1_Invalid Response 4.json");
+
+            var xx = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList();
+            ConnectorFunction function = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList()[11];
+            RecalcEngine engine = new RecalcEngine(pfxConfig);
+
+            string analysisInput = @"{ conversationItem: { modality: ""text"", language: ""en-us"", text: ""Book me a flight for Munich"" } }";
+            string parameters = @"{ deploymentName: ""deploy1"", projectName: ""project1"", verbose: true, stringIndexType: ""TextElement_V8"" }";
+            FormulaValue analysisInputParam = engine.Eval(analysisInput);
+            FormulaValue parametersParam = engine.Eval(parameters);
+            FormulaValue kind = FormulaValue.New("Conversation");
+
+            using PowerPlatformConnectorClient client = new PowerPlatformConnectorClient("https://lucgen-apim.azure-api.net", "aaa373836ffd4915bf6eefd63d164adc" /* environment Id */, "16e7c181-2f8d-4cae-b1f0-179c5c4e4d8b" /* connectionId */, () => "No Auth", httpClient) { SessionId = "a41bd03b-6c3c-4509-a844-e8c51b61f878", };
+            BaseRuntimeConnectorContext context = new TestConnectorRuntimeContext("ACSL", client, console: _output);
+
+            FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
+
+            ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
+            Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting String but received a Table with 2 elements, in result/prediction/entities/category", ev.Errors.First().Message);
+        }
+
+        [Fact]
+        public async Task ACSL_InvokeFunction_v21_WithInvalidResponse5()
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\Azure Cognitive Service for Language v2.1.json", _output);
+            OpenApiDocument apiDoc = testConnector._apiDocument;
+            ConsoleLogger logger = new ConsoleLogger(_output);
+
+            PowerFxConfig pfxConfig = new PowerFxConfig(Features.PowerFxV1);
+            using var httpClient = new HttpClient(testConnector);
+
+            // "intent" is an array of arrays of records
+            testConnector.SetResponseFromFile(@"Responses\Azure Cognitive Service For Language v2.1_Invalid Response 5.json");
+
+            var xx = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList();
+            ConnectorFunction function = OpenApiParser.GetFunctions("ACSL", apiDoc, logger).OrderBy(cf => cf.Name).ToList()[11];
+            RecalcEngine engine = new RecalcEngine(pfxConfig);
+
+            string analysisInput = @"{ conversationItem: { modality: ""text"", language: ""en-us"", text: ""Book me a flight for Munich"" } }";
+            string parameters = @"{ deploymentName: ""deploy1"", projectName: ""project1"", verbose: true, stringIndexType: ""TextElement_V8"" }";
+            FormulaValue analysisInputParam = engine.Eval(analysisInput);
+            FormulaValue parametersParam = engine.Eval(parameters);
+            FormulaValue kind = FormulaValue.New("Conversation");
+
+            using PowerPlatformConnectorClient client = new PowerPlatformConnectorClient("https://lucgen-apim.azure-api.net", "aaa373836ffd4915bf6eefd63d164adc" /* environment Id */, "16e7c181-2f8d-4cae-b1f0-179c5c4e4d8b" /* connectionId */, () => "No Auth", httpClient) { SessionId = "a41bd03b-6c3c-4509-a844-e8c51b61f878", };
+            BaseRuntimeConnectorContext context = new TestConnectorRuntimeContext("ACSL", client, console: _output);
+
+            FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
+
+            // valid result
+            Assert.IsAssignableFrom<RecordValue>(httpResult);
+        }
+
         internal class UOValueVisitor : IValueVisitor
         {
             public string Result { get; private set; }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
@@ -219,6 +219,8 @@ namespace Microsoft.PowerFx.Tests
 
                 Assert.Equal(ErrorKind.Network, err.Kind);
                 Assert.Equal(ErrorSeverity.Critical, err.Severity);
+                Assert.Equal(statusCode, err.Span.Min);
+                Assert.Equal(statusCode, err.Span.Lim);
                 Assert.Equal($"TestConnector12.GenerateError failed: The server returned an HTTP error with code {statusCode} ({reasonPhrase}). Response: {statusCode}", err.Message);
             }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
@@ -215,13 +215,15 @@ namespace Microsoft.PowerFx.Tests
                 Assert.Equal(FormulaType.Decimal, ev.Type);
                 Assert.Single(ev.Errors);
 
-                var err = ev.Errors[0];
+                ExpressionError err = ev.Errors[0];
 
                 Assert.Equal(ErrorKind.Network, err.Kind);
                 Assert.Equal(ErrorSeverity.Critical, err.Severity);
-                Assert.Equal(statusCode, err.Span.Min);
-                Assert.Equal(statusCode, err.Span.Lim);
                 Assert.Equal($"TestConnector12.GenerateError failed: The server returned an HTTP error with code {statusCode} ({reasonPhrase}). Response: {statusCode}", err.Message);
+
+                HttpExpressionError her = Assert.IsType<HttpExpressionError>(err);
+
+                Assert.Equal(statusCode, her.StatusCode);
             }
 
             testConnector.SetResponse($"{statusCode}", (HttpStatusCode)statusCode);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 2.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 2.json
@@ -1,0 +1,65 @@
+{
+  "kind": "ConversationResult",
+  "result": {
+    "prediction": {
+      "entities": [
+        {
+          "category": "Count",
+          "text": "1",
+          "offset": 5,
+          "length": 1,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "NumberResolution",
+              "numberKind": "Integer",
+              "value": 1
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "NumberResolution",
+            "numberKind": "Integer",
+            "value": 1
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "quantity.number"
+            }
+          ]
+        },
+        {
+          "category": "When",
+          "text": "tomorrow",
+          "offset": 23,
+          "length": 8,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "DateTimeResolution",
+              "dateTimeSubKind": "Date",
+              "timex": "2023-02-25",
+              "value": "2023-02-25"
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "DateTimeResolution",
+            "dateTimeSubKind": "Date",
+            "timex": "2023-02-25",
+            "value": "2023-02-25"
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "datetime.date"
+            }
+          ]
+        }
+      ],
+      "intents": 99,
+      "projectKind": "Conversation",
+      "topIntent": "Book me a flight to Paris next week"
+    },
+    "query": "Book me a flight for Munich"
+  }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 3.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 3.json
@@ -1,0 +1,68 @@
+{
+  "kind": "ConversationResult",
+  "result": {
+    "prediction": {
+      "entities": [
+        {
+          "category": [ "Count" ],
+          "text": "1",
+          "offset": 5,
+          "length": 1,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "NumberResolution",
+              "numberKind": "Integer",
+              "value": 1
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "NumberResolution",
+            "numberKind": "Integer",
+            "value": 1
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "quantity.number"
+            }
+          ]
+        },
+        {
+          "category": "When",
+          "text": "tomorrow",
+          "offset": 23,
+          "length": 8,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "DateTimeResolution",
+              "dateTimeSubKind": "Date",
+              "timex": "2023-02-25",
+              "value": "2023-02-25"
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "DateTimeResolution",
+            "dateTimeSubKind": "Date",
+            "timex": "2023-02-25",
+            "value": "2023-02-25"
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "datetime.date"
+            }
+          ]
+        }
+      ],
+      "intents": {
+        "category": "Book me a flight to Paris next week",
+        "confidenceScore": 0.89360607
+      },
+      "projectKind": "Conversation",
+      "topIntent": "Book me a flight to Paris next week"
+    },
+    "query": "Book me a flight for Munich"
+  }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 4.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 4.json
@@ -1,0 +1,68 @@
+{
+  "kind": "ConversationResult",
+  "result": {
+    "prediction": {
+      "entities": [
+        {
+          "category": [ "Count", "Invalid" ],
+          "text": "1",
+          "offset": 5,
+          "length": 1,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "NumberResolution",
+              "numberKind": "Integer",
+              "value": 1
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "NumberResolution",
+            "numberKind": "Integer",
+            "value": 1
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "quantity.number"
+            }
+          ]
+        },
+        {
+          "category": "When",
+          "text": "tomorrow",
+          "offset": 23,
+          "length": 8,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "DateTimeResolution",
+              "dateTimeSubKind": "Date",
+              "timex": "2023-02-25",
+              "value": "2023-02-25"
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "DateTimeResolution",
+            "dateTimeSubKind": "Date",
+            "timex": "2023-02-25",
+            "value": "2023-02-25"
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "datetime.date"
+            }
+          ]
+        }
+      ],
+      "intents": {
+        "category": "Book me a flight to Paris next week",
+        "confidenceScore": 0.89360607
+      },
+      "projectKind": "Conversation",
+      "topIntent": "Book me a flight to Paris next week"
+    },
+    "query": "Book me a flight for Munich"
+  }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 5.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response 5.json
@@ -1,0 +1,78 @@
+{
+  "kind": "ConversationResult",
+  "result": {
+    "prediction": {
+      "entities": [
+        {
+          "category": "Count",
+          "text": "1",
+          "offset": 5,
+          "length": 1,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "NumberResolution",
+              "numberKind": "Integer",
+              "value": 1
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "NumberResolution",
+            "numberKind": "Integer",
+            "value": 1
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "quantity.number"
+            }
+          ]
+        },
+        {
+          "category": "When",
+          "text": "tomorrow",
+          "offset": 23,
+          "length": 8,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "DateTimeResolution",
+              "dateTimeSubKind": "Date",
+              "timex": "2023-02-25",
+              "value": "2023-02-25"
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "DateTimeResolution",
+            "dateTimeSubKind": "Date",
+            "timex": "2023-02-25",
+            "value": "2023-02-25"
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "datetime.date"
+            }
+          ]
+        }
+      ],
+      "intents": [
+        [
+          {
+            "category": "Book me a flight to Paris next week",
+            "confidenceScore": 0.89360607
+          }
+        ],
+        [
+          {
+            "category": "None",
+            "confidenceScore": 0
+          }
+        ]
+      ],
+      "projectKind": "Conversation",
+      "topIntent": "Book me a flight to Paris next week"
+    },
+    "query": "Book me a flight for Munich"
+  }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Azure Cognitive Service For Language v2.1_Invalid Response.json
@@ -1,0 +1,68 @@
+{
+  "kind": "ConversationResult",
+  "result": {
+    "prediction": {
+      "entities": [
+        {
+          "category": "Count",
+          "text": "1",
+          "offset": 5,
+          "length": 1,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "NumberResolution",
+              "numberKind": "Integer",
+              "value": 1
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "NumberResolution",
+            "numberKind": "Integer",
+            "value": 1
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "quantity.number"
+            }
+          ]
+        },
+        {
+          "category": "When",
+          "text": "tomorrow",
+          "offset": 23,
+          "length": 8,
+          "confidenceScore": 1,
+          "resolutions": [
+            {
+              "resolutionKind": "DateTimeResolution",
+              "dateTimeSubKind": "Date",
+              "timex": "2023-02-25",
+              "value": "2023-02-25"
+            }
+          ],
+          "topResolution": {
+            "resolutionKind": "DateTimeResolution",
+            "dateTimeSubKind": "Date",
+            "timex": "2023-02-25",
+            "value": "2023-02-25"
+          },
+          "extraInformation": [
+            {
+              "extraInformationKind": "EntitySubtype",
+              "value": "datetime.date"
+            }
+          ]
+        }
+      ],
+      "intents": {
+        "category": "Book me a flight to Paris next week",
+        "confidenceScore": 0.89360607
+      },      
+      "projectKind": "Conversation",
+      "topIntent": "Book me a flight to Paris next week"
+    },
+    "query": "Book me a flight for Munich"
+  }
+}

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Error.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Error.txt
@@ -249,6 +249,12 @@ Error({Kind:ErrorKind.EditPermissions})
 >> IfError(Error({Kind:ErrorKind.Timeout}), $"{FirstError.Kind}: {FirstError.Message}")
 "28: Timeout error"
 
+>> IfError(Error({Kind:ErrorKind.ServiceUnavailable}), $"{FirstError.Kind}: {FirstError.Message}")
+"29: Online service connection not available"
+
+>> IfError(Error({Kind:ErrorKind.InvalidJson}), $"{FirstError.Kind}: {FirstError.Message}")
+"30: Invalid Json format"
+
 >> IfError(Error({Kind:ErrorKind.Custom}), $"{FirstError.Kind}: {FirstError.Message}")
 "1000: Custom error"
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         // AddSuggestionsForEnums
         [InlineData("Monday|", "StartOfWeek.Monday", "StartOfWeek.MondayZero")]
         [InlineData("Value(Missing|", "ErrorKind.MissingRequired")]
-        [InlineData("ErrorKind.Inv|", "InvalidArgument", "InvalidFunctionUsage")]
+        [InlineData("ErrorKind.Inv|", "InvalidArgument", "InvalidFunctionUsage", "InvalidJson")]
         [InlineData("Quota|", "ErrorKind.QuotaExceeded")]
         [InlineData("DateTimeFormat.h|", "ShortDate", "ShortTime", "ShortTime24", "ShortDateTime", "ShortDateTime24")]
         [InlineData("SortOrder|", "SortOrder", "SortOrder.Ascending", "SortOrder.Descending")]

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.FormulaWithParameters",
                 "Microsoft.PowerFx.FunctionInfo",
                 "Microsoft.PowerFx.FunctionInfoSignature",
+                "Microsoft.PowerFx.HttpExpressionError",
                 "Microsoft.PowerFx.ParameterInfoSignature",
                 "Microsoft.PowerFx.NameCollisionException",
                 "Microsoft.PowerFx.OptionSet",

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/ParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/ParseJSONTests.cs
@@ -68,12 +68,12 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.Equal(17m, ((DecimalValue)wv2).Value);
             Assert.Equal("w", wv2.Type.ToStringWithDisplayNames());
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, RecordType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color));
+            Assert.Equal($"PowerFxJsonException Expecting Table but received a Number", (FormulaValueJSON.FromJson(expr, TableType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Record but received a Number", (FormulaValueJSON.FromJson(expr, RecordType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.String) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.Guid) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.Color) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType());
             Assert.NotNull(fv3);
@@ -116,12 +116,12 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.Equal(17m, ((DecimalValue)wv2).Value);
             Assert.Equal("w", wv2.Type.ToStringWithDisplayNames());
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty(), numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, RecordType.Empty(), numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color, numberIsFloat: true));
+            Assert.Equal($"PowerFxJsonException Expecting Table but received a Number", (FormulaValueJSON.FromJson(expr, TableType.Empty(), numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Record but received a Number", (FormulaValueJSON.FromJson(expr, RecordType.Empty(), numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.String, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.Guid, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Number", (FormulaValueJSON.FromJson(expr, FormulaType.Color, numberIsFloat: true) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType(), numberIsFloat: true);
             Assert.NotNull(fv3);
@@ -154,13 +154,13 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.True(fv2 is StringValue);
             Assert.Equal("abc", ((StringValue)sv).Value);
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, RecordType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Number));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Decimal));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color));
+            Assert.Equal($"PowerFxJsonException Expecting Table but received a String", (FormulaValueJSON.FromJson(expr, TableType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Record but received a String", (FormulaValueJSON.FromJson(expr, RecordType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Number but received a String", (FormulaValueJSON.FromJson(expr, FormulaType.Number) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Decimal but received a String", (FormulaValueJSON.FromJson(expr, FormulaType.Decimal) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a String", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a String", (FormulaValueJSON.FromJson(expr, FormulaType.Guid) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a String", (FormulaValueJSON.FromJson(expr, FormulaType.Color) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType());
             Assert.NotNull(fv3);
@@ -224,13 +224,14 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.True(fv2 is BooleanValue);
             Assert.Equal(expectedBoolean, ((BooleanValue)bv).Value);
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, RecordType.Empty()));            
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Number));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Decimal));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color));
+            string expectedBooleanStr = expectedBoolean.ToString().ToLowerInvariant();
+            Assert.Equal($"PowerFxJsonException Expecting Table but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, TableType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Record but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, RecordType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Number but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, FormulaType.Number) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Decimal but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, FormulaType.Decimal) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, FormulaType.String) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, FormulaType.Guid) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Boolean ({expectedBooleanStr})", (FormulaValueJSON.FromJson(expr, FormulaType.Color) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType());
             Assert.NotNull(fv3);
@@ -261,13 +262,13 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.NotNull(fv2);
             Assert.True(fv2 is RecordValue);
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Number));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Decimal));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color));
+            Assert.IsAssignableFrom<TableValue>(FormulaValueJSON.FromJson(expr, TableType.Empty()));
+            Assert.Equal($"PowerFxJsonException Expecting Number but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Number) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Decimal but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Decimal) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.String) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Guid) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Color) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType());
             Assert.NotNull(fv3);
@@ -311,13 +312,13 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.NotNull(fv2);
             Assert.True(fv2 is RecordValue);
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Number));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Decimal));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color));
+            Assert.IsAssignableFrom<TableValue>(FormulaValueJSON.FromJson(expr, TableType.Empty()));
+            Assert.Equal($"PowerFxJsonException Expecting Number but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Number) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Decimal but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Decimal) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.String) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Guid) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Color) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType());
             Assert.NotNull(fv3);
@@ -388,13 +389,13 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.NotNull(fv2);
             Assert.True(fv2 is RecordValue);
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, TableType.Empty(), numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Number, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Decimal, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid, numberIsFloat: true));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color, numberIsFloat: true));
+            Assert.IsAssignableFrom<TableValue>(FormulaValueJSON.FromJson(expr, TableType.Empty(), numberIsFloat: true));
+            Assert.Equal($"PowerFxJsonException Expecting Number but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Number, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Decimal but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Decimal, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.String, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Guid, numberIsFloat: true) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Record", (FormulaValueJSON.FromJson(expr, FormulaType.Color, numberIsFloat: true) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType(), numberIsFloat: true);
             Assert.NotNull(fv3);
@@ -448,13 +449,13 @@ namespace Microsoft.PowerFx.Json.Tests
             Assert.NotNull(fv2);
             Assert.True(fv2 is TableValue);
 
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, RecordType.Empty()));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Number));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Decimal));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.String));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Boolean));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Guid));
-            Assert.Throws<NotImplementedException>(() => FormulaValueJSON.FromJson(expr, FormulaType.Color));
+            Assert.Equal($"PowerFxJsonException Expecting Record but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, RecordType.Empty()) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Number but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, FormulaType.Number) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Decimal but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, FormulaType.Decimal) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting String but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, FormulaType.String) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Boolean but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, FormulaType.Boolean) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Guid but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, FormulaType.Guid) as ErrorValue).Errors.First().Message);
+            Assert.Equal($"PowerFxJsonException Expecting Color but received a Table with 0 elements", (FormulaValueJSON.FromJson(expr, FormulaType.Color) as ErrorValue).Errors.First().Message);
 
             FormulaValue fv3 = FormulaValueJSON.FromJson(expr, new UntypedObjectType());
             Assert.NotNull(fv3);


### PR DESCRIPTION
Json deserialization can be "broken" with some exceptions which are impossible to understand for customers
This PR fixes/updates the error messages and wraps the Json deserialization issues into an ErrorValue instead of being inconsistent (previously, we would have an ErrorValue for invalid Json and a NotImplementedException if there was a type mismatch between what the connector code expects and what we got from the server)
We also accept some trivial mismatches
Add ErrorKind.InvalidJson
Add HttpExpressionError to return StatusCode in ErrorValue