### PR TITLE
Update to use Expression Locale string instead of CultureInfo

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.PowerFx.Intellisense;
@@ -54,7 +55,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
                 Sentence = _nl2FxRequestParams.Sentence,
                 SymbolSummary = summary,
                 Engine = check.Engine,
-                ExpressionLocale = check.ParserCultureInfo
+                ExpressionLocaleName = check.ParserCultureInfo?.Name
             };
          }
 

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
@@ -68,10 +68,10 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         public Engine Engine { get; set; }
 
         /// <summary>
-        /// Set the locale that expect the output expression to be.
+        /// Set the locale name that expect the output expression to be.
         /// For example: "vi-VN" or "fr-FR".
         /// </summary>
-        public CultureInfo ExpressionLocale { get; set; }
+        public string ExpressionLocaleName { get; set; }
     }
 
     /// <summary>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
@@ -71,9 +71,9 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             sb.Append(this.Expected);
             sb.Append(": ");
 
-            if (nl2FxParameters.ExpressionLocale != null)
+            if (string.IsNullOrEmpty(nl2FxParameters.ExpressionLocaleName))
             {
-                sb.Append(nl2FxParameters.ExpressionLocale.Name);
+                sb.Append(nl2FxParameters.ExpressionLocaleName);
                 sb.Append(": ");
             }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             sb.Append(this.Expected);
             sb.Append(": ");
 
-            if (string.IsNullOrEmpty(nl2FxParameters.ExpressionLocaleName))
+            if (!string.IsNullOrEmpty(nl2FxParameters.ExpressionLocaleName))
             {
                 sb.Append(nl2FxParameters.ExpressionLocaleName);
                 sb.Append(": ");


### PR DESCRIPTION
Update to use Expression Locale string instead of CultureInfo to avoid json serialization failure in https://msazure.visualstudio.com/OneAgile/_workitems/edit/28863116