### PR TITLE
Update ErrorKind.InvalidJSON to use proper capitalization

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -861,7 +861,7 @@ namespace Microsoft.PowerFx.Connectors
         {
             ExpressionError er = null;
 
-            if (result is ErrorValue ev && (er = ev.Errors.FirstOrDefault(e => e.Kind == ErrorKind.Network || e.Kind == ErrorKind.InvalidJson)) != null)
+            if (result is ErrorValue ev && (er = ev.Errors.FirstOrDefault(e => e.Kind == ErrorKind.Network || e.Kind == ErrorKind.InvalidJSON)) != null)
             {
                 runtimeContext.ExecutionLogger?.LogError($"{this.LogFunction(nameof(PostProcessResultAsync))}, ErrorValue is returned with {er.Message}");
                 ExpressionError newError = er is HttpExpressionError her

--- a/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/ErrorKind.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerFx
         NotApplicable = 27,
         Timeout = 28,
         ServiceUnavailable = 29,
-        InvalidJson = 30,
+        InvalidJSON = 30,
         Custom = 1000,
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/BuiltInEnums.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/BuiltInEnums.cs
@@ -154,7 +154,7 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                 { "NotApplicable", 27 },
                 { "Timeout", 28 },
                 { "ServiceUnavailable", 29 },
-                { "InvalidJson", 30 },
+                { "InvalidJSON", 30 },
                 { "Custom", 1000 },
             },
             canCompareNumeric: true,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -2517,7 +2517,7 @@ namespace Microsoft.PowerFx.Functions
                     return "Division by zero";
                 case ErrorKind.BadLanguageCode:
                     // Default message that is shown to users when they try to pass a language code to a function that is invalid
-                    return "Bad langauge code or invalid value";
+                    return "Bad language code or invalid value";
                 case ErrorKind.BadRegex:
                     // Default message that is shown to users when they use an invalid regular expression in one of their formulas
                     return "Syntax error in regular expression";
@@ -2560,9 +2560,9 @@ namespace Microsoft.PowerFx.Functions
                 case ErrorKind.ServiceUnavailable:
                     // Default message that is shown to users when they execute an operation requires a online service connection that is not available
                     return "Online service connection not available";
-                case ErrorKind.InvalidJson:
-                    // Default message that is shown to users when they receive a Json result that is invalid 
-                    return "Invalid Json format";
+                case ErrorKind.InvalidJSON:
+                    // Default message that is shown to users when they receive a JSON result that is invalid 
+                    return "Invalid JSON format";
                 case ErrorKind.Custom:
                     // Default message that is shown to users when they create an error with a custom kind
                     return "Custom error";

--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Types
                 {
                     Message = $"{je.GetType().Name} {je.Message}",
                     Span = new Syntax.Span(0, 0),
-                    Kind = ErrorKind.InvalidJson
+                    Kind = ErrorKind.InvalidJSON
                 });
             }
             catch (PowerFxJsonException pfxje)
@@ -58,7 +58,7 @@ namespace Microsoft.PowerFx.Types
                 {
                     Message = $"{pfxje.GetType().Name} {pfxje.Message}",
                     Span = new Syntax.Span(0, 0),
-                    Kind = ErrorKind.InvalidJson
+                    Kind = ErrorKind.InvalidJSON
                 });
             }
         }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -1104,7 +1104,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.NotNull(returnType);
             Assert.True(returnType.FormulaType is RecordType);
 
-            string input = testConnector._log.ToString().Replace("\r", string.Empty);
+            string input = testConnector._log.ToString();
             var version = PowerPlatformConnectorClient.Version;
             string expected = $@"POST https://tip1002-002.azure-apihub.net/invoke
  authority: tip1002-002.azure-apihub.net
@@ -1138,6 +1138,9 @@ POST https://tip1002-002.azure-apihub.net/invoke
  x-ms-user-agent: PowerFx/{version}
 ";
 
+            // Normalize CRLF ==> LF
+            expected = expected.Replace("\r", string.Empty);
+            input = input.Replace("\r", string.Empty);
             Assert.Equal(expected, input);
         }
 
@@ -1184,7 +1187,7 @@ POST https://tip1002-002.azure-apihub.net/invoke
             Assert.Equal("accountcategorycode", suggestions2.Suggestions[0].DisplayName);
             Assert.Equal("Decimal", suggestions2.Suggestions[0].Suggestion.Type.ToString());
 
-            string input = testConnector._log.ToString().Replace("\r", string.Empty);
+            string input = testConnector._log.ToString();
             var version = PowerPlatformConnectorClient.Version;
             string expected = @$"POST https://tip1-shared.azure-apim.net/invoke
  authority: tip1-shared.azure-apim.net
@@ -1210,6 +1213,9 @@ POST https://tip1-shared.azure-apim.net/invoke
  x-ms-user-agent: PowerFx/{version}
 ";
 
+            // Normalize CRLF ==> LF
+            expected = expected.Replace("\r", string.Empty);
+            input = input.Replace("\r", string.Empty);
             Assert.Equal(expected, input);
         }
 
@@ -1258,9 +1264,9 @@ POST https://tip1-shared.azure-apim.net/invoke
                 runtimeContext,
                 CancellationToken.None);
 
-            string input = testConnector._log.ToString().Replace("\r", string.Empty);
+            string input = testConnector._log.ToString();
             Assert.Equal("AdaptiveCard", (((RecordValue)result).GetField("type") as UntypedObjectValue).Impl.GetString());
-            Assert.Equal(
+            var expected =
                 $@"POST https://tip1002-002.azure-apihub.net/invoke
  authority: tip1002-002.azure-apihub.net
  Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dC...
@@ -1273,7 +1279,12 @@ POST https://tip1-shared.azure-apim.net/invoke
  x-ms-user-agent: PowerFx/{PowerPlatformConnectorClient.Version}
  [content-header] Content-Type: application/json; charset=utf-8
  [body] {{""inputs"":{{""property1"":""test1"",""property2"":""test2""}}}}
-", input);
+";
+
+            // Normalize CRLF ==> LF
+            expected = expected.Replace("\r", string.Empty);
+            input = input.Replace("\r", string.Empty);
+            Assert.Equal(expected, input);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -610,7 +610,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
 
             ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
-            Assert.Equal(ErrorKind.InvalidJson, ev.Errors.First().Kind);
+            Assert.Equal(ErrorKind.InvalidJSON, ev.Errors.First().Kind);
             Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting Table but received a Number, in result/prediction/intents", ev.Errors.First().Message);
         }
 
@@ -675,7 +675,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             FormulaValue httpResult = await function.InvokeAsync(new FormulaValue[] { kind, analysisInputParam, parametersParam }, context, CancellationToken.None);
 
             ErrorValue ev = Assert.IsType<ErrorValue>(httpResult);
-            Assert.Equal(ErrorKind.InvalidJson, ev.Errors.First().Kind);
+            Assert.Equal(ErrorKind.InvalidJSON, ev.Errors.First().Kind);
             Assert.Equal("ACSL.ConversationAnalysisAnalyzeConversationConversation failed: PowerFxJsonException Expecting String but received a Table with 2 elements, in result/prediction/entities/category", ev.Errors.First().Message);
         }
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Error.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Error.txt
@@ -252,8 +252,8 @@ Error({Kind:ErrorKind.EditPermissions})
 >> IfError(Error({Kind:ErrorKind.ServiceUnavailable}), $"{FirstError.Kind}: {FirstError.Message}")
 "29: Online service connection not available"
 
->> IfError(Error({Kind:ErrorKind.InvalidJson}), $"{FirstError.Kind}: {FirstError.Message}")
-"30: Invalid Json format"
+>> IfError(Error({Kind:ErrorKind.InvalidJSON}), $"{FirstError.Kind}: {FirstError.Message}")
+"30: Invalid JSON format"
 
 >> IfError(Error({Kind:ErrorKind.Custom}), $"{FirstError.Kind}: {FirstError.Message}")
 "1000: Custom error"

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Error.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Error.txt
@@ -205,7 +205,7 @@ Error({Kind:ErrorKind.EditPermissions})
 "13: Division by zero"
 
 >> IfError(Error({Kind:ErrorKind.BadLanguageCode}), $"{FirstError.Kind}: {FirstError.Message}")
-"14: Bad langauge code or invalid value"
+"14: Bad language code or invalid value"
 
 >> IfError(Error({Kind:ErrorKind.BadRegex}), $"{FirstError.Kind}: {FirstError.Message}")
 "15: Syntax error in regular expression"

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
@@ -181,7 +181,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         // AddSuggestionsForEnums
         [InlineData("Monday|", "StartOfWeek.Monday", "StartOfWeek.MondayZero")]
         [InlineData("Value(Missing|", "ErrorKind.MissingRequired")]
-        [InlineData("ErrorKind.Inv|", "InvalidArgument", "InvalidFunctionUsage", "InvalidJson")]
+        [InlineData("ErrorKind.Inv|", "InvalidArgument", "InvalidFunctionUsage", "InvalidJSON")]
         [InlineData("Quota|", "ErrorKind.QuotaExceeded")]
         [InlineData("DateTimeFormat.h|", "ShortDate", "ShortTime", "ShortTime24", "ShortDateTime", "ShortDateTime24")]
         [InlineData("SortOrder|", "SortOrder", "SortOrder.Ascending", "SortOrder.Descending")]


### PR DESCRIPTION
The newly added ErrorKind.InvalidJson should be called InvalidJSON, as JSON is an acronym and should be capitalized as in other places of the framework (such as in the ParseJSON function) 