### PR TITLE
Allow UDF to return record without special syntax

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -472,6 +472,11 @@ namespace Microsoft.PowerFx.Core.Parser
 
             lookAheadIdx = PeekSkipTrivia(lookAheadIdx);
 
+            if (_curs.TidPeek(lookAheadIdx) == TokKind.CurlyClose)
+            {
+                return true;
+            }
+
             if (_curs.TidPeek(lookAheadIdx++) != TokKind.Ident)
             {
                 return false;

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -413,7 +413,7 @@ namespace Microsoft.PowerFx.Core.Parser
                         _curs.TokMove();
                         ParseTrivia();
 
-                        var isImperative = _curs.TidCur == TokKind.CurlyOpen && parserOptions.AllowsSideEffects;
+                        var isImperative = _curs.TidCur == TokKind.CurlyOpen && parserOptions.AllowsSideEffects && !PeekIsRecord();
 
                         var errorCount = _errors?.Count;
                         
@@ -458,6 +458,45 @@ namespace Microsoft.PowerFx.Core.Parser
             }
 
             return new ParseUserDefinitionResult(namedFormulas, udfs, definedTypes, _errors, _comments);
+        }
+
+        // Look ahead to check if the upcoming token sequence is a record
+        private bool PeekIsRecord()
+        {
+            if (_curs.TidCur != TokKind.CurlyOpen)
+            {
+                return false;
+            }
+
+            int lookAheadIdx = 1;
+
+            lookAheadIdx = PeekSkipTrivia(lookAheadIdx);
+
+            if (_curs.TidPeek(lookAheadIdx++) != TokKind.Ident)
+            {
+                return false;
+            }
+
+            lookAheadIdx = PeekSkipTrivia(lookAheadIdx);
+
+            if (_curs.TidPeek(lookAheadIdx) != TokKind.Colon)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        // Return look-ahead index skipping any whitespace or comments
+        private int PeekSkipTrivia(int startIdx)
+        {
+            int endOfTrivia = startIdx;
+            while (_curs.TidPeek(endOfTrivia) == TokKind.Whitespace || _curs.TidPeek(endOfTrivia) == TokKind.Comment)
+            {
+                endOfTrivia++;
+            }
+
+            return endOfTrivia;
         }
 
         private TexlNode ParseUDFBody()

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -989,6 +989,10 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("SomeFunc(): SomeType = { /*comment1*/  x /*comment2*/ :  5};", false, false)]
         [InlineData("SomeFunc(): SomeType = { /*comment1  x :  5};", true, true)]
         [InlineData("SomeFunc(): SomeType = { //comment1  x :  5};", true, true)]
+        [InlineData("SomeFunc(): SomeType = {};", false, false)]
+        [InlineData("SomeFunc(): SomeType = { /*somecomment*/ };", false, false)]
+        [InlineData("SomeFunc(): SomeType = { /*somecomment*/ ", true, true)]
+        [InlineData("SomeFunc(): SomeType = { /*somecomm }", true, true)]
         public void TestUDFReturnsRecord(string script, bool expectErrors, bool isImperative)
         {
             var parserOptions = new ParserOptions()

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -982,5 +982,23 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(validUdfCount, parseResult.UDFs.Where(udf => udf.IsParseValid).Count());
             Assert.Equal(expectErrors, parseResult.HasErrors);
         }
+
+        [Theory]
+        [InlineData("SomeFunc(): SomeType = {x:5, y: 5};", false, false)]
+        [InlineData("F1(): Void = { F2({x:5, y: 5}); };", false, true)]
+        [InlineData("SomeFunc(): SomeType = { /*comment1*/  x /*comment2*/ :  5};", false, false)]
+        [InlineData("SomeFunc(): SomeType = { /*comment1  x :  5};", true, true)]
+        [InlineData("SomeFunc(): SomeType = { //comment1  x :  5};", true, true)]
+        public void TestUDFReturnsRecord(string script, bool expectErrors, bool isImperative)
+        {
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = true
+            };
+
+            var parseResult = UserDefinitions.Parse(script, parserOptions);
+            Assert.Equal(expectErrors, parseResult.HasErrors);
+            Assert.Equal(isImperative, parseResult.UDFs.First().IsImperative);
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -1734,6 +1734,50 @@ namespace Microsoft.PowerFx.Tests
             }
         }
 
+        [Theory]
+        [InlineData(
+            "F():Point = {x: 5, y:5};",
+            "F().x",
+            true,
+            5.0)]
+        [InlineData(
+            "F():Number = { Sqrt(1); 42; };",
+            "F()",
+            true,
+            42.0)]
+        [InlineData(
+            "F():Point = { {x:0, y:1729}; };",
+            "F().y",
+            true,
+            1729.0)]
+        [InlineData(
+            "F():Point = {x: 5, 42};",
+            "F().x",
+            false)]
+        public void UDFImperativeVsRecordAmbiguityTest(string udf, string evalExpression, bool isValid, double expectedResult = 0)
+        {
+            var config = new PowerFxConfig();
+            var recalcEngine = new RecalcEngine(config);
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = true,
+                AllowParseAsTypeLiteral = true
+            };
+
+            var extraSymbols = new SymbolTable();
+            extraSymbols.AddType(new DName("Point"), FormulaType.Build(TestUtils.DT("![x:n, y:n]")));
+
+            if (isValid)
+            {
+                recalcEngine.AddUserDefinedFunction(udf, CultureInfo.InvariantCulture, extraSymbols, true);
+                Assert.Equal(expectedResult, recalcEngine.Eval(evalExpression, options: parserOptions).ToObject());
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => recalcEngine.AddUserDefinedFunction(udf, CultureInfo.InvariantCulture, extraSymbols, true));
+            }
+        }
+
         #region Test
 
         private readonly StringBuilder _updates = new StringBuilder();


### PR DESCRIPTION
***Current State***
When Imperative UDF feature is enabled, UDF returning a record value needs to wrap it in parenthesis (eg: `F(): Point = ({x: 5, y:5})`) to parse it without errors.

***Fix***
* This PR adds logic to look ahead and decide between imperative definition and record value.
* UDFs with a body containing just `{}` is considered empty record and not imperative definition.