### PR TITLE
Make Nl2Fx/Fx2nl Handler creation Async to allow for setting up custom NlHandler with Nl2Fx context reduction filters

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Fx2Nl/Fx2NlLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Fx2Nl/Fx2NlLanguageServerOperationHandler.cs
@@ -88,8 +88,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
                 return;
             }
 
-            var nlHandler = await operationContext.GetNLHandler(fx2NlRequestParams.TextDocument.Uri, _nLHandlerFactory, fx2NlRequestParams, cancellationToken).ConfigureAwait(false);
-            _ = nlHandler ?? throw new ArgumentNullException(nameof(nlHandler));
+            var nlHandler = await operationContext.GetNLHandlerAsync(fx2NlRequestParams.TextDocument.Uri, _nLHandlerFactory, fx2NlRequestParams, cancellationToken).ConfigureAwait(false);
             if (!nlHandler.SupportsFx2NL)
             {
                 throw new NotSupportedException("Fx2Nl is not supported");

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Fx2Nl/Fx2NlLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Fx2Nl/Fx2NlLanguageServerOperationHandler.cs
@@ -21,14 +21,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
 
         private readonly INLHandlerFactory _nLHandlerFactory;
 
-        private CheckResult _preHandleCheckResult;
-
-        private Fx2NLParameters _fx2NlParameters;
-
-        private CustomFx2NLParams _fx2NlRequestParams;
-
-        private NLHandler _nLHandler;
-
         public Fx2NlLanguageServerOperationHandler(INLHandlerFactory nLHandlerFactory)
         {
             _nLHandlerFactory = nLHandlerFactory;
@@ -37,35 +29,35 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <summary>
         /// Performs pre-handle operations for Fx2Nl.
         /// </summary>
+        /// <param name="fx2NlRequestParams">Fx2nl Parameters sent by client.</param>
+        /// <param name="nlHandler">Custom Nl Handler.</param>
         /// <param name="operationContext">Language Server Operation Context.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
-        private Task PreHandleFx2NlAsync(LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
+        /// <returns>Fx2nl parameters and check result derived from host and client provided parameters.</returns>
+        private static Task<(Fx2NLParameters fx2NLParameters, CheckResult preHandleCheckResult)> PreHandleFx2NlAsync(CustomFx2NLParams fx2NlRequestParams, NLHandler nlHandler, LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            _nLHandler = operationContext.GetNLHandler(_fx2NlRequestParams.TextDocument.Uri, _nLHandlerFactory, _fx2NlRequestParams) ?? throw new NullReferenceException("No suitable handler found to handle Fx2Nl");
-            if (!_nLHandler.SupportsFx2NL)
-            {
-                throw new NotSupportedException("Fx2Nl is not supported");
-            }
-
             return operationContext.ExecuteHostTaskAsync(
-            _fx2NlRequestParams.TextDocument.Uri,
+            fx2NlRequestParams.TextDocument.Uri,
             (scope) =>
             {
-                _preHandleCheckResult = scope?.Check(_fx2NlRequestParams.Expression) ?? throw new NullReferenceException("Check result was not found for Fx2NL operation");
-                _fx2NlParameters = GetFx2NlHints(scope, operationContext);
+                var preHandleCheckResult = scope?.Check(fx2NlRequestParams.Expression) ?? throw new NullReferenceException("Check result was not found for Fx2NL operation");
+                var fx2NlParameters = GetFx2NlHints(fx2NlRequestParams, scope, operationContext);
+
+                return Task.FromResult((fx2NlParameters, preHandleCheckResult));    
             }, cancellationToken);
         }
 
         /// <summary>
         /// Gets the Fx2Nl hints including Usage hints and optional range.
         /// </summary>
+        /// <param name="customFx2NLParams">Fx2nl params sent by client.</param>
         /// <param name="scope"> PowerFx Scope.</param>
         /// <param name="operationContext">Language Server Operation Context.</param>
         /// <returns>Fx2Nl hints.</returns>
-        private Fx2NLParameters GetFx2NlHints(IPowerFxScope scope,  LanguageServerOperationContext operationContext)
+        private static Fx2NLParameters GetFx2NlHints(CustomFx2NLParams customFx2NLParams, IPowerFxScope scope,  LanguageServerOperationContext operationContext)
         {
             var parameters = scope is IPowerFxScopeFx2NL fx2NLScope ? fx2NLScope.GetFx2NLParameters() : new Fx2NLParameters();
-            parameters.Range ??= _fx2NlRequestParams.Range;
+            parameters.Range ??= customFx2NLParams.Range;
 
             return parameters;
         }
@@ -73,11 +65,14 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <summary>
         /// Performs core Fx2Nl operation.
         /// </summary>
+        /// <param name="fx2NLParameters">Fx2nl parameters derived from host and client provided parameters.</param>
+        /// <param name="nlHandler">Custom Nl Handler.</param>
+        /// <param name="preHandleCheckResult">Check result computed during pre handle operation.</param>
         /// <param name="operationContext">Language Server Operation Context.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
-        private async Task Fx2NlAsync(LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
+        private static async Task Fx2NlAsync(NLHandler nlHandler, Fx2NLParameters fx2NLParameters, CheckResult preHandleCheckResult,  LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            var result = await _nLHandler.Fx2NLAsync(_preHandleCheckResult, _fx2NlParameters, cancellationToken).ConfigureAwait(false);
+            var result = await nlHandler.Fx2NLAsync(preHandleCheckResult, fx2NLParameters, cancellationToken).ConfigureAwait(false);
             operationContext.OutputBuilder.AddSuccessResponse(operationContext.RequestId, result);
         }
 
@@ -88,18 +83,25 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <param name="cancellationToken">Cancellation Token.</param>
         public async Task HandleAsync(LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            if (!operationContext.TryParseParamsAndAddErrorResponseIfNeeded(out _fx2NlRequestParams))
+            if (!operationContext.TryParseParamsAndAddErrorResponseIfNeeded(out CustomFx2NLParams fx2NlRequestParams))
             {
                 return;
             }
 
-            await PreHandleFx2NlAsync(operationContext, cancellationToken).ConfigureAwait(false);
-            if (_preHandleCheckResult == null)
+            var nlHandler = await operationContext.GetNLHandler(fx2NlRequestParams.TextDocument.Uri, _nLHandlerFactory, fx2NlRequestParams, cancellationToken).ConfigureAwait(false);
+            _ = nlHandler ?? throw new ArgumentNullException(nameof(nlHandler));
+            if (!nlHandler.SupportsFx2NL)
+            {
+                throw new NotSupportedException("Fx2Nl is not supported");
+            }
+        
+            var (fx2NLParameters, preHandleCheckResult) = await PreHandleFx2NlAsync(fx2NlRequestParams, nlHandler, operationContext, cancellationToken).ConfigureAwait(false);
+            if (preHandleCheckResult == null)
             {
                 return;
             }
 
-            await Fx2NlAsync(operationContext, cancellationToken).ConfigureAwait(false);
+            await Fx2NlAsync(nlHandler, fx2NLParameters, preHandleCheckResult, operationContext, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/GetCustomCapibilities/GetCustomCapabilitiesLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/GetCustomCapibilities/GetCustomCapabilitiesLanguageServerOperationHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
                 return;
             }
 
-            var nlHandler = operationContext.GetNLHandler(customGetCapabilitiesParams.TextDocument.Uri, _nlHandlerFactory, null);
+            var nlHandler = await operationContext.GetNLHandler(customGetCapabilitiesParams.TextDocument.Uri, _nlHandlerFactory, null, cancellationToken).ConfigureAwait(false);
             if (nlHandler == null)
             {
                 operationContext.OutputBuilder.AddSuccessResponse(operationContext.RequestId, new CustomGetCapabilitiesResult());

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/GetCustomCapibilities/GetCustomCapabilitiesLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/GetCustomCapibilities/GetCustomCapabilitiesLanguageServerOperationHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
                 return;
             }
 
-            var nlHandler = await operationContext.GetNLHandler(customGetCapabilitiesParams.TextDocument.Uri, _nlHandlerFactory, null, cancellationToken).ConfigureAwait(false);
+            var nlHandler = await operationContext.GetNLHandlerAsync(customGetCapabilitiesParams.TextDocument.Uri, _nlHandlerFactory, null, cancellationToken).ConfigureAwait(false);
             if (nlHandler == null)
             {
                 operationContext.OutputBuilder.AddSuccessResponse(operationContext.RequestId, new CustomGetCapabilitiesResult());

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/LanguageServerOperationContext.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/LanguageServerOperationContext.cs
@@ -77,10 +77,13 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <param name="uri">Uri to use for scope creation.</param>
         /// <param name="factory">Nl Handler Factory.</param>
         /// <param name="nLParams">Ml Params.</param>
+        /// <param name="cancellationToken"> Cancellation Token. </param>
         /// <returns>NlHandler Instance.</returns>
-        internal NLHandler GetNLHandler(string uri, INLHandlerFactory factory, BaseNLParams nLParams = null)
+        internal Task<NLHandler> GetNLHandler(string uri, INLHandlerFactory factory, BaseNLParams nLParams = null, CancellationToken cancellationToken = default)
         {
-            return factory.GetNLHandler(GetScope(uri), nLParams);
+            return factory is IAsyncNLHandlerFactory asyncNLHandlerFactory ?
+                   asyncNLHandlerFactory.GetNLHandlerAsync(GetScope(uri), nLParams, cancellationToken) :
+                   Task.FromResult(factory.GetNLHandler(GetScope(uri), nLParams));
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/LanguageServerOperationContext.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/LanguageServerOperationContext.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <param name="nLParams">Ml Params.</param>
         /// <param name="cancellationToken"> Cancellation Token. </param>
         /// <returns>NlHandler Instance.</returns>
-        internal Task<NLHandler> GetNLHandler(string uri, INLHandlerFactory factory, BaseNLParams nLParams = null, CancellationToken cancellationToken = default)
+        internal Task<NLHandler> GetNLHandlerAsync(string uri, INLHandlerFactory factory, BaseNLParams nLParams = null, CancellationToken cancellationToken = default)
         {
             return factory is IAsyncNLHandlerFactory asyncNLHandlerFactory ?
                    asyncNLHandlerFactory.GetNLHandlerAsync(GetScope(uri), nLParams, cancellationToken) :

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
@@ -21,14 +21,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
 
         private readonly INLHandlerFactory _nLHandlerFactory;
 
-        private CustomNL2FxParams _nl2FxRequestParams;
-
-        private NLHandler _nlHandler;
-
-        private CustomNL2FxResult _nl2FxResult;
-
-        private NL2FxParameters _nl2FxParameters;
-
         public Nl2FxLanguageServerOperationHandler(INLHandlerFactory nLHandlerFactory)
         {
             _nLHandlerFactory = nLHandlerFactory;
@@ -37,46 +29,62 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <summary>
         /// Performs pre-handle operations for NL2FX.
         /// </summary>
-        /// <param name="scope"> PowerFx Scope. </param>
+        /// <param name="handler"> Custom Nl Handler provided by the consumer of the Language Server. </param>
+        /// <param name="requestNl2FxParams"> Nl2Fx params sent by client. </param>
         /// <param name="operationContext"> Language Server Operation Context. </param>
-        private void PreHandleNl2Fx(IPowerFxScope scope, LanguageServerOperationContext operationContext)
+        /// <param name="cancellationToken">Cancellation Token.</param>
+        /// <returns>Nl2Fx Parameters computed from the client request.</returns>
+        private static Task<NL2FxParameters> PreHandleNl2Fx(NLHandler handler, CustomNL2FxParams requestNl2FxParams, LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            _nlHandler = operationContext.GetNLHandler(_nl2FxRequestParams.TextDocument.Uri, _nLHandlerFactory, _nl2FxRequestParams) ?? throw new NullReferenceException("No suitable handler found to handle Nl2Fx");
-            if (!_nlHandler.SupportsNL2Fx)
+            if (handler.SkipDefaultPreHandleForNl2Fx)
             {
-                throw new NotSupportedException("Nl2fx is not supported");
+                return Task.FromResult(new NL2FxParameters()
+                {
+                    Sentence = requestNl2FxParams.Sentence
+                });
             }
 
-            var check = scope?.Check(LanguageServer.Nl2FxDummyFormula) ?? throw new NullReferenceException("Check result was not found for NL2Fx operation");
-            var summary = check.ApplyGetContextSummary();
-            _nl2FxParameters = new NL2FxParameters
+            return operationContext.ExecuteHostTaskAsync(
+            requestNl2FxParams.TextDocument.Uri, 
+            (scope) =>
             {
-                Sentence = _nl2FxRequestParams.Sentence,
-                SymbolSummary = summary,
-                Engine = check.Engine,
-                ExpressionLocale = check.ParserCultureInfo
-            };
-         }
+                var check = scope?.Check(LanguageServer.Nl2FxDummyFormula) ?? throw new NullReferenceException("Check result was not found for NL2Fx operation");
+                var summary = check.ApplyGetContextSummary();
+
+                var nl2FxParameters = new NL2FxParameters
+                {
+                    Sentence = requestNl2FxParams.Sentence,
+                    SymbolSummary = summary,
+                    Engine = check.Engine,
+                    ExpressionLocale = check.ParserCultureInfo
+                };
+                handler.PreHandleNl2Fx(requestNl2FxParams, nl2FxParameters, operationContext);
+                return Task.FromResult(nl2FxParameters);
+            }, 
+            cancellationToken);
+        }
 
         /// <summary>
         /// Performs Core NL2FX operation.
         /// </summary>
+        /// <param name="nL2FxParameters">Nl2Fx Parameters.</param>
+        /// <param name="nlHandler">Custom Nl Handler.</param>
         /// <param name="operationContext">Language Server Operation Context.</param>
         /// <param name="cancellationToken">Cancellation Token.</param>
-        /// <returns> Nl2Fx Handle Context extended with NL2Fx result. </returns>
-        private async Task Nl2FxAsync(LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
+        /// <returns> Nl2Fx Model Call Result. </returns>
+        private static Task<CustomNL2FxResult> Nl2FxAsync(NL2FxParameters nL2FxParameters, NLHandler nlHandler, LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            _nl2FxResult = await _nlHandler.NL2FxAsync(_nl2FxParameters, cancellationToken).ConfigureAwait(false);
+            return nlHandler.NL2FxAsync(nL2FxParameters, cancellationToken);
         }
 
         /// <summary>
         /// Performs post-handle operations for NL2FX.
         /// </summary>
+        /// <param name="nl2FxResult">Nl2Fx model call result.</param>
         /// <param name="scope">PowerFx Scope.</param>
         /// <param name="operationContext">Language Server Operation Context.</param>
-        private void PostHandleNl2FxResults(IPowerFxScope scope, LanguageServerOperationContext operationContext)
+        private static void PostHandleNl2FxResults(CustomNL2FxResult nl2FxResult, IPowerFxScope scope, LanguageServerOperationContext operationContext)
         {
-            var nl2FxResult = _nl2FxResult;
             if (nl2FxResult?.Expressions != null)
             {
                 foreach (var item in nl2FxResult.Expressions)
@@ -107,31 +115,32 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <param name="cancellationToken">Cancellation Token.</param>
         public async Task HandleAsync(LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            if (!operationContext.TryParseParamsAndAddErrorResponseIfNeeded(out _nl2FxRequestParams))
+            if (!operationContext.TryParseParamsAndAddErrorResponseIfNeeded(out CustomNL2FxParams nl2FxRequestParams))
             {
                 return;
             }
 
-            await operationContext.ExecuteHostTaskAsync(
-            _nl2FxRequestParams.TextDocument.Uri,   
-            (scope) => 
+            var nlHandler = await operationContext.GetNLHandler(nl2FxRequestParams.TextDocument.Uri, _nLHandlerFactory, nl2FxRequestParams, cancellationToken).ConfigureAwait(false);
+            _ = nlHandler ?? throw new ArgumentNullException(nameof(nlHandler));
+
+            if (!nlHandler.SupportsNL2Fx) 
             {
-                PreHandleNl2Fx(scope, operationContext);
-                _nlHandler.PreHandleNl2Fx(_nl2FxRequestParams, _nl2FxParameters, operationContext);
-            }, 
-            cancellationToken).ConfigureAwait(false);
-            if (_nl2FxParameters == null)
+                throw new NotSupportedException("Nl2fx is not supported");
+            }
+
+            var nl2FxParamters = await PreHandleNl2Fx(nlHandler, nl2FxRequestParams, operationContext, cancellationToken).ConfigureAwait(false);
+            if (nl2FxParamters == null)
             {
                 return;
             }
 
-            await Nl2FxAsync(operationContext, cancellationToken).ConfigureAwait(false);
-            if (_nl2FxResult == null)
+            var nl2FxResult = await Nl2FxAsync(nl2FxParamters, nlHandler, operationContext, cancellationToken).ConfigureAwait(false);
+            if (nl2FxResult == null)
             {
                 return;
             }
 
-            await operationContext.ExecuteHostTaskAsync(_nl2FxRequestParams.TextDocument.Uri, (scope) => PostHandleNl2FxResults(scope, operationContext), cancellationToken).ConfigureAwait(false);
+            await operationContext.ExecuteHostTaskAsync(nl2FxRequestParams.TextDocument.Uri, (scope) => PostHandleNl2FxResults(nl2FxResult, scope, operationContext), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
@@ -120,9 +120,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
                 return;
             }
 
-            var nlHandler = await operationContext.GetNLHandler(nl2FxRequestParams.TextDocument.Uri, _nLHandlerFactory, nl2FxRequestParams, cancellationToken).ConfigureAwait(false);
-            _ = nlHandler ?? throw new ArgumentNullException(nameof(nlHandler));
-
+            var nlHandler = await operationContext.GetNLHandlerAsync(nl2FxRequestParams.TextDocument.Uri, _nLHandlerFactory, nl2FxRequestParams, cancellationToken).ConfigureAwait(false);
             if (!nlHandler.SupportsNL2Fx) 
             {
                 throw new NotSupportedException("Nl2fx is not supported");

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Nl2Fx/Nl2FxLanguageServerOperationHandler.cs
@@ -36,28 +36,24 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
         /// <returns>Nl2Fx Parameters computed from the client request.</returns>
         private static Task<NL2FxParameters> PreHandleNl2Fx(NLHandler handler, CustomNL2FxParams requestNl2FxParams, LanguageServerOperationContext operationContext, CancellationToken cancellationToken)
         {
-            if (handler.SkipDefaultPreHandleForNl2Fx)
-            {
-                return Task.FromResult(new NL2FxParameters()
-                {
-                    Sentence = requestNl2FxParams.Sentence
-                });
-            }
-
             return operationContext.ExecuteHostTaskAsync(
             requestNl2FxParams.TextDocument.Uri, 
             (scope) =>
             {
-                var check = scope?.Check(LanguageServer.Nl2FxDummyFormula) ?? throw new NullReferenceException("Check result was not found for NL2Fx operation");
-                var summary = check.ApplyGetContextSummary();
-
                 var nl2FxParameters = new NL2FxParameters
                 {
-                    Sentence = requestNl2FxParams.Sentence,
-                    SymbolSummary = summary,
-                    Engine = check.Engine,
-                    ExpressionLocale = check.ParserCultureInfo
+                    Sentence = requestNl2FxParams.Sentence
                 };
+
+                if (!handler.SkipDefaultPreHandleForNl2Fx)
+                {
+                    var check = scope?.Check(LanguageServer.Nl2FxDummyFormula) ?? throw new NullReferenceException("Check result was not found for NL2Fx operation");
+                    var summary = check.ApplyGetContextSummary();
+                    nl2FxParameters.SymbolSummary = summary;
+                    nl2FxParameters.ExpressionLocale = check.ParserCultureInfo;
+                    nl2FxParameters.Engine = check.Engine;
+                }
+
                 handler.PreHandleNl2Fx(requestNl2FxParams, nl2FxParameters, operationContext);
                 return Task.FromResult(nl2FxParameters);
             }, 

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/INLHandlerFactory.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/INLHandlerFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.PowerFx.Intellisense;
 using Microsoft.PowerFx.LanguageServerProtocol.Protocol;
 
@@ -18,5 +20,17 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         /// <param name="nlParams">NL operation params.</param>
         /// <returns>NLHandler for the given scope.</returns>
         NLHandler GetNLHandler(IPowerFxScope scope, BaseNLParams nlParams);
+    }
+
+    public interface IAsyncNLHandlerFactory : INLHandlerFactory
+    {
+        /// <summary>
+        /// Get the NLHandler from the given scope.
+        /// </summary>
+        /// <param name="scope">IPowerFxScope instance.</param>
+        /// <param name="nlParams">NL operation params.</param>
+        /// <param name="cancellationToken"> Cancellation Token. </param>
+        /// <returns>NLHandler for the given scope.</returns>
+        Task<NLHandler> GetNLHandlerAsync(IPowerFxScope scope, BaseNLParams nlParams, CancellationToken cancellationToken = default);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 
         private readonly IHostTaskExecutor _hostTaskExecutor;
 
-        [Obsolete("Use the constructor with ILanguageServerOperationHandlerFactory")]
+        [Obsolete("Use the constructor that takes aeguments in this order -> IPowerFxScopeFactory, IHostTaskExecutor, ILanguageServerLogger")]
         public LanguageServer(SendToClient sendToClient, IPowerFxScopeFactory scopeFactory, Action<string> logger = null)
         {
             Contracts.AssertValue(sendToClient);

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/LanguageServer/LanguageServer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 
         private readonly IHostTaskExecutor _hostTaskExecutor;
 
-        [Obsolete("Use the constructor that takes aeguments in this order -> IPowerFxScopeFactory, IHostTaskExecutor, ILanguageServerLogger")]
+        [Obsolete("Use the constructor that takes arguments in this order -> IPowerFxScopeFactory, IHostTaskExecutor, ILanguageServerLogger")]
         public LanguageServer(SendToClient sendToClient, IPowerFxScopeFactory scopeFactory, Action<string> logger = null)
         {
             Contracts.AssertValue(sendToClient);

--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
@@ -23,6 +23,8 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
 
         public virtual bool SupportsFx2NL { get; } = false;
 
+        public virtual bool SkipDefaultPreHandleForNl2Fx { get; } = false;
+
         public virtual Task<CustomNL2FxResult> NL2FxAsync(NL2FxParameters request, CancellationToken cancel)
         {
             throw new NotImplementedException();

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/PublicSurfaceTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 "Microsoft.PowerFx.LanguageServerProtocol.NLHandler",
                 "Microsoft.PowerFx.LanguageServerProtocol.NL2FxParameters",
                 "Microsoft.PowerFx.LanguageServerProtocol.INLHandlerFactory",
+                "Microsoft.PowerFx.LanguageServerProtocol.IAsyncNLHandlerFactory",
                 "Microsoft.PowerFx.LanguageServerProtocol.IPowerFxScopeFx2NL",
                 "Microsoft.PowerFx.LanguageServerProtocol.Fx2NLParameters",
                 "Microsoft.PowerFx.LanguageServerProtocol.UsageHints",

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         private TestFx2NlHandler CreateAndConfigureFx2NlHandler()
         {
             var fx2NlHandler = new TestFx2NlHandler();
-            HandlerFactory.SetHandler(CustomProtocolNames.FX2NL, new Fx2NlLanguageServerOperationHandler(new BackwardsCompatibleNLHandlerFactory(fx2NlHandler)));
+            HandlerFactory.SetHandler(CustomProtocolNames.FX2NL, new Fx2NlLanguageServerOperationHandler(TestNlHandlerFactory.Create(fx2NlHandler)));
         
             return fx2NlHandler;
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Fx2NLTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         private TestFx2NlHandler CreateAndConfigureFx2NlHandler()
         {
             var fx2NlHandler = new TestFx2NlHandler();
-            HandlerFactory.SetHandler(CustomProtocolNames.FX2NL, new Fx2NlLanguageServerOperationHandler(TestNlHandlerFactory.Create(fx2NlHandler)));
+            HandlerFactory.SetHandler(CustomProtocolNames.FX2NL, new Fx2NlLanguageServerOperationHandler(TestNlHandlerFactory.Create(fx2NlHandler, true)));
         
             return fx2NlHandler;
         }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/GetCustomCapibilitiesTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/GetCustomCapibilitiesTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                 testNLHandler = null;
             }
 
-            HandlerFactory.SetHandler(CustomProtocolNames.GetCapabilities, new GetCustomCapabilitiesLanguageServerOperationHandler(new BackwardsCompatibleNLHandlerFactory(testNLHandler)));
+            HandlerFactory.SetHandler(CustomProtocolNames.GetCapabilities, new GetCustomCapabilitiesLanguageServerOperationHandler(new TestNlHandlerFactory(testNLHandler)));
             var payload = GetRequestPayload(
             new CustomGetCapabilitiesParams()
             {

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
@@ -112,7 +112,10 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
         [InlineData("Score < 50", true, "#$PowerFxResolvedObject$# < #$decimal$#")]
         [InlineData("missing < 50", false, "#$firstname$# < #$decimal$#")] // doesn't compile, should get filtered out by LSP 
         [InlineData("Score > 50", true, null, "vi-VN")]
-        public async Task TestNL2FX(string expectedExpr, bool success, string anonExpr = null, string expressionCultureName = null)
+        [InlineData("Score < 50", true, "#$PowerFxResolvedObject$# < #$decimal$#", null, true)]
+        [InlineData("missing < 50", false, "#$firstname$# < #$decimal$#", null, true)] // doesn't compile, should get filtered out by LSP 
+        [InlineData("Score > 50", true, null, "vi-VN", true)]
+        public async Task TestNL2FX(string expectedExpr, bool success, string anonExpr = null, string expressionCultureName = null, bool useAsyncFactory = false)
         {
             // Arrange
             var documentUri = "powerfx://app?context=1";
@@ -129,7 +132,7 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             var scope = engine.CreateEditorScope(parserOptions: parserOptions, symbols: symbols);
             var scopeFactory = new TestPowerFxScopeFactory((string documentUri) => scope);
             Init(new InitParams(scopeFactory: scopeFactory));
-            var nl2FxHandler = CreateAndConfigureNl2FxHandler();
+            var nl2FxHandler = CreateAndConfigureNl2FxHandler(useAsyncFactory);
             nl2FxHandler.Nl2FxDelayTime = 100;
             nl2FxHandler.Expected = expectedExpr;
 
@@ -213,6 +216,18 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             Assert.Equal(1, nl2FxHandler.PreHandleNl2FxCallCount);
         }
 
+        [Fact]
+        public void TestDefaultNlHanderIsConfiguredCorrectly()
+        {
+            // Arrange
+            var handler = new NLHandler();
+
+            // Assert
+            Assert.False(handler.SupportsFx2NL);
+            Assert.False(handler.SupportsNL2Fx);
+            Assert.False(handler.SkipDefaultPreHandleForNl2Fx);
+        }
+
         private static (string payload, string id) NL2FxMessageJson(string documentUri)
         {
             var nl2FxParams = new CustomNL2FxParams()
@@ -229,10 +244,10 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             return GetRequestPayload(nl2FxParams, CustomProtocolNames.NL2FX);
         }
 
-        private TestNL2FxHandler CreateAndConfigureNl2FxHandler()
+        private TestNL2FxHandler CreateAndConfigureNl2FxHandler(bool asyncFactory = false)
         {
             var nl2FxHandler = new TestNL2FxHandler();
-            HandlerFactory.SetHandler(CustomProtocolNames.NL2FX, new Nl2FxLanguageServerOperationHandler(TestNlHandlerFactory.Create(nl2FxHandler)));
+            HandlerFactory.SetHandler(CustomProtocolNames.NL2FX, new Nl2FxLanguageServerOperationHandler(TestNlHandlerFactory.Create(nl2FxHandler, asyncFactory)));
             return nl2FxHandler;
         }
 
@@ -252,14 +267,12 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
                     await Task.Delay(DelayTime, cancellationToken).ConfigureAwait(false);
                 }
 
-                return base.GetNLHandler(scope, nlParams);
+                return GetNLHandler(scope, nlParams);
             }
 
-            public static INLHandlerFactory Create(NLHandler handler)
+            public static INLHandlerFactory Create(NLHandler handler, bool asyncFactory = true)
             {
-                var random = new Random();
-                var useAsyncFactory = random.Next(0, 2) == 1;
-                return useAsyncFactory ? new TestNlHandlerFactory(handler) : new BackwardsCompatibleNLHandlerFactory(handler);
+                return asyncFactory ? new TestNlHandlerFactory(handler) : new BackwardsCompatibleNLHandlerFactory(handler);
             }
         }
     }


### PR DESCRIPTION
This pr makes nl handler creation async so during creation time, PA can attach context reduction filters with Nl handler which would then later be used to trim down the context. This pr also refactors nl2fx, fx2nl handlers to avoid class fields 
