### PR TITLE
Fixes reuse of expandinfo from cache when expand is accessed via a different path

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3837,6 +3837,16 @@ namespace Microsoft.PowerFx.Core.Binding
                     type.ExpandInfo.UpdateEntityInfo(expandEntityInfo.ParentDataSource, relatedEntityPath);
                     entityTypes.Add(expandEntityInfo.ExpandPath, type);
                 }
+                else if (!type.ExpandInfo.ExpandPath.IsReachedFromPath(relatedEntityPath))
+                {
+                    // Expands reached via a different path should have a different relatedentitypath.
+                    // If we found an expand in the cache but it's not accessed via the same relationship
+                    // we need to create a different expand info but with the same type. 
+                    // DType.Clone doesn't clone expand info, so we force that with CopyExpandInfo,
+                    // because that sadly mutates expand info on what should otherwise be an immutable dtype. 
+                    type = DType.CopyExpandInfo(type.Clone(), type);
+                    type.ExpandInfo.UpdateEntityInfo(expandEntityInfo.ParentDataSource, relatedEntityPath);
+                }
 
                 return type;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/ExpandPath.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/ExpandPath.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Core.Types
@@ -33,6 +34,11 @@ namespace Microsoft.PowerFx.Core.Types
         public static bool operator ==(ExpandPath lhsPath, ExpandPath rhsPath) => lhsPath.ToString() == rhsPath.ToString();
 
         public static bool operator !=(ExpandPath lhsPath, ExpandPath rhsPath) => lhsPath.ToString() != rhsPath.ToString();
+
+        public bool IsReachedFromPath(string relatedEntityPath)
+        {
+            return relatedEntityPath?.TrimEnd(PathSeperator) == RelatedEntityPath;
+        }
 
         public bool Equals(ExpandPath path)
         {


### PR DESCRIPTION
Unable to easily test in this repo. Tests added in PA Client. 

Scenario is, e.g. for this expression, the expand info to the second PrimaryContact access should have ManagingPartner as part of it's expand path. 

"ClearCollect(c3,  Filter(Accounts,'Primary Contact'.Status <> 'Status (Contacts)'.Active));" +
            "ClearCollect(c4,  Filter(Contacts, 'Managing Partner'.'Primary Contact'.Status <> 'Status (Contacts)'.Inactive))"