### PR TITLE
Fix check to exclude UDFs from being marked as async if binding does not exist

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2261,7 +2261,7 @@ namespace Microsoft.PowerFx.Core.Binding
             if (function != null)
             {
                 // If the invocation is async then the whole call path is async.
-                if (markIfAsync && (function is UserDefinedFunction udf && udf.Binding != null) && function.IsAsyncInvocation(node, this))
+                if (markIfAsync && (function is not UserDefinedFunction udf || udf.Binding != null) && function.IsAsyncInvocation(node, this))
                 {
                     FlagPathAsAsync(node);
                 }


### PR DESCRIPTION
There was a mistake in following PR: https://github.com/microsoft/Power-Fx/commit/752efe46c476975a5433d9aab127f0b66808c187