### PR TITLE
Option to anonymize unknown public functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2261,7 +2261,7 @@ namespace Microsoft.PowerFx.Core.Binding
             if (function != null)
             {
                 // If the invocation is async then the whole call path is async.
-                if (markIfAsync && (function is UserDefinedFunction udf && udf.Binding != null) && function.IsAsyncInvocation(node, this))
+                if (markIfAsync && (function is not UserDefinedFunction udf || udf.Binding != null) && function.IsAsyncInvocation(node, this))
                 {
                     FlagPathAsAsync(node);
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -715,9 +715,9 @@ namespace Microsoft.PowerFx
             return summary;
         }
 
-        public IEnumerable<string> GetFunctionNames()
+        public IEnumerable<string> GetFunctionNames(bool annonymizeUnknownPublicFunctions = false)
         {
-            return ListFunctionVisitor.Run(ApplyParse());
+            return ListFunctionVisitor.Run(ApplyParse(), annonymizeUnknownPublicFunctions);
         }
     }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/ListFunctionVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/ListFunctionVisitor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerFx.Syntax
         // Use Fullname as key because it's unique. 
         private readonly HashSet<string> _functionNames = new HashSet<string>();
         private readonly Dictionary<string, string> _unknownFunctionNames = new Dictionary<string, string>();
-        private readonly bool _annonymizeUnknownPublicFunctions;
+        private readonly bool _anonymizedUnknownPublicFunctions;
 
         public static IEnumerable<string> Run(ParseResult parse, bool annonymizeUnknownPublicFunctions = false)
         {
@@ -23,29 +23,30 @@ namespace Microsoft.PowerFx.Syntax
 
         private ListFunctionVisitor(bool annonymizeUnknownPublicFunctions)
         {
-            _annonymizeUnknownPublicFunctions = annonymizeUnknownPublicFunctions;
+            _anonymizedUnknownPublicFunctions = annonymizeUnknownPublicFunctions;
         }
 
         public override bool PreVisit(CallNode node)
         {
             var hasNamespace = node.Head.Namespace.Length > 0;
+            var name = node.Head.Name;
 
-            if (_annonymizeUnknownPublicFunctions && !BuiltinFunctionsCore.IsKnownPublicFunction(node.Head.Name))
+            if (_anonymizedUnknownPublicFunctions && !BuiltinFunctionsCore.IsKnownPublicFunction(name))
             {
                 // An expression can have multiple unknown function names.
                 // Track them all to ensure they are uniquely anonymized.
-                if (!_unknownFunctionNames.ContainsKey(node.Head.Name))
+                if (!_unknownFunctionNames.ContainsKey(name))
                 {
-                    _unknownFunctionNames[node.Head.Name] = $"$#CustomFunction{_unknownFunctionNames.Count + 1}#$";
+                    _unknownFunctionNames[name] = $"$#CustomFunction{_unknownFunctionNames.Count + 1}#$";
                 }
 
-                _functionNames.Add(_unknownFunctionNames[node.Head.Name]);
+                _functionNames.Add(_unknownFunctionNames[name]);
             }
             else
             {
                 var fullName = hasNamespace ?
-                        node.Head.Namespace + "." + node.Head.Name :
-                        node.Head.Name;
+                        node.Head.Namespace + "." + name :
+                        name;
 
                 _functionNames.Add(fullName);
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/ListFunctionVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/ListFunctionVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.PowerFx.Core.Texl;
 
 namespace Microsoft.PowerFx.Syntax
 {
@@ -10,24 +11,44 @@ namespace Microsoft.PowerFx.Syntax
         // FullName --> Name 
         // Use Fullname as key because it's unique. 
         private readonly HashSet<string> _functionNames = new HashSet<string>();
+        private readonly Dictionary<string, string> _unknownFunctionNames = new Dictionary<string, string>();
+        private readonly bool _annonymizeUnknownPublicFunctions;
 
-        public static IEnumerable<string> Run(ParseResult parse)
+        public static IEnumerable<string> Run(ParseResult parse, bool annonymizeUnknownPublicFunctions = false)
         {
-            var visitor = new ListFunctionVisitor();
+            var visitor = new ListFunctionVisitor(annonymizeUnknownPublicFunctions);
             parse.Root.Accept(visitor);
             return visitor._functionNames;
+        }
+
+        private ListFunctionVisitor(bool annonymizeUnknownPublicFunctions)
+        {
+            _annonymizeUnknownPublicFunctions = annonymizeUnknownPublicFunctions;
         }
 
         public override bool PreVisit(CallNode node)
         {
             var hasNamespace = node.Head.Namespace.Length > 0;
 
-            var name = node.Head.Name;
-            var fullName = hasNamespace ?
-                    node.Head.Namespace + "." + name :
-                    name;
+            if (_annonymizeUnknownPublicFunctions && !BuiltinFunctionsCore.IsKnownPublicFunction(node.Head.Name))
+            {
+                // An expression can have multiple unknown function names.
+                // Track them all to ensure they are uniquely anonymized.
+                if (!_unknownFunctionNames.ContainsKey(node.Head.Name))
+                {
+                    _unknownFunctionNames[node.Head.Name] = $"$#CustomFunction{_unknownFunctionNames.Count + 1}#$";
+                }
 
-            _functionNames.Add(fullName);
+                _functionNames.Add(_unknownFunctionNames[node.Head.Name]);
+            }
+            else
+            {
+                var fullName = hasNamespace ?
+                        node.Head.Namespace + "." + node.Head.Name :
+                        node.Head.Name;
+
+                _functionNames.Add(fullName);
+            }
 
             return base.PreVisit(node);
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ListFunctionVisitorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ListFunctionVisitorTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("SomeNameSpace.Foo() + SomeNameSpace.Bar()", "SomeNameSpace.Foo,SomeNameSpace.Bar")]
         [InlineData("SomeNameSpace.Foo() + SomeNameSpace.Bar()", "$#CustomFunction1#$,$#CustomFunction2#$", true)]
         [InlineData("SomeNameSpace.Foo() + SomeNameSpace.Bar() + SomeNameSpace.Foo()", "$#CustomFunction1#$,$#CustomFunction2#$", true)]
+        [InlineData("Foo() + Abs(1) + Foo()", "$#CustomFunction1#$,Abs", true)]
         [InlineData("true And true", "")]
         [InlineData("If(true, Blank(),Error())", "If,Blank,Error")]
         public void ListFunctionNamesTest(string expression, string expectedNames, bool annonymizeUnknownPublicFunctions = false)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ListFunctionVisitorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ListFunctionVisitorTests.cs
@@ -13,9 +13,11 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Abs(Abs(Abs(Abs(Abs(1)))))", "Abs")]
         [InlineData("With({x:Today()}, x+1)", "With,Today")]
         [InlineData("SomeNameSpace.Foo() + SomeNameSpace.Bar()", "SomeNameSpace.Foo,SomeNameSpace.Bar")]
+        [InlineData("SomeNameSpace.Foo() + SomeNameSpace.Bar()", "$#CustomFunction1#$,$#CustomFunction2#$", true)]
+        [InlineData("SomeNameSpace.Foo() + SomeNameSpace.Bar() + SomeNameSpace.Foo()", "$#CustomFunction1#$,$#CustomFunction2#$", true)]
         [InlineData("true And true", "")]
         [InlineData("If(true, Blank(),Error())", "If,Blank,Error")]
-        public void ListFunctionNamesTest(string expression, string expectedNames)
+        public void ListFunctionNamesTest(string expression, string expectedNames, bool annonymizeUnknownPublicFunctions = false)
         {
             foreach (var textFirst in new bool[] { false, true })
             {
@@ -24,7 +26,7 @@ namespace Microsoft.PowerFx.Core.Tests
                     expression = $"={expression}";
                 }
 
-                CheckFunctionNames(textFirst, expression, expectedNames);
+                CheckFunctionNames(textFirst, expression, expectedNames, annonymizeUnknownPublicFunctions);
             }
         }
 
@@ -33,7 +35,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("3 ' {} ${Upper(3+3)} \" ${Lower($\"{7+7}\")}", "Upper,Lower")]
         public void ListFunctionNamesTextFirstTest(string expression, string expectedNames)
         {
-            CheckFunctionNames(true, expression, expectedNames);
+            CheckFunctionNames(true, expression, expectedNames, false);
         }
 
         [Fact]
@@ -43,15 +45,15 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Throws<InvalidOperationException>(() => checkResult.GetFunctionNames());
         }
 
-        private static void CheckFunctionNames(bool textFirst, string expression, string expectedNames)
+        private static void CheckFunctionNames(bool textFirst, string expression, string expectedNames, bool annonymizeUnknownPublicFunctions)
         {
             var options = new ParserOptions() { TextFirst = textFirst };
             var engine = new Engine();
             var check = engine.Check(expression, options);
             var checkResult = new CheckResult(engine).SetText(expression, options);
 
-            var functionsNames1 = check.GetFunctionNames();
-            var functionsNames2 = checkResult.GetFunctionNames();
+            var functionsNames1 = check.GetFunctionNames(annonymizeUnknownPublicFunctions);
+            var functionsNames2 = checkResult.GetFunctionNames(annonymizeUnknownPublicFunctions);
 
             var actualNames1 = string.Join(",", functionsNames1);
             var actualNames2 = string.Join(",", functionsNames2);


### PR DESCRIPTION
Previously at https://github.com/microsoft/Power-Fx/pull/2474 we introduced an API to get a list of called functions from an expression.
We are now adding an option to anonymize a custom function to mask any private information.