### PR TITLE
Split WeekNum tests to better reflect setup

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/WeekNum.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/WeekNum.txt
@@ -161,23 +161,6 @@ Error({Kind:ErrorKind.Div0})
 
 
 // Invalid StartOfWeek enumeration
->> WeekNum(Date(2016, 1, 3),0)
-Errors: Error 25-26: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
-
->> WeekNum(Date(2016, 1, 3),5)
-Errors: Error 25-26: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
-
->> WeekNum(Date(2016, 1, 3),12.5)
-Errors: Error 25-29: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
-
->> WeekNum(Date(2016, 1, 3),-12)
-Errors: Error 25-26: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
-
->> WeekNum(Date(2022,1,2),1E308)
-Errors: Errors: Error 23-28: Numeric value is too large.|Error 23-28: Invalid argument type (Error). Expecting a Enum (StartOfWeek) value instead.
-
->> WeekNum(Date(2016, 1, 3),"")
-Errors: Error 25-27: Invalid argument type (Text). Expecting a Enum (StartOfWeek) value instead.
 
 >> WeekNum(Date(2020, 5, 3),StartOfWeek.MondayZero)
 Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/WeekNum_StronglyTypedEnumDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/WeekNum_StronglyTypedEnumDisabled.txt
@@ -37,6 +37,3 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> WeekNum(Date(2016, 1, 3), -12)
 Error({Kind:ErrorKind.InvalidArgument})
-
->> WeekNum(DateValue("1/2/2022"), 1E308)
-Error({Kind:ErrorKind.InvalidArgument})

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/WeekNum_StronglyTypedEnumEnabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/WeekNum_StronglyTypedEnumEnabled.txt
@@ -1,0 +1,17 @@
+#SETUP: StronglyTypedBuiltinEnums
+
+// Invalid StartOfWeek enumeration
+>> WeekNum(Date(2016, 1, 3),0)
+Errors: Error 25-26: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
+
+>> WeekNum(Date(2016, 1, 3),5)
+Errors: Error 25-26: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
+
+>> WeekNum(Date(2016, 1, 3),12.5)
+Errors: Error 25-29: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
+
+>> WeekNum(Date(2016, 1, 3),-12)
+Errors: Error 25-26: Invalid argument type (Decimal). Expecting a Enum (StartOfWeek) value instead.
+
+>> WeekNum(Date(2016, 1, 3),"")
+Errors: Error 25-27: Invalid argument type (Text). Expecting a Enum (StartOfWeek) value instead.


### PR DESCRIPTION
Some tests for WeekNum should be split properly between those with support for strongly-typed enums and those without.