### PR TITLE
Dont anonymize known custom functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -724,6 +724,11 @@ namespace Microsoft.PowerFx
         {
             return ListFunctionVisitor.Run(ApplyParse(), anonymizeUnknownPublicFunctions);
         }
+
+        public IEnumerable<string> GetFunctionNames(bool anonymizeUnknownPublicFunctions, ICollection<string> customKnownFunctions)
+        {
+            return ListFunctionVisitor.Run(ApplyParse(), anonymizeUnknownPublicFunctions, customKnownFunctions);
+        }
     }
 
     // Internal interface to ensure that Result objects have a common contract

--- a/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/CheckResult.cs
@@ -720,11 +720,22 @@ namespace Microsoft.PowerFx
             return GetFunctionNames(false);
         }
 
+        /// <summary>
+        /// Get all function names used in the expression.
+        /// </summary>
+        /// <param name="anonymizeUnknownPublicFunctions">If true, anonymize the name of unknown public functions.</param>
+        /// <returns></returns>
         public IEnumerable<string> GetFunctionNames(bool anonymizeUnknownPublicFunctions)
         {
-            return ListFunctionVisitor.Run(ApplyParse(), anonymizeUnknownPublicFunctions);
+            return GetFunctionNames(anonymizeUnknownPublicFunctions, null);
         }
 
+        /// <summary>
+        /// Get all function names used in the expression.
+        /// </summary>
+        /// <param name="anonymizeUnknownPublicFunctions">If true, anonymize the name of unknown public functions.</param>
+        /// <param name="customKnownFunctions">List containing custom functions names that will not be anonymized.</param>
+        /// <returns></returns>
         public IEnumerable<string> GetFunctionNames(bool anonymizeUnknownPublicFunctions, ICollection<string> customKnownFunctions)
         {
             return ListFunctionVisitor.Run(ApplyParse(), anonymizeUnknownPublicFunctions, customKnownFunctions);

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/ListFunctionVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/ListFunctionVisitor.cs
@@ -11,19 +11,27 @@ namespace Microsoft.PowerFx.Syntax
         // FullName --> Name 
         // Use Fullname as key because it's unique. 
         private readonly HashSet<string> _functionNames = new HashSet<string>();
-        private readonly Dictionary<string, string> _unknownFunctionNames = new Dictionary<string, string>();
+        private readonly ICollection<string> _customPublicFunctionNames;
+        private readonly Dictionary<string, string> _unknownFunctionNames = new Dictionary<string, string>();        
         private readonly bool _anonymizedUnknownPublicFunctions;
 
-        public static IEnumerable<string> Run(ParseResult parse, bool anonymizeUnknownPublicFunctions = false)
+        public static IEnumerable<string> Run(ParseResult parse, bool anonymizeUnknownPublicFunctions = false, ICollection<string> customPublicFunctionNames = null)
         {
-            var visitor = new ListFunctionVisitor(anonymizeUnknownPublicFunctions);
+            var visitor = new ListFunctionVisitor(anonymizeUnknownPublicFunctions, customPublicFunctionNames);
             parse.Root.Accept(visitor);
             return visitor._functionNames;
         }
 
-        private ListFunctionVisitor(bool anonymizeUnknownPublicFunctions)
+        private ListFunctionVisitor(bool anonymizeUnknownPublicFunctions, ICollection<string> customPublicFunctionNames)
         {
             _anonymizedUnknownPublicFunctions = anonymizeUnknownPublicFunctions;
+            _customPublicFunctionNames = customPublicFunctionNames;
+        }
+
+        private bool IsKnownFunction(string name)
+        {
+            bool knownCustomFunction = _customPublicFunctionNames != null && _customPublicFunctionNames.Contains(name);
+            return BuiltinFunctionsCore.IsKnownPublicFunction(name) || knownCustomFunction;
         }
 
         public override bool PreVisit(CallNode node)
@@ -31,7 +39,7 @@ namespace Microsoft.PowerFx.Syntax
             var hasNamespace = node.Head.Namespace.Length > 0;
             var name = node.Head.Name;
 
-            if (_anonymizedUnknownPublicFunctions && !BuiltinFunctionsCore.IsKnownPublicFunction(name))
+            if (_anonymizedUnknownPublicFunctions && !IsKnownFunction(name))
             {
                 // An expression can have multiple unknown function names.
                 // Track them all to ensure they are uniquely anonymized.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ListFunctionVisitorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ListFunctionVisitorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.PowerFx.Core.Tests
@@ -18,6 +19,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Foo() + Abs(1) + Foo()", "$#CustomFunction1#$,Abs", true)]
         [InlineData("true And true", "")]
         [InlineData("If(true, Blank(),Error())", "If,Blank,Error")]
+        [InlineData("If(true && CustomKnownFunction() && CustomPrivateFunction(), Blank(),Error())", "If,CustomKnownFunction,$#CustomFunction1#$,Blank,Error", true)]
         public void ListFunctionNamesTest(string expression, string expectedNames, bool anonymizeUnknownPublicFunctions = false)
         {
             foreach (var textFirst in new bool[] { false, true })
@@ -53,8 +55,10 @@ namespace Microsoft.PowerFx.Core.Tests
             var check = engine.Check(expression, options);
             var checkResult = new CheckResult(engine).SetText(expression, options);
 
-            var functionsNames1 = check.GetFunctionNames(anonymizeUnknownPublicFunctions);
-            var functionsNames2 = checkResult.GetFunctionNames(anonymizeUnknownPublicFunctions);
+            var knownFunctionNames = new HashSet<string> { "CustomKnownFunction" };
+
+            var functionsNames1 = check.GetFunctionNames(anonymizeUnknownPublicFunctions, knownFunctionNames);
+            var functionsNames2 = checkResult.GetFunctionNames(anonymizeUnknownPublicFunctions, knownFunctionNames);
 
             var actualNames1 = string.Join(",", functionsNames1);
             var actualNames2 = string.Join(",", functionsNames2);


### PR DESCRIPTION
We are adding a way for the hosts to declare a list of non-core public functions that should be kept plain when getting function names from an expression. 