### PR TITLE
Avoid NRE in cycle edge case of imperative UDF binding

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4891,7 +4891,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 var call = _txb.GetInfo(node).VerifyValue();
                 var func = call.Function;
-                if (func == null || func.IsSelfContained)
+                if (func == null || func.IsSelfContained || (func is UserDefinedFunction udf && udf.Binding == null))
                 {
                     return false;
                 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -734,7 +734,6 @@ namespace Microsoft.PowerFx.Tests
 
             // Imperative function is not delegable
             // E():Void = { E() }; ---> binding will be null so no attempt to get datasource should happen
-            Assert.True(func.IsAsync);
             Assert.True(!func.IsDelegatable);
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -680,7 +680,7 @@ namespace Microsoft.PowerFx.Tests
 
         [Fact]
 
-        public void DelegatableUDFTest()
+        public void DelegableUDFTest()
         {
             var symbolTable = new DelegatableSymbolTable();
             var schema = DType.CreateTable(
@@ -708,7 +708,7 @@ namespace Microsoft.PowerFx.Tests
 
             var recalcEngine = new RecalcEngine(config);
 
-            recalcEngine.AddUserDefinedFunction("A():MyDataSourceTableType = Filter(MyDataSource, Value > 10);C():MyDataSourceTableType = A(); B():MyDataSourceTableType = Filter(C(), Value > 11); D():MyDataSourceTableType = { Filter(B(), Value > 12); };", CultureInfo.InvariantCulture, symbolTable: recalcEngine.EngineSymbols, allowSideEffects: true);
+            recalcEngine.AddUserDefinedFunction("A():MyDataSourceTableType = Filter(MyDataSource, Value > 10);C():MyDataSourceTableType = A(); B():MyDataSourceTableType = Filter(C(), Value > 11); D():MyDataSourceTableType = { Filter(B(), Value > 12); }; E():Void = { E(); };", CultureInfo.InvariantCulture, symbolTable: recalcEngine.EngineSymbols, allowSideEffects: true);
             var func = recalcEngine.Functions.WithName("A").First() as UserDefinedFunction;
 
             Assert.True(func.IsAsync);
@@ -727,6 +727,13 @@ namespace Microsoft.PowerFx.Tests
             func = recalcEngine.Functions.WithName("D").First() as UserDefinedFunction;
 
             // Imperative function is not delegable
+            Assert.True(func.IsAsync);
+            Assert.True(!func.IsDelegatable);
+
+            func = recalcEngine.Functions.WithName("E").First() as UserDefinedFunction;
+
+            // Imperative function is not delegable
+            // E():Void = { E() }; ---> binding will be null so no attempt to get datasource should happen
             Assert.True(func.IsAsync);
             Assert.True(!func.IsDelegatable);
         }


### PR DESCRIPTION
In scenario of `F():Void = { F(); }`, when finalizing the binding, the Binder will attempt to fetch the CallNode datasource,

Because UDF `TryGetDatasource` override needs the binding, in this cycle/"recursive" edge case, there will be a null reference exception without the check added in this PR.