### PR TITLE
CDP connectors - manage enums per OpenApi spec

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1378,7 +1378,8 @@ namespace Microsoft.PowerFx.Connectors
                         // Ex: Api-Version
                         hiddenRequired = true;
                     }
-                    else if (ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility)
+                    else if (ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility || 
+                             ConnectorSettings.Compatibility == ConnectorCompatibility.CdpCompatibility)
                     {
                         continue;
                     }
@@ -1448,7 +1449,8 @@ namespace Microsoft.PowerFx.Connectors
 
                                             bodyPropertyHiddenRequired = ConnectorSettings.Compatibility != ConnectorCompatibility.PowerAppsCompatibility || !requestBody.Required;
                                         }
-                                        else if (ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility)
+                                        else if (ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility || 
+                                                 ConnectorSettings.Compatibility == ConnectorCompatibility.CdpCompatibility)
                                         {
                                             continue;
                                         }

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1378,8 +1378,7 @@ namespace Microsoft.PowerFx.Connectors
                         // Ex: Api-Version
                         hiddenRequired = true;
                     }
-                    else if (ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility || 
-                             ConnectorSettings.Compatibility == ConnectorCompatibility.CdpCompatibility)
+                    else if (ConnectorSettings.Compatibility.ExcludeInternals())
                     {
                         continue;
                     }
@@ -1447,10 +1446,9 @@ namespace Microsoft.PowerFx.Connectors
                                                 continue;
                                             }
 
-                                            bodyPropertyHiddenRequired = ConnectorSettings.Compatibility != ConnectorCompatibility.PowerAppsCompatibility || !requestBody.Required;
+                                            bodyPropertyHiddenRequired = !ConnectorSettings.Compatibility.IsPowerAppsCompliant() || !requestBody.Required;
                                         }
-                                        else if (ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility || 
-                                                 ConnectorSettings.Compatibility == ConnectorCompatibility.CdpCompatibility)
+                                        else if (ConnectorSettings.Compatibility.ExcludeInternals())
                                         {
                                             continue;
                                         }
@@ -1537,7 +1535,7 @@ namespace Microsoft.PowerFx.Connectors
             // Required params are first N params in the final list, "in" parameters first.
             // Optional params are fields on a single record argument at the end.
             // Hidden required parameters do not count here
-            _requiredParameters = ConnectorSettings.Compatibility == ConnectorCompatibility.PowerAppsCompatibility ? GetPowerAppsParameterOrder(requiredParameters) : requiredParameters.ToArray();
+            _requiredParameters = ConnectorSettings.Compatibility.IsPowerAppsCompliant() ? GetPowerAppsParameterOrder(requiredParameters) : requiredParameters.ToArray();
             _optionalParameters = optionalParameters.ToArray();
             _hiddenRequiredParameters = hiddenRequiredParameters.ToArray();
             _arityMin = _requiredParameters.Length;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
@@ -436,7 +436,9 @@ namespace Microsoft.PowerFx.Connectors
             if (statusCode < 300)
             {
                 // We only return UO for unknown fields (not declared in swagger file) if compatibility is SwaggerCompatibility
-                bool returnUnknownRecordFieldAsUO = _function.ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility && _function.ConnectorSettings.ReturnUnknownRecordFieldsAsUntypedObjects;
+                bool returnUnknownRecordFieldAsUO = (_function.ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility || 
+                                                     _function.ConnectorSettings.Compatibility == ConnectorCompatibility.CdpCompatibility) && 
+                                                     _function.ConnectorSettings.ReturnUnknownRecordFieldsAsUntypedObjects;
 
                 var typeToUse = _function.ReturnType;
                 if (returnTypeOverride != null)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
@@ -435,10 +435,9 @@ namespace Microsoft.PowerFx.Connectors
 
             if (statusCode < 300)
             {
-                // We only return UO for unknown fields (not declared in swagger file) if compatibility is SwaggerCompatibility
-                bool returnUnknownRecordFieldAsUO = (_function.ConnectorSettings.Compatibility == ConnectorCompatibility.SwaggerCompatibility || 
-                                                     _function.ConnectorSettings.Compatibility == ConnectorCompatibility.CdpCompatibility) && 
-                                                     _function.ConnectorSettings.ReturnUnknownRecordFieldsAsUntypedObjects;
+                // We only return UO for unknown fields (not declared in swagger file) if compatibility is SwaggerCompatibility or CDP
+                bool returnUnknownRecordFieldAsUO = _function.ConnectorSettings.Compatibility.IncludeUntypedObjects() && 
+                                                    _function.ConnectorSettings.ReturnUnknownRecordFieldsAsUntypedObjects;
 
                 var typeToUse = _function.ReturnType;
                 if (returnTypeOverride != null)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Internal/Wrappers/SwaggerJsonSchema.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Internal/Wrappers/SwaggerJsonSchema.cs
@@ -97,9 +97,23 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         public IList<IOpenApiAny> Enum
-        {
-            // Not supported yet
-            get => null;
+        {           
+            get
+            {
+                if (_schema.TryGetProperty("enum", out JsonElement items) && items.ValueKind == JsonValueKind.Array)
+                {
+                    List<IOpenApiAny> e = new List<IOpenApiAny>();
+
+                    foreach (JsonElement je in items.EnumerateArray())
+                    {
+                        e.Add(new OpenApiString(je.GetString()));
+                    }
+
+                    return e;
+                }
+
+                return null;
+            }
 
             set => throw new NotImplementedException();
         }

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -434,7 +434,7 @@ namespace Microsoft.PowerFx.Connectors
                             return new ConnectorType(schema, openApiParameter, FormulaType.Blob);
                     }
 
-                    if (schema.Enum != null && (settings.Compatibility == ConnectorCompatibility.CdpCompatibility || schema.Format == "enum"))
+                    if (schema.Enum != null && (settings.Compatibility.IsCDP() || schema.Format == "enum"))
                     {
                         if (schema.Enum.All(e => e is OpenApiString))
                         {
@@ -573,8 +573,7 @@ namespace Microsoft.PowerFx.Connectors
 
                                     hiddenRequired = true;
                                 }
-                                else if (settings.Compatibility == ConnectorCompatibility.SwaggerCompatibility ||
-                                         settings.Compatibility == ConnectorCompatibility.CdpCompatibility)
+                                else if (settings.Compatibility.ExcludeInternals())
                                 {
                                     continue;
                                 }
@@ -1155,5 +1154,15 @@ namespace Microsoft.PowerFx.Connectors
 
             return null;
         }
+
+        internal static bool ExcludeInternals(this ConnectorCompatibility compatibility) => compatibility == ConnectorCompatibility.SwaggerCompatibility ||
+                                                                                            compatibility == ConnectorCompatibility.CdpCompatibility;
+
+        internal static bool IsPowerAppsCompliant(this ConnectorCompatibility compatibility) => compatibility == ConnectorCompatibility.PowerAppsCompatibility;
+
+        internal static bool IncludeUntypedObjects(this ConnectorCompatibility compatibility) => compatibility == ConnectorCompatibility.SwaggerCompatibility ||
+                                                                                                 compatibility == ConnectorCompatibility.CdpCompatibility;
+
+        internal static bool IsCDP(this ConnectorCompatibility compatibility) => compatibility == ConnectorCompatibility.CdpCompatibility;
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerFx.Connectors
         /// <summary>
         /// In Power Apps, all record fields which are not declared in the swagger file will not be part of the Power Fx response.
         /// ReturnUnknownRecordFieldsAsUntypedObjects modifies this behavior to return all unknown fields as UntypedObjects. 
-        /// This flag is only working when Compatibility is set to ConnectorCompatibility.SwaggerCompatibility.
+        /// This flag is only working when Compatibility is set to ConnectorCompatibility.SwaggerCompatibility or  ConnectorCompatibility.CdpCompatibility.
         /// </summary>
         public bool ReturnUnknownRecordFieldsAsUntypedObjects { get; init; } = false;
 
@@ -64,6 +64,11 @@ namespace Microsoft.PowerFx.Connectors
         // Swagger File Conformity
         // - parameters appear in the order specified in the swagger file
         // - internal visible parameters are completely hidden (required/optional, with or without default value)
-        SwaggerCompatibility = 2
+        SwaggerCompatibility = 2,
+
+        // Swagger File Conformity for CDP connectors
+        // - same as Swagger File Conformity
+        // - does not require format="enum" for identifying enumerations
+        CdpCompatibility = 3
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/CdpTableResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/CdpTableResolver.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerFx.Connectors
                 }
 
                 string connectorName = _uriPrefix.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)[1];
-                ConnectorType ct = ConnectorFunction.GetConnectorTypeAndTableCapabilities(this, connectorName, "Schema/Items", FormulaValue.New(text), sqlRelationships, ConnectorCompatibility.SwaggerCompatibility, _tabularTable.DatasetName, out string name, out string displayName, out ServiceCapabilities tableCapabilities);
+                ConnectorType ct = ConnectorFunction.GetConnectorTypeAndTableCapabilities(this, connectorName, "Schema/Items", FormulaValue.New(text), sqlRelationships, ConnectorCompatibility.CdpCompatibility, _tabularTable.DatasetName, out string name, out string displayName, out ServiceCapabilities tableCapabilities);
 
                 return new CdpTableDescriptor() { ConnectorType = ct, Name = name, DisplayName = displayName, TableCapabilities = tableCapabilities };
             }

--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.Json;
 using Microsoft.PowerFx.Core.IR;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Functions;
 
 namespace Microsoft.PowerFx.Types
@@ -161,7 +162,11 @@ namespace Microsoft.PowerFx.Types
                     {
                         return FormulaValue.NewBlob(element.GetBytesFromBase64());
                     }
-                    else
+                    else if (formulaType is OptionSetValueType osvt && osvt.TryGetValue(new DName(element.GetString()), out OptionSetValue osv))
+                    {
+                        return osv;
+                    }
+                    else 
                     {
                         throw new PowerFxJsonException($"Expecting {formulaType._type.Kind} but received a String", data.Path);
                     }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CompatibilityTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CompatibilityTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.PowerFx.Connectors;
+using Microsoft.PowerFx.Connectors.Tests;
+using Microsoft.PowerFx.Core.Tests;
+using Microsoft.PowerFx.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PowerFx.Tests
+{
+    public class CompatibilityTests : PowerFxTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public CompatibilityTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void CompatibilityTest()
+        {
+            using LoggingTestServer loggingTestServer = new LoggingTestServer(null, _output);
+            using HttpClient httpClient = new HttpClient(loggingTestServer);
+
+            ConnectorLogger connectorLogger = new ConsoleLogger(_output);
+            CdpTable tabularTable = new CdpTable("dataset", "table", new List<RawTable>() { });
+            CdpTableResolver tableResolver = new CdpTableResolver(tabularTable, httpClient, "prefix", true, connectorLogger);
+
+            string text = (string)LoggingTestServer.GetFileText(@"Responses\Compatibility GetSchema.json");
+
+            ConnectorType ctCdp = ConnectorFunction.GetConnectorTypeAndTableCapabilities(tableResolver, "name", "Schema/Items", StringValue.New(text), null, ConnectorCompatibility.CdpCompatibility, "dataset", out _, out _, out _);
+            ConnectorType ctPa = ConnectorFunction.GetConnectorTypeAndTableCapabilities(tableResolver, "name", "Schema/Items", StringValue.New(text), null, ConnectorCompatibility.PowerAppsCompatibility, "dataset", out _, out _, out _);
+            ConnectorType ctSw = ConnectorFunction.GetConnectorTypeAndTableCapabilities(tableResolver, "name", "Schema/Items", StringValue.New(text), null, ConnectorCompatibility.SwaggerCompatibility, "dataset", out _, out _, out _);
+
+            string cdp = ctCdp.FormulaType._type.ToString();
+            string pa = ctPa.FormulaType._type.ToString();
+            string sw = ctSw.FormulaType._type.ToString();
+
+            // CDP compatibility: priority is an enum, when "format": "enum" isn't present
+            Assert.Equal("![Id1:s, Id3:s, Id4:s, priority:l, priority2:l]", cdp);
+
+            // Swagger compatibility: priority is a string as "format": "enum" isn't present
+            Assert.Equal("![Id1:s, Id3:s, Id4:s, priority:s, priority2:l]", sw);
+
+            // PA compatibility: Id2 is internal and present (not the case for CDP/Swagger compatibilities)
+            Assert.Equal("![Id1:s, Id2:s, Id3:s, Id4:s, priority:s, priority2:l]", pa);            
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Helpers/LoggingTestServer.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Helpers/LoggingTestServer.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerFx.Tests
             }
         }
 
-        private static object GetFileText(string filename)
+        internal static object GetFileText(string filename)
         {
             return !string.IsNullOrEmpty(filename) ? Helpers.ReadStream(filename) : string.Empty;
         }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyProperties2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BaseConnectorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BasicRestTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CompatibilityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConnectorWizardTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DynamicTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileTabularConnector.cs" />
@@ -70,6 +71,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Bing Maps GetRouteV3.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\CardsForPowerApps_CreateCardInstance.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\CardsForPowerApps_Suggestions.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Compatibility GetSchema.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Dataverse_Response_1.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Dataverse_Response_2.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Dataverse_Response_3.json" />

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
@@ -647,13 +647,13 @@ namespace Microsoft.PowerFx.Connectors.Tests
             //   OwnerId`'Owner ID'[User]:s
             //   ParentId`'Parent Account ID'[Account]:s
             Assert.Equal(
-                "![AccountSource`'Account Source':s, BillingCity`'Billing City':s, BillingCountry`'Billing Country':s, BillingGeocodeAccuracy`'Billing Geocode Accuracy':s, BillingLatitude`'Billing Latitude':w, BillingLongitude`'Billing " +
+                "![AccountSource`'Account Source':l, BillingCity`'Billing City':s, BillingCountry`'Billing Country':s, BillingGeocodeAccuracy`'Billing Geocode Accuracy':l, BillingLatitude`'Billing Latitude':w, BillingLongitude`'Billing " +
                 "Longitude':w, BillingPostalCode`'Billing Zip/Postal Code':s, BillingState`'Billing State/Province':s, BillingStreet`'Billing Street':s, CreatedById`'Created By ID'[User]:s, CreatedDate`'Created Date':d, " +
-                "Description`'Account Description':s, Id`'Account ID':s, Industry:s, IsDeleted`Deleted:b, Jigsaw`'Data.com Key':s, JigsawCompanyId`'Jigsaw Company ID':s, LastActivityDate`'Last Activity':D, LastModifiedById`'Last " +
+                "Description`'Account Description':s, Id`'Account ID':s, Industry:l, IsDeleted`Deleted:b, Jigsaw`'Data.com Key':s, JigsawCompanyId`'Jigsaw Company ID':s, LastActivityDate`'Last Activity':D, LastModifiedById`'Last " +
                 "Modified By ID'[User]:s, LastModifiedDate`'Last Modified Date':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, MasterRecordId`'Master Record ID'[Account]:s, Name`'Account " +
                 "Name':s, NumberOfEmployees`Employees:w, OwnerId`'Owner ID'[User]:s, ParentId`'Parent Account ID'[Account]:s, Phone`'Account Phone':s, PhotoUrl`'Photo URL':s, ShippingCity`'Shipping City':s, ShippingCountry`'Shipping " +
-                "Country':s, ShippingGeocodeAccuracy`'Shipping Geocode Accuracy':s, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping Zip/Postal Code':s, ShippingState`'Shipping " +
-                "State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':s, Website:s]", ((CdpRecordType)sfTable.TabularRecordType).ToStringWithDisplayNames());
+                "Country':s, ShippingGeocodeAccuracy`'Shipping Geocode Accuracy':l, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping Zip/Postal Code':s, ShippingState`'Shipping " +
+                "State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s]", ((CdpRecordType)sfTable.TabularRecordType).ToStringWithDisplayNames());
 
             Assert.Equal("Account", sfTable.TabularRecordType.TableSymbolName);
 
@@ -720,16 +720,16 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.Equal(
                 "![AboutMe`'About Me':s, AccountId`'Account ID'[Account]:s, Alias:s, BadgeText`'User Photo badge text overlay':s, BannerPhotoUrl`'Url for banner photo':s, CallCenterId`'Call Center ID':s, City:s, CommunityNickname`Nickname:s, " +
                 "CompanyName`'Company Name':s, ContactId`'Contact ID'[Contact]:s, Country:s, CreatedById`'Created By ID'[User]:s, CreatedDate`'Created Date':d, DefaultGroupNotificationFrequency`'Default Notification Frequency " +
-                "when Joining Groups':s, DelegatedApproverId`'Delegated Approver ID':s, Department:s, DigestFrequency`'Chatter Email Highlights Frequency':s, Division:s, Email:s, EmailEncodingKey`'Email Encoding':s, EmailPreferencesAutoBcc`AutoBcc:b, " +
+                "when Joining Groups':l, DelegatedApproverId`'Delegated Approver ID':s, Department:s, DigestFrequency`'Chatter Email Highlights Frequency':l, Division:s, Email:s, EmailEncodingKey`'Email Encoding':l, EmailPreferencesAutoBcc`AutoBcc:b, " +
                 "EmailPreferencesAutoBccStayInTouch`AutoBccStayInTouch:b, EmailPreferencesStayInTouchReminder`StayInTouchReminder:b, EmployeeNumber`'Employee Number':s, Extension:s, Fax:s, FederationIdentifier`'SAML Federation " +
-                "ID':s, FirstName`'First Name':s, ForecastEnabled`'Allow Forecasting':b, FullPhotoUrl`'Url for full-sized Photo':s, GeocodeAccuracy`'Geocode Accuracy':s, Id`'User ID':s, IsActive`Active:b, IsExtIndicatorVisible`'Show " +
-                "external indicator':b, IsProfilePhotoActive`'Has Profile Photo':b, LanguageLocaleKey`Language:s, LastLoginDate`'Last Login':d, LastModifiedById`'Last Modified By ID'[User]:s, LastModifiedDate`'Last Modified " +
-                "Date':d, LastName`'Last Name':s, LastPasswordChangeDate`'Last Password Change or Reset':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, Latitude:w, LocaleSidKey`Locale:s, " +
+                "ID':s, FirstName`'First Name':s, ForecastEnabled`'Allow Forecasting':b, FullPhotoUrl`'Url for full-sized Photo':s, GeocodeAccuracy`'Geocode Accuracy':l, Id`'User ID':s, IsActive`Active:b, IsExtIndicatorVisible`'Show " +
+                "external indicator':b, IsProfilePhotoActive`'Has Profile Photo':b, LanguageLocaleKey`Language:l, LastLoginDate`'Last Login':d, LastModifiedById`'Last Modified By ID'[User]:s, LastModifiedDate`'Last Modified " +
+                "Date':d, LastName`'Last Name':s, LastPasswordChangeDate`'Last Password Change or Reset':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, Latitude:w, LocaleSidKey`Locale:l, " +
                 "Longitude:w, ManagerId`'Manager ID'[User]:s, MediumBannerPhotoUrl`'Url for Android banner photo':s, MediumPhotoUrl`'Url for medium profile photo':s, MiddleName`'Middle Name':s, MobilePhone`Mobile:s, Name`'Full " +
                 "Name':s, OfflinePdaTrialExpirationDate`'Sales Anywhere Trial Expiration Date':d, OfflineTrialExpirationDate`'Offline Edition Trial Expiration Date':d, OutOfOfficeMessage`'Out of office message':s, Phone:s, " +
                 "PostalCode`'Zip/Postal Code':s, ProfileId`'Profile ID'[Profile]:s, ReceivesAdminInfoEmails`'Admin Info Emails':b, ReceivesInfoEmails`'Info Emails':b, SenderEmail`'Email Sender Address':s, SenderName`'Email " +
                 "Sender Name':s, Signature`'Email Signature':s, SmallBannerPhotoUrl`'Url for IOS banner photo':s, SmallPhotoUrl`Photo:s, State`'State/Province':s, StayInTouchNote`'Stay-in-Touch Email Note':s, StayInTouchSignature`'Stay-in-Touch " +
-                "Email Signature':s, StayInTouchSubject`'Stay-in-Touch Email Subject':s, Street:s, Suffix:s, SystemModstamp`'System Modstamp':d, TimeZoneSidKey`'Time Zone':s, Title:s, UserPermissionsAvantgoUser`'AvantGo " +
+                "Email Signature':s, StayInTouchSubject`'Stay-in-Touch Email Subject':s, Street:s, Suffix:s, SystemModstamp`'System Modstamp':d, TimeZoneSidKey`'Time Zone':l, Title:s, UserPermissionsAvantgoUser`'AvantGo " +
                 "User':b, UserPermissionsCallCenterAutoLogin`'Auto-login To Call Center':b, UserPermissionsInteractionUser`'Flow User':b, UserPermissionsKnowledgeUser`'Knowledge User':b, UserPermissionsLiveAgentUser`'Chat " +
                 "User':b, UserPermissionsMarketingUser`'Marketing User':b, UserPermissionsMobileUser`'Apex Mobile User':b, UserPermissionsOfflineUser`'Offline User':b, UserPermissionsSFContentUser`'Salesforce CRM Content " +
                 "User':b, UserPermissionsSupportUser`'Service Cloud User':b, UserPreferencesActivityRemindersPopup`ActivityRemindersPopup:b, UserPreferencesApexPagesDeveloperMode`ApexPagesDeveloperMode:b, UserPreferencesCacheDiagnostics`CacheDiagnostics:b, " +
@@ -751,7 +751,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 "deToGuestUsers:b, UserPreferencesShowProfilePicToGuestUsers`ShowProfilePicToGuestUsers:b, UserPreferencesShowStateToExternalUsers`ShowStateToExternalUsers:b, UserPreferencesShowStateToGuestUsers`ShowStateToGuestUsers:b, " +
                 "UserPreferencesShowStreetAddressToExternalUsers`ShowStreetAddressToExternalUsers:b, UserPreferencesShowStreetAddressToGuestUsers`ShowStreetAddressToGuestUsers:b, UserPreferencesShowTitleToExternalUsers`ShowTitleToExternalUsers:b, " +
                 "UserPreferencesShowTitleToGuestUsers`ShowTitleToGuestUsers:b, UserPreferencesShowWorkPhoneToExternalUsers`ShowWorkPhoneToExternalUsers:b, UserPreferencesShowWorkPhoneToGuestUsers`ShowWorkPhoneToGuestUsers:b, " +
-                "UserPreferencesSortFeedByComment`SortFeedByComment:b, UserPreferencesTaskRemindersCheckboxDefault`TaskRemindersCheckboxDefault:b, UserRoleId`'Role ID'[UserRole]:s, UserType`'User Type':s, Username:s]", userTable.ToStringWithDisplayNames());
+                "UserPreferencesSortFeedByComment`SortFeedByComment:b, UserPreferencesTaskRemindersCheckboxDefault`TaskRemindersCheckboxDefault:b, UserRoleId`'Role ID'[UserRole]:s, UserType`'User Type':l, Username:s]", userTable.ToStringWithDisplayNames());
 
             // Missing field
             b = sfTable.TabularRecordType.TryGetFieldType("XYZ", out FormulaType xyzType);
@@ -809,13 +809,13 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.True(sfTable.IsDelegable);
 
             Assert.Equal(
-                "*[AccountSource`'Account Source':s, BillingCity`'Billing City':s, BillingCountry`'Billing Country':s, BillingGeocodeAccuracy`'Billing Geocode Accuracy':s, BillingLatitude`'Billing Latitude':w, BillingLongitude`'Billing " +
+                "*[AccountSource`'Account Source':l, BillingCity`'Billing City':s, BillingCountry`'Billing Country':s, BillingGeocodeAccuracy`'Billing Geocode Accuracy':l, BillingLatitude`'Billing Latitude':w, BillingLongitude`'Billing " +
                 "Longitude':w, BillingPostalCode`'Billing Zip/Postal Code':s, BillingState`'Billing State/Province':s, BillingStreet`'Billing Street':s, CreatedById`'Created By ID':s, CreatedDate`'Created Date':d, Description`'Account " +
-                "Description':s, Id`'Account ID':s, Industry:s, IsDeleted`Deleted:b, Jigsaw`'Data.com Key':s, JigsawCompanyId`'Jigsaw Company ID':s, LastActivityDate`'Last Activity':D, LastModifiedById`'Last Modified By " +
+                "Description':s, Id`'Account ID':s, Industry:l, IsDeleted`Deleted:b, Jigsaw`'Data.com Key':s, JigsawCompanyId`'Jigsaw Company ID':s, LastActivityDate`'Last Activity':D, LastModifiedById`'Last Modified By " +
                 "ID':s, LastModifiedDate`'Last Modified Date':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, MasterRecordId`'Master Record ID':s, Name`'Account Name':s, NumberOfEmployees`Employees:w, " +
                 "OwnerId`'Owner ID':s, ParentId`'Parent Account ID':s, Phone`'Account Phone':s, PhotoUrl`'Photo URL':s, ShippingCity`'Shipping City':s, ShippingCountry`'Shipping Country':s, ShippingGeocodeAccuracy`'Shipping " +
-                "Geocode Accuracy':s, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping Zip/Postal Code':s, ShippingState`'Shipping State/Province':s, ShippingStreet`'Shipping " +
-                "Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':s, Website:s]", sfTable.Type.ToStringWithDisplayNames());
+                "Geocode Accuracy':l, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping Zip/Postal Code':s, ShippingState`'Shipping State/Province':s, ShippingStreet`'Shipping " +
+                "Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s]", sfTable.Type.ToStringWithDisplayNames());
 
             SymbolValues symbolValues = new SymbolValues().Add("Accounts", sfTable);
             RuntimeConfig rc = new RuntimeConfig(symbolValues).AddService<ConnectorLogger>(logger);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Compatibility GetSchema.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Compatibility GetSchema.json
@@ -1,0 +1,53 @@
+{
+  "name": "User",
+  "title": "Users",  
+  "schema": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "title": "User",
+      "properties": {
+        "Id1": {
+          "title": "User ID 1",
+          "type": "string"
+        },
+        "Id2": {
+          "title": "User ID 2",
+          "type": "string",
+          "x-ms-visibility": "internal"
+        },
+        "Id3": {
+          "title": "User ID 3",
+          "type": "string",
+          "x-ms-visibility": "advanced"
+        },
+        "Id4": {
+          "title": "User ID 4",
+          "type": "string",
+          "x-ms-visibility": "important"
+        },
+        "priority": {
+          "title": "priority",
+          "type": "string",
+          "enum": [
+            "low",
+            "normal",
+            "high",
+            "urgent"
+          ]
+        },
+        "priority2": {
+          "title": "priority",
+          "type": "string",
+          "format":  "enum",
+          "enum": [
+            "low",
+            "normal",
+            "high",
+            "urgent"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add CDP compatibility flag
When enabled, we don't require format=enum