### PR TITLE
Add OnlyOneLevel option to JSON function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Json.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Json.cs
@@ -17,12 +17,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 {
     // JSON(data:any, [format:s])    
     internal class JsonFunction : BuiltinFunction
-    {        
-        private const char _includeBinaryDataEnumValue = 'B';
-        private const char _ignoreBinaryDataEnumValue = 'G';
-        private const char _ignoreUnsupportedTypesEnumValue = 'I';
-        private const char _flattenTableValuesEnumValue = '_';
-        private const char _indentFourEnumValue = '4';
+    {
+        protected const char _includeBinaryDataEnumValue = 'B';
+        protected const char _ignoreBinaryDataEnumValue = 'G';
+        protected const char _ignoreUnsupportedTypesEnumValue = 'I';
+        protected const char _flattenTableValuesEnumValue = '_';
+        protected const char _indentFourEnumValue = '4';
+        protected const char _onlyOneLevel = '1';
 
         protected bool supportsLazyTypes = false;
 
@@ -31,18 +32,18 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             DKind.DataEntity,
             DKind.LazyRecord,
             DKind.LazyTable,
-            DKind.View, 
+            DKind.View,
             DKind.ViewValue
         };
 
         private static readonly DKind[] _unsupportedTypes = new[]
         {
-            DKind.Control, 
+            DKind.Control,
             DKind.LazyRecord,
             DKind.LazyTable,
             DKind.Metadata,
-            DKind.OptionSet, 
-            DKind.PenImage, 
+            DKind.OptionSet,
+            DKind.PenImage,
             DKind.Polymorphic,
             DKind.UntypedObject,
             DKind.Void
@@ -50,7 +51,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
         public override bool IsSelfContained => true;
 
-        public override bool IsAsync => true;       
+        public override bool IsAsync => true;
 
         public override bool SupportsParamCoercion => false;
 
@@ -78,13 +79,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             // Do not call base.CheckTypes for arg0
             if (args.Length > 1)
             {
-                if (context.Features.StronglyTypedBuiltinEnums && 
+                if (context.Features.StronglyTypedBuiltinEnums &&
                     !base.CheckType(context, args[1], argTypes[1], BuiltInEnums.JSONFormatEnum.FormulaType._type, errors, ref nodeToCoercedTypeMap))
                 {
                     return false;
                 }
 
-                TexlNode optionsNode = args[1];                
+                TexlNode optionsNode = args[1];
                 if (!IsConstant(context, argTypes, optionsNode, out string nodeValue))
                 {
                     errors.EnsureError(optionsNode, TexlStrings.ErrFunctionArg2ParamMustBeConstant, "JSON", TexlStrings.JSONArg2.Invoke());
@@ -117,11 +118,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
             bool includeBinaryData = false;
             bool ignoreUnsupportedTypes = false;
-            bool ignoreBinaryData = false;            
-
+            bool ignoreBinaryData = false;
+            
             if (args.Length > 1)
             {
-                TexlNode optionsNode = args[1];                
+                TexlNode optionsNode = args[1];
                 if (!IsConstant(binding.CheckTypesContext, argTypes, optionsNode, out string nodeValue))
                 {
                     return;
@@ -144,6 +145,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                                 break;
                             case _flattenTableValuesEnumValue:
                             case _indentFourEnumValue:
+                            case _onlyOneLevel:
                                 // Runtime-only options
                                 break;
                             default:
@@ -185,7 +187,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 {
                     errors.EnsureError(dataNode, TexlStrings.ErrJSONArg1UnsupportedNestedType, unsupportedColumnName, unsupportedNestedType.GetKindString());
                 }
-            }            
+            }
         }
 
         private static bool IsConstant(CheckTypesContext context, DType[] argTypes, TexlNode optionsNode, out string nodeValue)

--- a/src/libraries/Microsoft.PowerFx.Core/Types/Enums/BuiltInEnums.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/Enums/BuiltInEnums.cs
@@ -170,7 +170,8 @@ namespace Microsoft.PowerFx.Core.Types.Enums
                 { "IgnoreBinaryData", "G" },
                 { "IncludeBinaryData", "B" },
                 { "IgnoreUnsupportedTypes", "I" },
-                { "FlattenValueTables", "_" }
+                { "FlattenValueTables", "_" },
+                { "OnlyOneLevel", "1" }
             },
             canConcatenateStronglyTyped: true);
 

--- a/src/libraries/Microsoft.PowerFx.Json/Functions/JsonFunctionImpl.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/Functions/JsonFunctionImpl.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                             optionString = sv.Value;
                             break;
 
-                        // if not one of these, will check optionString != null below
+                            // if not one of these, will check optionString != null below
                     }
 
                     if (optionString != null)
@@ -133,7 +133,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 private readonly Utf8JsonWriter _writer;
                 private readonly TimeZoneInfo _timeZoneInfo;
                 private readonly bool _flattenValueTables;
-                private readonly bool _onlyOneLevel;                               
+                private readonly bool _onlyOneLevel;
 
                 internal readonly List<ErrorValue> ErrorValues = new List<ErrorValue>();
                 private int _level = 0;
@@ -177,7 +177,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 }
 
                 public void Visit(ErrorValue errorValue)
-                {                    
+                {
                     ErrorValues.Add(errorValue);
                     _writer.WriteStringValue("ErrorValue");
                 }
@@ -263,7 +263,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     if (!_onlyOneLevel || _level < 1)
                     {
                         _level++;
-                        
+
                         foreach (NamedValue namedValue in recordValue.Fields)
                         {
                             _writer.WritePropertyName(namedValue.Name);
@@ -287,8 +287,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
 
                     if (!_onlyOneLevel || _level < 1)
                     {
-                        _level++;
-
                         var isSingleColumnValueTable = false;
                         if (_flattenValueTables)
                         {
@@ -323,8 +321,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                                 }
                             }
                         }
-
-                        _level--;
                     }
 
                     _writer.WriteEndArray();
@@ -350,7 +346,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                     {
                         _writer.WriteBase64StringValue(value.GetAsByteArrayAsync(CancellationToken.None).Result);
                     }
-                }                
+                }
             }
 
             internal static string GetColorString(Color color) => $"#{color.R:x2}{color.G:x2}{color.B:x2}{color.A:x2}";

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/JSON_OnlyTopLevel.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/JSON_OnlyTopLevel.txt
@@ -1,0 +1,142 @@
+#SETUP: EnableJsonFunctions
+
+>> JSON(Blank(), JSONFormat.OnlyOneLevel)
+"null"
+
+>> JSON(If(1<0,"true",{a:1}), JSONFormat.OnlyOneLevel)
+Errors: Error 5-25: The JSON function cannot serialize objects of type 'Void'.
+
+>> JSON("hello", JSONFormat.OnlyOneLevel)
+"""hello"""
+
+>> JSON(1.23, JSONFormat.OnlyOneLevel)
+"1.23"
+
+>> JSON(0, JSONFormat.OnlyOneLevel)
+"0"
+
+>> JSON(1, JSONFormat.OnlyOneLevel)
+"1"
+
+>> JSON(-1, JSONFormat.OnlyOneLevel)
+"-1"
+
+>> JSON(true, JSONFormat.OnlyOneLevel)
+"true"
+
+>> JSON(false, JSONFormat.OnlyOneLevel)
+"false"
+
+>> JSON("Back\slash", JSONFormat.OnlyOneLevel)
+"""Back\\slash"""
+
+>> JSON("Quotes "" and ' may be escaped", JSONFormat.OnlyOneLevel)
+"""Quotes \"" and ' may be escaped"""
+
+>> JSON($"Other {Char(13)} escaped {Char(10)} chars {Char(4)} should {Char(9)} also {Char(8)} be {Char(1)} escaped {Char(20)} properly", JSONFormat.OnlyOneLevel)
+"""Other \r escaped \n chars \u0004 should \t also \b be \u0001 escaped \u0014 properly"""
+
+// In \uXXXX escapings, letters of hex characters are upper case while they are lower case in Power Apps.
+// Technically, this is the exactly the same character.
+>> JSON(Concat(Sequence(128), Char(Value)), JSONFormat.OnlyOneLevel)
+"""\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000B\f\r\u000E\u000F\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F !\""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F\u0080"""
+
+>> JSON(RGBA(10, 30, 50, 0.75), JSONFormat.OnlyOneLevel)
+"""#0a1e32bf"""
+
+>> JSON(Color.Turquoise, JSONFormat.OnlyOneLevel)
+"""#40e0d0ff"""
+
+>> JSON(TimeUnit.Hours, JSONFormat.OnlyOneLevel)
+"""hours"""
+
+>> JSON(Date(2022,8,7), JSONFormat.OnlyOneLevel)
+"""2022-08-07"""
+
+>> JSON(DateTimeValue("1970-01-01T00:00:00Z"), JSONFormat.OnlyOneLevel)
+"""1970-01-01T00:00:00.000Z"""
+
+// Independent from local timezone
+>> With({dt: DateTime(1987,6,5,4,30,0)}, JSON(DateAdd(dt,-TimeZoneOffset(dt),TimeUnit.Minutes), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel))
+"""1987-06-05T04:30:00.000Z"""
+
+>> JSON({a:1,b:"hello",c:true}, JSONFormat.OnlyOneLevel)
+"{""a"":1,""b"":""hello"",""c"":true}"
+
+>> JSON({a:1,b:"hello",c:true}, JSONFormat.Compact & JSONFormat.OnlyOneLevel)
+"{""a"":1,""b"":""hello"",""c"":true}"
+
+>> Substitute(Substitute(Substitute(JSON({a:1,b:"hello",c:true}, JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
+"{*<t>""a"": 1,*<t>""b"": ""hello"",*<t>""c"": true*}"
+
+>> JSON(Table({a:1,b:"hello",c:true,e:Blank()},{a:-3,b:"world",c:false,d:GUID("01234567-89AB-CDEF-0123-456789ABCDEF")}), JSONFormat.OnlyOneLevel)
+"[{},{}]"
+
+>> Substitute(Substitute(Substitute(JSON(Table({a:1,b:"hello",c:true},{a:-3,b:"world",c:false}), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
+"[*<t>{},*<t>{}*]"
+
+>> Substitute(Substitute(Substitute(JSON({a:1,b:"hello",c:true}, JSONFormat.IndentFour & JSONFormat.Compact & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
+"{*<t>""a"": 1,*<t>""b"": ""hello"",*<t>""c"": true*}"
+
+>> JSON(DateTimeValue("2022-08-07T12:34:56Z"), JSONFormat.OnlyOneLevel)
+"""2022-08-07T12:34:56.000Z"""
+
+>> JSON(Table({a:GUID("01234567-89AB-CDEF-0123-456789ABCDEF"),b:RGBA(18, 52, 86, 0.5),c:"https://www.microsoft.com",d:Sqrt(9)}), JSONFormat.OnlyOneLevel)
+"[{}]"
+
+>> Substitute(Substitute(Substitute(JSON(Table({a:1,b:"hello",c:Blank()},{a:-3,b:"world",c:{d: 1, h:"test"}}), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
+"[*<t>{},*<t>{}*]"
+
+// .Net 4.6.2 returns [*<t>{*<t><t>""a"": 1,*<t><t>""b"": ""hello"",*<t><t>""c"": null*<t>},*<t>{*<t><t>""a"": -3,*<t><t>""b"": ""world"",*<t><t>""c"": [*<t><t><t>{*<t><t><t><t>""r"": 3.1000000000000001,*<t><t><t><t>""s"": ""inner"",*<t><t><t><t>""t"": -7*<t><t><t>}*<t><t>]*<t>}*]
+#DISABLE.NET: 462
+>> Substitute(Substitute(Substitute(JSON(Table({a:1,b:"hello",c:Blank()},{a:-3,b:"world",c:Table({r:3.1,s:"inner",t:-7})}), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
+"[*<t>{},*<t>{}*]"
+
+>> JSON(1/0, JSONFormat.OnlyOneLevel)
+Error({Kind:ErrorKind.Div0})
+
+>> JSON({a:1,b:Sqrt(-1),c:true}, JSONFormat.OnlyOneLevel)
+Error({Kind:ErrorKind.Numeric})
+
+// No error is returned here as we only look at top level, so 1/0 is not evaluated
+>> JSON([{a:1,b:[2]},{a:3,b:[4,5]},{a:6,b:[7,1/0,9]}], JSONFormat.OnlyOneLevel)
+"[{},{},{}]"
+
+// Blank records
+>> JSON(Table({a:1},Blank(),{a:3}), JSONFormat.OnlyOneLevel)
+"[{},null,{}]"
+
+// Error records
+>> JSON(Filter([-2,-1,0,1,2], 1/Value>0), JSONFormat.OnlyOneLevel)
+Error({Kind:ErrorKind.Div0})
+
+// Flattened tables
+>> JSON([1, 2, 3], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"[1,2,3]"
+
+>> JSON({a:["one", "two"]}, JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"{""a"":[]}"
+
+>> JSON([true, false, true], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"[true,false,true]"
+
+// Only flatten single-column tables where the column name is 'Value'
+>> JSON([{a:1}, {a:2}], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"[{},{}]"
+
+// No difference between blank records and blank values
+>> JSON([{Value:1},Blank(),{Value:3},{Value:Blank()},{Value:5}], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"[1,null,3,null,5]"
+
+// Flattening nested tables
+>> JSON([[1,2,3],[4,5],[6]], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"[[],[],[]]"
+
+>> JSON([[[1],[2]],[[4],[5]],[[6],[7]]], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
+"[[],[],[]]"
+
+>> JSON({a:1, b:["a", "b"], c:Blank(), d:{e:1, f:3}})
+"{""a"":1,""b"":[{""Value"":""a""},{""Value"":""b""}],""c"":null,""d"":{""e"":1,""f"":3}}"
+
+>> JSON({a:1, b:["a", "b"], c:Blank(), d:{e:1, f:3}}, JSONFormat.OnlyOneLevel)
+"{""a"":1,""b"":[],""c"":null,""d"":{}}"

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/JSON_OnlyTopLevel.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/JSON_OnlyTopLevel.txt
@@ -70,10 +70,10 @@ Errors: Error 5-25: The JSON function cannot serialize objects of type 'Void'.
 "{*<t>""a"": 1,*<t>""b"": ""hello"",*<t>""c"": true*}"
 
 >> JSON(Table({a:1,b:"hello",c:true,e:Blank()},{a:-3,b:"world",c:false,d:GUID("01234567-89AB-CDEF-0123-456789ABCDEF")}), JSONFormat.OnlyOneLevel)
-"[{},{}]"
+"[{""a"":1,""b"":""hello"",""c"":true,""d"":null,""e"":null},{""a"":-3,""b"":""world"",""c"":false,""d"":""01234567-89ab-cdef-0123-456789abcdef"",""e"":null}]"
 
 >> Substitute(Substitute(Substitute(JSON(Table({a:1,b:"hello",c:true},{a:-3,b:"world",c:false}), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
-"[*<t>{},*<t>{}*]"
+"[*<t>{*<t><t>""a"": 1,*<t><t>""b"": ""hello"",*<t><t>""c"": true*<t>},*<t>{*<t><t>""a"": -3,*<t><t>""b"": ""world"",*<t><t>""c"": false*<t>}*]"
 
 >> Substitute(Substitute(Substitute(JSON({a:1,b:"hello",c:true}, JSONFormat.IndentFour & JSONFormat.Compact & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
 "{*<t>""a"": 1,*<t>""b"": ""hello"",*<t>""c"": true*}"
@@ -82,15 +82,15 @@ Errors: Error 5-25: The JSON function cannot serialize objects of type 'Void'.
 """2022-08-07T12:34:56.000Z"""
 
 >> JSON(Table({a:GUID("01234567-89AB-CDEF-0123-456789ABCDEF"),b:RGBA(18, 52, 86, 0.5),c:"https://www.microsoft.com",d:Sqrt(9)}), JSONFormat.OnlyOneLevel)
-"[{}]"
+"[{""a"":""01234567-89ab-cdef-0123-456789abcdef"",""b"":""#12345680"",""c"":""https://www.microsoft.com"",""d"":3}]"
 
 >> Substitute(Substitute(Substitute(JSON(Table({a:1,b:"hello",c:Blank()},{a:-3,b:"world",c:{d: 1, h:"test"}}), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
-"[*<t>{},*<t>{}*]"
+"[*<t>{*<t><t>""a"": 1,*<t><t>""b"": ""hello"",*<t><t>""c"": null*<t>},*<t>{*<t><t>""a"": -3,*<t><t>""b"": ""world"",*<t><t>""c"": {}*<t>}*]"
 
 // .Net 4.6.2 returns [*<t>{*<t><t>""a"": 1,*<t><t>""b"": ""hello"",*<t><t>""c"": null*<t>},*<t>{*<t><t>""a"": -3,*<t><t>""b"": ""world"",*<t><t>""c"": [*<t><t><t>{*<t><t><t><t>""r"": 3.1000000000000001,*<t><t><t><t>""s"": ""inner"",*<t><t><t><t>""t"": -7*<t><t><t>}*<t><t>]*<t>}*]
 #DISABLE.NET: 462
 >> Substitute(Substitute(Substitute(JSON(Table({a:1,b:"hello",c:Blank()},{a:-3,b:"world",c:Table({r:3.1,s:"inner",t:-7})}), JSONFormat.IndentFour & JSONFormat.OnlyOneLevel), Char(10), "*"), Char(13), ""), "    ", "<t>")
-"[*<t>{},*<t>{}*]"
+"[*<t>{*<t><t>""a"": 1,*<t><t>""b"": ""hello"",*<t><t>""c"": null*<t>},*<t>{*<t><t>""a"": -3,*<t><t>""b"": ""world"",*<t><t>""c"": []*<t>}*]"
 
 >> JSON(1/0, JSONFormat.OnlyOneLevel)
 Error({Kind:ErrorKind.Div0})
@@ -100,11 +100,11 @@ Error({Kind:ErrorKind.Numeric})
 
 // No error is returned here as we only look at top level, so 1/0 is not evaluated
 >> JSON([{a:1,b:[2]},{a:3,b:[4,5]},{a:6,b:[7,1/0,9]}], JSONFormat.OnlyOneLevel)
-"[{},{},{}]"
+"[{""a"":1,""b"":[]},{""a"":3,""b"":[]},{""a"":6,""b"":[]}]"
 
 // Blank records
 >> JSON(Table({a:1},Blank(),{a:3}), JSONFormat.OnlyOneLevel)
-"[{},null,{}]"
+"[{""a"":1},null,{""a"":3}]"
 
 // Error records
 >> JSON(Filter([-2,-1,0,1,2], 1/Value>0), JSONFormat.OnlyOneLevel)
@@ -122,7 +122,7 @@ Error({Kind:ErrorKind.Div0})
 
 // Only flatten single-column tables where the column name is 'Value'
 >> JSON([{a:1}, {a:2}], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
-"[{},{}]"
+"[{""a"":1},{""a"":2}]"
 
 // No difference between blank records and blank values
 >> JSON([{Value:1},Blank(),{Value:3},{Value:Blank()},{Value:5}], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
@@ -130,13 +130,19 @@ Error({Kind:ErrorKind.Div0})
 
 // Flattening nested tables
 >> JSON([[1,2,3],[4,5],[6]], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
-"[[],[],[]]"
+"[[1,2,3],[4,5],[6]]"
 
 >> JSON([[[1],[2]],[[4],[5]],[[6],[7]]], JSONFormat.FlattenValueTables & JSONFormat.OnlyOneLevel)
-"[[],[],[]]"
+"[[[1],[2]],[[4],[5]],[[6],[7]]]"
 
 >> JSON({a:1, b:["a", "b"], c:Blank(), d:{e:1, f:3}})
 "{""a"":1,""b"":[{""Value"":""a""},{""Value"":""b""}],""c"":null,""d"":{""e"":1,""f"":3}}"
 
 >> JSON({a:1, b:["a", "b"], c:Blank(), d:{e:1, f:3}}, JSONFormat.OnlyOneLevel)
 "{""a"":1,""b"":[],""c"":null,""d"":{}}"
+
+>> JSON([{a:1, b:["a", "b"], c:Blank(), d:{e:1, f:3}}])
+"[{""a"":1,""b"":[{""Value"":""a""},{""Value"":""b""}],""c"":null,""d"":{""e"":1,""f"":3}}]"
+
+>> JSON([{a:1, b:["a", "b"], c:Blank(), d:{e:1, f:3}}], JSONFormat.OnlyOneLevel)
+"[{""a"":1,""b"":[],""c"":null,""d"":{}}]"


### PR DESCRIPTION
Allows to serialize only one level of the object 
Needed for complex database/tabular connectors where following relationships is very expensive like Dataverse or ServiceNow