### PR TITLE
Add new ConnectorSettings "IncludeWebhookFunctions" to allow using more Teams operation

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiParser.cs
@@ -155,7 +155,7 @@ namespace Microsoft.PowerFx.Connectors
                 string notSupportedReasonForPath = string.Empty;
 
                 // Skip Webhooks
-                if (ops.Extensions.Any(kvp => kvp.Key == XMsNotificationContent))
+                if (!connectorSettings.IncludeWebhookFunctions && ops.Extensions.Any(kvp => kvp.Key == XMsNotificationContent))
                 {
                     configurationLogger?.LogInformation($"Skipping Webhook {path} {ops.Description}");
                     continue;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
@@ -36,6 +36,12 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         public bool AllowUnsupportedFunctions { get; init; } = false;
 
+        /// <summary>
+        /// Include webhook functions that contain "x-ms-notification-content" in definition.
+        /// By default these functions won't be accessible by end users.
+        /// </summary>
+        public bool IncludeWebhookFunctions { get; init; } = false;
+
         /// <summary>        
         /// By default these functions won't be accessible by end users.
         /// Internally, internal functions will be kept (ConnectorFunction.FunctionList) as some of those are used for dynamic intellisense.

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -1372,8 +1372,8 @@ POST https://tip1-shared.azure-apim.net/invoke
             ConnectorFunction[] functionsWithWebhooks = OpenApiParser.GetFunctions(new ConnectorSettings("DV") { Compatibility = ConnectorCompatibility.SwaggerCompatibility, IncludeWebhookFunctions = true }, testConnector._apiDocument).ToArray();
             ConnectorFunction[] functionsWithoutWebhooks = OpenApiParser.GetFunctions(new ConnectorSettings("DV") { Compatibility = ConnectorCompatibility.SwaggerCompatibility }, testConnector._apiDocument).ToArray();
 
-            Assert.Null(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse"));
-            Assert.NotNull(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse"));
+            Assert.NotNull(functionsWithWebhooks.FirstOrDefault(f => f.Name == "PostCardAndWaitForResponse"));
+            Assert.Null(functionsWithoutWebhooks.FirstOrDefault(f => f.Name == "PostCardAndWaitForResponse"));
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -1361,6 +1361,22 @@ POST https://tip1-shared.azure-apim.net/invoke
         }
 
         [Fact]
+        public async Task Teams_PostCardAndWaitForResponse()
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\Teams.json", _output);
+            using var httpClient = new HttpClient(testConnector);
+            using PowerPlatformConnectorClient client = new PowerPlatformConnectorClient("https://tip1002-002.azure-apihub.net", "7592282b-e371-e3f6-8e04-e8f23e64227c" /* environment Id */, "shared-cardsforpower-eafc4fa0-c560-4eba-a5b2-3e1ebc63193a" /* connectionId */, () => "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dC...", httpClient) { SessionId = "a41bd03b-6c3c-4509-a844-e8c51b61f878" };
+
+            BaseRuntimeConnectorContext runtimeContext = new TestConnectorRuntimeContext("DV", client, console: _output);
+
+            ConnectorFunction[] functionsWithWebhooks = OpenApiParser.GetFunctions(new ConnectorSettings("DV") { Compatibility = ConnectorCompatibility.SwaggerCompatibility, IncludeWebhookFunctions = true }, testConnector._apiDocument).ToArray();
+            ConnectorFunction[] functionsWithoutWebhooks = OpenApiParser.GetFunctions(new ConnectorSettings("DV") { Compatibility = ConnectorCompatibility.SwaggerCompatibility }, testConnector._apiDocument).ToArray();
+
+            Assert.Null(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse");
+            Assert.NotNull(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse");
+        }
+
+        [Fact]
         public void ABS_GetTriggers()
         {
             OpenApiDocument doc = Helpers.ReadSwagger(@"Swagger\AzureBlobStorage.json", _output);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -1372,8 +1372,8 @@ POST https://tip1-shared.azure-apim.net/invoke
             ConnectorFunction[] functionsWithWebhooks = OpenApiParser.GetFunctions(new ConnectorSettings("DV") { Compatibility = ConnectorCompatibility.SwaggerCompatibility, IncludeWebhookFunctions = true }, testConnector._apiDocument).ToArray();
             ConnectorFunction[] functionsWithoutWebhooks = OpenApiParser.GetFunctions(new ConnectorSettings("DV") { Compatibility = ConnectorCompatibility.SwaggerCompatibility }, testConnector._apiDocument).ToArray();
 
-            Assert.Null(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse");
-            Assert.NotNull(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse");
+            Assert.Null(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse"));
+            Assert.NotNull(functionsWithoutWebhooks.First(f => f.Name == "PostCardAndWaitForResponse"));
         }
 
         [Fact]


### PR DESCRIPTION
In the Teams connector, the operation "PostCardAndWaitForResponse" contains extension "x-ms-notification-content" and is excluded from the parse result of `GetFunctions`.

In MCS, we want to make this operation available to our internal users to keep parity with Power Automate behavior.

This PR fixes the issue by
1. Creating a new setting "IncludeWebhookFunctions" to conditionally include those "webhook" functions on demand.
2. Consume that new setting when filtering on the webhook functions, it set to true, it won't filter away those functions.

As a result, 4 more operations inside Teams connector will be supported by merging this change.
On MCS side, PFX `GetFunctions` will be invoked with an additional setting parameter `IncludeWebhookFunctions = true`.