### PR TITLE
Try fallback to "value" and "displayName" when building connector suggestions API response

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1177,7 +1177,7 @@ namespace Microsoft.PowerFx.Connectors
                     JsonElement value = ExtractFromJson(jElement, cdv.ValuePath);
 
                     // Note: Some connectors have misalignment between the Swagger definition and the actual response, caused suggestion API
-                    // returning empty result.For example, Teams declares the GetMessageLocations response as List<{id, displayName}> but
+                    // returning empty result. For example, Teams declares the GetMessageLocations response as List<{id, displayName}> but
                     // in fact returns List<{value, displayName}>.
                     // Fallback to "displayName" and "value" which are the most commonly used property names in suggestion response.
                     if (title.ValueKind == JsonValueKind.Undefined)

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1176,6 +1176,19 @@ namespace Microsoft.PowerFx.Connectors
                     JsonElement title = ExtractFromJson(jElement, cdv.ValueTitle);
                     JsonElement value = ExtractFromJson(jElement, cdv.ValuePath);
 
+                    // Note: Some connectors have misalignment between the Swagger definition and the actual response, caused suggestion API returns empty result.
+                    // For example, Teams declares the GetMessageLocations response as List<{id, displayName}> but actually returns List<{value, displayName}>.
+                    // Fallback to "displayName" and "value" which are the most commonly used property names in suggestion response.
+                    if (title.ValueKind == JsonValueKind.Undefined)
+                    {
+                        title = ExtractFromJson(jElement, "displayName");
+                    }
+
+                    if (value.ValueKind == JsonValueKind.Undefined)
+                    { 
+                        value = ExtractFromJson(jElement, "value");
+                    }
+
                     if (title.ValueKind == JsonValueKind.Undefined || value.ValueKind == JsonValueKind.Undefined)
                     {
                         continue;
@@ -1214,6 +1227,16 @@ namespace Microsoft.PowerFx.Connectors
             {
                 JsonElement title = ExtractFromJson(jElement, cdl.ItemTitlePath);
                 JsonElement value = ExtractFromJson(jElement, cdl.ItemValuePath);
+
+                if (title.ValueKind == JsonValueKind.Undefined)
+                {
+                    title = ExtractFromJson(jElement, "displayName");
+                }
+
+                if (value.ValueKind == JsonValueKind.Undefined)
+                {
+                    value = ExtractFromJson(jElement, "value");
+                }
 
                 if (title.ValueKind == JsonValueKind.Undefined || value.ValueKind == JsonValueKind.Undefined)
                 {

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1176,8 +1176,9 @@ namespace Microsoft.PowerFx.Connectors
                     JsonElement title = ExtractFromJson(jElement, cdv.ValueTitle);
                     JsonElement value = ExtractFromJson(jElement, cdv.ValuePath);
 
-                    // Note: Some connectors have misalignment between the Swagger definition and the actual response, caused suggestion API returns empty result.
-                    // For example, Teams declares the GetMessageLocations response as List<{id, displayName}> but actually returns List<{value, displayName}>.
+                    // Note: Some connectors have misalignment between the Swagger definition and the actual response, caused suggestion API
+                    // returning empty result.For example, Teams declares the GetMessageLocations response as List<{id, displayName}> but
+                    // in fact returns List<{value, displayName}>.
                     // Fallback to "displayName" and "value" which are the most commonly used property names in suggestion response.
                     if (title.ValueKind == JsonValueKind.Undefined)
                     {

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
@@ -263,6 +263,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\SQL Server TestAllFunctions.jsonSet" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Teams_GetMessageDetails_GetSuggestionsForChannel.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Teams_GetMessageDetails_InputType.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\Teams_GetMessageLocations.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\TestConnectorDateTimeFormatResponse.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\ZD GetDatasetsMetadata.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\ZD GetTables.json" />

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Teams_GetMessageLocations.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/Teams_GetMessageLocations.json
@@ -1,0 +1,16 @@
+{
+  "value": [
+    {
+      "value": "Channel",
+      "displayName": "Channel"
+    },
+    {
+      "value": "Group chat",
+      "displayName": "Group chat"
+    },
+    {
+      "value": "Chat with Flow bot",
+      "displayName": "Chat with Flow bot"
+    }
+  ]
+}


### PR DESCRIPTION
Address the schema and actual response misalignment issue especially for Teams Connector.

**Context**:
In Teams connector, the suggestions API "GetMessageLocations" is declared as below:

```ts
// dynamic schema
"x-ms-dynamic-values": {
    "operationId": "GetMessageLocations",
    "value-path": "id",
    "value-title": "displayName",
    "value-collection": "value",
    "parameters": {
        "messageType": "ParentMessage",
        "poster": {
            "parameter": "poster"
        }
    }
}

// response type
{
  "type": "object",
  "properties": {
      "locations": {
          "type": "array",
          "items": {
              "type": "object"
          },
          "description": "valid locations to post a message or reply, make verbose"
      }
  }
}
```

It's a historical issue (PAuto supports weak type and consumes this format) that the actual response format ("value" and "displayName") is misaligned with the expected format ("id" and "displayName"). Then it caused the MCS suggestions API returning empty result.

**Proposed solution**:
Fallback to accept "value" and "displayName" when building the suggestion response.
This approached was proved to work in MCS but since some version update there was a regression.