### PR TITLE
Power-Fx WORKDAY function

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -389,6 +389,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static StringGetter DateTimeValueArg2 = (b) => StringResources.Get("DateTimeValueArg2", b);
 
         public static StringGetter AboutDateAdd = (b) => StringResources.Get("AboutDateAdd", b);
+        public static StringGetter AboutWorkday = (b) => StringResources.Get("AboutWorkday", b);
         public static StringGetter DateAddArg1 = (b) => StringResources.Get("DateAddArg1", b);
         public static StringGetter DateAddArg2 = (b) => StringResources.Get("DateAddArg2", b);
         public static StringGetter DateAddArg3 = (b) => StringResources.Get("DateAddArg3", b);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -81,6 +81,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction Date = _library.Add(new DateFunction());
         public static readonly TexlFunction DateAdd = _library.Add(new DateAddFunction());
         public static readonly TexlFunction DateAddT = _library.Add(new DateAddTFunction());
+        public static readonly TexlFunction Workday = _library.Add(new WorkdayFunction());
         public static readonly TexlFunction DateDiff = _library.Add(new DateDiffFunction());
         public static readonly TexlFunction DateDiffT = _library.Add(new DateDiffTFunction());
         public static readonly TexlFunction DateTime = _library.Add(new DateTimeFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
@@ -628,14 +628,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool IsSelfContained => true;
 
         public WorkdayFunction()
-            : base("Workday", TexlStrings.AboutWorkday, FunctionCategories.DateTime, DType.DateTime, 0, 2, 3, DType.DateTime, DType.Number)
+            : base("Workday", TexlStrings.AboutWorkday, FunctionCategories.DateTime, DType.DateTime, 0, 2, 2, DType.DateTime, DType.Number)
         {
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.DateAddArg1, TexlStrings.DateAddArg2 };
-            yield return new[] { TexlStrings.DateAddArg1, TexlStrings.DateAddArg2, TexlStrings.DateAddArg3 };
         }
 
         public override IEnumerable<string> GetRequiredEnumNames()
@@ -697,13 +696,14 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
         public override bool HasPreciseErrors => true;
 
         public DateDiffFunction()
-            : base("DateDiff", TexlStrings.AboutDateDiff, FunctionCategories.DateTime, DType.Number, 0, 2, 2, DType.DateTime, DType.DateTime, BuiltInEnums.TimeUnitEnum.FormulaType._type)
+            : base("DateDiff", TexlStrings.AboutDateDiff, FunctionCategories.DateTime, DType.Number, 0, 2, 3, DType.DateTime, DType.DateTime, BuiltInEnums.TimeUnitEnum.FormulaType._type)
         {
         }
 
         public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
         {
             yield return new[] { TexlStrings.DateDiffArg1, TexlStrings.DateDiffArg2 };
+            yield return new[] { TexlStrings.DateDiffArg1, TexlStrings.DateDiffArg2, TexlStrings.DateDiffArg3 };
         }
 
         public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
@@ -471,6 +471,22 @@ namespace Microsoft.PowerFx.Functions
                     targetFunction: DateAdd)
             },
             {
+                BuiltinFunctionsCore.Workday,
+                StandardErrorHandling<FormulaValue>(
+                    BuiltinFunctionsCore.Workday.Name,
+                    expandArguments: InsertDefaultValues(outputArgsCount: 3, fillWith: new BlankValue(IRContext.NotInSource(FormulaType.Blank))),
+                    replaceBlankValues: ReplaceBlankWith(
+                        new DateTimeValue(IRContext.NotInSource(FormulaType.DateTime), _epoch),
+                        new NumberValue(IRContext.NotInSource(FormulaType.Number), 0)),
+                    checkRuntimeTypes: ExactSequence(
+                        DateOrTimeOrDateTime,
+                        ExactValueTypeOrBlank<NumberValue>,
+                        StringOrOptionSetBackedByString),
+                    checkRuntimeValues: DeferRuntimeValueChecking,
+                    returnBehavior: ReturnBehavior.ReturnBlankIfAnyArgIsBlank,
+                    targetFunction: Workday)
+            },
+            {
                 BuiltinFunctionsCore.DateDiff,
                 StandardErrorHandling<FormulaValue>(
                     BuiltinFunctionsCore.DateDiff.Name,

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
@@ -176,6 +176,78 @@ namespace Microsoft.PowerFx.Functions
             }
         }
 
+        public static FormulaValue Workday(EvalVisitor runner, EvalVisitorContext context, IRContext irContext, FormulaValue[] args)
+        {
+            var timeZoneInfo = runner.TimeZoneInfo;
+
+            DateTime dateTime = runner.GetNormalizedDateTimeAllowTimeValue(args[0]);
+
+            int delta;
+            string timeUnit;
+
+            if (args[1] is NumberValue number)
+            {
+                delta = (int)number.Value;
+                timeUnit = "days";
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+
+            var useUtcConversion = NeedToConvertToUtc(runner, dateTime, timeUnit);
+
+            if (useUtcConversion)
+            {
+                dateTime = TimeZoneInfo.ConvertTimeToUtc(dateTime, timeZoneInfo);
+            }
+
+            try
+            {
+                // Determine the increment direction (forward or backward)
+                int increment = delta > 0 ? 1 : -1;
+
+                // Add days until the required number of workdays is reached
+                while (delta != 0)
+                {
+                    dateTime = dateTime.AddDays(increment);
+
+                    // If the current date is a weekend, continue without decreasing days
+                    if (dateTime.DayOfWeek == DayOfWeek.Saturday || dateTime.DayOfWeek == DayOfWeek.Sunday)
+                    {
+                        continue;
+                    }
+
+                    // If it's a valid workday, decrement the days
+                    delta -= increment;
+                }
+
+                if (useUtcConversion)
+                {
+                    dateTime = TimeZoneInfo.ConvertTimeFromUtc(dateTime, timeZoneInfo);
+                }
+
+                dateTime = MakeValidDateTime(runner, dateTime, timeZoneInfo);
+
+                if (irContext.ResultType._type.Kind == Core.Types.DKind.Date)
+                {
+                    return new DateValue(irContext, dateTime);
+                }
+                else if (irContext.ResultType._type.Kind == Core.Types.DKind.Time)
+                {
+                    return new TimeValue(irContext, dateTime.Subtract(_epoch));
+                }
+                else
+                {
+                    return new DateTimeValue(irContext, dateTime);
+                }
+            }
+            catch
+            {
+                return CommonErrors.ArgumentOutOfRange(irContext);
+            }
+        }
+
         private static DateTime MakeValidDateTime(EvalVisitor runner, DateTime dateTime, TimeZoneInfo timeZoneInfo)
         {
             return MakeValidDateTime(runner.TimeZoneInfo, dateTime);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TexlTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TexlTests.cs
@@ -93,6 +93,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("DateAdd(\"2000-01-01\", 1)", "d")] // Coercion on date argument from string
         [InlineData("DateAdd(45678, 1)", "d")] // Coercion on date argument from number
         [InlineData("DateAdd(Time(12,34,56), 1)", "T")] // Coercion on date argument from time
+        [InlineData("Workday(Date(2024,9,13), 9999)", "D")]
         public void TexlDateAdd(string script, string expectedType)
         {
             Assert.True(DType.TryParse(expectedType, out var type));


### PR DESCRIPTION
**WORKDAY** function which returns a number that represents a date that is the indicated number of working days before or after a date (the starting date).

**In Scope:** Working days exclude weekends.
**Out Of Scope:** Holidays will not be consider in this function.

**Affected Files:**
- src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
- src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
- src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/DateTime.cs
- src/libraries/Microsoft.PowerFx.Interpreter/Functions/Library.cs
- src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryDate.cs
- src/tests/Microsoft.PowerFx.Core.Tests.Shared/TexlTests.cs

