### PR TITLE
Add a warning to the CountRows function if a data source that caches its count is passed to it

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/ExternalCdpDataSource.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/ExternalCdpDataSource.cs
@@ -36,6 +36,8 @@ namespace Microsoft.PowerFx.Connectors
 
         public TabularDataQueryOptions QueryOptions => new TabularDataQueryOptions(this);
 
+        public bool HasCachedCountRows => false;
+
         public string Name => EntityName.Value;
 
         public bool IsSelectable => ServiceCapabilities.IsSelectable;

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalTabularDataSource.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/IExternalTabularDataSource.cs
@@ -11,6 +11,13 @@ namespace Microsoft.PowerFx.Core.Entities
     {
         TabularDataQueryOptions QueryOptions { get; }
 
+        /// <summary>
+        /// Some data sources (like Dataverse) may return a cached value for
+        /// the number of rows (calls to CountRows) instead of always retrieving
+        /// the latest count.
+        /// </summary>
+        bool HasCachedCountRows { get; }
+
         IReadOnlyList<string> GetKeyColumns();
 
         IEnumerable<string> GetKeyColumns(IExpandInfo expandInfo);

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -745,6 +745,8 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey WarnDeferredType = new ErrorResourceKey("WarnDeferredType");
         public static ErrorResourceKey ErrColRenamedTwice_Name = new ErrorResourceKey("ErrColRenamedTwice_Name");
 
+        public static ErrorResourceKey WrnCountRowsMayReturnCachedValue = new ErrorResourceKey("WrnCountRowsMayReturnCachedValue");
+
         public static StringGetter InfoMessage = (b) => StringResources.Get("InfoMessage", b);
         public static StringGetter InfoNode_Node = (b) => StringResources.Get("InfoNode_Node", b);
         public static StringGetter InfoTok_Tok = (b) => StringResources.Get("InfoTok_Tok", b);

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4332,6 +4332,10 @@
     <value>Can't delegate {0}: contains a behavior function '{1}'.</value>
     <comment>Warning message.</comment>
   </data>
+  <data name="WrnCountRowsMayReturnCachedValue" xml:space="preserve">
+    <value>CountRows may return a cached value. Use CountIf(DataSource, true) to get the latest count.</value>
+    <comment>{Locked=CountRows}. Warning message when an expression with the CountRows function is used with a data source that caches its size.</comment>
+  </data>
   <data name="AboutIsMatch" xml:space="preserve">
     <value>Determines if the supplied text has a match of the supplied text format.</value>
     <comment>Description of 'IsMatch' function.</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDVEntity.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDVEntity.cs
@@ -15,6 +15,13 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
 {
     public class AccountsEntity : IExternalEntity, IExternalDataSource
     {
+        private readonly bool _hasCachedCountRows;
+
+        public AccountsEntity(bool hasCachedCountRows = false)
+        {
+            this._hasCachedCountRows = hasCachedCountRows;
+        }
+
         public DName EntityName => new DName("Accounts");
 
         public string Name => "Accounts";
@@ -33,7 +40,7 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
 
         public bool IsClearable => true;
 
-        DType IExternalEntity.Type => AccountsTypeHelper.GetDType();
+        DType IExternalEntity.Type => AccountsTypeHelper.GetDType(this._hasCachedCountRows);
 
         IExternalDataEntityMetadataProvider IExternalDataSource.DataEntityMetadataProvider => throw new NotImplementedException();
 
@@ -54,14 +61,15 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
                                                          "name`Account Name`:s, numberofemployees:n, primarytwitterid:s, stockexchange:s, telephone1:s, telephone2:s, telephone3:s, tickersymbol:s, versionnumber:n, " +
                                                          "websiteurl:h, nonsearchablestringcol`Non-searchable string column`:s, nonsortablestringcolumn`Non-sortable string column`:s]";
 
-        public static DType GetDType()
+        public static DType GetDType(bool hasCachedCountRows = false)
         {
             DType accountsType = TestUtils.DT2(SimplifiedAccountsSchema);
             var dataSource = new TestDataSource(
                 "Accounts", 
                 accountsType, 
                 keyColumns: new[] { "accountid" },
-                selectableColumns: new[] { "name", "address1_city", "accountid", "address1_country", "address1_line1" });
+                selectableColumns: new[] { "name", "address1_city", "accountid", "address1_country", "address1_line1" },
+                hasCachedCountRows: hasCachedCountRows);
             var displayNameMapping = dataSource.DisplayNameMapping;            
             displayNameMapping.Add("name", "Account Name");
             displayNameMapping.Add("address1_city", "Address 1: City");

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/Helpers/TestTabularDataSource.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/Helpers/TestTabularDataSource.cs
@@ -175,8 +175,9 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
         private readonly string[] _keyColumns;
         private readonly HashSet<string> _selectableColumns;
         private readonly TabularDataQueryOptions _tabularDataQueryOptions;
+        private readonly bool _hasCachedCountRows;
 
-        internal TestDataSource(string name, DType schema, string[] keyColumns = null, IEnumerable<string> selectableColumns = null)
+        internal TestDataSource(string name, DType schema, string[] keyColumns = null, IEnumerable<string> selectableColumns = null, bool hasCachedCountRows = false)
         {
             ExternalDataEntityMetadataProvider = new ExternalDataEntityMetadataProvider();
             Type = DType.AttachDataSourceInfo(schema, this);
@@ -185,9 +186,12 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
             _keyColumns = keyColumns ?? Array.Empty<string>();
             _selectableColumns = new HashSet<string>(selectableColumns ?? Enumerable.Empty<string>());
             _tabularDataQueryOptions = new TabularDataQueryOptions(this);
+            _hasCachedCountRows = hasCachedCountRows;
         }
 
         public string Name { get; }
+
+        public bool HasCachedCountRows => this._hasCachedCountRows;
 
         public virtual bool IsSelectable => true;
 


### PR DESCRIPTION
Some data sources, like Dataverse, will cache its count and not return the accurate result if a CountRows call is made to it (see note at https://learn.microsoft.com/power-platform/power-fx/reference/function-table-counts#description). This adds a warning to the node if this happens, to make it more explicit to the makers that this is the case.