### PR TITLE
Fix CompletionItemKind for Types to display correct Intellisense Icon

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Completions/CompletionsLanguageServerOperationHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Handlers/Completions/CompletionsLanguageServerOperationHandler.cs
@@ -145,6 +145,8 @@ namespace Microsoft.PowerFx.LanguageServerProtocol.Handlers
                     return CompletionItemKind.Module;
                 case SuggestionKind.ScopeVariable:
                     return CompletionItemKind.Variable;
+                case SuggestionKind.Type:
+                    return CompletionItemKind.TypeParameter;
                 default:
                     return CompletionItemKind.Text;
             }


### PR DESCRIPTION
Fixes CompletionItemKind for SuggestioonKind.Types to display correct Intellisense Icon . 

![image](https://github.com/user-attachments/assets/59f5806c-0046-42ca-85e8-46c3995eb255)
