### PR TITLE
Make syntax localization util internal instead of private

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/ExpressionLocalizationHelper.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/ExpressionLocalizationHelper.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerFx.Core
             return ConvertExpression(expressionText, parameters, bindingConfig, resolver, binderGlue, new ParserOptions() { Culture = culture }, flags, toDisplay);
         }
 
-        private static IDictionary<Span, string> GetLocaleSpecificTokenConversions(string script, TexlLexer sourceLexer, TexlLexer targetLexer)
+        internal static IDictionary<Span, string> GetLocaleSpecificTokenConversions(string script, TexlLexer sourceLexer, TexlLexer targetLexer)
         {
             var worklist = new Dictionary<Span, string>();
 


### PR DESCRIPTION
Working on some cleanup of localization code, and this utility is duplicated in PA Client. 