### PR TITLE
Fix PlainText's handling of open tags

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -47,8 +47,8 @@ namespace Microsoft.PowerFx.Functions
         private static readonly Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegExFlags);
         private static readonly Regex _milisecondsDetokenizeRegex = new Regex("[\u000e]+", RegExFlags);
         private static readonly Regex _tdTagRegex = new Regex("<\\s*(td)[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
-        private static readonly Regex _lineBreakTagRegex = new Regex("<\\s*(br|li)[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
-        private static readonly Regex _doubleLineBreakTagRegex = new Regex("<\\s*(div|p|tr)[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
+        private static readonly Regex _lineBreakTagRegex = new Regex("<\\s*(br|li)\b[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
+        private static readonly Regex _doubleLineBreakTagRegex = new Regex("<\\s*(div|p|tr)\b[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
         private static readonly Regex _commentTagRegex = new Regex("<!--[\\s\\S]*?--\\s*>", RegExFlags_IgnoreCase);
         private static readonly Regex _headerTagRegex = new Regex("<\\s*(header)[\\s\\S]*?>[\\s\\S]*?<\\s*\\/\\s*(header)\\s*>", RegExFlags_IgnoreCase);
         private static readonly Regex _scriptTagRegex = new Regex("<\\s*(script)[\\s\\S]*?>[\\s\\S]*?<\\s*\\/\\s*(script)\\s*>", RegExFlags_IgnoreCase);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryText.cs
@@ -47,8 +47,8 @@ namespace Microsoft.PowerFx.Functions
         private static readonly Regex _secondsDetokenizeRegex = new Regex("[\u0008][\u0008]+", RegExFlags);
         private static readonly Regex _milisecondsDetokenizeRegex = new Regex("[\u000e]+", RegExFlags);
         private static readonly Regex _tdTagRegex = new Regex("<\\s*(td)[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
-        private static readonly Regex _lineBreakTagRegex = new Regex("<\\s*(br|li)\b[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
-        private static readonly Regex _doubleLineBreakTagRegex = new Regex("<\\s*(div|p|tr)\b[\\s\\S]*?\\/{0,1}>", RegExFlags_IgnoreCase);
+        private static readonly Regex _lineBreakTagRegex = new Regex("<\\s*(br|li)((\\s+[\\s\\S]*?)|(\\s*\\/\\s*))?>", RegExFlags_IgnoreCase);
+        private static readonly Regex _doubleLineBreakTagRegex = new Regex("<\\s*(div|p|tr)((\\s+[\\s\\S]*?)|(\\s*\\/\\s*))?>", RegExFlags_IgnoreCase);
         private static readonly Regex _commentTagRegex = new Regex("<!--[\\s\\S]*?--\\s*>", RegExFlags_IgnoreCase);
         private static readonly Regex _headerTagRegex = new Regex("<\\s*(header)[\\s\\S]*?>[\\s\\S]*?<\\s*\\/\\s*(header)\\s*>", RegExFlags_IgnoreCase);
         private static readonly Regex _scriptTagRegex = new Regex("<\\s*(script)[\\s\\S]*?>[\\s\\S]*?<\\s*\\/\\s*(script)\\s*>", RegExFlags_IgnoreCase);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/PlainText.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/PlainText.txt
@@ -105,5 +105,5 @@ Error({Kind:ErrorKind.Div0})
 >> PlainText("More character references: &#X1f970; - &#x1F948;")
 "More character references: 🥰 - 🥈"
 
->> PlainText("<para>Not a <br>line break.</para><para>Also not a line break.</para>")
+>> PlainText("<para>Not a <break>line break.</para><para>Also not a line break.</para>")
 "Not a line break.Also not a line break."

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/PlainText.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/PlainText.txt
@@ -1,4 +1,4 @@
->> PlainText("")
+﻿>> PlainText("")
 ""
 
 >> PlainText("<>")
@@ -98,3 +98,12 @@ Error({Kind:ErrorKind.Div0})
 
 >> PlainText("Hello&lt;br/&gt;world")
 "Hello<br/>world"
+
+>> PlainText("Many character entities: &lt;&gt;&amp;&quot;&apos;&cent;&pound;&yen;&euro;&copy;&reg;&aacute;&egrave;&otilde;&ccedil;&ucirc;&alpha;&beta;&gamma;&delta;&Delta;")
+"Many character entities: <>&""'¢£¥€©®áèõçûαβγδΔ"
+
+>> PlainText("More character references: &#X1f970; - &#x1F948;")
+"More character references: 🥰 - 🥈"
+
+>> PlainText("<para>Not a <br>line break.</para><para>Also not a line break.</para>")
+"Not a line break.Also not a line break."


### PR DESCRIPTION
Fixes #2679 . Currently the PlainText doesn't handle some open tags correctly - the function is supposed to convert things like &lt;br/&gt; to a new line or &lt;p&gt; to two new lines, but it is matching tags such as &lt;bra&gt; and &lt;para&gt; which should not be matched.