### PR TITLE
Change Lookup order in BinderUtils.TryGetConstantValue to check entitystore first

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BinderUtils.cs
@@ -1564,17 +1564,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     var dottedNameNode = node.AsDottedName();
                     if (dottedNameNode.Left.Kind == NodeKind.FirstName)
                     {
-                        // Strongly-typed enums
-                        if (context.NameResolver.Lookup(dottedNameNode.Left.AsFirstName().Ident.Name, out NameLookupInfo nameInfo) && nameInfo.Kind == BindKind.Enum)
-                        {
-                            if (nameInfo.Data is EnumSymbol enumSymbol && enumSymbol.TryGetValue(dottedNameNode.Right.Name, out OptionSetValue osv))
-                            {
-                                nodeValue = osv.ToObject().ToString();
-                                return true;
-                            }
-                        }
-
-                        // With strongly-typed enums disabled
+                        // If the entity scope exists, look up from there.
+                        // Once PA Client impls Strongly Typed enums, this may need to update.
                         DType enumType = DType.Invalid;
                         if (context.NameResolver.EntityScope?.TryGetNamedEnum(dottedNameNode.Left.AsFirstName().Ident.Name, out enumType) ?? false)
                         {
@@ -1585,6 +1576,16 @@ namespace Microsoft.PowerFx.Core.Binding
                                     nodeValue = strValue;
                                     return true;
                                 }
+                            }
+                        }
+
+                        // Strongly-typed enums
+                        if (context.NameResolver.Lookup(dottedNameNode.Left.AsFirstName().Ident.Name, out NameLookupInfo nameInfo, NameLookupPreferences.GlobalsOnly) && nameInfo.Kind == BindKind.Enum)
+                        {
+                            if (nameInfo.Data is EnumSymbol enumSymbol && enumSymbol.TryGetValue(dottedNameNode.Right.Name, out OptionSetValue osv))
+                            {
+                                nodeValue = osv.ToObject().ToString();
+                                return true;
                             }
                         }
                     }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Json.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Json.cs
@@ -82,13 +82,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 {
                     return false;
                 }
-
-                TexlNode optionsNode = args[1];
-                if (!IsConstant(context, argTypes, optionsNode, out string nodeValue))
-                {
-                    errors.EnsureError(optionsNode, TexlStrings.ErrFunctionArg2ParamMustBeConstant, "JSON", TexlStrings.JSONArg2.Invoke());
-                    return false;
-                }
             }
 
             return true;
@@ -123,6 +116,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 TexlNode optionsNode = args[1];
                 if (!IsConstant(binding.CheckTypesContext, argTypes, optionsNode, out string nodeValue))
                 {
+                    errors.EnsureError(optionsNode, TexlStrings.ErrFunctionArg2ParamMustBeConstant, "JSON", TexlStrings.JSONArg2.Invoke());
                     return;
                 }
 


### PR DESCRIPTION
NameResolver.Lookup is a weirdly expensive operation when done from the middle of a running analysis pass. 
A few functions call TryGetConstantValue from CheckTypes, which is called during analysis to get functions result types.
In JSON it was possible to move that to CheckSemantics, but in Match, we want to avoid the expensive call to Lookup if we can, so we first look in the EntityStore to resolve enums. 

This doesn't meaningfully change the scenario for non PA hosts, as the entity store is a PA-only concept. 