### PR TITLE
Added a new property on IExternalRule interface.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
@@ -19,5 +19,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
         TexlBinding Binding { get; }
 
         bool HasErrorsOrWarnings { get; }
+
+        bool HasValidBinding { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         bool HasErrorsOrWarnings { get; }
 
+        // Returns true when Binding is non-null, otherwise false.
         bool HasValidBinding { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     return Enumerable.Empty<string>();
                 }
 
-                var ruleQueryOptions = Rule.Binding?.QueryOptions.GetQueryOptions(ds);
+                var ruleQueryOptions = Rule.HasValidBinding ? Rule.Binding.QueryOptions.GetQueryOptions(ds) : null;
                 if (ruleQueryOptions != null)
                 {
                     foreach (var nodeQO in Rule.TexlNodeQueryOptions)
@@ -3618,7 +3618,10 @@ namespace Microsoft.PowerFx.Core.Binding
                     // If the reference is to Control.Property and the rule for that Property is a constant,
                     // we need to mark the node as constant, and save the control info so we may look up the
                     // rule later.
-                    if (controlInfo?.GetRule(property.InvariantName) is IExternalRule rule && rule.Binding != null && !rule.HasErrorsOrWarnings && rule.Binding.IsConstant(rule.Binding.Top))
+                    if (controlInfo?.GetRule(property.InvariantName) is IExternalRule rule &&
+                        rule.HasValidBinding &&
+                        !rule.HasErrorsOrWarnings &&
+                        rule.Binding.IsConstant(rule.Binding.Top))
                     {
                         value = controlInfo;
                         isConstant = true;


### PR DESCRIPTION
As PA is moving away from rules with null binding, this PR introduces a new property called HasValidBinding which needs to be used to check the binding validity in future rather than Binding property itself. Eventually we should remove the Binding property from rule to abstract that. This change is first step towards that direction.