### PR TITLE
Fix formatting and structural printing for type literals

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Logging/StructuralPrint.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Logging/StructuralPrint.cs
@@ -339,6 +339,22 @@ namespace Microsoft.PowerFx.Core.Logging
             return ApplyPrecedence(parentPrecedence, Precedence.Primary, result);
         }
 
+        public override LazyList<string> Visit(TypeLiteralNode node, Precedence context)
+        {
+            Contracts.AssertValue(node);
+
+            var result = LazyList<string>.Empty;
+
+            result = result
+                .With(
+                    LanguageConstants.TypeLiteralInvariantName,
+                    TexlLexer.PunctuatorParenOpen)
+                .With(node.TypeRoot.Accept(this, Precedence.None))
+                .With(TexlLexer.PunctuatorParenClose);
+
+            return result;
+        }
+
         public override LazyList<string> Visit(ListNode node, Precedence parentPrecedence)
         {
             Contracts.AssertValue(node);

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TypeLiteralNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TypeLiteralNode.cs
@@ -35,7 +35,13 @@ namespace Microsoft.PowerFx.Syntax
 
         internal override TexlNode Clone(ref int idNext, Span ts)
         {
-            return new TypeLiteralNode(ref idNext, Token.Clone(ts).As<Token>(), TypeRoot, this.SourceList.Clone(ts, new Dictionary<TexlNode, TexlNode>()));
+            var typeRoot = TypeRoot.Clone(ref idNext, ts);
+            var newNodes = new Dictionary<TexlNode, TexlNode>
+            {
+                { TypeRoot, typeRoot }
+            };
+
+            return new TypeLiteralNode(ref idNext, Token.Clone(ts).As<Token>(), TypeRoot, this.SourceList.Clone(ts, newNodes));
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/TexlPretty.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/TexlPretty.cs
@@ -526,7 +526,7 @@ namespace Microsoft.PowerFx.Syntax
                     case UserDefinitionType.NamedFormula:
                         var nf = result.NamedFormulas.First(nf => nf.Ident == name);
 
-                        definitions.Add(declaration + " = " + string.Concat(visitor.CommentsOf(before).With(nf.Formula.ParseTree.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after)))));
+                        definitions.Add(declaration + $" {TexlLexer.PunctuatorEqual} " + string.Concat(visitor.CommentsOf(before).With(nf.Formula.ParseTree.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after)))));
                         break;
                     case UserDefinitionType.UDF:
                         var udf = result.UDFs.First(udf => udf.Ident == name);
@@ -535,12 +535,12 @@ namespace Microsoft.PowerFx.Syntax
                             $"\n{{\n\t{string.Concat(visitor.CommentsOf(before).With(udf.Body.Accept(visitor, new Context(1)).With(visitor.CommentsOf(after)))).Trim()}\n}}" :
                             string.Concat(visitor.CommentsOf(before).With(udf.Body.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after))));
 
-                        definitions.Add(declaration + " = " + udfBody);
+                        definitions.Add(declaration + $" {TexlLexer.PunctuatorEqual} " + udfBody);
                         break;
                     case UserDefinitionType.DefinedType:
                         var type = result.DefinedTypes.First(type => type.Ident == name);
 
-                        definitions.Add(declaration + $" = {LanguageConstants.TypeLiteralInvariantName}(" + string.Concat(visitor.CommentsOf(before).With(type.Type.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after)))) + ")");
+                        definitions.Add(declaration + $" {TexlLexer.PunctuatorColonEqual} " + string.Concat(visitor.CommentsOf(before).With(type.Type.Accept(visitor, new Context(0))).With(visitor.CommentsOf(after))));
                         break;
                     default:
                         continue;
@@ -991,6 +991,13 @@ namespace Microsoft.PowerFx.Syntax
         }
 
         public override LazyList<string> Visit(AsNode node, Context context)
+        {
+            Contracts.AssertValue(node);
+
+            return Basic(node, context);
+        }
+
+        public override LazyList<string> Visit(TypeLiteralNode node, Context context)
         {
             Contracts.AssertValue(node);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/AggregateVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/AggregateVisitor.cs
@@ -64,6 +64,11 @@ namespace Microsoft.PowerFx.Syntax
             return node.Left.Accept(this, context);
         }
 
+        public override TResult Visit(TypeLiteralNode node, TContext context)
+        {
+            return node.TypeRoot.Accept(this, context);
+        }
+
         private IEnumerable<TResult> Lazily(params Func<TResult>[] actions)
         {
             foreach (var action in actions)

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlFunctionalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlFunctionalVisitor.cs
@@ -16,10 +16,7 @@ namespace Microsoft.PowerFx.Syntax
         /// <param name="node">The visited node.</param>
         /// <param name="context">The context passed to the node.</param>
         /// <returns>The node visit result.</returns>
-        public virtual TResult Visit(TypeLiteralNode node, TContext context)
-        {
-            throw new System.NotImplementedException();
-        }
+        public abstract TResult Visit(TypeLiteralNode node, TContext context);
 
         /// <summary>
         /// Visit <see cref="ErrorNode" /> leaf node.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
@@ -260,6 +260,8 @@ namespace Microsoft.PowerFx.Tests
         [InlineData("Set(str, $\"{{}}\")", "Set(\n    str,\n    $\"{{}}\"\n)")]
         [InlineData("Set(additionText, $\"The sum of 1 and 3 is {{{1 + 3}}})\")", "Set(\n    additionText,\n    $\"The sum of 1 and 3 is {{{1 + 3}}})\"\n)")]
         [InlineData("$\"This is {{\"Another\"}} interpolated {{string}}\"", "$\"This is {{\"Another\"}} interpolated {{string}}\"")]
+        [InlineData("ParseJSON(\"[]\", Type([{Age: Number}]))", "ParseJSON(\n    \"[]\",\n    Type([{Age: Number}])\n)")]
+        [InlineData("Type([{Age: Number, Name: Text}])", "Type(\n    [\n        {\n            Age: Number,\n            Name: Text\n        }\n    ]\n)")]
         public void TestPrettyPrint(string script, string expected)
         {
             // Act & Assert

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -496,6 +496,16 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Theory]
+        [InlineData("Type(Decimal)", "Type(Decimal)")]
+        [InlineData("Type([Number])", "Type([ Number ])")]
+        [InlineData("Type([{Age: Number}])", "Type([ { Age: Number } ])")]
+        [InlineData("IsType(ParseJSON(\"42\",Type(Decimal))", "IsType(ParseJSON(\"42\",Type(Decimal))")]
+        public void TexlParseTypeLiteral(string script, string expected)
+        {
+            TestRoundtrip(script, expected, features: Features.PowerFxV1);
+        }
+
+        [Theory]
         [InlineData("DateValue(,", 2)]
         [InlineData("DateValue(,,", 3)]
         [InlineData("DateValue(,,,,,,,,,", 10)]
@@ -804,9 +814,9 @@ namespace Microsoft.PowerFx.Core.Tests
             TestRoundtrip(script, expected, flags: TexlParser.Flags.EnableExpressionChaining);
         }
 
-        internal void TestRoundtrip(string script, string expected = null, NodeKind expectedNodeKind = NodeKind.Error, Action<TexlNode> customTest = null, TexlParser.Flags flags = TexlParser.Flags.None)
+        internal void TestRoundtrip(string script, string expected = null, NodeKind expectedNodeKind = NodeKind.Error, Action<TexlNode> customTest = null, TexlParser.Flags flags = TexlParser.Flags.None, Features features = null)
         {
-            var result = TexlParser.ParseScript(script, flags: flags);
+            var result = TexlParser.ParseScript(script, flags: flags, features: features ?? Features.None);
             var node = result.Root;            
                         
             Assert.NotNull(node);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -498,8 +498,8 @@ namespace Microsoft.PowerFx.Core.Tests
         [Theory]
         [InlineData("Type(Decimal)", "Type(Decimal)")]
         [InlineData("Type([Number])", "Type([ Number ])")]
-        [InlineData("Type([{Age: Number}])", "Type([ { Age: Number } ])")]
-        [InlineData("IsType(ParseJSON(\"42\",Type(Decimal))", "IsType(ParseJSON(\"42\",Type(Decimal))")]
+        [InlineData("Type([{Age: Number}])", "Type([ { Age:Number } ])")]
+        [InlineData("IsType(ParseJSON(\"42\"),Type(Decimal))", "IsType(ParseJSON(\"42\"),Type(Decimal))")]
         public void TexlParseTypeLiteral(string script, string expected)
         {
             TestRoundtrip(script, expected, features: Features.PowerFxV1);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -499,7 +499,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Type(Decimal)", "Type(Decimal)")]
         [InlineData("Type([Number])", "Type([ Number ])")]
         [InlineData("Type([{Age: Number}])", "Type([ { Age:Number } ])")]
-        [InlineData("IsType(ParseJSON(\"42\"),Type(Decimal))", "IsType(ParseJSON(\"42\"),Type(Decimal))")]
+        [InlineData("IsType(ParseJSON(\"42\"),Type(Decimal))", "IsType(ParseJSON(\"42\"), Type(Decimal))")]
         public void TexlParseTypeLiteral(string script, string expected)
         {
             TestRoundtrip(script, expected, features: Features.PowerFxV1);


### PR DESCRIPTION
Formatting , structural printing and cloning were broken for type literals. This PR fixes these issues and adds tests to ensure the changes work as expected.

Formatting of user definitions is still not perfect and has a bug where it would fail if we had definitions of same kind with same name.  That is not in the scope of this PR and shall be fixed as a follow up