### PR TITLE
Fixes enum store when SymbolTable is replaced while setting up config.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -23,13 +23,31 @@ namespace Microsoft.PowerFx
         internal static readonly int DefaultMaxCallDepth = 20;
         internal static readonly int DefaultMaximumExpressionLength = 1000;
 
-        /// <summary>
-        /// Global symbols. Additional symbols beyond default function set and primitive types. 
-        /// </summary>
-        public SymbolTable SymbolTable { get; set; } = new SymbolTable
+        private SymbolTable _symbolTable = new SymbolTable
         {
             DebugName = "DefaultConfig"
         };
+
+        private static EnumStoreBuilder BuiltInEnumStoreBuilder => new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library);
+
+        /// <summary>
+        /// Global symbols. Additional symbols beyond default function set and primitive types. 
+        /// </summary>
+        /// 
+        public SymbolTable SymbolTable
+        {
+            get => _symbolTable;
+            set
+            {
+                if (value == null)
+                {
+                    value = new SymbolTable();
+                }
+
+                value.EnumStoreBuilder = BuiltInEnumStoreBuilder;
+                _symbolTable = value;
+            }
+        }
 
         internal readonly Dictionary<TexlFunction, IAsyncTexlFunction> AdditionalFunctions = new ();
 
@@ -74,7 +92,7 @@ namespace Microsoft.PowerFx
         /// </summary>        
         /// <param name="features">Features to use.</param>
         public PowerFxConfig(Features features)
-            : this(new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library), features)
+            : this(BuiltInEnumStoreBuilder, features)
         {
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -400,13 +400,21 @@ namespace Microsoft.PowerFx.Tests
         }
 
         [Fact]
-        public void BasicEval()
+        public void BuiltInEnumConfigCheck()
         {
-            var engine = new RecalcEngine();
-            engine.UpdateVariable("M", 10.0);
-            engine.UpdateVariable("M2", -4);
-            var result = engine.Eval("M + Abs(M2)");
-            Assert.Equal(14.0, ((NumberValue)result).Value);
+            var config = new PowerFxConfig()
+            {
+                SymbolTable = null
+            };
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            config.EnableRegExFunctions();
+#pragma warning restore CS0618 // Type or member is obsolete
+            var expression = "Match(\"test\", \"t\", MatchOptions.Contains)";
+
+            var engine = new RecalcEngine(config);
+            var check = engine.Check(expression);
+            Assert.True(check.IsSuccess);
         }
 
         [Fact]


### PR DESCRIPTION
This PR fixes the issue where inbuilt enums are no longer part of the config if the config's symbol table is replaced after initialization.

After initializing the config if SymbolTable was replaced, we were loosing the enums attached to the previous default symbol table. This PR will again attach the enums if SymbolTable is replaced.
