### PR TITLE
Remove ServiceCapabilities.FilterFunctions and TableDelegationInfo.FilterFunctions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ServiceCapabilities.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ServiceCapabilities.cs
@@ -54,13 +54,6 @@ namespace Microsoft.PowerFx.Connectors
         public readonly GroupRestriction GroupRestriction;
 
         [JsonInclude]
-        [JsonPropertyName(CapabilityConstants.FilterFunctions)]
-        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public readonly IEnumerable<string> FilterFunctions;
-
-        public IEnumerable<DelegationOperator> FilterFunctionsEnum => GetDelegationOperatorEnumList(FilterFunctions);
-
-        [JsonInclude]
         [JsonPropertyName(CapabilityConstants.FilterFunctionSupport)]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public readonly IEnumerable<string> FilterSupportedFunctions;
@@ -115,12 +108,11 @@ namespace Microsoft.PowerFx.Connectors
             Contracts.AssertValue(pagingCapabilities);
 
             SortRestriction = sortRestriction;
-            FilterRestriction = filterRestriction;
-            FilterFunctions = filterFunctions;
+            FilterRestriction = filterRestriction;            
             PagingCapabilities = pagingCapabilities;
             SelectionRestriction = selectionRestriction;
             GroupRestriction = groupRestriction;
-            IsDelegable = (SortRestriction != null) || (FilterRestriction != null) || (FilterFunctions != null);
+            IsDelegable = (SortRestriction != null) || (FilterRestriction != null) || (FilterSupportedFunctions != null);
             IsPagable = PagingCapabilities.IsOnlyServerPagable || IsDelegable;
             SupportsDataverseOffline = supportsDataverseOffline;
             FilterSupportedFunctions = filterSupportedFunctions;
@@ -190,8 +182,7 @@ namespace Microsoft.PowerFx.Connectors
                 SortRestriction = sortRestriction,
                 FilterRestriction = filterRestriction,
                 SelectionRestriction = selectionRestriction,
-                GroupRestriction = groupRestriction,
-                FilterFunctions = serviceCapabilities?.FilterFunctionsEnum,
+                GroupRestriction = groupRestriction,                
                 FilterSupportedFunctions = serviceCapabilities?.FilterSupportedFunctionsEnum,
                 PagingCapabilities = pagingCapabilities,
                 SupportsRecordPermission = serviceCapabilities?.SupportsRecordPermission ?? false,

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Connectors
 
         public override HttpClient HttpClient => _httpClient;
 
-        public override bool IsDelegable => (DelegationInfo?.SortRestriction != null) || (DelegationInfo?.FilterRestriction != null) || (DelegationInfo?.FilterFunctions != null);
+        public override bool IsDelegable => (DelegationInfo?.SortRestriction != null) || (DelegationInfo?.FilterRestriction != null) || (DelegationInfo?.FilterSupportedFunctions != null);
 
         internal TableDelegationInfo DelegationInfo => ((DataSourceInfo)TabularTableDescriptor.FormulaType._type.AssociatedDataSources.First()).DelegationInfo;
 

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
@@ -26,9 +26,6 @@ namespace Microsoft.PowerFx.Core.Entities
         public GroupRestrictions GroupRestriction { get; init; }
 
         // Filter functions supported by all columns of the table        
-        public IEnumerable<DelegationOperator> FilterFunctions { get; init; }
-
-        // Filter functions supported by the table
         public IEnumerable<DelegationOperator> FilterSupportedFunctions { get; init; }
 
         // Defines paging capabilities
@@ -59,7 +56,7 @@ namespace Microsoft.PowerFx.Core.Entities
         // Key = field logical name, Value = foreign table logical name
         internal Dictionary<string, string> ColumnsWithRelationships { get; init; }
 
-        public virtual bool IsDelegable => IsSortable || (FilterRestriction != null) || (FilterFunctions != null);
+        public virtual bool IsDelegable => IsSortable || (FilterRestriction != null) || (FilterSupportedFunctions != null);
 
         public TableDelegationInfo()
         {

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationMetadata/CdpFilterOpMetadata.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/Delegation/DelegationMetadata/CdpFilterOpMetadata.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata
         private readonly TableDelegationInfo _delegationInfo;
 
         public CdpFilterOpMetadata(AggregateType schema, TableDelegationInfo delegationInfo)
-           : base(schema._type, null, null, GetFilterFunctionsSupportedByAllColumns(delegationInfo), GetFilterFunctionSupportedByTable(delegationInfo))
+           : base(schema._type, null, null, GetFilterFunctionsSupportedByAllColumns(delegationInfo), null)
         {
             _delegationInfo = delegationInfo;
         }
@@ -21,9 +21,9 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata
         {
             DelegationCapability filterFunctionSupportedByAllColumns = DelegationCapability.None;
 
-            if (delegationInfo?.FilterFunctions != null)
+            if (delegationInfo?.FilterSupportedFunctions != null)
             {
-                foreach (DelegationOperator globalFilterFunctionEnum in delegationInfo.FilterFunctions)
+                foreach (DelegationOperator globalFilterFunctionEnum in delegationInfo.FilterSupportedFunctions)
                 {
                     string globalFilterFunction = globalFilterFunctionEnum.ToString().ToLowerInvariant();
 
@@ -35,29 +35,7 @@ namespace Microsoft.PowerFx.Core.Functions.Delegation.DelegationMetadata
             }
 
             return filterFunctionSupportedByAllColumns;
-        }
-
-        private static DelegationCapability? GetFilterFunctionSupportedByTable(TableDelegationInfo delegationInfo)
-        {
-            DelegationCapability? filterFunctionsSupportedByTable = null;
-
-            if (delegationInfo?.FilterSupportedFunctions != null)
-            {
-                filterFunctionsSupportedByTable = DelegationCapability.None;
-
-                foreach (DelegationOperator globalSupportedFilterFunctionEnum in delegationInfo.FilterSupportedFunctions)
-                {
-                    string globalSupportedFilterFunction = globalSupportedFilterFunctionEnum.ToString().ToLowerInvariant();
-
-                    if (DelegationCapability.OperatorToDelegationCapabilityMap.TryGetValue(globalSupportedFilterFunction, out DelegationCapability globalSupportedFilterFunctionCapability))
-                    {
-                        filterFunctionsSupportedByTable |= globalSupportedFilterFunctionCapability | DelegationCapability.Filter;
-                    }
-                }
-            }
-
-            return filterFunctionsSupportedByTable;
-        }
+        }       
 
         public override bool TryGetColumnCapabilities(DPath columnPath, out DelegationCapability capabilities)
         {


### PR DESCRIPTION
Those are apparently useless and were creating confusion
FilterFunctions stays at column level