### PR TITLE
Added new method on IExternalRule to help with invariantexpression ch…

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerFx.Core.App.Controls
         // Returns true when Binding is non-null, otherwise false.
         bool HasValidBinding { get; }
 
-        // Returns true when rule is constant.Adds valid null binding when addValidBindingIfNotPresent is true.
-        bool IsInvariantExpression(bool addValidBindingIfNotPresent);
+        // Returns true when rule is constant.
+        bool IsInvariantExpression { get; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/App/Controls/IExternalRule.cs
@@ -22,5 +22,8 @@ namespace Microsoft.PowerFx.Core.App.Controls
 
         // Returns true when Binding is non-null, otherwise false.
         bool HasValidBinding { get; }
+
+        // Returns true when rule is constant.Adds valid null binding when addValidBindingIfNotPresent is true.
+        bool IsInvariantExpression(bool addValidBindingIfNotPresent);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3619,9 +3619,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // we need to mark the node as constant, and save the control info so we may look up the
                     // rule later.
                     if (controlInfo?.GetRule(property.InvariantName) is IExternalRule rule &&
-                        rule.HasValidBinding &&
-                        !rule.HasErrorsOrWarnings &&
-                        rule.Binding.IsConstant(rule.Binding.Top))
+                        rule.IsInvariantExpression(addValidBindingIfNotPresent: true))
                     {
                         value = controlInfo;
                         isConstant = true;

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3619,7 +3619,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     // we need to mark the node as constant, and save the control info so we may look up the
                     // rule later.
                     if (controlInfo?.GetRule(property.InvariantName) is IExternalRule rule &&
-                        rule.IsInvariantExpression(addValidBindingIfNotPresent: true))
+                        rule.IsInvariantExpression)
                     {
                         value = controlInfo;
                         isConstant = true;


### PR DESCRIPTION
On an effort to remove null rule binding, we need the ability to have an option to apply null binding before doing the check if binding is null. This change adds a new method on IExternalRule to help with that.