### PR TITLE
Fixes enum store when SymbolTable is replaced while setting up config

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
@@ -287,20 +287,5 @@ namespace Microsoft.PowerFx
                 return default;
             }
         }
-
-        internal override bool TryGetVariable(DName name, out NameLookupInfo symbol, out DName displayName)
-        {
-            foreach (var symbolTable in _symbolTables)
-            {
-                if (symbolTable.TryGetVariable(name, out symbol, out displayName))
-                {
-                    return true;
-                }
-            }
-
-            symbol = default;
-            displayName = default;
-            return false;
-        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ComposedReadOnlySymbolTable.cs
@@ -287,5 +287,20 @@ namespace Microsoft.PowerFx
                 return default;
             }
         }
+
+        internal override bool TryGetVariable(DName name, out NameLookupInfo symbol, out DName displayName)
+        {
+            foreach (var symbolTable in _symbolTables)
+            {
+                if (symbolTable.TryGetVariable(name, out symbol, out displayName))
+                {
+                    return true;
+                }
+            }
+
+            symbol = default;
+            displayName = default;
+            return false;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -23,13 +23,31 @@ namespace Microsoft.PowerFx
         internal static readonly int DefaultMaxCallDepth = 20;
         internal static readonly int DefaultMaximumExpressionLength = 1000;
 
-        /// <summary>
-        /// Global symbols. Additional symbols beyond default function set and primitive types. 
-        /// </summary>
-        public SymbolTable SymbolTable { get; set; } = new SymbolTable
+        private SymbolTable _symbolTable = new SymbolTable
         {
             DebugName = "DefaultConfig"
         };
+
+        private static EnumStoreBuilder BuiltInEnumStoreBuilder => new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library);
+
+        /// <summary>
+        /// Global symbols. Additional symbols beyond default function set and primitive types. 
+        /// </summary>
+        /// 
+        public SymbolTable SymbolTable
+        {
+            get => _symbolTable;
+            set
+            {
+                if (value == null)
+                {
+                    value = new SymbolTable();
+                }
+
+                value.EnumStoreBuilder = BuiltInEnumStoreBuilder;
+                _symbolTable = value;
+            }
+        }
 
         internal readonly Dictionary<TexlFunction, IAsyncTexlFunction> AdditionalFunctions = new ();
 
@@ -74,7 +92,7 @@ namespace Microsoft.PowerFx
         /// </summary>        
         /// <param name="features">Features to use.</param>
         public PowerFxConfig(Features features)
-            : this(new EnumStoreBuilder().WithRequiredEnums(BuiltinFunctionsCore._library), features)
+            : this(BuiltInEnumStoreBuilder, features)
         {
         }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Xml.Linq;
-using Microsoft.CodeAnalysis;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.Errors;
@@ -51,7 +49,7 @@ namespace Microsoft.PowerFx
         public SymbolTable SymbolTable
         {
             get => _symbolTable;
-            set => _symbolTable = value ?? new SymbolTable();
+            set => _symbolTable = value;
         }
 
         internal readonly Dictionary<TexlFunction, IAsyncTexlFunction> AdditionalFunctions = new ();
@@ -184,6 +182,11 @@ namespace Microsoft.PowerFx
             InternalConfigSymbols.AddFunctions(functionSet);
         }
 
+        /// <summary>
+        /// Adds optionset to <see cref="SymbolTable"/>.
+        /// </summary>
+        /// <param name="optionSet"></param>
+        /// <param name="optionalDisplayName"></param>
         public void AddOptionSet(OptionSet optionSet, DName optionalDisplayName = default)
         {
             SymbolTable.AddOptionSet(optionSet, optionalDisplayName);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -354,6 +354,9 @@ namespace Microsoft.PowerFx
         // These do not compose - only bottom one wins. 
         // ComposedReadOnlySymbolTable will handle composition by looking up in each symbol table. 
         private protected EnumStoreBuilder _enumStoreBuilder;
+
+        internal EnumStoreBuilder EnumStoreBuilder => _enumStoreBuilder;
+
         private EnumSymbol[] _enumSymbolCache;
 
         private EnumSymbol[] GetEnumSymbolSnapshot

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/ReadOnlySymbolTable.cs
@@ -355,8 +355,6 @@ namespace Microsoft.PowerFx
         // ComposedReadOnlySymbolTable will handle composition by looking up in each symbol table. 
         private protected EnumStoreBuilder _enumStoreBuilder;
 
-        internal EnumStoreBuilder EnumStoreBuilder => _enumStoreBuilder;
-
         private EnumSymbol[] _enumSymbolCache;
 
         private EnumSymbol[] GetEnumSymbolSnapshot

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerFx
             // Compose all the symbol tables most likely to have functions into a single 
             // symbol table and then cache that. 
             // That will cache unifying into a single TexlFunctionSet - which is the most expensive part. 
-            var functionList = _functionListCache.GetComposedCached(SupportedFunctions, Config.SymbolTable);
+            var functionList = _functionListCache.GetComposedCached(SupportedFunctions, Config.ComposedConfigSymbols);
 
             var symbols = ReadOnlySymbolTable.Compose(EngineSymbols, functionList, PrimitiveTypes);
 
@@ -548,7 +548,7 @@ namespace Microsoft.PowerFx
 
         public DefinitionsCheckResult AddUserDefinedFunction(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, bool allowSideEffects = false)
         {
-            var engineTypesAndFunctions = ReadOnlySymbolTable.Compose(PrimitiveTypes, SupportedFunctions);
+            var engineTypesAndFunctions = ReadOnlySymbolTable.Compose(PrimitiveTypes, SupportedFunctions, Config.InternalConfigSymbols);
             return Config.SymbolTable.AddUserDefinedFunction(script, parseCulture, engineTypesAndFunctions, symbolTable, allowSideEffects);
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -70,12 +70,12 @@ namespace Microsoft.PowerFx
 
             foreach (KeyValuePair<TexlFunction, IAsyncTexlFunction> func in Library.RegexFunctions(regExTimeout, regexTypeCache))
             {
-                if (config.SymbolTable.Functions.AnyWithName(func.Key.Name))
+                if (config.ComposedConfigSymbols.Functions.AnyWithName(func.Key.Name))
                 {
                     throw new InvalidOperationException("Cannot add RegEx functions more than once.");
                 }
 
-                config.SymbolTable.AddFunction(func.Key);
+                config.InternalConfigSymbols.AddFunction(func.Key);
                 config.AdditionalFunctions.Add(func.Key, func.Value);
             }
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/RecalcEngine.cs
@@ -420,7 +420,7 @@ namespace Microsoft.PowerFx
             }
 
             // Compose will handle null symbols
-            var composedSymbols = SymbolTable.Compose(Config.SymbolTable, SupportedFunctions, PrimitiveTypes, _symbolTable);
+            var composedSymbols = SymbolTable.Compose(Config.ComposedConfigSymbols, SupportedFunctions, PrimitiveTypes, _symbolTable);
 
             if (parseResult.DefinedTypes.Any())
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/SymbolTableTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/SymbolTableTests.cs
@@ -487,12 +487,12 @@ namespace Microsoft.PowerFx.Core.Tests
 
             PowerFxConfig config = new PowerFxConfig();
 
-            bool fOk = config.SymbolTable.TryGetSymbolType("os1", out var type);
+            bool fOk = config.ComposedConfigSymbols.TryGetSymbolType("os1", out var type);
             Assert.False(fOk);
 
             config.AddOptionSet(os);
 
-            fOk = config.SymbolTable.TryGetSymbolType("os1", out type);
+            fOk = config.ComposedConfigSymbols.TryGetSymbolType("os1", out type);
             Assert.True(fOk);
 
             AssertOptionSetType(type, os);

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -400,13 +400,21 @@ namespace Microsoft.PowerFx.Tests
         }
 
         [Fact]
-        public void BasicEval()
+        public void BuiltInEnumConfigCheck()
         {
-            var engine = new RecalcEngine();
-            engine.UpdateVariable("M", 10.0);
-            engine.UpdateVariable("M2", -4);
-            var result = engine.Eval("M + Abs(M2)");
-            Assert.Equal(14.0, ((NumberValue)result).Value);
+            var config = new PowerFxConfig()
+            {
+                SymbolTable = null
+            };
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            config.EnableRegExFunctions();
+#pragma warning restore CS0618 // Type or member is obsolete
+            var expression = "Match(\"test\", \"t\", MatchOptions.Contains)";
+
+            var engine = new RecalcEngine(config);
+            var check = engine.Check(expression);
+            Assert.True(check.IsSuccess);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -400,6 +400,16 @@ namespace Microsoft.PowerFx.Tests
         }
 
         [Fact]
+        public void BasicEval()
+        {
+            var engine = new RecalcEngine();
+            engine.UpdateVariable("M", 10.0);
+            engine.UpdateVariable("M2", -4);
+            var result = engine.Eval("M + Abs(M2)");
+            Assert.Equal(14.0, ((NumberValue)result).Value);
+        }
+
+        [Fact]
         public void BuiltInEnumConfigCheck()
         {
             var config = new PowerFxConfig()


### PR DESCRIPTION
This PR fixes the issue where inbuilt enums are no longer part of the config if the config's symbol table is replaced after initialization.

After initializing the config if SymbolTable was replaced, we were loosing the enums attached to the previous default symbol table. This PR will adds a default symbol table(seprate from existing table) to handle that.