### PR TITLE
Make TypeLiteralNode visitor abstract in TexlVisitor

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/IdentityTexlVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/IdentityTexlVisitor.cs
@@ -54,6 +54,11 @@ namespace Microsoft.PowerFx.Syntax
         }
 
         /// <inheritdoc />
+        public override void Visit(TypeLiteralNode node)
+        {
+        }
+
+        /// <inheritdoc />
         public override void PostVisit(DottedNameNode node)
         {
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/TexlVisitor.cs
@@ -12,9 +12,7 @@ namespace Microsoft.PowerFx.Syntax
         /// Visit <see cref="TypeLiteralNode"/> leaf node.
         /// </summary>
         /// <param name="node">The visited node.</param>
-        public virtual void Visit(TypeLiteralNode node)
-        {
-        }
+        public abstract void Visit(TypeLiteralNode node);
 
         /// <summary>
         /// Visit <see cref="ErrorNode" /> leaf node.

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/ViewFilterDataSourceVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/ViewFilterDataSourceVisitor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerFx.Core.Texl
     /// This visitor is used to walkthrough the first node of a filter to get the datasource name and
     /// whether or not there is any other filter sub expression that uses a view.
     /// </summary>
-    internal sealed class ViewFilterDataSourceVisitor : TexlVisitor
+    internal sealed class ViewFilterDataSourceVisitor : IdentityTexlVisitor
     {
         private const string FilterFunctionName = "Filter";
         private readonly TexlBinding _txb;
@@ -51,74 +51,6 @@ namespace Microsoft.PowerFx.Core.Texl
                     }
                 }
             }
-        }
-
-        public override void PostVisit(DottedNameNode node)
-        {
-        }
-
-        public override void PostVisit(VariadicOpNode node)
-        {
-        }
-
-        public override void PostVisit(StrInterpNode node)
-        {
-        }
-
-        public override void PostVisit(RecordNode node)
-        {
-        }
-
-        public override void PostVisit(ListNode node)
-        {
-        }
-
-        public override void PostVisit(BinaryOpNode node)
-        {
-        }
-
-        public override void PostVisit(UnaryOpNode node)
-        {
-        }
-
-        public override void PostVisit(TableNode node)
-        {
-        }
-
-        public override void PostVisit(AsNode node)
-        {
-        }
-
-        public override void Visit(ParentNode node)
-        {
-        }
-
-        public override void Visit(NumLitNode node)
-        {
-        }
-
-        public override void Visit(DecLitNode node)
-        {
-        }
-
-        public override void Visit(StrLitNode node)
-        {
-        }
-
-        public override void Visit(BoolLitNode node)
-        {
-        }
-
-        public override void Visit(BlankNode node)
-        {
-        }
-
-        public override void Visit(ErrorNode node)
-        {
-        }
-
-        public override void Visit(SelfNode node)
-        {
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/ViewFinderVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/ViewFinderVisitor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerFx.Core.Texl
     /// <summary>
     /// This visitor is used to walkthrough the tree to check the existence of a view.
     /// </summary>
-    internal sealed class ViewFinderVisitor : TexlVisitor
+    internal sealed class ViewFinderVisitor : IdentityTexlVisitor
     {
         private readonly TexlBinding _txb;
 
@@ -41,74 +41,6 @@ namespace Microsoft.PowerFx.Core.Texl
             {
                 ContainsView = true;
             }
-        }
-
-        public override void PostVisit(CallNode node)
-        {
-        }
-
-        public override void PostVisit(VariadicOpNode node)
-        {
-        }
-
-        public override void PostVisit(StrInterpNode node)
-        {
-        }
-
-        public override void PostVisit(RecordNode node)
-        {
-        }
-
-        public override void PostVisit(ListNode node)
-        {
-        }
-
-        public override void PostVisit(BinaryOpNode node)
-        {
-        }
-
-        public override void PostVisit(UnaryOpNode node)
-        {
-        }
-
-        public override void PostVisit(TableNode node)
-        {
-        }
-
-        public override void PostVisit(AsNode node)
-        {
-        }
-
-        public override void Visit(ParentNode node)
-        {
-        }
-
-        public override void Visit(NumLitNode node)
-        {
-        }
-
-        public override void Visit(DecLitNode node)
-        {
-        }
-
-        public override void Visit(StrLitNode node)
-        {
-        }
-
-        public override void Visit(BoolLitNode node)
-        {
-        }
-
-        public override void Visit(BlankNode node)
-        {
-        }
-
-        public override void Visit(ErrorNode node)
-        {
-        }
-
-        public override void Visit(SelfNode node)
-        {
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/EngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/EngineTests.cs
@@ -138,6 +138,11 @@ namespace Microsoft.PowerFx.Core.Tests
             {
                 throw new NotImplementedException();
             }
+
+            public override void Visit(TypeLiteralNode node)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }


### PR DESCRIPTION
Making the `TypeLiteralNode` visitor abstract in the `TexlVisitor` to ensure we consider handling TypeLiteralNode in future TexlVisitor implementations. keeping it virtual sometimes made this go unnoticed.