### PR TITLE
Undo breaking change in Features

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -94,7 +94,12 @@ namespace Microsoft.PowerFx
 
         internal static readonly Features None = new Features();
 
-        public static readonly Features PowerFxV1 = new Features
+        /// <summary>
+        /// The default V1 Power Fx feature set. 
+        /// </summary>
+        public static Features PowerFxV1 => _powerFxV1;
+
+        private static readonly Features _powerFxV1 = new Features
         {
             TableSyntaxDoesntWrapRecords = true,
             ConsistentOneColumnTableResult = true,

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FeaturesTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FeaturesTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.PowerFx.Tests
+{
+    public class FeaturesTest
+    {
+        [Fact]
+        public void Singleton()
+        {
+            // Ensure that we have a singleton - this is for performance reasons.
+            Assert.True(object.ReferenceEquals(Features.PowerFxV1, Features.PowerFxV1));
+
+            // Equality checks
+            Assert.True(Features.PowerFxV1 == Features.PowerFxV1);
+            Assert.False(Features.PowerFxV1 != Features.PowerFxV1);
+
+            Assert.True(object.ReferenceEquals(Features.None, Features.None));
+        }
+
+        [Fact]
+        public void Flag()
+        {
+            // Ensure the V1 object is actually initialized. 
+            var v1 = Features.PowerFxV1;
+            Assert.True(v1.SupportColumnNamesAsIdentifiers);
+        }
+    }
+}


### PR DESCRIPTION
Followup to #2740
This changes Features.PowerFxV1 from property to field - which is binary breaking change. 
Undo the break  - but still keep as singleton. 

Add test. 

