### PR TITLE
Fix flaky tests - Features is now a singleton.

### DIFF
--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TestRunnerTests/InternalSetup.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TestRunnerTests/InternalSetup.cs
@@ -16,7 +16,15 @@ namespace Microsoft.PowerFx.Core.Tests
 
         internal TexlParser.Flags Flags { get; set; }
 
-        internal Features Features { get; set; }
+        private Features _features;
+
+        internal Features Features
+        {
+            get => _features;
+
+            // Clone since we'll use reflection to mutate it. 
+            init => _features = new Features(value);
+        }
 
         internal TimeZoneInfo TimeZoneInfo { get; set; }
 


### PR DESCRIPTION
Tests would use reflection to mutate the Features object. 

But #2740 made `Features` a singleton.  So the object was getting randomly mutated. We'd see this as dataverse tests failing. 

