### PR TITLE
Allow multiple relationships in ConnectorType

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -18,6 +18,8 @@ using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
 using static Microsoft.PowerFx.Connectors.Constants;
 
+#pragma warning disable SA1000 // The keyword 'new' should be followeed by a space
+
 namespace Microsoft.PowerFx.Connectors
 {
     // See definitions for x-ms extensions:
@@ -325,7 +327,7 @@ namespace Microsoft.PowerFx.Connectors
             }
             else if (openApiAny is IDictionary<string, IOpenApiAny> o)
             {
-                Dictionary<string, FormulaValue> dvParams = new ();
+                Dictionary<string, FormulaValue> dvParams = new();
 
                 foreach (KeyValuePair<string, IOpenApiAny> kvp in o)
                 {
@@ -675,17 +677,14 @@ namespace Microsoft.PowerFx.Connectors
                                 // Here, we have a circular reference and default to a string
                                 return new ConnectorType(schema, openApiParameter, FormulaType.String, hiddenfields.ToRecordType());
                             }
-                            
+
                             ConnectorType propertyType = new SwaggerParameter(propLogicalName, schema.Required.Contains(propLogicalName), kv.Value, kv.Value.Extensions).GetConnectorType(settings.Stack(schemaIdentifier));
 
-                            if (settings.SqlRelationships != null)
-                            {
-                                IEnumerable<SqlRelationship> relationships = settings.SqlRelationships.Where(sr => sr.ColumnName == propLogicalName);
+                            IEnumerable<SqlRelationship> relationships = settings.SqlRelationships?.Where(sr => sr.ColumnName == propLogicalName);
 
-                                if (relationships.Any())
-                                {
-                                    propertyType.SetRelationships(relationships);
-                                }
+                            if (relationships?.Any() == true)
+                            {
+                                propertyType.SetRelationships(relationships);
                             }
 
                             settings.UnStack();
@@ -817,7 +816,7 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         public static FormulaType GetReturnType(this OpenApiOperation openApiOperation, ConnectorCompatibility compatibility)
-        {            
+        {
             ConnectorType connectorType = openApiOperation.GetConnectorReturnType(compatibility);
             FormulaType ft = connectorType.HasErrors ? ConnectorType.DefaultType : connectorType?.FormulaType ?? new BlankType();
             return ft;
@@ -889,7 +888,7 @@ namespace Microsoft.PowerFx.Connectors
         /// <exception cref="NotImplementedException">When we cannot determine the content type to use.</exception>
         public static (string ContentType, OpenApiMediaType MediaType) GetContentTypeAndSchema(this IDictionary<string, OpenApiMediaType> content)
         {
-            Dictionary<string, OpenApiMediaType> list = new ();
+            Dictionary<string, OpenApiMediaType> list = new();
 
             foreach (var ct in _knownContentTypes)
             {
@@ -1044,7 +1043,7 @@ namespace Microsoft.PowerFx.Connectors
             {
                 // Parameters is required in the spec but there are examples where it's not specified and we'll support this condition with an empty list
                 IDictionary<string, IOpenApiAny> op_prms = apiObj.TryGetValue("parameters", out IOpenApiAny openApiAny) && openApiAny is IDictionary<string, IOpenApiAny> apiString ? apiString : null;
-                ConnectorDynamicValue cdv = new (op_prms);
+                ConnectorDynamicValue cdv = new(op_prms);
 
                 // Mandatory operationId for connectors, except when capibility or builtInOperation are defined
                 apiObj.WhenPresent("operationId", (opId) => cdv.OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId));
@@ -1073,7 +1072,7 @@ namespace Microsoft.PowerFx.Connectors
                 {
                     // Parameters is required in the spec but there are examples where it's not specified and we'll support this condition with an empty list
                     IDictionary<string, IOpenApiAny> op_prms = apiObj.TryGetValue("parameters", out IOpenApiAny openApiAny) && openApiAny is IDictionary<string, IOpenApiAny> apiString ? apiString : null;
-                    ConnectorDynamicList cdl = new (op_prms)
+                    ConnectorDynamicList cdl = new(op_prms)
                     {
                         OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
                     };
@@ -1106,7 +1105,7 @@ namespace Microsoft.PowerFx.Connectors
 
         internal static Dictionary<string, IConnectorExtensionValue> GetParameterMap(this IDictionary<string, IOpenApiAny> opPrms, SupportsConnectorErrors errors, bool forceString = false)
         {
-            Dictionary<string, IConnectorExtensionValue> dvParams = new ();
+            Dictionary<string, IConnectorExtensionValue> dvParams = new();
 
             if (opPrms == null)
             {
@@ -1203,7 +1202,7 @@ namespace Microsoft.PowerFx.Connectors
                     // Parameters is required in the spec but there are examples where it's not specified and we'll support this condition with an empty list
                     IDictionary<string, IOpenApiAny> op_prms = apiObj.TryGetValue("parameters", out IOpenApiAny openApiAny) && openApiAny is IDictionary<string, IOpenApiAny> apiString ? apiString : null;
 
-                    ConnectorDynamicSchema cds = new (op_prms)
+                    ConnectorDynamicSchema cds = new(op_prms)
                     {
                         OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
                     };
@@ -1235,7 +1234,7 @@ namespace Microsoft.PowerFx.Connectors
                     // Parameters is required in the spec but there are examples where it's not specified and we'll support this condition with an empty list
                     IDictionary<string, IOpenApiAny> op_prms = apiObj.TryGetValue("parameters", out IOpenApiAny openApiAny) && openApiAny is IDictionary<string, IOpenApiAny> apiString ? apiString : null;
 
-                    ConnectorDynamicProperty cdp = new (op_prms)
+                    ConnectorDynamicProperty cdp = new(op_prms)
                     {
                         OperationId = OpenApiHelperFunctions.NormalizeOperationId(opId.Value),
                     };

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -675,17 +675,16 @@ namespace Microsoft.PowerFx.Connectors
                                 // Here, we have a circular reference and default to a string
                                 return new ConnectorType(schema, openApiParameter, FormulaType.String, hiddenfields.ToRecordType());
                             }
-
-                            //ConnectorType propertyType = new OpenApiParameter() { Name = propLogicalName, Required = schema.Required.Contains(propLogicalName), Schema = kv.Value, Extensions = kv.Value.Extensions }.GetConnectorType(settings.Stack(schemaIdentifier));
+                            
                             ConnectorType propertyType = new SwaggerParameter(propLogicalName, schema.Required.Contains(propLogicalName), kv.Value, kv.Value.Extensions).GetConnectorType(settings.Stack(schemaIdentifier));
 
                             if (settings.SqlRelationships != null)
                             {
-                                SqlRelationship relationship = settings.SqlRelationships.FirstOrDefault(sr => sr.ColumnName == propLogicalName);
+                                IEnumerable<SqlRelationship> relationships = settings.SqlRelationships.Where(sr => sr.ColumnName == propLogicalName);
 
-                                if (relationship != null)
+                                if (relationships.Any())
                                 {
-                                    propertyType.SetRelationship(relationship);
+                                    propertyType.SetRelationships(relationships);
                                 }
                             }
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpExtensions.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
     public static class CdpExtensions
     {
-        public static bool TryGetFieldExternalTableName(this RecordType recordType, string fieldName, out string tableName, out string foreignKey)
+        public static bool TryGetFieldRelationships(this RecordType recordType, string fieldName, out IEnumerable<ConnectorRelationship> relationships)
         {
-            if (recordType is not CdpRecordType cdpRecordType)
+            if (recordType is not CdpRecordType cdpRecordType || (!cdpRecordType.TryGetFieldRelationships(fieldName, out relationships) && relationships.Any()))
             {
-                tableName = null;
-                foreignKey = null;
+                relationships = null;
                 return false;
-            }
+            }           
 
-            return cdpRecordType.TryGetFieldExternalTableName(fieldName, out tableName, out foreignKey);
+            return true;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Types;
@@ -9,6 +10,7 @@ namespace Microsoft.PowerFx.Connectors
 {
     public static class CdpExtensions
     {
+        [Obsolete("This API is CDP-only and doens't work for 'shim'-based tabular connectors and is subject to removal/refactoring when we'll fix relationship management for tabular connectors.")]
         public static bool TryGetFieldRelationships(this RecordType recordType, string fieldName, out IEnumerable<ConnectorRelationship> relationships)
         {
             if (recordType is not CdpRecordType cdpRecordType || (!cdpRecordType.TryGetFieldRelationships(fieldName, out relationships) && relationships.Any()))

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpRecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpRecordType.cs
@@ -23,20 +23,17 @@ namespace Microsoft.PowerFx.Connectors
             TableResolver = tableResolver;
         }
 
-        public bool TryGetFieldExternalTableName(string fieldName, out string tableName, out string foreignKey)
+        public bool TryGetFieldRelationships(string fieldName, out IEnumerable<ConnectorRelationship> relationships)
         {
-            tableName = null;
-            foreignKey = null;
-
             ConnectorType connectorType = ConnectorType.Fields.First(ct => ct.Name == fieldName);
 
             if (connectorType == null || connectorType.ExternalTables?.Any() != true)
             {
+                relationships = null;
                 return false;
             }
 
-            // $$$ We should NOT call First() here but consider all possible foreign tables
-            (tableName, foreignKey) = connectorType.ExternalTables.First();
+            relationships = connectorType.ExternalTables;
             return true;
         }
 
@@ -61,7 +58,7 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             // $$$ We should NOT call First() here but consider all possible foreign tables
-            string tableName = field.ExternalTables.First().foreignTable;
+            string tableName = field.ExternalTables.First().ForeignTable;
 
             try
             {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpRecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpRecordType.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerFx.Connectors
             TableResolver = tableResolver;
         }
 
+        [Obsolete("We shouldn't be exposing relationships and will remove this class in next iterations.")]
         public bool TryGetFieldRelationships(string fieldName, out IEnumerable<ConnectorRelationship> relationships)
         {
             ConnectorType connectorType = ConnectorType.Fields.First(ct => ct.Name == fieldName);

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpRecordType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpRecordType.cs
@@ -35,8 +35,8 @@ namespace Microsoft.PowerFx.Connectors
                 return false;
             }
 
-            tableName = connectorType.ExternalTables.First();
-            foreignKey = connectorType.ForeignKey;
+            // $$$ We should NOT call First() here but consider all possible foreign tables
+            (tableName, foreignKey) = connectorType.ExternalTables.First();
             return true;
         }
 
@@ -60,7 +60,8 @@ namespace Microsoft.PowerFx.Connectors
                 return true;
             }
 
-            string tableName = field.ExternalTables.First();
+            // $$$ We should NOT call First() here but consider all possible foreign tables
+            string tableName = field.ExternalTables.First().foreignTable;
 
             try
             {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorRelationship.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorRelationship.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Microsoft.PowerFx.Core.Utils;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    public class ConnectorRelationship
+    {
+        public string ForeignTable { get; internal init; }
+
+        public string ForeignKey { get; internal init; }
+
+        public override int GetHashCode()
+        {
+            return Hashing.CombineHash(ForeignTable?.GetHashCode() ?? 0, ForeignKey?.GetHashCode() ?? 0);
+        }
+
+        public override string ToString() => $"{ForeignTable ?? "<null>"}:{ForeignKey ?? "<null>"}";       
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorRelationship.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorRelationship.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    [Obsolete("We shouldn't be exposing relationships and will remove this class in next iterations.")]
     public class ConnectorRelationship
     {
         public string ForeignTable { get; internal init; }
@@ -16,6 +18,6 @@ namespace Microsoft.PowerFx.Connectors
             return Hashing.CombineHash(ForeignTable?.GetHashCode() ?? 0, ForeignKey?.GetHashCode() ?? 0);
         }
 
-        public override string ToString() => $"{ForeignTable ?? "<null>"}:{ForeignKey ?? "<null>"}";       
+        public override string ToString() => $"{ForeignTable ?? "<null>"}:{ForeignKey ?? "<null>"}";
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
@@ -114,10 +114,12 @@ namespace Microsoft.PowerFx.Connectors
 
         internal ISwaggerSchema Schema { get; private set; } = null;
 
-        // Relationships to external tables
+        // Relationships to external tables        
+#pragma warning disable CS0618 // Type or member is obsolete
         internal IEnumerable<ConnectorRelationship> ExternalTables => _externalTables;
 
         private List<ConnectorRelationship> _externalTables;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         internal ConnectorType(ISwaggerSchema schema, ISwaggerParameter openApiParameter, FormulaType formulaType, ErrorResourceKey warning = default)
         {
@@ -150,11 +152,13 @@ namespace Microsoft.PowerFx.Connectors
                 // SalesForce only
                 if (schema.ReferenceTo != null && schema.ReferenceTo.Count == 1)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     _externalTables = schema.ReferenceTo.Select(r => new ConnectorRelationship()
                     {
                         ForeignTable = r,
                         ForeignKey = null // Seems to always be Id 
                     }).ToList();
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
 
                 Fields = Array.Empty<ConnectorType>();
@@ -296,6 +300,7 @@ namespace Microsoft.PowerFx.Connectors
 
         internal void SetRelationships(IEnumerable<SqlRelationship> relationships)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             _externalTables ??= new List<ConnectorRelationship>();
 
             foreach (SqlRelationship relationship in relationships)
@@ -306,6 +311,7 @@ namespace Microsoft.PowerFx.Connectors
                     ForeignKey = relationship.ReferencedColumnName
                 });
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private void AggregateErrors(ConnectorType[] types)
@@ -349,31 +355,69 @@ namespace Microsoft.PowerFx.Connectors
 
         public bool Equals(ConnectorType other)
         {
-            if (other == null)
+            return Equals(this, other, 0);                  
+        }
+
+        internal static bool Equals(ConnectorType left, ConnectorType right, int depth)
+        {
+            if (left == null && right == null)
+            {
+                return true;
+            }
+
+            if (left == null || right == null)
             {
                 return false;
             }
 
-            return this.Name == other.Name &&
-                   this.DisplayName == other.DisplayName &&
-                   this.Description == other.Description &&
-                   this.IsRequired == other.IsRequired &&
-                   Enumerable.SequenceEqual((IList<ConnectorType>)this.Fields ?? Array.Empty<ConnectorType>(), (IList<ConnectorType>)other.Fields ?? Array.Empty<ConnectorType>()) &&
-                   Enumerable.SequenceEqual((IList<ConnectorType>)this.HiddenFields ?? Array.Empty<ConnectorType>(), (IList<ConnectorType>)other.HiddenFields ?? Array.Empty<ConnectorType>()) &&
-                   this.ExplicitInput == other.ExplicitInput &&
-                   this.IsEnum == other.IsEnum &&
-                   Enumerable.SequenceEqual((IList<FormulaValue>)this.EnumValues ?? Array.Empty<FormulaValue>(), (IList<FormulaValue>)other.EnumValues ?? Array.Empty<FormulaValue>()) &&
-                   Enumerable.SequenceEqual((IList<string>)this.EnumDisplayNames ?? Array.Empty<string>(), (IList<string>)other.EnumDisplayNames ?? Array.Empty<string>()) &&
-                   this.Visibility == other.Visibility &&
-                   ((this.Capabilities == null && other.Capabilities == null) || this.Capabilities.Equals(other.Capabilities)) &&
-                   this.KeyType == other.KeyType &&
-                   this.KeyOrder == other.KeyOrder &&
-                   this.Permission == other.Permission &&
-                   this.NotificationUrl == other.NotificationUrl &&
-                   ((this.HiddenRecordType == null && other.HiddenRecordType == null) || this.HiddenRecordType.Equals(other.HiddenRecordType)) &&
-                   this.Binary == other.Binary &&
-                   this.MediaKind == other.MediaKind &&
-                   Enumerable.SequenceEqual((IList<string>)this.ExternalTables ?? Array.Empty<string>(), (IList<string>)other.ExternalTables ?? Array.Empty<string>());
+            return left.Name == right.Name &&
+                   left.DisplayName == right.DisplayName &&
+                   left.Description == right.Description &&
+                   left.IsRequired == right.IsRequired &&
+                   ArrayEquals(left.Fields, right.Fields, depth) &&
+                   ArrayEquals(left.HiddenFields, right.HiddenFields, depth) &&
+                   left.ExplicitInput == right.ExplicitInput &&
+                   left.IsEnum == right.IsEnum &&
+                   Enumerable.SequenceEqual((IList<FormulaValue>)left.EnumValues ?? Array.Empty<FormulaValue>(), (IList<FormulaValue>)right.EnumValues ?? Array.Empty<FormulaValue>()) &&
+                   Enumerable.SequenceEqual((IList<string>)left.EnumDisplayNames ?? Array.Empty<string>(), (IList<string>)right.EnumDisplayNames ?? Array.Empty<string>()) &&
+                   left.Visibility == right.Visibility &&
+                   ((left.Capabilities == null && right.Capabilities == null) || left.Capabilities.Equals(right.Capabilities)) &&
+                   left.KeyType == right.KeyType &&
+                   left.KeyOrder == right.KeyOrder &&
+                   left.Permission == right.Permission &&
+                   left.NotificationUrl == right.NotificationUrl &&
+                   ((left.HiddenRecordType == null && right.HiddenRecordType == null) || left.HiddenRecordType.Equals(right.HiddenRecordType)) &&
+                   left.Binary == right.Binary &&
+                   left.MediaKind == right.MediaKind &&
+                   Enumerable.SequenceEqual((IList<string>)left.ExternalTables ?? Array.Empty<string>(), (IList<string>)right.ExternalTables ?? Array.Empty<string>());
+        }
+
+        internal static bool ArrayEquals(ConnectorType[] leftArray, ConnectorType[] rightArray, int depth)
+        {
+            if (depth > 30)
+            {
+                return false;
+            }
+
+            if (leftArray == null && rightArray == null)
+            {
+                return true;
+            }
+
+            if (leftArray.Count() != rightArray.Count())
+            {
+                return false;
+            }
+            
+            for (int i = 0; i < leftArray.Count(); i++)
+            {                
+                if (!Equals(leftArray[i], rightArray[i], depth + 1))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public override bool Equals(object obj)
@@ -425,10 +469,12 @@ namespace Microsoft.PowerFx.Connectors
 
             if (ExternalTables != null)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 foreach (ConnectorRelationship relationship in ExternalTables)
                 {
                     h = Hashing.CombineHash(h, relationship.GetHashCode());                   
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             return h;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilities.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -12,7 +13,7 @@ using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Connectors
 {
-    internal sealed class ColumnCapabilities : ColumnCapabilitiesBase, IColumnsCapabilities
+    internal sealed class ColumnCapabilities : ColumnCapabilitiesBase, IColumnsCapabilities, IEquatable<ColumnCapabilities>
     {
         [JsonInclude]
         [JsonPropertyName(CapabilityConstants.ColumnProperties)]
@@ -71,6 +72,33 @@ namespace Microsoft.PowerFx.Connectors
                 QueryAlias = propertyAlias,
                 IsChoice = isChoice
             });
+        }
+
+        public bool Equals(ColumnCapabilities other)
+        {
+            return Enumerable.SequenceEqual((IEnumerable<KeyValuePair<string, ColumnCapabilitiesBase>>)this._childColumnsCapabilities ?? Array.Empty<KeyValuePair<string, ColumnCapabilitiesBase>>(), (IEnumerable<KeyValuePair<string, ColumnCapabilitiesBase>>)other._childColumnsCapabilities ?? Array.Empty<KeyValuePair<string, ColumnCapabilitiesBase>>()) &&
+                   this.Capabilities.Equals(other.Capabilities);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ColumnCapabilities);
+        }        
+
+        public override int GetHashCode()
+        {
+            int h = Capabilities.GetHashCode();
+
+            if (_childColumnsCapabilities != null)
+            {
+                foreach (KeyValuePair<string, ColumnCapabilitiesBase> kvp in _childColumnsCapabilities)
+                {
+                    h = Hashing.CombineHash(h, kvp.Key.GetHashCode());
+                    h = Hashing.CombineHash(h, kvp.Value.GetHashCode());                    
+                }
+            }
+
+            return h;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilitiesBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilitiesBase.cs
@@ -8,5 +8,6 @@ namespace Microsoft.PowerFx.Connectors
     [JsonConverter(typeof(AbstractTypeConverter<ColumnCapabilitiesBase>))]
     internal abstract class ColumnCapabilitiesBase
     {
+        public abstract override int GetHashCode();        
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilitiesDefinition.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilitiesDefinition.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Microsoft.PowerFx.Core.Utils;
 
@@ -10,7 +12,7 @@ using Microsoft.PowerFx.Core.Utils;
 
 namespace Microsoft.PowerFx.Connectors
 {
-    internal sealed class ColumnCapabilitiesDefinition
+    internal sealed class ColumnCapabilitiesDefinition : IEquatable<ColumnCapabilitiesDefinition>
     {
         [JsonInclude]
         [JsonPropertyName(CapabilityConstants.FilterFunctions)]
@@ -32,6 +34,33 @@ namespace Microsoft.PowerFx.Connectors
         {                   
             // ex: lt, le, eq, ne, gt, ge, and, or, not, contains, startswith, endswith, countdistinct, day, month, year, time
             FilterFunctions = filterFunction;           
+        }
+
+        public bool Equals(ColumnCapabilitiesDefinition other)
+        {
+            return Enumerable.SequenceEqual(this.FilterFunctions ?? Array.Empty<string>(), other.FilterFunctions ?? Array.Empty<string>()) &&
+                   this.QueryAlias == other.QueryAlias &&
+                   this.IsChoice == other.IsChoice;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ColumnCapabilitiesDefinition);
+        }
+
+        public override int GetHashCode()
+        {
+            int h = Hashing.CombineHash(QueryAlias.GetHashCode(), IsChoice?.GetHashCode() ?? 0);
+
+            if (FilterFunctions != null)
+            {
+                foreach (var filterFunction in FilterFunctions)
+                {
+                    h = Hashing.CombineHash(h, filterFunction.GetHashCode());
+                }
+            }
+
+            return h;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilitiesDefinition.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ColumnCapabilitiesDefinition.cs
@@ -38,6 +38,11 @@ namespace Microsoft.PowerFx.Connectors
 
         public bool Equals(ColumnCapabilitiesDefinition other)
         {
+            if (other == null)
+            {
+                return false;
+            }
+
             return Enumerable.SequenceEqual(this.FilterFunctions ?? Array.Empty<string>(), other.FilterFunctions ?? Array.Empty<string>()) &&
                    this.QueryAlias == other.QueryAlias &&
                    this.IsChoice == other.IsChoice;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ComplexColumnCapabilities.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ComplexColumnCapabilities.cs
@@ -25,5 +25,10 @@ namespace Microsoft.PowerFx.Connectors
 
             _childColumnsCapabilities.Add(name, capability);
         }
+
+        public override int GetHashCode()
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ServiceCapabilities.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ServiceCapabilities.cs
@@ -172,7 +172,8 @@ namespace Microsoft.PowerFx.Connectors
                     _ => throw new NotImplementedException()
                 });
 
-            Dictionary<string, string> columnWithRelationships = connectorType.Fields.Where(f => f.ExternalTables?.Any() == true).Select(f => (f.Name, f.ExternalTables.First())).ToDictionary(tpl => tpl.Name, tpl => tpl.Item2);
+            // $$$ We should not use ExternalTables.First() but consider all relationships here
+            Dictionary<string, string> columnWithRelationships = connectorType.Fields.Where(f => f.ExternalTables?.Any() == true).Select(f => (f.Name, f.ExternalTables.First().foreignTable)).ToDictionary(tpl => tpl.Name, tpl => tpl.foreignTable);
 
             return new CdpDelegationInfo()
             {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ServiceCapabilities.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Capabilities/ServiceCapabilities.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerFx.Connectors
                 });
 
             // $$$ We should not use ExternalTables.First() but consider all relationships here
-            Dictionary<string, string> columnWithRelationships = connectorType.Fields.Where(f => f.ExternalTables?.Any() == true).Select(f => (f.Name, f.ExternalTables.First().foreignTable)).ToDictionary(tpl => tpl.Name, tpl => tpl.foreignTable);
+            Dictionary<string, string> columnWithRelationships = connectorType.Fields.Where(f => f.ExternalTables?.Any() == true).Select(f => (f.Name, f.ExternalTables.First().ForeignTable)).ToDictionary(tpl => tpl.Name, tpl => tpl.ForeignTable);
 
             return new CdpDelegationInfo()
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/CompileTimeTypeWrapperRecordValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/CompileTimeTypeWrapperRecordValue.cs
@@ -44,10 +44,10 @@ namespace Microsoft.PowerFx.Types
         protected override bool TryGetField(FormulaType fieldType, string fieldName, out FormulaValue result)
         {
             if (Type.TryGetFieldType(fieldName, out var compileTimeType))
-            {
+            {                                
                 // Only return field which were specified via the expectedType (IE RecordType),
                 // because inner record value may have more fields than the expected type.
-                if (compileTimeType == fieldType && _fields.TryGetValue(fieldName, out result))
+                if (compileTimeType.Equals(fieldType) && _fields.TryGetValue(fieldName, out result))
                 {
                     return true;
                 }

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
@@ -643,22 +643,24 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.True(sfTable._tabularService.IsInitialized);
             Assert.True(sfTable.IsDelegable);
 
-            // Note relationships with external tables (logicalName`displayName[externalTable]:type)
-            //   CreatedById`'Created By ID'[User]:s
-            //   LastModifiedById`'Last Modified By ID'[User]:s
-            //   Modified By ID'[User]:s
-            //   MasterRecordId`'Master Record ID'[Account]:s
-            //   OwnerId`'Owner ID'[User]:s
-            //   ParentId`'Parent Account ID'[Account]:s
+            // Note relationships with external tables (logicalName`displayName[(externalTable, foreignKey)]:type)
+            // In this particular case, foreignKey is always null with SalesForce
+            //   CreatedById`'Created By ID'[(User, )]:s
+            //   LastModifiedById`'Last Modified By ID'[(User, )]:s
+            //   Modified By ID'[(User, )]:s
+            //   MasterRecordId`'Master Record ID'[(Account, )]:s
+            //   OwnerId`'Owner ID'[(User, )]:s
+            //   ParentId`'Parent Account ID'[(Account, )]:s
             // Note 2: ~ notation denotes a relationship. Ex: fieldname`displayname:~externaltable:type
             Assert.Equal<object>(
-                "r![AccountSource`'Account Source':l, BillingCity`'Billing City':s, BillingCountry`'Billing Country':s, BillingGeocodeAccuracy`'Billing Geocode Accuracy':l, BillingLatitude`'Billing Latitude':w, BillingLongitude`'Billing " +
-                "Longitude':w, BillingPostalCode`'Billing Zip/Postal Code':s, BillingState`'Billing State/Province':s, BillingStreet`'Billing Street':s, CreatedById`'Created By ID'[User]:~User:s, CreatedDate`'Created Date':d, " +
-                "Description`'Account Description':s, Id`'Account ID':s, Industry:l, IsDeleted`Deleted:b, Jigsaw`'Data.com Key':s, JigsawCompanyId`'Jigsaw Company ID':s, LastActivityDate`'Last Activity':D, LastModifiedById`'Last " +
-                "Modified By ID'[User]:~User:s, LastModifiedDate`'Last Modified Date':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, MasterRecordId`'Master Record ID'[Account]:~Account:s, " +
-                "Name`'Account Name':s, NumberOfEmployees`Employees:w, OwnerId`'Owner ID'[User]:~User:s, ParentId`'Parent Account ID'[Account]:~Account:s, Phone`'Account Phone':s, PhotoUrl`'Photo URL':s, ShippingCity`'Shipping " +
-                "City':s, ShippingCountry`'Shipping Country':s, ShippingGeocodeAccuracy`'Shipping Geocode Accuracy':l, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping " +
-                "Zip/Postal Code':s, ShippingState`'Shipping State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s]",
+                "r![AccountSource`'Account Source':l, BillingCity`'Billing City':s, BillingCountry`'Billing Country':s, BillingGeocodeAccuracy`'Billing Geocode Accuracy':l, BillingLatitude`'Billing " +
+                "Latitude':w, BillingLongitude`'Billing Longitude':w, BillingPostalCode`'Billing Zip/Postal Code':s, BillingState`'Billing State/Province':s, BillingStreet`'Billing Street':s, CreatedById`'Created " +
+                "By ID'[(User, )]:~User:s, CreatedDate`'Created Date':d, Description`'Account Description':s, Id`'Account ID':s, Industry:l, IsDeleted`Deleted:b, Jigsaw`'Data.com Key':s, JigsawCompanyId`'Jigsaw " +
+                "Company ID':s, LastActivityDate`'Last Activity':D, LastModifiedById`'Last Modified By ID'[(User, )]:~User:s, LastModifiedDate`'Last Modified Date':d, LastReferencedDate`'Last Referenced " +
+                "Date':d, LastViewedDate`'Last Viewed Date':d, MasterRecordId`'Master Record ID'[(Account, )]:~Account:s, Name`'Account Name':s, NumberOfEmployees`Employees:w, OwnerId`'Owner ID'[(User, " +
+                ")]:~User:s, ParentId`'Parent Account ID'[(Account, )]:~Account:s, Phone`'Account Phone':s, PhotoUrl`'Photo URL':s, ShippingCity`'Shipping City':s, ShippingCountry`'Shipping Country':s, " +
+                "ShippingGeocodeAccuracy`'Shipping Geocode Accuracy':l, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping Zip/Postal Code':s, " +
+                "ShippingState`'Shipping State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s]",
                 ((CdpRecordType)sfTable.RecordType).ToStringWithDisplayNames());
 
             Assert.Equal("Account", sfTable.RecordType.TableSymbolName);
@@ -705,7 +707,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
             bool b = sfTable.RecordType.TryGetFieldExternalTableName("OwnerId", out string externalTableName, out string foreignKey);
             Assert.True(b);
             Assert.Equal("User", externalTableName);
-            Assert.Null(foreignKey); // Always the case with SalesForce
+            Assert.Null(foreignKey); // Always the case with SalesForce          
 
             testConnector.SetResponseFromFile(@"Responses\SF GetSchema Users.json");
             b = sfTable.RecordType.TryGetFieldType("OwnerId", out FormulaType ownerIdType);
@@ -720,24 +722,24 @@ namespace Microsoft.PowerFx.Connectors.Tests
             Assert.Equal("User", userTable.TableSymbolName);
 
             Assert.Equal<object>(
-                "r![AboutMe`'About Me':s, AccountId`'Account ID'[Account]:~Account:s, Alias:s, BadgeText`'User Photo badge text overlay':s, BannerPhotoUrl`'Url for banner photo':s, CallCenterId`'Call " +
-                "Center ID':s, City:s, CommunityNickname`Nickname:s, CompanyName`'Company Name':s, ContactId`'Contact ID'[Contact]:~Contact:s, Country:s, CreatedById`'Created By ID'[User]:~User:s, CreatedDate`'Created " +
-                "Date':d, DefaultGroupNotificationFrequency`'Default Notification Frequency when Joining Groups':l, DelegatedApproverId`'Delegated Approver ID':s, Department:s, DigestFrequency`'Chatter " +
-                "Email Highlights Frequency':l, Division:s, Email:s, EmailEncodingKey`'Email Encoding':l, EmailPreferencesAutoBcc`AutoBcc:b, EmailPreferencesAutoBccStayInTouch`AutoBccStayInTouch:b, " +
-                "EmailPreferencesStayInTouchReminder`StayInTouchReminder:b, EmployeeNumber`'Employee Number':s, Extension:s, Fax:s, FederationIdentifier`'SAML Federation ID':s, FirstName`'First Name':s, " +
-                "ForecastEnabled`'Allow Forecasting':b, FullPhotoUrl`'Url for full-sized Photo':s, GeocodeAccuracy`'Geocode Accuracy':l, Id`'User ID':s, IsActive`Active:b, IsExtIndicatorVisible`'Show " +
-                "external indicator':b, IsProfilePhotoActive`'Has Profile Photo':b, LanguageLocaleKey`Language:l, LastLoginDate`'Last Login':d, LastModifiedById`'Last Modified By ID'[User]:~User:s, " +
+                "r![AboutMe`'About Me':s, AccountId`'Account ID'[(Account, )]:~Account:s, Alias:s, BadgeText`'User Photo badge text overlay':s, BannerPhotoUrl`'Url for banner photo':s, CallCenterId`'Call " +
+                "Center ID':s, City:s, CommunityNickname`Nickname:s, CompanyName`'Company Name':s, ContactId`'Contact ID'[(Contact, )]:~Contact:s, Country:s, CreatedById`'Created By ID'[(User, )]:~User:s, " +
+                "CreatedDate`'Created Date':d, DefaultGroupNotificationFrequency`'Default Notification Frequency when Joining Groups':l, DelegatedApproverId`'Delegated Approver ID':s, Department:s, " +
+                "DigestFrequency`'Chatter Email Highlights Frequency':l, Division:s, Email:s, EmailEncodingKey`'Email Encoding':l, EmailPreferencesAutoBcc`AutoBcc:b, EmailPreferencesAutoBccStayInTouch`AutoBccStayInTouc" +
+                "h:b, EmailPreferencesStayInTouchReminder`StayInTouchReminder:b, EmployeeNumber`'Employee Number':s, Extension:s, Fax:s, FederationIdentifier`'SAML Federation ID':s, FirstName`'First " +
+                "Name':s, ForecastEnabled`'Allow Forecasting':b, FullPhotoUrl`'Url for full-sized Photo':s, GeocodeAccuracy`'Geocode Accuracy':l, Id`'User ID':s, IsActive`Active:b, IsExtIndicatorVisible`'Show " +
+                "external indicator':b, IsProfilePhotoActive`'Has Profile Photo':b, LanguageLocaleKey`Language:l, LastLoginDate`'Last Login':d, LastModifiedById`'Last Modified By ID'[(User, )]:~User:s, " +
                 "LastModifiedDate`'Last Modified Date':d, LastName`'Last Name':s, LastPasswordChangeDate`'Last Password Change or Reset':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last " +
-                "Viewed Date':d, Latitude:w, LocaleSidKey`Locale:l, Longitude:w, ManagerId`'Manager ID'[User]:~User:s, MediumBannerPhotoUrl`'Url for Android banner photo':s, MediumPhotoUrl`'Url for " +
-                "medium profile photo':s, MiddleName`'Middle Name':s, MobilePhone`Mobile:s, Name`'Full Name':s, OfflinePdaTrialExpirationDate`'Sales Anywhere Trial Expiration Date':d, OfflineTrialExpirationDate`'Offlin" +
-                "e Edition Trial Expiration Date':d, OutOfOfficeMessage`'Out of office message':s, Phone:s, PostalCode`'Zip/Postal Code':s, ProfileId`'Profile ID'[Profile]:~Profile:s, ReceivesAdminInfoEmails`'Admin " +
-                "Info Emails':b, ReceivesInfoEmails`'Info Emails':b, SenderEmail`'Email Sender Address':s, SenderName`'Email Sender Name':s, Signature`'Email Signature':s, SmallBannerPhotoUrl`'Url for " +
-                "IOS banner photo':s, SmallPhotoUrl`Photo:s, State`'State/Province':s, StayInTouchNote`'Stay-in-Touch Email Note':s, StayInTouchSignature`'Stay-in-Touch Email Signature':s, StayInTouchSubject`'Stay-in-T" +
-                "ouch Email Subject':s, Street:s, Suffix:s, SystemModstamp`'System Modstamp':d, TimeZoneSidKey`'Time Zone':l, Title:s, UserPermissionsAvantgoUser`'AvantGo User':b, UserPermissionsCallCenterAutoLogin`'Au" +
-                "to-login To Call Center':b, UserPermissionsInteractionUser`'Flow User':b, UserPermissionsKnowledgeUser`'Knowledge User':b, UserPermissionsLiveAgentUser`'Chat User':b, UserPermissionsMarketingUser`'Mark" +
-                "eting User':b, UserPermissionsMobileUser`'Apex Mobile User':b, UserPermissionsOfflineUser`'Offline User':b, UserPermissionsSFContentUser`'Salesforce CRM Content User':b, UserPermissionsSupportUser`'Ser" +
-                "vice Cloud User':b, UserPreferencesActivityRemindersPopup`ActivityRemindersPopup:b, UserPreferencesApexPagesDeveloperMode`ApexPagesDeveloperMode:b, UserPreferencesCacheDiagnostics`CacheDiagnostics:b, " +
-                "UserPreferencesCreateLEXAppsWTShown`CreateLEXAppsWTShown:b, UserPreferencesDisCommentAfterLikeEmail`DisCommentAfterLikeEmail:b, UserPreferencesDisMentionsCommentEmail`DisMentionsCommentEmail:b, " +
+                "Viewed Date':d, Latitude:w, LocaleSidKey`Locale:l, Longitude:w, ManagerId`'Manager ID'[(User, )]:~User:s, MediumBannerPhotoUrl`'Url for Android banner photo':s, MediumPhotoUrl`'Url " +
+                "for medium profile photo':s, MiddleName`'Middle Name':s, MobilePhone`Mobile:s, Name`'Full Name':s, OfflinePdaTrialExpirationDate`'Sales Anywhere Trial Expiration Date':d, OfflineTrialExpirationDate`'Of" +
+                "fline Edition Trial Expiration Date':d, OutOfOfficeMessage`'Out of office message':s, Phone:s, PostalCode`'Zip/Postal Code':s, ProfileId`'Profile ID'[(Profile, )]:~Profile:s, ReceivesAdminInfoEmails`'A" +
+                "dmin Info Emails':b, ReceivesInfoEmails`'Info Emails':b, SenderEmail`'Email Sender Address':s, SenderName`'Email Sender Name':s, Signature`'Email Signature':s, SmallBannerPhotoUrl`'Url " +
+                "for IOS banner photo':s, SmallPhotoUrl`Photo:s, State`'State/Province':s, StayInTouchNote`'Stay-in-Touch Email Note':s, StayInTouchSignature`'Stay-in-Touch Email Signature':s, StayInTouchSubject`'Stay-" +
+                "in-Touch Email Subject':s, Street:s, Suffix:s, SystemModstamp`'System Modstamp':d, TimeZoneSidKey`'Time Zone':l, Title:s, UserPermissionsAvantgoUser`'AvantGo User':b, UserPermissionsCallCenterAutoLogin" +
+                "`'Auto-login To Call Center':b, UserPermissionsInteractionUser`'Flow User':b, UserPermissionsKnowledgeUser`'Knowledge User':b, UserPermissionsLiveAgentUser`'Chat User':b, UserPermissionsMarketingUser`'" +
+                "Marketing User':b, UserPermissionsMobileUser`'Apex Mobile User':b, UserPermissionsOfflineUser`'Offline User':b, UserPermissionsSFContentUser`'Salesforce CRM Content User':b, UserPermissionsSupportUser`" +
+                "'Service Cloud User':b, UserPreferencesActivityRemindersPopup`ActivityRemindersPopup:b, UserPreferencesApexPagesDeveloperMode`ApexPagesDeveloperMode:b, UserPreferencesCacheDiagnostics`CacheDiagnostics:" +
+                "b, UserPreferencesCreateLEXAppsWTShown`CreateLEXAppsWTShown:b, UserPreferencesDisCommentAfterLikeEmail`DisCommentAfterLikeEmail:b, UserPreferencesDisMentionsCommentEmail`DisMentionsCommentEmail:b, " +
                 "UserPreferencesDisProfPostCommentEmail`DisProfPostCommentEmail:b, UserPreferencesDisableAllFeedsEmail`DisableAllFeedsEmail:b, UserPreferencesDisableBookmarkEmail`DisableBookmarkEmail:b, " +
                 "UserPreferencesDisableChangeCommentEmail`DisableChangeCommentEmail:b, UserPreferencesDisableEndorsementEmail`DisableEndorsementEmail:b, UserPreferencesDisableFileShareNotificationsForApi`DisableFileSha" +
                 "reNotificationsForApi:b, UserPreferencesDisableFollowersEmail`DisableFollowersEmail:b, UserPreferencesDisableLaterCommentEmail`DisableLaterCommentEmail:b, UserPreferencesDisableLikeEmail`DisableLikeEma" +
@@ -758,7 +760,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 "ToExternalUsers`ShowStateToExternalUsers:b, UserPreferencesShowStateToGuestUsers`ShowStateToGuestUsers:b, UserPreferencesShowStreetAddressToExternalUsers`ShowStreetAddressToExternalUsers:b, " +
                 "UserPreferencesShowStreetAddressToGuestUsers`ShowStreetAddressToGuestUsers:b, UserPreferencesShowTitleToExternalUsers`ShowTitleToExternalUsers:b, UserPreferencesShowTitleToGuestUsers`ShowTitleToGuestUs" +
                 "ers:b, UserPreferencesShowWorkPhoneToExternalUsers`ShowWorkPhoneToExternalUsers:b, UserPreferencesShowWorkPhoneToGuestUsers`ShowWorkPhoneToGuestUsers:b, UserPreferencesSortFeedByComment`SortFeedByComme" +
-                "nt:b, UserPreferencesTaskRemindersCheckboxDefault`TaskRemindersCheckboxDefault:b, UserRoleId`'Role ID'[UserRole]:~UserRole:s, UserType`'User Type':l, Username:s]", userTable.ToStringWithDisplayNames());
+                "nt:b, UserPreferencesTaskRemindersCheckboxDefault`TaskRemindersCheckboxDefault:b, UserRoleId`'Role ID'[(UserRole, )]:~UserRole:s, UserType`'User Type':l, Username:s]", userTable.ToStringWithDisplayNames());
 
             // Missing field
             b = sfTable.RecordType.TryGetFieldType("XYZ", out FormulaType xyzType);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
@@ -237,7 +237,9 @@ namespace Microsoft.PowerFx.Connectors.Tests
             StringValue address = Assert.IsType<StringValue>(result);
             Assert.Equal("HL Road Frame - Black, 58", address.Value);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             bool b = sqlTable.RecordType.TryGetFieldRelationships("ProductModelID", out IEnumerable<ConnectorRelationship> relationships);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.True(b);
             Assert.Single(relationships);
             Assert.Equal("[SalesLT].[ProductModel]", relationships.First().ForeignTable); // Logical Name
@@ -705,7 +707,9 @@ namespace Microsoft.PowerFx.Connectors.Tests
 
             // needs Microsoft.PowerFx.Connectors.CdpExtensions
             // this call does not make any network call
+#pragma warning disable CS0618 // Type or member is obsolete
             bool b = sfTable.RecordType.TryGetFieldRelationships("OwnerId", out IEnumerable<ConnectorRelationship> relationships);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.True(b);
             Assert.Single(relationships);
             Assert.Equal("User", relationships.First().ForeignTable);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PublicSurfaceTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerFx.Connector.Tests
               "Microsoft.PowerFx.Connectors.ConnectorParameters",
               "Microsoft.PowerFx.Connectors.ConnectorParameterWithSuggestions",
               "Microsoft.PowerFx.Connectors.ConnectorPermission",
+              "Microsoft.PowerFx.Connectors.ConnectorRelationship",
               "Microsoft.PowerFx.Connectors.ConnectorSchema",
               "Microsoft.PowerFx.Connectors.ConnectorSettings",
               "Microsoft.PowerFx.Connectors.ConnectorType",


### PR DESCRIPTION
Allow multiple relationships in ConnectorType
Fix CompileTimeTypeWrapperRecordValue.TryGetField
Add Equals to ConnectorType

This update doesn't update CdpRecordType yet
DV and NL repos are not impacted by these changes