### PR TITLE
Scope args fix

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4473,10 +4473,7 @@ namespace Microsoft.PowerFx.Core.Binding
 
                             for (int i = 0; i < maybeFunc.ScopeArgs; i++)
                             {
-                                var chidNode = node.Args.Children[i];
-
-                                chidNode.Accept(this);
-                                types[i] = _txb.GetType(chidNode);
+                                node.Args.Children[i].Accept(this);
                             }
 
                             // At this point we know the type of the first argument, so we can check for untyped objects
@@ -4489,7 +4486,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             // Determine the Scope Identifier using the func.ScopeArgs arg
                             required = scopeInfo.GetScopeIdent(node.Args.Children.ToArray(), out scopeIdentifiers);
 
-                            if (scopeInfo.CheckInput(_txb.Features, node, node.Args.Children.ToArray(), out scope, types))
+                            if (scopeInfo.CheckInput(_txb.Features, node, node.Args.Children.ToArray(), out scope, GetScopeArgsTypes(node.Args.Children, maybeFunc.ScopeArgs)))
                             {
                                 if (_txb.TryGetEntityInfo(node.Args.Children[0], out expandInfo))
                                 {
@@ -4573,11 +4570,6 @@ namespace Microsoft.PowerFx.Core.Binding
                 var identRequired = false;
                 var fArgsValid = true;
 
-                var typeInputs = new Dictionary<int, DType>
-                {
-                    { nodeInput.Id, _txb.GetType(nodeInput) },
-                };
-
                 if (scopeInfo.ScopeType != null)
                 {
                     typeScope = scopeInfo.ScopeType;
@@ -4591,10 +4583,9 @@ namespace Microsoft.PowerFx.Core.Binding
                     {
                         _txb.AddVolatileVariables(node, _txb.GetVolatileVariables(args[i]));
                         args[i].Accept(this);
-                        typeInputs[args[i].Id] = _txb.GetType(args[i]);
                     }
 
-                    fArgsValid = scopeInfo.CheckInput(_txb.Features, node, args, out typeScope, typeInputs.Values.ToArray());
+                    fArgsValid = scopeInfo.CheckInput(_txb.Features, node, args, out typeScope, GetScopeArgsTypes(node.Args.Children, maybeFunc.ScopeArgs));
 
                     // Determine the scope identifier using the first node for lambda params
                     identRequired = scopeInfo.GetScopeIdent(args, out scopeIdent);
@@ -4670,16 +4661,13 @@ namespace Microsoft.PowerFx.Core.Binding
 
                     if (!isIdentifier || maybeFunc.GetIdentifierParamStatus(args[i], _features, i) == TexlFunction.ParamIdentifierStatus.PossiblyIdentifier)
                     {
-                        if (typeInputs.TryGetValue(args[i].Id, out _))
-                        {
-                            argTypes[i] = _txb.GetType(args[i]);
-                        }
-                        else 
+                        if (_txb.GetTypeAllowInvalid(args[i]) != null && !_txb.GetTypeAllowInvalid(args[i]).IsValid)
                         {
                             args[i].Accept(this);
                             _txb.AddVolatileVariables(node, _txb.GetVolatileVariables(args[i]));
-                            argTypes[i] = _txb.GetType(args[i]);
-                        }                        
+                        }
+
+                        argTypes[i] = _txb.GetType(args[i]);
 
                         Contracts.Assert(argTypes[i].IsValid);
                     }
@@ -4747,6 +4735,17 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 // We fully processed the call, so don't visit children or call PostVisit.
                 return false;
+            }
+
+            /// <summary>
+            /// Get all DType used to compose the scope of the function (func.ScopeArgs).
+            /// </summary>
+            /// <param name="args">Call child nodes.</param>
+            /// <param name="scopeArgs">TexlFunction ScopeArgs property.</param>
+            /// <returns>DType array.</returns>
+            private DType[] GetScopeArgsTypes(IReadOnlyList<TexlNode> args, int scopeArgs)
+            {
+                return args.Take(scopeArgs).Select(node => _txb.GetType(node)).ToArray();
             }
 
             private void FinalizeCall(CallNode node)

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4469,9 +4469,13 @@ namespace Microsoft.PowerFx.Core.Binding
                         }
                         else if (carg > 0)
                         {
-                            var types = new DType[maybeFunc.ScopeArgs];
+                            // Gets the lesser number between the CallNode chidl args and func.ScopeArgs.
+                            // There reason why is that the intellisense can visit this code and provide a number of args less than the func.ScopeArgs.
+                            // Example: Join(|
+                            var argsCount = Math.Min(node.Args.Children.Count, maybeFunc.ScopeArgs);
+                            var types = new DType[argsCount];
 
-                            for (int i = 0; i < maybeFunc.ScopeArgs; i++)
+                            for (int i = 0; i < argsCount; i++)
                             {
                                 node.Args.Children[i].Accept(this);
                             }
@@ -4486,7 +4490,7 @@ namespace Microsoft.PowerFx.Core.Binding
                             // Determine the Scope Identifier using the func.ScopeArgs arg
                             required = scopeInfo.GetScopeIdent(node.Args.Children.ToArray(), out scopeIdentifiers);
 
-                            if (scopeInfo.CheckInput(_txb.Features, node, node.Args.Children.ToArray(), out scope, GetScopeArgsTypes(node.Args.Children, maybeFunc.ScopeArgs)))
+                            if (scopeInfo.CheckInput(_txb.Features, node, node.Args.Children.ToArray(), out scope, GetScopeArgsTypes(node.Args.Children, argsCount)))
                             {
                                 if (_txb.TryGetEntityInfo(node.Args.Children[0], out expandInfo))
                                 {
@@ -4499,7 +4503,7 @@ namespace Microsoft.PowerFx.Core.Binding
                                 }
                             }
 
-                            argCountVisited = maybeFunc.ScopeArgs;
+                            argCountVisited = argsCount;
                         }
 
                         // If there is only one function with this name and its arity doesn't match,

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -297,17 +297,17 @@ namespace Microsoft.PowerFx.Core.Functions
         public override bool CheckInput(Features features, CallNode callNode, TexlNode[] inputNodes, out DType typeScope, params DType[] inputSchema)
         {
             var ret = true;
-            var input0 = inputSchema[0];
-            var input1 = inputSchema[1];
+            var argCount = Math.Min(inputNodes.Length, 2);
 
             typeScope = DType.EmptyRecord;
 
-            ret = base.CheckInput(features, callNode, callNode.Args.ChildNodes[0], input0, out var type0);
-            ret &= base.CheckInput(features, callNode, callNode.Args.ChildNodes[1], input1, out var type1);
-
             GetScopeIdent(inputNodes, out DName[] idents);
 
-            typeScope = typeScope.Add(idents[0], type0).Add(idents[1], type1);
+            for (var i = 0; i < argCount; i++)
+            {
+                ret &= base.CheckInput(features, callNode, inputNodes[i], inputSchema[i], out var type);
+                typeScope = typeScope.Add(idents[i], type);
+            }
 
             return ret;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -866,5 +866,6 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrJoinNotPlainJoinTypeEnum = new ErrorResourceKey("ErrJoinNotPlainJoinTypeEnum");
         public static ErrorResourceKey ErrJoinArgIsNotAsNode = new ErrorResourceKey("ErrJoinArgIsNotAsNode");
         public static ErrorResourceKey ErrJoinAtLeastOneRigthRecordField = new ErrorResourceKey("ErrJoinAtLeastOneRigthRecordField");
+        public static ErrorResourceKey ErrJoinDottedNameleft = new ErrorResourceKey("ErrJoinDottedNameleft");
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Join.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Join.cs
@@ -91,8 +91,15 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                         valid = false;
                         break;
                     }
+
+                    if (dottedNameNode.Left is not FirstNameNode firstNameNode)
+                    {
+                        errors.EnsureError(DocumentErrorSeverity.Severe, args[0], TexlStrings.ErrJoinDottedNameleft, dottedNameNode.Left, scopeIdent[0], scopeIdent[1]);
+                        valid = false;
+                        break;
+                    }
                     
-                    if (dottedNameNode.Left.AsFirstName().Ident.Name == scopeIdent[0])
+                    if (firstNameNode.Ident.Name == scopeIdent[0])
                     {
                         if (!leftTable.TryGetType(dottedNameNode.Right.Name, out var leftType))
                         {
@@ -104,7 +111,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                         returnType = returnType.Drop(ref fError, DPath.Root, dottedNameNode.Right.Name);
                         returnType = returnType.Add(ref fError, DPath.Root, asNode.Right.Name, leftType);
                     }
-                    else if (dottedNameNode.Left.AsFirstName().Ident.Name == scopeIdent[1])
+                    else if (firstNameNode.Ident.Name == scopeIdent[1])
                     {
                         if (!rightTable.TryGetType(dottedNameNode.Right.Name, out var rightType))
                         {

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4917,4 +4917,8 @@
     <value>At least one '{0}' column must be declared to compose the join result.</value>
     <comment>{Locked='RightRecord'}</comment>
   </data>
+  <data name="ErrJoinDottedNameleft" xml:space="preserve">
+    <value>The '{0}' value is invalid in this context. It should be a reference to either '{1}' or '{2}' scope name.</value>
+    <comment>{Locked='RightRecord'}</comment>
+  </data>
 </root>

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Join.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/Join.txt
@@ -63,3 +63,9 @@ Errors: Error 6-27: 'RightRecord.c As b' can not be added/renamed due to colissi
 
 >> Join(Table({a:1},{a:1},{a:0}),Table({b:1}),RightRecord.b/LeftRecord.a > 0,JoinType.Inner,RightRecord.b As b)
 Table({a:1,b:1},{a:1,b:1},Error({Kind:ErrorKind.Div0}))
+
+>> Join([{a:1}] As T1,[{a:1}] As T2,true,JoinType.Inner,{a:1}.a As AAA)
+Errors: Error 13-15: The '{ a:1 }' value is invalid in this context. It should be a reference to either 'T1' or 'T2' scope name.|Error 0-4: The function 'Join' has some invalid arguments.
+
+>> Join([{a:1}],[{a:1}],true,JoinType.Inner,{a:1}.a As AAA)
+Errors: Error 5-12: The '{ a:1 }' value is invalid in this context. It should be a reference to either 'LeftRecord' or 'RightRecord' scope name.|Error 0-4: The function 'Join' has some invalid arguments.


### PR DESCRIPTION
Fixing a possible order issue when passing scope types to `scopeInfo.CheckTypes`.