### PR TITLE
Fixing join result when using source alias

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/FunctionScopeInfo.cs
@@ -314,13 +314,11 @@ namespace Microsoft.PowerFx.Core.Functions
 
         public override bool GetScopeIdent(TexlNode[] nodes, out DName[] scopeIdents)
         {
-            var ret = false;
             scopeIdents = new DName[2];
 
             if (nodes.Length > 0 && nodes[0] is AsNode leftAsNode)
             {
                 scopeIdents[0] = leftAsNode.Right.Name;
-                ret = true;
             }
             else
             {
@@ -330,14 +328,15 @@ namespace Microsoft.PowerFx.Core.Functions
             if (nodes.Length > 1 && nodes[1] is AsNode rightAsNode)
             {
                 scopeIdents[1] = rightAsNode.Right.Name;
-                ret = true;
             }
             else
             {
                 scopeIdents[1] = RightRecord;
             }
 
-            return ret;
+            // Returning false to indicate that the scope is not a whole scope.
+            // Meaning that the scope is a record type and we are accessing the fields directly.
+            return false;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Join.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Join.cs
@@ -195,6 +195,18 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 recordValueMap[dName].Add(asNode.Left.AsDottedName().Right.Name, new TextLiteralNode(IRContext.NotInSource(FormulaType.String), asNode.Right.Name));
             }
 
+            // Scope names resolver record
+            var scopeNameResolverType = RecordType.Empty().Add(FunctionJoinScopeInfo.LeftRecord.Value, FormulaType.String).Add(FunctionJoinScopeInfo.RightRecord.Value, FormulaType.String);
+            var scopeNameResolver = new Dictionary<DName, IntermediateNode>()
+            {
+                { FunctionJoinScopeInfo.LeftRecord, new TextLiteralNode(IRContext.NotInSource(FormulaType.String), scopeIdent[0].Value) },
+                { FunctionJoinScopeInfo.RightRecord, new TextLiteralNode(IRContext.NotInSource(FormulaType.String), scopeIdent[1].Value) }
+            };
+
+            newArgs.Add(new RecordNode(
+                    IRContext.NotInSource(scopeNameResolverType),
+                    scopeNameResolver));
+
             if (recordTypesMap.ContainsKey(FunctionJoinScopeInfo.LeftRecord))
             {
                 newArgs.Add(new RecordNode(

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/Join.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/Join.txt
@@ -22,26 +22,47 @@ Table({Fruit:"Grapes",Price:220,Purchase:Date(2015,10,1),RowId:1,SupplierId:"AAA
 >> Join(t1, t2, LeftRecord.Id = RightRecord.SupplierId, JoinType.Inner, RightRecord.RowId As RowId)
 Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5})
 
+>> Join(t1 As x1, t2 As x2, x1.Id = x2.SupplierId, JoinType.Inner, x2.RowId As RowId)
+Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5})
+
 // Left
 >> Join(t1, t2, LeftRecord.Id = RightRecord.SupplierId, JoinType.Left, RightRecord.RowId As RowId)
+Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5},{Country:"MEX",Id:"EEE555",Name:"ACME INC.",RowId:Blank()},{Country:"USA",Id:"FFF666",Name:"Dunder Mifflin",RowId:Blank()})
+
+>> Join(t1 As x1, t2 As x2, x1.Id = x2.SupplierId, JoinType.Left, x2.RowId As RowId)
 Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5},{Country:"MEX",Id:"EEE555",Name:"ACME INC.",RowId:Blank()},{Country:"USA",Id:"FFF666",Name:"Dunder Mifflin",RowId:Blank()})
 
 // Right
 >> Join(t1, t2, LeftRecord.Id = RightRecord.SupplierId, JoinType.Right, RightRecord.RowId As RowId)
 Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:7},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:8})
 
+>> Join(t1 As x1, t2 As x2, x1.Id = x2.SupplierId, JoinType.Right, x2.RowId As RowId)
+Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:7},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:8})
+
 // Full
 >> Join(t1, t2, LeftRecord.Id = RightRecord.SupplierId, JoinType.Full, RightRecord.RowId As RowId)
+Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5},{Country:"USA",Id:"FFF666",Name:"Dunder Mifflin",RowId:Blank()},{Country:"MEX",Id:"EEE555",Name:"ACME INC.",RowId:Blank()},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:7},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:8})
+
+>> Join(t1 As x1, t2 As x2, x1.Id = x2.SupplierId, JoinType.Full, x2.RowId As RowId)
 Table({Country:"USA",Id:"AAA111",Name:"Contoso",RowId:1},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:3},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:4},{Country:"USA",Id:"AAA111",Name:"Contoso",RowId:6},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:2},{Country:"CAN",Id:"BBB222",Name:"Fabrikam",RowId:5},{Country:"USA",Id:"FFF666",Name:"Dunder Mifflin",RowId:Blank()},{Country:"MEX",Id:"EEE555",Name:"ACME INC.",RowId:Blank()},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:7},{Country:Blank(),Id:Blank(),Name:Blank(),RowId:8})
 
 // Renaming columns with 'As' keyword
 >> Join(t1, t2, LeftRecord.Id = RightRecord.SupplierId, JoinType.Inner, LeftRecord.Id As SupId, LeftRecord.Name As SupName, RightRecord.Fruit As FruitName)
 Table({Country:"USA",FruitName:"Grapes",SupId:"AAA111",SupName:"Contoso"},{Country:"USA",FruitName:"Lemons",SupId:"AAA111",SupName:"Contoso"},{Country:"USA",FruitName:"Grapes",SupId:"AAA111",SupName:"Contoso"},{Country:"USA",FruitName:"Bananas",SupId:"AAA111",SupName:"Contoso"},{Country:"CAN",FruitName:"Lemons",SupId:"BBB222",SupName:"Fabrikam"},{Country:"CAN",FruitName:"Lemons",SupId:"BBB222",SupName:"Fabrikam"})
 
+>> Join(t1 As x1, t2 As x2, x1.Id = x2.SupplierId, JoinType.Inner, x1.Id As SupId, x1.Name As SupName, x2.Fruit As FruitName)
+Table({Country:"USA",FruitName:"Grapes",SupId:"AAA111",SupName:"Contoso"},{Country:"USA",FruitName:"Lemons",SupId:"AAA111",SupName:"Contoso"},{Country:"USA",FruitName:"Grapes",SupId:"AAA111",SupName:"Contoso"},{Country:"USA",FruitName:"Bananas",SupId:"AAA111",SupName:"Contoso"},{Country:"CAN",FruitName:"Lemons",SupId:"BBB222",SupName:"Fabrikam"},{Country:"CAN",FruitName:"Lemons",SupId:"BBB222",SupName:"Fabrikam"})
+
 // Renaming first, then joining
 >> First(Join(t1, t2, LeftRecord.Id = RightRecord.SupplierId, JoinType.Inner, LeftRecord.Id As SupId, LeftRecord.Name As SupName, RightRecord.Fruit As FruitName)).SupId
 "AAA111"
 
+>> First(Join(t1 As x1, t2 As x2, x1.Id = x2.SupplierId, JoinType.Inner, x1.Id As SupId, x1.Name As SupName, x2.Fruit As FruitName)).SupId
+"AAA111"
+
 // Renaming first, with duplicated column names
 >> Join(RenameColumns(t1, Id, SupplierId, Name, SupName), RenameColumns(t2, Fruit, FruitName), LeftRecord.SupplierId = RightRecord.SupplierId, JoinType.Inner, LeftRecord.SupplierId As RowId , RightRecord.RowId As RowId)
-Errors: Errors: Error 5-53: 'RightRecord.RowId As RowId' can not be added/renamed due to colission with another column with same name.|Error 0-4: The function 'Join' has some invalid arguments.
+Errors: Error 5-53: 'RightRecord.RowId As RowId' can not be added/renamed due to colission with another column with same name.|Error 0-4: The function 'Join' has some invalid arguments.
+
+>> Join(RenameColumns(t1, Id, SupplierId, Name, SupName) As x1, RenameColumns(t2, Fruit, FruitName) As x2, x1.SupplierId = x2.SupplierId, JoinType.Inner, x1.SupplierId As RowId , x2.RowId As RowId)
+Errors: Error 54-56: 'x2.RowId As RowId' can not be added/renamed due to colission with another column with same name.|Error 0-4: The function 'Join' has some invalid arguments.


### PR DESCRIPTION
When joining along with alias (`Join(t1 As x1, ...)`), the binder would try to access the fields from the wrong scope to evaluate the predicate, resulting in a wrong output.