### PR TITLE
Prevent _Min from showing up in error messages

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -984,6 +984,11 @@ namespace Microsoft.PowerFx.Core.Types
         /// <returns>String representation of DType.Kind.</returns>
         public string GetKindString()
         {
+            if (Kind == DKind._Min)
+            {
+                return "Unknown";
+            }
+
             if (Kind == DKind._MinPrimitive)
             {
                 return "Boolean";


### PR DESCRIPTION
This isn't great
![image](https://github.com/user-attachments/assets/e58e1cbb-7644-4abe-b6ec-43daaccdeec8)

"Unknown" isn't a ton more helpful, but at least it's not obviously broken