### PR TITLE
Fix User-Defined Type error messages 

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2566,7 +2566,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 Contracts.AssertValue(node);
                 
                 _txb.SetType(node, DType.Error);
-                _txb.ErrorContainer.Error(node, TexlStrings.ErrTypeLiteral_UnsupportedUsage);
+                _txb.ErrorContainer.Error(node, TexlStrings.ErrTypeFunction_UnsupportedUsage);
             }
 
             // Method to bind TypeLiteralNode from valid context where a type is expected.
@@ -2592,7 +2592,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 else
                 {
                     _txb.SetType(node, DType.Error);
-                    _txb.ErrorContainer.Error(node, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString());
+                    _txb.ErrorContainer.Error(node, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString());
                 }
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -773,7 +773,7 @@ namespace Microsoft.PowerFx.Core.Localization
 
         public static ErrorResourceKey ErrNamedFormula_MissingSemicolon = new ErrorResourceKey("ErrNamedFormula_MissingSemicolon");
         public static ErrorResourceKey ErrNamedFormula_MissingValue = new ErrorResourceKey("ErrNamedFormula_MissingValue");
-        public static ErrorResourceKey ErrNamedType_MissingTypeLiteral = new ErrorResourceKey("ErrNamedType_MissingTypeLiteral");
+        public static ErrorResourceKey ErrNamedType_MissingTypeExpression = new ErrorResourceKey("ErrNamedType_MissingTypeExpression");
         public static ErrorResourceKey ErrUDF_MissingFunctionBody = new ErrorResourceKey("ErrUDF_MissingFunctionBody");
         public static ErrorResourceKey ErrNamedFormula_AlreadyDefined = new ErrorResourceKey("ErrNamedFormula_AlreadyDefined");
         public static ErrorResourceKey ErrorResource_NameConflict = new ErrorResourceKey("ErrorResource_NameConflict");
@@ -789,10 +789,10 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrUDF_InvalidParamType = new ErrorResourceKey("ErrUDF_InvalidParamType");
         public static ErrorResourceKey WrnUDF_ShadowingBuiltInFunction = new ErrorResourceKey("WrnUDF_ShadowingBuiltInFunction");
 
-        public static ErrorResourceKey ErrTypeLiteral_InvalidTypeDefinition = new ErrorResourceKey("ErrTypeLiteral_InvalidTypeDefinition");
-        public static ErrorResourceKey ErrTypeLiteral_UnsupportedUsage = new ErrorResourceKey("ErrTypeLiteral_UnsupportedUsage");
+        public static ErrorResourceKey ErrTypeFunction_InvalidTypeExpression = new ErrorResourceKey("ErrTypeFunction_InvalidTypeExpression");
+        public static ErrorResourceKey ErrTypeFunction_UnsupportedUsage = new ErrorResourceKey("ErrTypeFunction_UnsupportedUsage");
         public static ErrorResourceKey ErrNamedType_InvalidCycles = new ErrorResourceKey("ErrNamedType_InvalidCycles");
-        public static ErrorResourceKey ErrNamedType_InvalidTypeDefinition = new ErrorResourceKey("ErrNamedType_InvalidTypeDefinition");
+        public static ErrorResourceKey ErrNamedType_InvalidTypeDeclaration = new ErrorResourceKey("ErrNamedType_InvalidTypeDeclaration");
         public static ErrorResourceKey ErrNamedType_InvalidTypeName = new ErrorResourceKey("ErrNamedType_InvalidTypeName");
         public static ErrorResourceKey ErrNamedType_TypeAlreadyDefined = new ErrorResourceKey("ErrNamedType_TypeAlreadyDefined");
         public static ErrorResourceKey ErrRecordContainsInvalidFields_Arg = new ErrorResourceKey("ErrRecordContainsInvalidFields_Arg");

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -315,7 +315,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                     if (_curs.TidCur == TokKind.Semicolon)
                     {
-                        CreateError(thisIdentifier, TexlStrings.ErrNamedType_MissingTypeLiteral);
+                        CreateError(thisIdentifier, TexlStrings.ErrNamedType_MissingTypeExpression);
                     }
 
                     // Extract expression
@@ -343,7 +343,7 @@ namespace Microsoft.PowerFx.Core.Parser
                         }
                         else
                         {
-                            CreateError(_curs.TokCur, TexlStrings.ErrNamedType_MissingTypeLiteral);
+                            CreateError(_curs.TokCur, TexlStrings.ErrNamedType_MissingTypeExpression);
                         }
 
                         // If the result was an error, keep moving cursor until end of named type expression

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TypeLiteralNode.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/TypeLiteralNode.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerFx.Syntax
             {
                 if (node.ChildNodes.Count > 1)
                 {
-                    _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                    _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                     return false;
                 }
 
@@ -116,94 +116,94 @@ namespace Microsoft.PowerFx.Syntax
             // Invalid nodes
             public override void Visit(ErrorNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(BlankNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(BoolLitNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(StrLitNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(NumLitNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(DecLitNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(ParentNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(SelfNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override void Visit(TypeLiteralNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
             }
 
             public override bool PreVisit(StrInterpNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(DottedNameNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(UnaryOpNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(BinaryOpNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(VariadicOpNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(CallNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(ListNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 
             public override bool PreVisit(AsNode node)
             {
-                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeLiteral_InvalidTypeDefinition, node.ToString()));
+                _errors.Add(new TexlError(node, DocumentErrorSeverity.Severe, TexlStrings.ErrTypeFunction_InvalidTypeExpression, node.ToString()));
                 return false;
             }
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DefinedTypeResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DefinedTypeResolver.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerFx.Core.Types
 
                 if (resolvedType == DType.Invalid)
                 {
-                    _errors.Add(new TexlError(currentType.Type.TypeRoot, DocumentErrorSeverity.Severe, TexlStrings.ErrNamedType_InvalidTypeDefinition, currentType.Ident.Name));
+                    _errors.Add(new TexlError(currentType.Type.TypeRoot, DocumentErrorSeverity.Severe, TexlStrings.ErrNamedType_InvalidTypeDeclaration, currentType.Ident.Name));
                     continue;
                 }
 

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4879,8 +4879,8 @@
     <comment>Error Message.</comment>
   </data>
   <data name="ErrInvalidArgumentExpectedType" xml:space="preserve">
-    <value>Invalid argument '{0}'. Expected valid type name or inline type definition.</value>
-    <comment>Error Message shown to user when a value other name or inline type definition is passed into AsType, IsType and ParseJSON functions.</comment>
+    <value>Invalid argument '{0}'. Expected valid type name or inline type expression.</value>
+    <comment>Error Message shown to user when a value other name or inline type expression is passed into AsType, IsType and ParseJSON functions.</comment>
   </data>
   <data name="ErrUnsupportedTypeInTypeArgument" xml:space="preserve">
     <value>Unsupported type '{0}' in type argument.</value>

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1817,7 +1817,7 @@
   </data>
   <data name="IsTypeUOArg2" xml:space="preserve">
     <value>type</value>
-    <comment>function_parameter - Second argument of the IsTypeUO function - Type value - either a typeliteral or global named type.</comment>
+    <comment>function_parameter - Second argument of the IsTypeUO function - Type value - either a inline type expression or a type name.</comment>
   </data>
   <data name="AboutIsType_untypedValue" xml:space="preserve">
     <value>The untyped value to check if it can be casted as specified type.</value>
@@ -4181,10 +4181,10 @@
     <value>Named formula must be an expression.</value>
     <comment>This error message shows up when Named formula is not an expression. For example, a = ;</comment>
   </data>
-  <data name="ErrNamedType_MissingTypeLiteral" xml:space="preserve">
-    <value>Named type must be a type literal.</value>
+  <data name="ErrNamedType_MissingTypeExpression" xml:space="preserve">
+    <value>A named type declaration must be a valid type expression.</value>
     <comment>
-      This error message shows up when Named type is not a type literal. A valid type literal expression is of syntax "Type(Expression)". 
+      This error message shows up when a named type declaration is not valid a type expression. A valid type expression is of syntax "Type(Expression)". 
       Some examples for valid named type declarations - "Point := Type({x: Number, y: Number});" , "T1 := Type(Number);" , "T2 := Type([Boolean]);".
       Some examples for invalid named type declarations - "T1 := 5;" , "T2 := ;" , "T3 := [1, 2, 3];".
     </comment>
@@ -4556,21 +4556,21 @@
     <value>Set a variable with an online datasource value (table or record) can cause multiple requests to the server. Soon this will be blocked.</value>
     <comment>Warning for makers that a certain capability should be avoided.</comment>
   </data>
-  <data name="ErrTypeLiteral_InvalidTypeDefinition" xml:space="preserve">
-    <value>Type literal declaration is invalid. The expression '{0}' cannot be used in a type definition.</value>
-    <comment>Error message when validation of type literal fails.</comment>
+  <data name="ErrTypeFunction_InvalidTypeExpression" xml:space="preserve">
+    <value>Type expression is invalid. '{0}' cannot be used in a type expression.</value>
+    <comment>Error message when validation of type expression fails.</comment>
   </data>
-  <data name="ErrTypeLiteral_UnsupportedUsage" xml:space="preserve">
-    <value>Unsupported usage: type literals can only be used in type arguments and type definitions.</value>
-    <comment>Error message shown when a type literal is used in an unsupported expression.</comment>
+  <data name="ErrTypeFunction_UnsupportedUsage" xml:space="preserve">
+    <value>Unsupported usage: Type function can only be used in type arguments and type declarations.</value>
+    <comment>{Locked=Type}Error message shown when Type function is used in an unsupported expression.</comment>
   </data>
-  <data name="ErrNamedType_InvalidTypeDefinition" xml:space="preserve">
-    <value>Definition of type {0} is invalid.</value>
-    <comment>Error message when type binding is invalid.</comment>
+  <data name="ErrNamedType_InvalidTypeDeclaration" xml:space="preserve">
+    <value>Declaration of type {0} is invalid.</value>
+    <comment>Error message when type declaration is invalid.</comment>
   </data>
   <data name="ErrNamedType_InvalidCycles" xml:space="preserve">
-    <value>Definition of type {0} is invalid and may contain cycles.</value>
-    <comment>Error message when type binding may have cycles.</comment>
+    <value>Declaration of type {0} is invalid and may contain cycles.</value>
+    <comment>Error message when type declaration may contain cycles.</comment>
   </data>
   <data name="ErrNamedType_InvalidTypeName" xml:space="preserve">
     <value>Restricted type name {0} cannot be used.</value>
@@ -4875,8 +4875,8 @@
     <comment>Error Message.</comment>
   </data>
   <data name="ErrInvalidArgumentExpectedType" xml:space="preserve">
-    <value>Invalid argument '{0}'. Expected valid type name or type literal.</value>
-    <comment>Error Message shown to user when a value other name or type literal is passed into AsType, IsType and ParseJSON functions.</comment>
+    <value>Invalid argument '{0}'. Expected valid type name or inline type definition.</value>
+    <comment>Error Message shown to user when a value other name or inline type definition is passed into AsType, IsType and ParseJSON functions.</comment>
   </data>
   <data name="ErrUnsupportedTypeInTypeArgument" xml:space="preserve">
     <value>Unsupported type '{0}' in type argument.</value>

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
@@ -98,13 +98,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> AsType(ParseJSON("1"), 1)
-Errors: Error 23-24: Invalid argument '1'. Expected valid type name or inline type definition.
+Errors: Error 23-24: Invalid argument '1'. Expected valid type name or inline type expression.
 
 >> AsType(ParseJSON("5"), Type(5))
 Errors: Error 28-29: Type expression is invalid. '5' cannot be used in a type expression.|Error 27-28: Type expression is invalid. 'Type(5)' cannot be used in a type expression.
 
 >> AsType(ParseJSON("true"), UnKnown)
-Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or inline type definition.
+Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or inline type expression.
 
 >> AsType(ParseJSON("fasle"), Boolean)
 Error({Kind:ErrorKind.InvalidJSON})
@@ -134,7 +134,7 @@ Error({Kind:ErrorKind.Div0})
 Blank()
 
 >> AsType(ParseJSON("42"), Blank())
-Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type definition.
+Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type expression.
 
 >> AsType(ParseJSON("42"), 1/0)
-Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or inline type definition.
+Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or inline type expression.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
@@ -98,13 +98,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> AsType(ParseJSON("1"), 1)
-Errors: Error 23-24: Invalid argument '1'. Expected valid type name or type literal.
+Errors: Error 23-24: Invalid argument '1'. Expected valid type name or inline type definition.
 
 >> AsType(ParseJSON("5"), Type(5))
-Errors: Error 28-29: Type literal declaration is invalid. The expression '5' cannot be used in a type definition.|Error 27-28: Type literal declaration is invalid. The expression 'Type(5)' cannot be used in a type definition.
+Errors: Error 28-29: Type expression is invalid. '5' cannot be used in a type expression.|Error 27-28: Type expression is invalid. 'Type(5)' cannot be used in a type expression.
 
 >> AsType(ParseJSON("true"), UnKnown)
-Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or type literal.
+Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or inline type definition.
 
 >> AsType(ParseJSON("fasle"), Boolean)
 Error({Kind:ErrorKind.InvalidJSON})
@@ -134,7 +134,7 @@ Error({Kind:ErrorKind.Div0})
 Blank()
 
 >> AsType(ParseJSON("42"), Blank())
-Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or type literal.
+Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type definition.
 
 >> AsType(ParseJSON("42"), 1/0)
-Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or type literal.
+Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or inline type definition.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/If.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/If.txt
@@ -237,4 +237,4 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 // Type literal should cause error
 >> If(Type(Boolean), 1, 2)
-Errors: Error 7-8: Unsupported usage: type literals can only be used in type arguments and type definitions.|Error 0-2: The function 'If' has some invalid arguments.
+Errors: Error 7-8: Unsupported usage: Type function can only be used in type arguments and type declarations.|Error 0-2: The function 'If' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
@@ -93,13 +93,13 @@ false
 false
 
 >> IsType(ParseJSON("1"), 1)
-Errors: Error 23-24: Invalid argument '1'. Expected valid type name or type literal.
+Errors: Error 23-24: Invalid argument '1'. Expected valid type name or inline type definition.
 
 >> IsType(ParseJSON("5"), Type(5))
-Errors: Error 28-29: Type literal declaration is invalid. The expression '5' cannot be used in a type definition.|Error 27-28: Type literal declaration is invalid. The expression 'Type(5)' cannot be used in a type definition.
+Errors: Error 28-29: Type expression is invalid. '5' cannot be used in a type expression.|Error 27-28: Type expression is invalid. 'Type(5)' cannot be used in a type expression.
 
 >> IsType(ParseJSON("true"), UnKnown)
-Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or type literal.
+Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or inline type definition.
 
 >> IsType(ParseJSON("fasle"), Boolean)
 Error({Kind:ErrorKind.InvalidJSON})
@@ -123,7 +123,7 @@ Error({Kind:ErrorKind.Div0})
 Blank()
 
 >> IsType(ParseJSON("42"), Blank())
-Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or type literal.
+Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type definition.
 
 >> IsType(ParseJSON("42"), 1/0)
-Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or type literal.
+Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or inline type definition.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
@@ -93,13 +93,13 @@ false
 false
 
 >> IsType(ParseJSON("1"), 1)
-Errors: Error 23-24: Invalid argument '1'. Expected valid type name or inline type definition.
+Errors: Error 23-24: Invalid argument '1'. Expected valid type name or inline type expression.
 
 >> IsType(ParseJSON("5"), Type(5))
 Errors: Error 28-29: Type expression is invalid. '5' cannot be used in a type expression.|Error 27-28: Type expression is invalid. 'Type(5)' cannot be used in a type expression.
 
 >> IsType(ParseJSON("true"), UnKnown)
-Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or inline type definition.
+Errors: Error 26-33: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-34: Invalid argument 'UnKnown'. Expected valid type name or inline type expression.
 
 >> IsType(ParseJSON("fasle"), Boolean)
 Error({Kind:ErrorKind.InvalidJSON})
@@ -123,7 +123,7 @@ Error({Kind:ErrorKind.Div0})
 Blank()
 
 >> IsType(ParseJSON("42"), Blank())
-Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type definition.
+Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type expression.
 
 >> IsType(ParseJSON("42"), 1/0)
-Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or inline type definition.
+Errors: Error 25-26: Invalid argument '1 / 0'. Expected valid type name or inline type expression.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
@@ -104,16 +104,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("1", 1)
-Errors: Error 15-16: Invalid argument '1'. Expected valid type name or type literal.
+Errors: Error 15-16: Invalid argument '1'. Expected valid type name or inline type definition.
 
 >> ParseJSON("""RED""", Color)
 Errors: Error 21-26: Unsupported type 'Color' in type argument.
 
 >> ParseJSON("5", Type(5))
-Errors: Error 20-21: Type literal declaration is invalid. The expression '5' cannot be used in a type definition.|Error 19-20: Type literal declaration is invalid. The expression 'Type(5)' cannot be used in a type definition.
+Errors: Error 20-21: Type expression is invalid. '5' cannot be used in a type expression.|Error 19-20: Type expression is invalid. 'Type(5)' cannot be used in a type expression.
 
 >> ParseJSON("true", UnKnown)
-Errors: Error 18-25: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-26: Invalid argument 'UnKnown'. Expected valid type name or type literal.
+Errors: Error 18-25: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-26: Invalid argument 'UnKnown'. Expected valid type name or inline type definition.
 
 >> ParseJSON("fasle", Boolean)
 Error({Kind:ErrorKind.InvalidJSON})
@@ -143,10 +143,10 @@ Error({Kind:ErrorKind.Div0})
 Blank()
 
 >> ParseJSON("42", Blank())
-Errors: Error 16-23: Invalid argument 'Blank()'. Expected valid type name or type literal.
+Errors: Error 16-23: Invalid argument 'Blank()'. Expected valid type name or inline type definition.
 
 >> ParseJSON("42", 1/0)
-Errors: Error 17-18: Invalid argument '1 / 0'. Expected valid type name or type literal.
+Errors: Error 17-18: Invalid argument '1 / 0'. Expected valid type name or inline type definition.
 
 >> ParseJSON(Type(Text))
-Errors: Error 14-15: Unsupported usage: type literals can only be used in type arguments and type definitions.|Error 0-9: The function 'ParseJSON' has some invalid arguments.
+Errors: Error 14-15: Unsupported usage: Type function can only be used in type arguments and type declarations.|Error 0-9: The function 'ParseJSON' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
@@ -104,7 +104,7 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("1", 1)
-Errors: Error 15-16: Invalid argument '1'. Expected valid type name or inline type definition.
+Errors: Error 15-16: Invalid argument '1'. Expected valid type name or inline type expression.
 
 >> ParseJSON("""RED""", Color)
 Errors: Error 21-26: Unsupported type 'Color' in type argument.
@@ -113,7 +113,7 @@ Errors: Error 21-26: Unsupported type 'Color' in type argument.
 Errors: Error 20-21: Type expression is invalid. '5' cannot be used in a type expression.|Error 19-20: Type expression is invalid. 'Type(5)' cannot be used in a type expression.
 
 >> ParseJSON("true", UnKnown)
-Errors: Error 18-25: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-26: Invalid argument 'UnKnown'. Expected valid type name or inline type definition.
+Errors: Error 18-25: Name isn't valid. 'UnKnown' isn't recognized.|Error 0-26: Invalid argument 'UnKnown'. Expected valid type name or inline type expression.
 
 >> ParseJSON("fasle", Boolean)
 Error({Kind:ErrorKind.InvalidJSON})
@@ -143,10 +143,10 @@ Error({Kind:ErrorKind.Div0})
 Blank()
 
 >> ParseJSON("42", Blank())
-Errors: Error 16-23: Invalid argument 'Blank()'. Expected valid type name or inline type definition.
+Errors: Error 16-23: Invalid argument 'Blank()'. Expected valid type name or inline type expression.
 
 >> ParseJSON("42", 1/0)
-Errors: Error 17-18: Invalid argument '1 / 0'. Expected valid type name or inline type definition.
+Errors: Error 17-18: Invalid argument '1 / 0'. Expected valid type name or inline type expression.
 
 >> ParseJSON(Type(Text))
 Errors: Error 14-15: Unsupported usage: Type function can only be used in type arguments and type declarations.|Error 0-9: The function 'ParseJSON' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -142,11 +142,11 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Points := Type([{ x: Number, y: Number }]); F(): Number = RecordOf(Points).x; ", "ErrKnownTypeHelperFunction")]
 
         // RecordOf record type
-        [InlineData("Point := Type({ x: Number, y: Number }); PointR := Type(RecordOf(Point)); ", "ErrNamedType_InvalidTypeDefinition")]
+        [InlineData("Point := Type({ x: Number, y: Number }); PointR := Type(RecordOf(Point)); ", "ErrNamedType_InvalidTypeDeclaration")]
 
         // Inline definitions within RecordOf
-        [InlineData("T1 := Type(RecordOf(Type([{A:Number}])));", "ErrTypeLiteral_InvalidTypeDefinition")]
-        [InlineData("T1 := Type(RecordOf(RecordOf([{x:Number, y:Number}])));", "ErrTypeLiteral_InvalidTypeDefinition")]
+        [InlineData("T1 := Type(RecordOf(Type([{A:Number}])));", "ErrTypeFunction_InvalidTypeExpression")]
+        [InlineData("T1 := Type(RecordOf(RecordOf([{x:Number, y:Number}])));", "ErrTypeFunction_InvalidTypeExpression")]
         public void TestRecordOfErrors(string typeDefinition, string expectedMessageKey)
         {
             var checkResult = new DefinitionsCheckResult()

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -109,12 +109,12 @@ namespace Microsoft.PowerFx.Core.Tests
 
         //To test DefinitionsCheckResult.ApplyErrors method and error messages
         [InlineData("Point := Type({ x: Number, y: Number }); Point := Type(Number);", 1, "ErrNamedType_TypeAlreadyDefined")]
-        [InlineData("X:= Type({ f:Number, f:Number});", 1, "ErrNamedType_InvalidTypeDefinition")]
+        [InlineData("X:= Type({ f:Number, f:Number});", 1, "ErrNamedType_InvalidTypeDeclaration")]
         [InlineData("B := Type({ x: A }); A := Type(B);", 2, "ErrNamedType_InvalidCycles")]
         [InlineData("B := Type(B);", 1, "ErrNamedType_InvalidCycles")]
         [InlineData("Currency := Type({x: Text}); Record := Type([DateTime]); D := Type(None);", 2, "ErrNamedType_InvalidTypeName")]
-        [InlineData("A = 5;C :=; B := Type(Number);", 1, "ErrNamedType_MissingTypeLiteral")]
-        [InlineData("C := 5; D := [1,2,3];", 2, "ErrNamedType_MissingTypeLiteral")]
+        [InlineData("A = 5;C :=; B := Type(Number);", 1, "ErrNamedType_MissingTypeExpression")]
+        [InlineData("C := 5; D := [1,2,3];", 2, "ErrNamedType_MissingTypeExpression")]
         public void TestUDTErrors(string typeDefinition, int expectedErrorCount, string expectedMessageKey)
         {
             var checkResult = new DefinitionsCheckResult()
@@ -150,7 +150,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var parseResult = checkResult.ApplyParse();
             Assert.True(parseResult.HasErrors);
 
-            var validatorErrors = parseResult.Errors.Where(e => e.MessageKey.Contains("ErrTypeLiteral_InvalidTypeDefinition"));
+            var validatorErrors = parseResult.Errors.Where(e => e.MessageKey.Contains("ErrTypeFunction_InvalidTypeExpression"));
             Assert.Equal(expectedErrorCount, validatorErrors.Count());
         }
     }

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerFx.Json.Tests
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5}\"", "Type({a: Text})", obj1, isValid: false);
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5, \"\"b\"\": 6}\"", "Type({a: Number})", obj1, false);
             CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type({a: Void})", TexlStrings.ErrUnsupportedTypeInTypeArgument.Key);
-            CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type(RecordOf(T))", TexlStrings.ErrTypeLiteral_InvalidTypeDefinition.Key);
+            CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type(RecordOf(T))", TexlStrings.ErrTypeFunction_InvalidTypeExpression.Key);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
@@ -122,10 +122,10 @@ namespace Microsoft.PowerFx.Json.Tests
 
         [Theory]
         [InlineData("\"42\"", "SomeType", "ErrInvalidName")]
-        [InlineData("\"42\"", "Type(5)", "ErrTypeLiteral_InvalidTypeDefinition")]
+        [InlineData("\"42\"", "Type(5)", "ErrTypeFunction_InvalidTypeExpression")]
         [InlineData("\"42\"", "Text(42)", "ErrInvalidArgumentExpectedType")]
         [InlineData("\"\"\"Hello\"\"\"", "\"Hello\"", "ErrInvalidArgumentExpectedType")]
-        [InlineData("\"{}\"", "Type([{a: 42}])", "ErrTypeLiteral_InvalidTypeDefinition")]
+        [InlineData("\"{}\"", "Type([{a: 42}])", "ErrTypeFunction_InvalidTypeExpression")]
         public void TestCompileErrorsAllStronglyTypedOverloads(string expression, string type, string expectedError)
         {
             var engine = SetupEngine();
@@ -138,9 +138,9 @@ namespace Microsoft.PowerFx.Json.Tests
         [InlineData("AsType(ParseJSON(\"42\"), Number , Text(5))", "ErrBadArity")]
         [InlineData("IsType(ParseJSON(\"42\"), Number, 5)", "ErrBadArity")]
         [InlineData("AsType(ParseJSON(\"123\"), 1)", "ErrInvalidArgumentExpectedType")]
-        [InlineData("AsType(Type(UntypedObject), ParseJSON(\"123\"))", "ErrTypeLiteral_UnsupportedUsage")]
-        [InlineData("IsType(Type(UntypedObject), Type(Boolean))", "ErrTypeLiteral_UnsupportedUsage")]
-        [InlineData("ParseJSON(Type(Text), Type(Text))", "ErrTypeLiteral_UnsupportedUsage")]
+        [InlineData("AsType(Type(UntypedObject), ParseJSON(\"123\"))", "ErrTypeFunction_UnsupportedUsage")]
+        [InlineData("IsType(Type(UntypedObject), Type(Boolean))", "ErrTypeFunction_UnsupportedUsage")]
+        [InlineData("ParseJSON(Type(Text), Type(Text))", "ErrTypeFunction_UnsupportedUsage")]
         public void TestCompileErrors(string expression, string expectedError)
         {
             var engine = SetupEngine();


### PR DESCRIPTION
we plan to refer `Type` as a special function in our documentation and hence changing all references of Type literal in error messages and some cosmetic changes 