### PR TITLE
Fix error message for mismatched types on untyped values

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryUntypedObject.cs
@@ -561,12 +561,13 @@ namespace Microsoft.PowerFx.Functions
 
         private static ErrorValue GetTypeMismatchError(IRContext irContext, string functionName, string expectedType, IUntypedObject actualValue)
         {
+            var actualType = actualValue.Type is ExternalType et ? et.Kind.ToString() : actualValue.Type.ToString();
             return new ErrorValue(irContext, new ExpressionError
             {
                 ResourceKey = RuntimeStringResources.ErrUntypedObjectIncorrectTypeArg,
                 Kind = ErrorKind.InvalidArgument,
                 Span = irContext.SourceContext,
-                MessageArgs = new[] { functionName, expectedType, actualValue.Type.ToString() }
+                MessageArgs = new[] { functionName, expectedType, actualType }
             });
         }
 

--- a/src/strings/PowerFxRuntimeResources.en-US.resx
+++ b/src/strings/PowerFxRuntimeResources.en-US.resx
@@ -362,7 +362,7 @@
     <comment>{Locked=Filter()}</comment>
   </data>
   <data name="ErrUntypedObjectIncorrectTypeArg" xml:space="preserve">
-    <value>The untyped object argument to the '{0}' function has an incorrect type. Expected: {1}, Actual: {0}.</value>
+    <value>The untyped object argument to the '{0}' function has an incorrect type. Expected: {1}, Actual: {2}.</value>
     <comment>Error Message.</comment>
   </data>
   <data name="ErrArgumentMustBeBigEnough" xml:space="preserve">


### PR DESCRIPTION
Fixes #2781 

Examples of old error:
![Image](https://github.com/user-attachments/assets/b4fab3ab-5e76-48ec-a4db-5133d869c770)

Example of new error:
![image](https://github.com/user-attachments/assets/c89e5663-1bf0-4828-9cc0-568b2db020c6)
