### PR TITLE
Fix UDF arg parse null reference

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -140,8 +140,11 @@ namespace Microsoft.PowerFx.Core.Parser
                 {
                     CreateError(_curs.TokCur, TexlStrings.ErrUDF_MissingParamType);
 
-                    // Add incomplete UDFArgs (type is mising) as well, these are needed for intellisense.
-                    args.Add(new UDFArg(varIdent.As<IdentToken>(), typeIdent: null, colonToken, argIndex));
+                    if (varIdent != null)
+                    {
+                        // Add incomplete UDFArgs (type is mising) as well, these are needed for intellisense.
+                        args.Add(new UDFArg(varIdent.As<IdentToken>(), typeIdent: null, colonToken, argIndex));
+                    }
 
                     // If the result was an error, keep moving cursor until end of expression
                     MoveToNextUserDefinition();

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ParseTests.cs
@@ -1028,5 +1028,16 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(namedFormulaCount, parseResult.NamedFormulas.Count());
             Assert.Contains(parseResult.Errors, e => e.MessageKey.Contains("ErrUserDefinedTypeIncorrectSyntax"));
         }
+
+        [Theory]
+        [InlineData("SomeFunc(:")]
+        [InlineData("F(a: Boolean,:):Number = 1; G(): Number = 1;")]
+        public void TestUDFParseArgDoesNotThrowException(string script)
+        {
+            var parserOptions = new ParserOptions();
+
+            var parseResult = UserDefinitions.Parse(script, parserOptions);
+            Assert.True(parseResult.HasErrors);
+        }
     }
 }


### PR DESCRIPTION
Arg Identifier is null for certain UDF declarations eg: `SomeFunc(:` and `F(a: Boolean,:):Number = 1;`. these are intermediate states when writing UDFs and these cause Null ref exception. this makes changes to prevent NRE.