### PR TITLE
Add UseDefaultBodyNameForSinglePropertyObject

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1462,6 +1462,11 @@ namespace Microsoft.PowerFx.Connectors
                                     bool bodyPropertyRequired = bodySchema.Required.Contains(bodyPropertyName);
                                     bool bodyPropertyHiddenRequired = false;
 
+                                    if (ConnectorSettings.UseDefaultBodyNameForSinglePropertyObject && bodySchema.Properties.Count == 1)
+                                    {
+                                        bodyPropertyName = bodyName;
+                                    }
+
                                     if (bodyPropertySchema.IsInternal())
                                     {
                                         if (bodyPropertyRequired)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
@@ -94,6 +94,14 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         public bool ReturnEnumsAsPrimitive { get; init; } = false;
 
+        /// <summary>
+        /// In Power Apps, when a body parameter is used it's flattened and we create one paramaeter for each
+        /// body object property. With that logic each parameter name will be the object property name.
+        /// When set, this setting will use the real body name specified in the swagger instead of the property name
+        /// of the object, provided there is only one property.
+        /// </summary>
+        public bool UseDefaultBodyNameForSinglePropertyObject { get; init; } = false;
+
         public ConnectorCompatibility Compatibility { get; init; } = ConnectorCompatibility.Default;
     }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
@@ -2399,6 +2399,25 @@ POST https://tip1-shared-002.azure-apim.net/invoke
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ExchangeOnlineTest2(bool useDefaultBodyNameForSinglePropertyObject)
+        {
+            using var testConnector = new LoggingTestServer(@"Swagger\ExcelOnlineBusiness.swagger.json", _output);
+            List<ConnectorFunction> functions = OpenApiParser.GetFunctions(
+                new ConnectorSettings("Excel")
+                {
+                    Compatibility = ConnectorCompatibility.Default,
+                    UseDefaultBodyNameForSinglePropertyObject = useDefaultBodyNameForSinglePropertyObject
+                },
+                testConnector._apiDocument).ToList();
+
+            ConnectorFunction patchItem = functions.First(f => f.Name == "PatchItem");
+
+            Assert.Equal(!useDefaultBodyNameForSinglePropertyObject ? "dynamicProperties" : "item", patchItem.OptionalParameters[2].Name);
+        }
+
         public class HttpLogger : HttpClient
         {
             private readonly ITestOutputHelper _console;


### PR DESCRIPTION
In Power Apps, when a body parameter is used it's flattened and we create one paramaeter for each
body object property. With that logic each parameter name will be the object property name.

When UseDefaultBodyNameForSinglePropertyObject is set, we will use the real body name specified 
in the swagger instead of the property name of the object, provided there is only one property.