### PR TITLE
Adds Count Capabilites.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
@@ -44,6 +44,11 @@ namespace Microsoft.PowerFx.Connectors
 
         public override IEnumerable<DValue<RecordValue>> Rows => GetRowsAsync(null, null, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
 
+        public DelegationParameterFeatures SupportedFeatures => DelegationParameterFeatures.Filter |
+                DelegationParameterFeatures.Top |
+                DelegationParameterFeatures.Columns | // $select
+                DelegationParameterFeatures.Sort; // $orderby
+
         public async Task<IReadOnlyCollection<DValue<RecordValue>>> GetRowsAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel)
         {
             if (parameters == null && _cachedRows != null)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
@@ -66,6 +66,11 @@ namespace Microsoft.PowerFx.Connectors
         {
             _cachedRows = null;
         }
+
+        public Task<FormulaValue> ExecuteQueryAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel)
+        {
+            throw new NotImplementedException();
+        }
     }   
 
     internal static class ODataParametersExtensions

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
@@ -311,7 +311,7 @@ namespace Microsoft.PowerFx.Core.Entities
 
         /// <summary>
         /// If the table is countable, return true. 
-        /// Relevant expression: CountRows(Table);
+        /// Relevant expression: CountRows(Table).
         /// </summary>
         /// <returns></returns>
         public virtual bool IsCountableTable()

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
@@ -26,6 +26,9 @@ namespace Microsoft.PowerFx.Core.Entities
         [Obsolete("preview")]
         public SummarizeCapabilities SummarizeCapabilities { get; init; }
 
+        [Obsolete("preview")]
+        public CountCapabilities CountCapabilities { get; init; }
+
         // Defines ungroupable columns
         public GroupRestrictions GroupRestriction { get; init; }
 
@@ -297,6 +300,54 @@ namespace Microsoft.PowerFx.Core.Entities
         Max,
         Count,
         CountRows
+    }
+
+    [Obsolete("preview")]
+    public class CountCapabilities
+    {
+        public CountCapabilities()
+        {
+        }
+
+        /// <summary>
+        /// If the table is countable, return true. 
+        /// Relevant expression: CountRows(Table);
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool IsCountableTable()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// If the table is countable after filter, return true.
+        /// Relevant expression: CountRows(Filter(Table, Condition)); / CountIf(Table, Condition).
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool IsCountableAfterFilter()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// If the table is countable after join, return true.
+        /// Relevant expression: CountRows(Join(Table1, Table2, ...)).
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool IsCountableAfterJoin()
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// If the table is countable after summarize, return true.
+        /// Relevant expression: CountRows(Summarize(Table, ...)).
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool IsCountableAfterSummarize()
+        {
+            return false;
+        }
     }
 
     public sealed class FilterRestrictions

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
@@ -76,14 +76,14 @@ namespace Microsoft.PowerFx.Types
         // $apply = groupby((field1, ..), field with sum as TotalSum)
         ApplyGroupBy = 1 << 5,
 
+        // $count
+        Count = 1 << 6,
+
         /*
           To be implemented later when needed
          
         // $compute
         Compute = 1 << 5,
-
-        // $count
-        Count = 1 << 6,
 
         // $expand
         Expand = 1 << 7,

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -37,6 +37,11 @@ namespace Microsoft.PowerFx.Types
         /// <param name="parameters">Delegation parameters.</param>
         /// <param name="cancel"></param>
         Task<FormulaValue> ExecuteQueryAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel);
+
+        /// <summary>
+        /// Supported features for delegation to verify correct Features are delegated at runtime.
+        /// </summary>
+        DelegationParameterFeatures SupportedFeatures { get; }
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -27,6 +27,7 @@ namespace Microsoft.PowerFx.Types
         /// <param name="parameters">delegation parameters.</param>
         /// <param name="cancel"></param>
         /// <returns></returns>
+        [Obsolete($"Use  {nameof(ExecuteQueryAsync)} instead.")]
         Task<IReadOnlyCollection<DValue<RecordValue>>> GetRowsAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel);
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -28,6 +28,14 @@ namespace Microsoft.PowerFx.Types
         /// <param name="cancel"></param>
         /// <returns></returns>
         Task<IReadOnlyCollection<DValue<RecordValue>>> GetRowsAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel);
+
+        /// <summary>
+        /// Evaluation will invoke this method on aggregation calls where return value is scaler.
+        /// </summary>
+        /// <param name="services">Pre-eval services.</param>
+        /// <param name="parameters">Delegation parameters.</param>
+        /// <param name="cancel"></param>
+        Task<FormulaValue> ExecuteQueryAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel);
     }
 
     /// <summary>

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
@@ -202,6 +202,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Entities.IRefreshable",                
                 "Microsoft.PowerFx.Core.Entities.SelectionRestrictions",
                 "Microsoft.PowerFx.Core.Entities.SortRestrictions",
+                "Microsoft.PowerFx.Core.Entities.CountCapabilities",
                 "Microsoft.PowerFx.Core.Entities.SummarizeCapabilities",
                 "Microsoft.PowerFx.Core.Entities.SummarizeMethod",
                 "Microsoft.PowerFx.Core.Entities.TableDelegationInfo",


### PR DESCRIPTION
This pull request introduces several changes to the PowerFx library to support counting capabilities in table delegation. The changes include adding a new method to count rows asynchronously, updating interfaces, and introducing a new class for count capabilities.

Enhancements to counting capabilities:

* [`src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs`](diffhunk://#diff-993c4c638e07f59077c442100bdb8ae7ae8bb5d6a56cc003d71468556198f930R69-R73): Added the `GetCountAsync` method to count rows asynchronously.
* [`src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs`](diffhunk://#diff-3262aeee6122a5873eb3c7866b3db562c90530f04d665f6186b26f32328abcf9R29-R31): Introduced the `CountCapabilities` class and added the `CountCapabilities` property to `TableDelegationInfo`. [[1]](diffhunk://#diff-3262aeee6122a5873eb3c7866b3db562c90530f04d665f6186b26f32328abcf9R29-R31) [[2]](diffhunk://#diff-3262aeee6122a5873eb3c7866b3db562c90530f04d665f6186b26f32328abcf9R305-R327)
* [`src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs`](diffhunk://#diff-acf9bad0ca58398efcb3fd3f6804a99623c3719c070b4f2d35f1775d040458c2R31-R39): Updated the `IDelegatableTableValue` interface to include the `GetCountAsync` method.