### PR TITLE
Fix issue when using Unicode characters in CDP datasets

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/CdpTableResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/CdpTableResolver.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Connectors
                 }
             }
 
-            string dataset = _doubleEncoding ? CdpServiceBase.DoubleEncode(_tabularTable.DatasetName) : _tabularTable.DatasetName;
+            string dataset = _doubleEncoding ? CdpServiceBase.DoubleEncode(_tabularTable.DatasetName) : CdpServiceBase.SingleEncode(_tabularTable.DatasetName);
             string uri = (_uriPrefix ?? string.Empty) + (UseV2(_uriPrefix) ? "/v2" : string.Empty) + $"/$metadata.json/datasets/{dataset}/tables/{CdpServiceBase.DoubleEncode(tableName)}?api-version=2015-09-01";
 
             string text = await CdpServiceBase.GetObject(_httpClient, $"Get table metadata", uri, null, cancellationToken, Logger).ConfigureAwait(false);

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpDataSource.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpDataSource.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerFx.Connectors
 
             string uri = (_uriPrefix ?? string.Empty)
                 + (CdpTableResolver.UseV2(uriPrefix) ? "/v2" : string.Empty)
-                + $"/datasets/{(DatasetMetadata.IsDoubleEncoding ? DoubleEncode(DatasetName) : DatasetName)}"
+                + $"/datasets/{(DatasetMetadata.IsDoubleEncoding ? DoubleEncode(DatasetName) : SingleEncode(DatasetName))}"
                 + (uriPrefix.Contains("/sharepointonline/") ? "/alltables" : "/tables");
 
             GetTables tables = await GetObject<GetTables>(httpClient, "Get tables", uri, null, cancellationToken, logger).ConfigureAwait(false);

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpServiceBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpServiceBase.cs
@@ -69,7 +69,12 @@ namespace Microsoft.PowerFx.Connectors
 
         internal static string DoubleEncode(string param)
         {
-            return Uri.EscapeDataString(Uri.EscapeDataString(param));
+            return SingleEncode(SingleEncode(param));
+        }
+
+        internal static string SingleEncode(string param)
+        {
+            return Uri.EscapeDataString(param);
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PowerFx.Connectors
             Uri uri = new Uri(
                    (_uriPrefix ?? string.Empty) +
                    (CdpTableResolver.UseV2(_uriPrefix) ? "/v2" : string.Empty) +
-                   $"/datasets/{(DatasetMetadata.IsDoubleEncoding ? DoubleEncode(DatasetName) : DatasetName)}/tables/{Uri.EscapeDataString(TableName)}/items?api-version=2015-09-01" + queryParams, UriKind.Relative);
+                   $"/datasets/{(DatasetMetadata.IsDoubleEncoding ? DoubleEncode(DatasetName) : SingleEncode(DatasetName))}/tables/{Uri.EscapeDataString(TableName)}/items?api-version=2015-09-01" + queryParams, UriKind.Relative);
 
             string text = await GetObject(_httpClient, $"List items ({nameof(GetItemsInternalAsync)})", uri.ToString(), null, cancellationToken, executionLogger).ConfigureAwait(false);
             return !string.IsNullOrWhiteSpace(text) ? GetResult(text) : Array.Empty<DValue<RecordValue>>();


### PR DESCRIPTION
When using Unicode characters, we were seeing HttpRequestException: Request headers must contain only ASCII characters.