### PR TITLE
Array to IReadList

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -837,12 +837,12 @@ namespace Microsoft.PowerFx.Connectors
             }
         }
 
-        internal Task<FormulaValue> InvokeInternalAsync(FormulaValue[] arguments, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)
+        internal Task<FormulaValue> InvokeInternalAsync(IReadOnlyList<FormulaValue> arguments, BaseRuntimeConnectorContext runtimeContext, CancellationToken cancellationToken)
         {
             return InvokeInternalAsync(arguments, runtimeContext, null, cancellationToken);
         }
 
-        internal async Task<FormulaValue> InvokeInternalAsync(FormulaValue[] arguments, BaseRuntimeConnectorContext runtimeContext, FormulaType outputTypeOverride, CancellationToken cancellationToken)
+        internal async Task<FormulaValue> InvokeInternalAsync(IReadOnlyList<FormulaValue> arguments, BaseRuntimeConnectorContext runtimeContext, FormulaType outputTypeOverride, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorHelperFunctions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorHelperFunctions.cs
@@ -58,14 +58,14 @@ namespace Microsoft.PowerFx.Connectors
             return $"{nameof(ConnectorParameter)} {connectorParameter.Name ?? Null(nameof(connectorParameter.Name))} Param.{LogConnectorType(connectorParameter.ConnectorType)}";
         }
 
-        internal static string LogArguments(FormulaValue[] arguments)
+        internal static string LogArguments(IReadOnlyList<FormulaValue> arguments)
         {
-            if (arguments == null || arguments.Length == 0)
+            if (arguments == null || arguments.Count == 0)
             {
                 return "no argument";
             }
 
-            return $"{arguments.Length} argument{(arguments.Length > 1 ? "s" : string.Empty)} {string.Join(" | ", arguments.Select(a => a.Type._type.ToAnonymousString()))}";
+            return $"{arguments.Count} argument{(arguments.Count > 1 ? "s" : string.Empty)} {string.Join(" | ", arguments.Select(a => a.Type._type.ToAnonymousString()))}";
         }
 
         internal static string LogFormulaValue(FormulaValue formulaValue)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "False positive")]
-        public async Task<HttpRequestMessage> BuildRequest(FormulaValue[] args, IConvertToUTC utcConverter, CancellationToken cancellationToken)
+        public async Task<HttpRequestMessage> BuildRequest(IReadOnlyList<FormulaValue> args, IConvertToUTC utcConverter, CancellationToken cancellationToken)
         {
             HttpContent body = null;
             var path = _function.OperationPath;
@@ -206,7 +206,7 @@ namespace Microsoft.PowerFx.Connectors
             return request;
         }
 
-        public Dictionary<string, FormulaValue> ConvertToNamedParameters(FormulaValue[] args)
+        public Dictionary<string, FormulaValue> ConvertToNamedParameters(IReadOnlyList<FormulaValue> args)
         {
             // First N are required params.
             // Last param is a record with each field being an optional.
@@ -255,9 +255,9 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             // Optional parameters are next and stored in a Record
-            if (_function.OptionalParameters.Length > 0 && args.Length > _function.RequiredParameters.Length)
+            if (_function.OptionalParameters.Length > 0 && args.Count > _function.RequiredParameters.Length)
             {
-                FormulaValue optionalArg = args[args.Length - 1];
+                FormulaValue optionalArg = args[args.Count - 1];
 
                 // Objects are always flattenned
                 if (optionalArg is RecordValue record)
@@ -483,7 +483,7 @@ namespace Microsoft.PowerFx.Connectors
                     _function.ReturnType);
         }
 
-        public async Task<FormulaValue> InvokeAsync(IConvertToUTC utcConverter, string cacheScope, FormulaValue[] args, HttpMessageInvoker localInvoker, CancellationToken cancellationToken, FormulaType expectedType, bool throwOnError = false)
+        public async Task<FormulaValue> InvokeAsync(IConvertToUTC utcConverter, string cacheScope, IReadOnlyList<FormulaValue> args, HttpMessageInvoker localInvoker, CancellationToken cancellationToken, FormulaType expectedType, bool throwOnError = false)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -551,7 +551,7 @@ namespace Microsoft.PowerFx.Connectors
 
         internal HttpFunctionInvoker Invoker => _invoker;
 
-        public async Task<FormulaValue> InvokeAsync(FormulaValue[] args, BaseRuntimeConnectorContext runtimeContext, FormulaType outputTypeOverride, CancellationToken cancellationToken)
+        public async Task<FormulaValue> InvokeAsync(IReadOnlyList<FormulaValue> args, BaseRuntimeConnectorContext runtimeContext, FormulaType outputTypeOverride, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs
@@ -88,7 +88,6 @@ namespace Microsoft.PowerFx.Connectors
 
         public async Task<FormulaValue> InvokeAsync(FunctionInvokeInfo invokeInfo, CancellationToken cancellationToken)
         {
-            FormulaValue[] args = invokeInfo.Args.ToArray(); // https://github.com/microsoft/Power-Fx/issues/2817
             var serviceProvider = invokeInfo.FunctionServices;
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -96,14 +95,14 @@ namespace Microsoft.PowerFx.Connectors
 
             try
             {
-                runtimeContext.ExecutionLogger?.LogInformation($"Entering in [Texl] {ConnectorFunction.LogFunction(nameof(InvokeAsync))} with {LogArguments(args)}");
-                FormulaValue formulaValue = await ConnectorFunction.InvokeInternalAsync(args, runtimeContext, cancellationToken).ConfigureAwait(false);
+                runtimeContext.ExecutionLogger?.LogInformation($"Entering in [Texl] {ConnectorFunction.LogFunction(nameof(InvokeAsync))} with {LogArguments(invokeInfo.Args)}");
+                FormulaValue formulaValue = await ConnectorFunction.InvokeInternalAsync(invokeInfo.Args, runtimeContext, cancellationToken).ConfigureAwait(false);
                 runtimeContext.ExecutionLogger?.LogInformation($"Exiting [Texl] {ConnectorFunction.LogFunction(nameof(InvokeAsync))} returning from {nameof(ConnectorFunction.InvokeInternalAsync)} with {LogFormulaValue(formulaValue)}");
                 return formulaValue;
             }
             catch (Exception ex)
             {
-                runtimeContext.ExecutionLogger?.LogException(ex, $"Exception in [Texl] {ConnectorFunction.LogFunction(nameof(InvokeAsync))} with {LogArguments(args)} {LogException(ex)}");
+                runtimeContext.ExecutionLogger?.LogException(ex, $"Exception in [Texl] {ConnectorFunction.LogFunction(nameof(InvokeAsync))} with {LogArguments(invokeInfo.Args)} {LogException(ex)}");
                 throw;
             }
         }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx
     /// </summary>
     internal class CustomTexlFunction : TexlFunction, IFunctionInvoker
     {
-        public Func<IServiceProvider, FormulaValue[], CancellationToken, Task<FormulaValue>> _impl;
+        public Func<IServiceProvider, IReadOnlyList<FormulaValue>, CancellationToken, Task<FormulaValue>> _impl;
 
         internal BigInteger LamdaParamMask;
 
@@ -57,8 +57,7 @@ namespace Microsoft.PowerFx
         public virtual Task<FormulaValue> InvokeAsync(FunctionInvokeInfo invokeInfo, CancellationToken cancellationToken)
         {
             var serviceProvider = invokeInfo.FunctionServices;
-            var args = invokeInfo.Args.ToArray(); // remove ToArray: https://github.com/microsoft/Power-Fx/issues/2817
-            return _impl(serviceProvider, args, cancellationToken);
+            return _impl(serviceProvider, invokeInfo.Args, cancellationToken);
         }
 
         public override bool IsLazyEvalParam(TexlNode node, int index, Features features)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
@@ -217,9 +217,15 @@ namespace Microsoft.PowerFx
             return _info.Name;
         }
 
+        [Obsolete("Soon to be removed.")]
         public FormulaValue Invoke(IServiceProvider serviceProvider, FormulaValue[] args)
         {
             return InvokeAsync(serviceProvider, args, CancellationToken.None).Result;
+        }
+
+        public async Task<FormulaValue> InvokeAsync(IServiceProvider serviceProvider, FormulaValue[] args, CancellationToken cancellationToken)
+        {
+            return await InvokeAsync(serviceProvider, (IReadOnlyList<FormulaValue>)args, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<FormulaValue> InvokeAsync(IServiceProvider serviceProvider, IReadOnlyList<FormulaValue> args, CancellationToken cancellationToken)

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
@@ -196,7 +196,7 @@ namespace Microsoft.PowerFx
             {
                 return new CustomSetPropertyFunction(info.NameSpace, info.Name, info.ArgNames)
                 {
-                    _impl = args => InvokeAsync(null, args, CancellationToken.None)
+                    _impl = args => InvokeAsync(null, (IReadOnlyList<FormulaValue>)args, CancellationToken.None)
                 };
             }
 
@@ -220,9 +220,15 @@ namespace Microsoft.PowerFx
         [Obsolete("Soon to be removed.")]
         public FormulaValue Invoke(IServiceProvider serviceProvider, FormulaValue[] args)
         {
+            return InvokeAsync(serviceProvider, (IReadOnlyList<FormulaValue>)args, CancellationToken.None).Result;
+        }
+
+        public FormulaValue Invoke(IServiceProvider serviceProvider, IReadOnlyList<FormulaValue> args)
+        {
             return InvokeAsync(serviceProvider, args, CancellationToken.None).Result;
         }
 
+        [Obsolete("Soon to be removed.")]
         public async Task<FormulaValue> InvokeAsync(IServiceProvider serviceProvider, FormulaValue[] args, CancellationToken cancellationToken)
         {
             return await InvokeAsync(serviceProvider, (IReadOnlyList<FormulaValue>)args, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs
@@ -222,7 +222,7 @@ namespace Microsoft.PowerFx
             return InvokeAsync(serviceProvider, args, CancellationToken.None).Result;
         }
 
-        public async Task<FormulaValue> InvokeAsync(IServiceProvider serviceProvider, FormulaValue[] args, CancellationToken cancellationToken)
+        public async Task<FormulaValue> InvokeAsync(IServiceProvider serviceProvider, IReadOnlyList<FormulaValue> args, CancellationToken cancellationToken)
         {
             var info = Scan();
 
@@ -241,7 +241,7 @@ namespace Microsoft.PowerFx
             }
 
             List<ErrorValue> errors = null;
-            for (var i = 0; i < args.Length; i++)
+            for (var i = 0; i < args.Count; i++)
             {
                 object arg = args[i];
 


### PR DESCRIPTION
Issue https://github.com/microsoft/Power-Fx/issues/2817.
This pull request focuses on updating method signatures to use `IReadOnlyList<FormulaValue>` instead of `FormulaValue[]` for improved type safety and consistency across the codebase. The changes span multiple files and functions.

Key changes include:

### Method Signature Updates:

* [`src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs`](diffhunk://#diff-720d55f6094e558103fec3c4f1440cbc4cd5d6af39c7d21ec887627f31f32facL840-R845): Updated `InvokeInternalAsync` method signatures to accept `IReadOnlyList<FormulaValue>` instead of `FormulaValue[]`.
* [`src/libraries/Microsoft.PowerFx.Connectors/ConnectorHelperFunctions.cs`](diffhunk://#diff-5fd134a20257176c5329f27cc3a8ba06ae4b5e69cc75ea248309bfabeec6a7dbL61-R68): Changed `LogArguments` method to use `IReadOnlyList<FormulaValue>` and updated related logic.
* [`src/libraries/Microsoft.PowerFx.Connectors/Execution/HttpFunctionInvoker.cs`](diffhunk://#diff-3daeaf7e821695daeab5cf02ea83945facda3f73962ad2b15755c96a57802da5L41-R41): Updated several method signatures, including `BuildRequest`, `ConvertToNamedParameters`, and `InvokeAsync`, to use `IReadOnlyList<FormulaValue>`. [[1]](diffhunk://#diff-3daeaf7e821695daeab5cf02ea83945facda3f73962ad2b15755c96a57802da5L41-R41) [[2]](diffhunk://#diff-3daeaf7e821695daeab5cf02ea83945facda3f73962ad2b15755c96a57802da5L209-R209) [[3]](diffhunk://#diff-3daeaf7e821695daeab5cf02ea83945facda3f73962ad2b15755c96a57802da5L258-R260) [[4]](diffhunk://#diff-3daeaf7e821695daeab5cf02ea83945facda3f73962ad2b15755c96a57802da5L486-R486) [[5]](diffhunk://#diff-3daeaf7e821695daeab5cf02ea83945facda3f73962ad2b15755c96a57802da5L554-R554)
* [`src/libraries/Microsoft.PowerFx.Connectors/Texl/ConnectorTexlFunction.cs`](diffhunk://#diff-4da029ce13f69e0f1dd774d71fb11c96038bf540ea42d78cdbf17bd35ff6a995L91-R105): Modified `InvokeAsync` to use `invokeInfo.Args` directly without converting to an array.
* [`src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/CustomTexlFunction.cs`](diffhunk://#diff-a395b04ce236d4f1f0ec819d7f3d4704f5a8f6e4ac7bcf31bbb338eb6329c2dfL28-R28): Updated `_impl` delegate and `InvokeAsync` method to use `IReadOnlyList<FormulaValue>`. [[1]](diffhunk://#diff-a395b04ce236d4f1f0ec819d7f3d4704f5a8f6e4ac7bcf31bbb338eb6329c2dfL28-R28) [[2]](diffhunk://#diff-a395b04ce236d4f1f0ec819d7f3d4704f5a8f6e4ac7bcf31bbb338eb6329c2dfL60-R60)
* [`src/libraries/Microsoft.PowerFx.Interpreter/CustomFunction/ReflectionFunction.cs`](diffhunk://#diff-4acf0a546b868a4d48ac51a2471caae848fceee1fc55221533ea2dbed92ee867L199-R199): Refactored several methods, including `Invoke` and `InvokeAsync`, to support `IReadOnlyList<FormulaValue>`. Added obsolete attributes to old method signatures. [[1]](diffhunk://#diff-4acf0a546b868a4d48ac51a2471caae848fceee1fc55221533ea2dbed92ee867L199-R199) [[2]](diffhunk://#diff-4acf0a546b868a4d48ac51a2471caae848fceee1fc55221533ea2dbed92ee867R220-R237) [[3]](diffhunk://#diff-4acf0a546b868a4d48ac51a2471caae848fceee1fc55221533ea2dbed92ee867L244-R256)