### PR TITLE
Dont anonymize Join nor default enums

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Logging/StructuralPrint.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Logging/StructuralPrint.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Parser;
 using Microsoft.PowerFx.Core.Texl;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.UtilityDataStructures;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Syntax;
@@ -122,6 +123,15 @@ namespace Microsoft.PowerFx.Core.Logging
             Contracts.AssertValue(node);
 
             var separator = TexlParser.GetTokString(node.Token.Kind);
+            var nodeType = _binding?.GetType(node);
+
+            // If default enum, show it plain.
+            if (nodeType != null && 
+                nodeType.OptionSetInfo != null &&
+                EnumStoreBuilder.DefaultEnumSymbols.ContainsKey(nodeType.OptionSetInfo.EntityName.Value))
+            {
+                return LazyList<string>.Of(node.ToString());
+            }
 
             var values = node.Left.Accept(this, Precedence.Primary);
             values = values.With(separator);

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -17,10 +17,13 @@ namespace Microsoft.PowerFx.Core.Texl
         // This is the list of Power Apps functions that aren't supported/implemeted in Power Fx
         // Binder will recognize these functions names and return a "recognized but not yet supported function" message 
         // instead of the classic "unknown or unsupported function".
+
+        // This list also contains functions that are added to the interpreter at runtime and dont have their definitions
+        // included into the BuiltinFunctionsLibrary library. Examples: Set, Join.
         internal static readonly IReadOnlyCollection<string> OtherKnownFunctions = new HashSet<string>()
         {
             "Assert", "Back", "Choices", "ClearData", "Concurrent", "Confirm", "Copy", "DataSourceInfo", "Defaults", "Disable", "Distinct", "Download", "EditForm", "Enable", "Errors", "Exit",
-            "GroupBy", "HashTags", "IsMatch", "IsType", "JSON", "Launch", "LoadData", "Match", "MatchAll", "Navigate", "NewForm", "Notify", "PDF", "Param", "Pending", "Print", "ReadNFC",
+            "GroupBy", "HashTags", "IsMatch", "IsType", "Join", "JSON", "Launch", "LoadData", "Match", "MatchAll", "Navigate", "NewForm", "Notify", "PDF", "Param", "Pending", "Print", "ReadNFC",
             "RecordInfo", "Relate", "RemoveAll", "RemoveIf", "RequestHide", "Reset", "ResetForm", "Revert", "SaveData", "ScanBarcode", "Select", "SetFocus",
             "SetProperty", "ShowColumns", "State", "SubmitForm", "TraceValue", "Ungroup", "Unrelate", "Update", "UpdateContext", "UpdateIf", "User", "Validate", "ValidateRecord", "ViewForm",
             "Collect", "Clear", "Patch", "Remove", "ClearCollect", "Set"

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.PowerFx.Tests
         [InlineData(
             "ParseJSON(\"{}\", Type(RecordOf(Accounts)))",
             "ParseJSON(#$string$#, Type(RecordOf(#$firstname$#)))")]
-
         public void TestStucturalPrint(string script, string expected)
         {
             var result = ParseScript(


### PR DESCRIPTION
This pull request includes changes to enhance the handling of enums in the `StructuralPrint` class, update the list of known functions, and improve test coverage.

Enhancements to `StructuralPrint`:

* [`src/libraries/Microsoft.PowerFx.Core/Logging/StructuralPrint.cs`](diffhunk://#diff-4760f19aba839606fcde0849467658572c272afd030c115afae8263986234a6dR9): Added logic to handle default enums in the `Visit` method for `DottedNameNode`, and included the `Enums` namespace. [[1]](diffhunk://#diff-4760f19aba839606fcde0849467658572c272afd030c115afae8263986234a6dR9) [[2]](diffhunk://#diff-4760f19aba839606fcde0849467658572c272afd030c115afae8263986234a6dR126-R134)

Updates to known functions:

* [`src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs`](diffhunk://#diff-5a3b8429b8a783e4a4f50cbc410c8c1d83eda1fc561760948b79fc8ce675a5baR20-R26): Updated the `OtherKnownFunctions` list to include the `Join` function.

Improvements to test coverage:

* [`src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs`](diffhunk://#diff-f6ab2187c7ce1b7dea3e0655fb70f738656098817671383d60e9233859294a34R8): Added new test cases for the `Join` and `WeekNum` functions in `TestStucturalPrintWithBinding`, and included the `Builtins` namespace. [[1]](diffhunk://#diff-f6ab2187c7ce1b7dea3e0655fb70f738656098817671383d60e9233859294a34R8) [[2]](diffhunk://#diff-f6ab2187c7ce1b7dea3e0655fb70f738656098817671383d60e9233859294a34R37-R46) [[3]](diffhunk://#diff-f6ab2187c7ce1b7dea3e0655fb70f738656098817671383d60e9233859294a34R72-R101)