### PR TITLE
Pass Feature Name as Telemetry for NL2Fx

### DIFF
--- a/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
+++ b/src/libraries/Microsoft.PowerFx.LanguageServerProtocol/Public/NLHandler.cs
@@ -74,8 +74,6 @@ namespace Microsoft.PowerFx.LanguageServerProtocol
         /// For example: "vi-VN" or "fr-FR".
         /// </summary>
         public CultureInfo ExpressionLocale { get; set; }
-
-        public string FeatureName { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
Currently for the telemetry object in NL2Fx, we only pass one unified identifier for all NL2Fx features which results in data not being classified at the feature level. We must change that, for better telemetry information.

This is a four-part change. In these repo, Power-Fx (GitHub), I need to write a variable in CustomNL2Fx, to pass to PPUX.