### PR TITLE
Fix DType.Add overloads

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1371,9 +1371,15 @@ namespace Microsoft.PowerFx.Core.Types
                 fullType = LazyTypeProvider.GetExpandedType(IsTable);
             }
 
-            Contracts.Assert(!TypeTree.Contains(name));
-            var tree = TypeTree.SetItem(name, type);
-            var newType = new DType(Kind, tree, AssociatedDataSources, DisplayNameProvider);
+            Contracts.Assert(!fullType.TypeTree.Contains(name));
+
+            var tree = fullType.TypeTree.SetItem(name, type);
+            var newType = new DType(fullType.Kind, tree, AssociatedDataSources, fullType.DisplayNameProvider);
+
+            if (fullType.HasExpandInfo)
+            {
+                newType = CopyExpandInfo(newType, fullType);
+            }
 
             return newType;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1346,6 +1346,11 @@ namespace Microsoft.PowerFx.Core.Types
                 fError = true;
             }
 
+            if (typeOuter.IsLazyType)
+            {
+                typeOuter = typeOuter.LazyTypeProvider.GetExpandedType(typeOuter.IsTable);
+            }
+
             var tree = typeOuter.TypeTree.SetItem(name, type);
             var updatedTypeOuter = new DType(typeOuter.Kind, tree, AssociatedDataSources, typeOuter.DisplayNameProvider);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -1341,14 +1341,14 @@ namespace Microsoft.PowerFx.Core.Types
 
             Contracts.Assert(typeOuter.IsRecord || typeOuter.IsTable);
 
-            if (typeOuter.TypeTree.TryGetValue(name, out var typeCur))
-            {
-                fError = true;
-            }
-
             if (typeOuter.IsLazyType)
             {
                 typeOuter = typeOuter.LazyTypeProvider.GetExpandedType(typeOuter.IsTable);
+            }
+
+            if (typeOuter.TypeTree.TryGetValue(name, out var typeCur))
+            {
+                fError = true;
             }
 
             var tree = typeOuter.TypeTree.SetItem(name, type);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TypeSystemTests/LazyTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TypeSystemTests/LazyTypeTests.cs
@@ -269,14 +269,26 @@ namespace Microsoft.PowerFx.Core.Tests
 
             Assert.Equal("![Bar:s, Baz:b, Foo:n, Test:O]", type1.ToString());
 
+            // test Add overload without path 
+            // using lazy record
             var type2 = _lazyRecord1._type.Add(new DName("ThisRecord"), TestUtils.DT("![a: n]"));
             Assert.Equal("r!", _lazyRecord1._type.ToString());
             Assert.Equal("![Bar:s, Baz:b, Foo:n, ThisRecord:![a:n]]", type2.ToString());
 
+            // using lazy table
             var type3 = _lazyTable2._type.Add(new DName("ThisRecord"), TestUtils.DT("![Value:O]"));
             Assert.Equal("r*", _lazyTable2._type.ToString());
             Assert.Equal(2, _getter2CalledCount);
             Assert.Equal("*[Nested:r!, Qux:n, ThisRecord:![Value:O]]", type3.ToString());
+
+            // test Add overload with path and LazyType as field
+            // using lazy record
+            var type4 = _lazyRecord2._type.Add(ref fError, DPath.Root.Append(new DName("Nested")), new DName("New"), DType.Number);
+            Assert.Equal("![Nested:![Bar:s, Baz:b, Foo:n, New:n], Qux:n]", type4.ToString());
+
+            // using lazy table
+            var type5 = _lazyTable2._type.Add(ref fError, DPath.Root.Append(new DName("Nested")), new DName("NewCol"), TestUtils.DT("![a:n]"));
+            Assert.Equal("*[Nested:![Bar:s, Baz:b, Foo:n, NewCol:![a:n]], Qux:n]", type5.ToString());
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TypeSystemTests/LazyTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TypeSystemTests/LazyTypeTests.cs
@@ -268,6 +268,15 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Equal(3, _getter1CalledCount);
 
             Assert.Equal("![Bar:s, Baz:b, Foo:n, Test:O]", type1.ToString());
+
+            var type2 = _lazyRecord1._type.Add(new DName("ThisRecord"), TestUtils.DT("![a: n]"));
+            Assert.Equal("r!", _lazyRecord1._type.ToString());
+            Assert.Equal("![Bar:s, Baz:b, Foo:n, ThisRecord:![a:n]]", type2.ToString());
+
+            var type3 = _lazyTable2._type.Add(new DName("ThisRecord"), TestUtils.DT("![Value:O]"));
+            Assert.Equal("r*", _lazyTable2._type.ToString());
+            Assert.Equal(2, _getter2CalledCount);
+            Assert.Equal("*[Nested:r!, Qux:n, ThisRecord:![Value:O]]", type3.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
`DType.Add` overload was broken and it did not work correctly for LazyTypes leading to errors and NullReferenceExceptions in some cases. 

this bug came to light when investigating a customer reported incident for new analysis.

This PR fixes the `DType.Add` overload and adds tests to ensure the fix works as expected.