### PR TITLE
EvalVisitor.Culture is always non-null.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerFx
 
             TimeZoneInfo = GetService<TimeZoneInfo>() ?? TimeZoneInfo.Local;
             Governor = GetService<Governor>() ?? new Governor();
-            CultureInfo = GetService<CultureInfo>();
+            CultureInfo = GetService<CultureInfo>() ?? throw new ArgumentNullException("Missing CultureInfo");
         }
 
         /// <summary>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageTest.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageTest.cs
@@ -49,13 +49,6 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public void GetLanguageForNullCulture()
         {
-            var runtimeConfig = new RuntimeConfig();
-            var runner = new EvalVisitor(runtimeConfig, CancellationToken.None);
-
-            var language = Language(runner, IRContext.NotInSource(FormulaType.String));
-            Assert.Equal("en-US", language.Value);
-
-            _defaultCulture = null;
             TestDefaultCulture(null);
         }
 


### PR DESCRIPTION
Add enforcement.

This is true because the class is private and it's always set here: 
https://github.com/microsoft/Power-Fx/blob/27928265741af482f8c650ccca7902231ead44c8/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs#L138

