### PR TITLE
Adds capabilities for top level aggregation.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
@@ -29,6 +29,9 @@ namespace Microsoft.PowerFx.Core.Entities
         [Obsolete("preview")]
         public CountCapabilities CountCapabilities { get; init; }
 
+        [Obsolete("preview")]
+        public TopLevelAggregationCapabilities TopLevelAggregationCapabilities { get; init; }
+
         // Defines ungroupable columns
         public GroupRestrictions GroupRestriction { get; init; }
 
@@ -346,6 +349,18 @@ namespace Microsoft.PowerFx.Core.Entities
         /// </summary>
         /// <returns></returns>
         public virtual bool IsCountableAfterSummarize()
+        {
+            return false;
+        }
+    }
+
+    [Obsolete("preview")]
+    public class TopLevelAggregationCapabilities
+    {
+        /// <summary>
+        /// If the table supports top level aggregation for a column, return true.
+        /// </summary>
+        public virtual bool IsTopLevelAggregationSupported(SummarizeMethod method, string propertyName)
         {
             return false;
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs
@@ -281,9 +281,17 @@ namespace Microsoft.PowerFx.Core.Entities
         }
     }
 
+    /// <summary>
+    /// If the table supports summarize, return true.
+    /// e.g. Summarize(Table, ColumnName, Sum(ColumnName)).
+    /// For top level aggregation Sum(Table, ColumnName), use <see cref="TopLevelAggregationCapabilities"/>.
+    /// </summary>
     [Obsolete("preview")]
     public class SummarizeCapabilities
     {
+        /// <summary>
+        /// If the table property supports summarize, return true.
+        /// </summary>
         public virtual bool IsSummarizableProperty(string propertyName, SummarizeMethod method)
         {
             return false;
@@ -354,6 +362,12 @@ namespace Microsoft.PowerFx.Core.Entities
         }
     }
 
+    /// <summary>
+    /// If the table supports top level aggregation for a column, return true.
+    /// e.g. Sum, Average, Min, Max, Count without Summarize(). 
+    /// e.g. expression: Sum(Table, ColumnName).
+    /// For aggregation with grouping, Summarize(Table, ColumnName, Sum(ColumnName)), use <see cref="SummarizeCapabilities"/>.
+    /// </summary>
     [Obsolete("preview")]
     public class TopLevelAggregationCapabilities
     {

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
@@ -79,6 +79,9 @@ namespace Microsoft.PowerFx.Types
         // $count
         Count = 1 << 6,
 
+        // $apply = aggregate(field1 with sum as TotalSum)
+        ApplyTopLevelAggregation = 1 << 7,
+
         /*
           To be implemented later when needed
          

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
@@ -206,6 +206,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Core.Entities.SummarizeCapabilities",
                 "Microsoft.PowerFx.Core.Entities.SummarizeMethod",
                 "Microsoft.PowerFx.Core.Entities.TableDelegationInfo",
+                "Microsoft.PowerFx.Core.Entities.TopLevelAggregationCapabilities",
                 "Microsoft.PowerFx.Core.Functions.Delegation.DelegationOperator",
                 "Microsoft.PowerFx.Core.Localization.ErrorResourceKey",
                 "Microsoft.PowerFx.Core.RenameDriver",


### PR DESCRIPTION
This pull request introduces new capabilities for handling top-level aggregations in the `Microsoft.PowerFx.Core` library. The changes primarily focus on adding support for top-level aggregation capabilities and updating related classes and enums.
This is different that Summarize capabilities. Since Summarize **requires** group by, while top level aggregation does not.
e.g.
`Select Sum(col1) from table1 group by col2` equivalent Fx uses Summarize capabilities.
vs
`Select Sum(col1) from table1` equivalent Fx uses TopLevelAggregation capabilities.

### Enhancements to Aggregation Capabilities:

* [`src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs`](diffhunk://#diff-3262aeee6122a5873eb3c7866b3db562c90530f04d665f6186b26f32328abcf9R32-R34): Added a new property `TopLevelAggregationCapabilities` to the `TableDelegationInfo` class and marked it as obsolete for preview purposes.
* [`src/libraries/Microsoft.PowerFx.Core/Entities/External/TableDelegationInfo.cs`](diffhunk://#diff-3262aeee6122a5873eb3c7866b3db562c90530f04d665f6186b26f32328abcf9R351-R362): Introduced a new class `TopLevelAggregationCapabilities` with a method `IsTopLevelAggregationSupported` to determine support for top-level aggregation on a column.
* [`src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs`](diffhunk://#diff-7d0c7991f2b0cafe204ca1ce9c4aafaa8424ef742874060d7dfb322de4a8c457R82-R84): Added a new enum value `ApplyTopLevelAggregation` to `DelegationParameterFeatures` to represent the ability to apply top-level aggregations.