### PR TITLE
Fix regular expression \u{...} issue in pre-V1

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Match.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Match.cs
@@ -279,6 +279,11 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 regexPattern = regexPatternWhitespace.Replace(regexPattern, "\n");
             }
 
+            // .NET doesn't support \u{...} notation.
+            // For the purposes of confirming this is a legitimate regular expression and finding the capture names, replace with something simple (an "A").
+            // Canvas pre-V1 allowed this, with as many digits as desired (but no spaces), so long as the result was less that or equal to 0xffff.
+            regexPattern = Regex.Replace(regexPattern, "\\\\u\\{[0-9a-fA-F]{1,}\\}", "\\u0041");
+
             // always .NET compile the regular expression, even if we don't need the return type (boolean), to ensure it is legal in .NET
             try
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Compat.txt
@@ -28,4 +28,10 @@ false
 >> IsMatch("!@#$%^&*()-=_+<>,.:;\'{}[]\|?/~`  1234567890", "\p{L}", MatchOptions.Complete )
 false
 
+// \u{...} notation not supported by .net
+// will be blocked in V1 by the regular expression checker (for now) with a compile time error
+// when V1 is disabled, runtime error on .NET because it doesn't support it in the interpreter
+>> IsMatch( "a", "\u{0061}" )
+Errors: Error 14-24: Invalid regular expression: Invalid escape code, found "\u".|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1CompatDisabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1CompatDisabled.txt
@@ -18,3 +18,9 @@ false
 // set options shouldn't override complete
 >> IsMatch( "aa", "a", MatchOptions.IgnoreCase )
 false
+
+// \u{...} notation not supported by .net
+// will be blocked in V1 by the regular expression checker (for now) with a compile time error
+// when V1 is disabled, runtime error on .NET because it doesn't support it in the interpreter
+>> IsMatch( "a", "\u{0061}" )
+Error({Kind:ErrorKind.BadRegex})


### PR DESCRIPTION
The recent change for regular expressions introduced a bug in pre-V1 for IsMatch (but not Match and MatchAll).  Since we were not previously checking syntax at compile time, we didn't block `\u{0041}` from being compiled, but this is not something that .NET's regular expression engine understands. The .NET engine is used for validating the regular expression and finding named groups at compile time, and so now this is a new error.  

The fix is straightforward, mapping `\u{0041}` to the supported `\u0041` for the purposes of validation and group detection for all three regular expression functions.

This does mean that Match and MatchAll will also start supporting the curly bracket syntax. We plan to add this in V1 so this is fine.