### PR TITLE
Update IsMatch constant check for pre-v1

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Match.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Match.cs
@@ -179,14 +179,17 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(returnType.IsRecord || returnType.IsTable || returnType == DType.Boolean);
 
             var regExNode = args[1];
+            var isMatchCheckSemanticsLater = false;
 
             if ((argTypes[1].Kind != DKind.String && argTypes[1].Kind != DKind.OptionSetValue) || !BinderUtils.TryGetConstantValue(context, regExNode, out var regularExpression))
             {
+                regularExpression = null;
+
                 if (returnType == DType.Boolean && !context.Features.PowerFxV1CompatibilityRules)
                 {
                     // error check is delayed until CheckSemantics for IsMatch only, where we have the binding
                     // don't leave CheckTypes until after we review the third argument, can still report a problem with a constant third argument and the new enum flags
-                    regularExpression = null;
+                    isMatchCheckSemanticsLater = true;
                 }
                 else
                 {
@@ -223,7 +226,7 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 // regularExpressionOptions will remain empty for the cache work below which is fine.
             }
 
-            if (regularExpression == null)
+            if (isMatchCheckSemanticsLater)
             {
                 return true;
             }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch.txt
@@ -48,9 +48,6 @@ Error({Kind:ErrorKind.Div0})
 >> IsMatch(Blank(), "Hi")
 false
 
->> IsMatch("Foo", Blank())
-Errors: Error 15-22: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
-
 >> IsMatch(28, "Bar")
 false
 
@@ -59,9 +56,6 @@ true
 
 >> IsMatch(Blank(), ".")
 false
-
->> IsMatch(Blank(), Blank())
-Errors: Error 17-24: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
 
 >> IsMatch("!@#$%^&*()-=_+<>,.:;\'{}[]\|?/~` A 1234567890", "\p{L}", MatchOptions.Complete)
 false
@@ -82,12 +76,6 @@ false
 // With Icelandic Eth
 >> IsMatch("!@#$%^&*()-=_+<>,.:;\'{}[]\|?/~` Ð 1234567890", "\p{L}", MatchOptions.Contains)
 true
-
->> IsMatch( "28", Concat( [2,8], Value ) )
-Errors: Error 15-37: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
-
->> IsMatch( "28", Concat( [2,8], If( false, Text(Now()), Value ) ) )
-Errors: Error 15-63: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
 
 >> IsMatch("(555) 123-4567", "^[\+]?[\(]?[0-9]{3}[\)]?[\-\s\.]?[0-9]{3}[\-\s\.]?[0-9]{4,6}$")
 true
@@ -118,12 +106,6 @@ true
 
 >> IsMatch(UniChar(Hex2Dec("1f47d")) & "Hello world", UniChar(128125) & "Hello", MatchOptions.Contains)
 true
-
->> IsMatch("""Hello world""", Mid( "Hello", 1 ), MatchOptions.Contains)
-Errors: Error 27-44: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
-
->> IsMatch("Hello 123 world", $"Hello {Sqrt(1)}{Sqrt(4)}{Sqrt(9)} world")
-Errors: Error 27-69: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
 
 >> IsMatch("Hello 123 world", $"Hello", MatchOptions.Contains)
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Disabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Disabled.txt
@@ -1,6 +1,7 @@
 ﻿#SETUP: RegEx,disable:PowerFxV1CompatibilityRules
 
-// Prior to V1, IsMatch would us IsConstant to determine if the second argument was a constant, instead of relying on TryGetConstantValue
+// Prior to V1, IsMatch would use IsConstant to determine if the second argument was a constant, instead of relying on TryGetConstantValue
+// MatchOptions was not required to be a compile time constant
 
 >> IsMatch("Foo", Blank())
 Errors: Error 15-22: Regular expression must be a constant value.
@@ -22,3 +23,35 @@ true
 
 >> IsMatch("Hello 123 world", $"Hello {Sqrt(1)}{Sqrt(4)}{Sqrt(9)} world")
 true
+
+// We give these errors when we can, as these options were not supported in pre-V1
+// They are not implemented in pre-V1
+
+>> IsMatch( "a", "a#f", MatchOptions.FreeSpacing )
+Errors: Error 33-45: Invalid regular expression: MatchOptions.DotAll and MatchOptions.FreeSpacing are only available with Power Fx V1, found "MatchOptions.FreeSpacing".|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch( Char(10), ".+", MatchOptions.DotAll )
+Errors: Error 37-44: Invalid regular expression: MatchOptions.DotAll and MatchOptions.FreeSpacing are only available with Power Fx V1, found "MatchOptions.DotAll".|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch( "A", "a", MatchOptions.IgnoreCase )
+true
+
+// we can't generate errors when options are supported at runtime (pre-V1)
+
+>> With( { mo: MatchOptions.FreeSpacing }, IsMatch( "a", "a#f", mo ) )
+true
+
+>> With( { mo: MatchOptions.FreeSpacing }, IsMatch( "a", "a#f" ) )
+false
+
+>> With( { mo: MatchOptions.DotAll }, IsMatch( Char(10), ".+", mo ) )
+true
+
+>> With( { mo: MatchOptions.DotAll }, IsMatch( Char(10), ".+" ) )
+false
+
+>> With( { mo: MatchOptions.IgnoreCase }, IsMatch( "A", "a", mo ) )
+true
+
+>> With( { mo: MatchOptions.IgnoreCase }, IsMatch( "A", "a" ) )
+false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Disabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Disabled.txt
@@ -1,0 +1,24 @@
+﻿#SETUP: RegEx,disable:PowerFxV1CompatibilityRules
+
+// Prior to V1, IsMatch would us IsConstant to determine if the second argument was a constant, instead of relying on TryGetConstantValue
+
+>> IsMatch("Foo", Blank())
+Errors: Error 15-22: Regular expression must be a constant value.
+
+>> IsMatch(Blank(), Blank())
+Errors: Error 17-24: Regular expression must be a constant value.
+
+>> IsMatch( "28", Concat( [2,8], Value ) )
+Errors: Error 15-37: Regular expression must be a constant value.
+
+>> IsMatch( "28", Concat( [2,8], If( false, Text(Now()), Value ) ) )
+Errors: Error 15-63: Regular expression must be a constant value.
+
+>> IsMatch("""Hello world""", Mid( "Hello", 1 ), MatchOptions.Contains)
+true
+
+>> IsMatch( "adfA", Left( Left( "asdf", 1 ), 1 ) & Right( "asdf", 2 ) & Char( 65 ) )
+true
+
+>> IsMatch("Hello 123 world", $"Hello {Sqrt(1)}{Sqrt(4)}{Sqrt(9)} world")
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Enabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Enabled.txt
@@ -22,3 +22,32 @@ Errors: Error 67-68: Regular expression must be a constant value.|Error 0-7: The
 
 >> IsMatch("Hello 123 world", $"Hello {Sqrt(1)}{Sqrt(4)}{Sqrt(9)} world")
 Errors: Error 27-69: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch( "a", "a#f", MatchOptions.FreeSpacing )
+true
+
+>> IsMatch( Char(10), ".+", MatchOptions.DotAll )
+true
+
+>> IsMatch( "A", "a", MatchOptions.IgnoreCase )
+true
+
+// we CAN generate errors here because options are compile time constants (V1)
+
+>> With( { mo: MatchOptions.FreeSpacing }, IsMatch( "a", "a#f", mo ) )
+Errors: Error 61-63: MatchOptions must be a constant value.|Error 40-47: The function 'IsMatch' has some invalid arguments.
+
+>> With( { mo: MatchOptions.FreeSpacing }, IsMatch( "a", "a#f" ) )
+false
+
+>> With( { mo: MatchOptions.DotAll }, IsMatch( Char(10), ".+", mo ) )
+Errors: Error 60-62: MatchOptions must be a constant value.|Error 35-42: The function 'IsMatch' has some invalid arguments.
+
+>> With( { mo: MatchOptions.DotAll }, IsMatch( Char(10), ".+" ) )
+false
+
+>> With( { mo: MatchOptions.IgnoreCase }, IsMatch( "A", "a", mo ) )
+Errors: Error 58-60: MatchOptions must be a constant value.|Error 39-46: The function 'IsMatch' has some invalid arguments.
+
+>> With( { mo: MatchOptions.IgnoreCase }, IsMatch( "A", "a" ) )
+false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Enabled.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsMatch_V1Enabled.txt
@@ -1,0 +1,24 @@
+﻿#SETUP: RegEx,PowerFxV1CompatibilityRules
+
+// Prior to V1, IsMatch would us IsConstant to determine if the second argument was a constant, instead of relying on TryGetConstantValue
+
+>> IsMatch("Foo", Blank())
+Errors: Error 15-22: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch(Blank(), Blank())
+Errors: Error 17-24: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch( "28", Concat( [2,8], Value ) )
+Errors: Error 15-37: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch( "28", Concat( [2,8], If( false, Text(Now()), Value ) ) )
+Errors: Error 15-63: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch("""Hello world""", Mid( "Hello", 1 ), MatchOptions.Contains)
+Errors: Error 27-44: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch( "adfA", Left( Left( "asdf", 1 ), 1 ) & Right( "asdf", 2 ) & Char( 65 ) )
+Errors: Error 67-68: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+
+>> IsMatch("Hello 123 world", $"Hello {Sqrt(1)}{Sqrt(4)}{Sqrt(9)} world")
+Errors: Error 27-69: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
@@ -173,10 +173,10 @@ Table({Value:3},{Value:2},{Value:1})
 "h"
 
 >> IsMatch("Foo", 17)
-Errors: Error 15-17: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+Errors: Error 15-17: Regular expression must be a constant value.
 
 >> IsMatch("Foo", 1/0)
-Errors: Error 16-17: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+Errors: Error 16-17: Regular expression must be a constant value.
 
 //===========================================================================================================
 //
@@ -1457,4 +1457,4 @@ true
 false
 
 >> IsMatch( "28", 28 )
-Errors: Error 15-17: Regular expression must be a constant value.|Error 0-7: The function 'IsMatch' has some invalid arguments.
+Errors: Error 15-17: Regular expression must be a constant value.


### PR DESCRIPTION
Restore IsMatch behavior where we fall back to IsConstant if TryGetConstantValue fails.  Takes us back to the old behavior in Power Apps' component properties when the compiler may believe that IsConstant is true when in reality it is not.