### PR TITLE
Must Compute Return Type For Patch For Dataflow Analysis

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Patch.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Patch.cs
@@ -301,11 +301,21 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            bool isValid = base.CheckTypes(context, args, argTypes, errors, out _, out nodeToCoercedTypeMap);
+            if (errors is DefaultNoOpErrorContainer)
+            {
+                nodeToCoercedTypeMap = null;
+                return CheckTypesCore(context, args, argTypes, errors, out returnType, ref nodeToCoercedTypeMap, expectsTableArgs: ExpectsTableArgs);
+            }
+
+            var isValid = base.CheckTypes(context, args, argTypes, errors, out _, out nodeToCoercedTypeMap);
 
             // We are going to discard the returnType infered by base.CheckTypes.
             // Use DType.Error until we can correctly infer the return type.
             returnType = DType.Error;
+
+            // CheckTypes server two purposes: 1) Check the types and sets the errors if any, 2) Compute the return type.
+            // During dataflow analysis, we only care about the 2) and we make that clear by passing in DefaultNoOpErrorContainer.
+            // So when errors is a noop error container, we omly really care about the return type so we can skip the base.CheckTypes.
             if (!isValid)
             {
                 return false;
@@ -653,7 +663,16 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             Contracts.Assert(args.Length == argTypes.Length);
             Contracts.AssertValue(errors);
 
-            bool isValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            nodeToCoercedTypeMap = null;
+            var isValid = true;
+
+            // CheckTypes server two purposes: 1) Check the types and sets the errors if any, 2) Compute the return type.
+            // During dataflow analysis, we only care about the 2) and we make that clear by passing in DefaultNoOpErrorContainer.
+            // So when errors is a noop error container, we omly really care about the return type so we can skip the base.CheckTypes.
+            if (errors is not DefaultNoOpErrorContainer)
+            {
+                isValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+            }
 
             // We are going to discard the returnType infered by base.CheckTypes.
             // Use DType.Error until we can correctly infer the return type.


### PR DESCRIPTION
It is possible to have an error type as one of the arguments to Patch during initial passes of dataflow analysis in Canvas Apps. The type corrects itself later which is when Patch.CheckTypes would not find any errors to report to. During dataflow analysis, we utilize CheckTypes just to compute the return type that we can propagate forward in the Dataflow graph. The current Patch.CheckTypes would set the return type to DType.Error which is then propagated forward and never corrected leading to misleading type errors in the app. Considering that we only care about return type during dataflow analysis and not the actual errors which actually become meaningful during later binding stage, this pr ensures that return type is computed even when there are errors. 
