### PR TITLE
Update FormulaValueSerializer to handle null schemas

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/FormulaValueSerializer.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/FormulaValueSerializer.cs
@@ -161,12 +161,14 @@ namespace Microsoft.PowerFx.Connectors.Execution
             // if connector has null as a type but "array" is provided, let's write it down. this is possible in case of x-ms-dynamic-properties
             if (fv is TableValue tableValue && ((propertySchema.Type ?? "array") == "array"))
             {
+                StartArray(propertyName);
+
                 // If we have an object schema, we will try to follow it
                 if (propertySchema.Items?.Type == "object" || propertySchema.Items?.Type == "array")
                 {
                     foreach (DValue<RecordValue> item in tableValue.Rows)
                     {
-                        StartArrayElement(propertyName);
+                        StartArrayElement(null);
                         RecordValue rva = item.Value;
 
                         await WritePropertyAsync(null, propertySchema.Items, rva).ConfigureAwait(false);
@@ -177,7 +179,7 @@ namespace Microsoft.PowerFx.Connectors.Execution
                     // Working with an array of simply types
                     foreach (DValue<RecordValue> item in tableValue.Rows)
                     {
-                        StartArrayElement(propertyName);
+                        StartArrayElement(null);
                         RecordValue rva = item.Value;
                         WriteValue(rva.Fields.First().Value);
                     }
@@ -188,7 +190,7 @@ namespace Microsoft.PowerFx.Connectors.Execution
                     foreach (DValue<RecordValue> item in tableValue.Rows)
                     {
                         // Add objects
-                        StartArrayElement(propertyName);
+                        StartArrayElement(null);
                         RecordValue rva = item.Value;
                         await WriteObjectAsync(
                             null,

--- a/src/libraries/Microsoft.PowerFx.Connectors/Execution/OpenApiFormUrlEncoder.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Execution/OpenApiFormUrlEncoder.cs
@@ -16,44 +16,37 @@ namespace Microsoft.PowerFx.Connectors.Execution
     internal class OpenApiFormUrlEncoder : FormulaValueSerializer
     {
         private readonly StringBuilder _writer;
-        private readonly Stack<string> _stack;
-        private readonly Stack<int> _arrayIndex;
+        private readonly Stack<(string, int)> _stack;
         private readonly CancellationToken _cancellationToken;
+        private bool _wrotePropertyName;
 
         public OpenApiFormUrlEncoder(IConvertToUTC utcConverter, bool schemaLessBody, CancellationToken cancellationToken)
             : base(utcConverter, schemaLessBody)
         {
             _writer = new StringBuilder(1024);
-            _stack = new Stack<string>();
-            _arrayIndex = new Stack<int>();
+            _stack = new Stack<(string, int)>();
             _cancellationToken = cancellationToken;
         }
 
         protected override void StartArray(string name = null)
         {
-            WritePropertyName(name);
-            _arrayIndex.Push(0);
+            _stack.Push((name, -1));
         }
 
         protected override void StartArrayElement(string name)
         {
-            var currentIndex = _arrayIndex.Pop();
-            if (currentIndex++ != 0)
-            {
-                WritePropertyName(name);
-            }
-
-            _arrayIndex.Push(currentIndex);
+            var (existingName, currentIndex) = _stack.Pop();
+            _stack.Push((existingName, currentIndex + 1));
         }
 
         protected override void EndArray()
         {
-            _arrayIndex.Pop();
+            _stack.Pop();
         }
 
         protected override void StartObject(string prefix = null)
         {
-            _stack.Push(prefix);
+            _stack.Push((prefix, -2));
         }
 
         protected override void EndObject(string name = null)
@@ -68,57 +61,83 @@ namespace Microsoft.PowerFx.Connectors.Execution
 
         protected override void WriteBooleanValue(bool booleanValue)
         {
+            WritePropertyName(null);
             _writer.Append(booleanValue ? "true" : "false");
+            _wrotePropertyName = false;
         }
 
         protected override void WriteDateTimeValue(DateTime dateTimeValue)
         {
+            WritePropertyName(null);
             _writer.Append(Uri.EscapeDataString(dateTimeValue.ToString(UtcDateTimeFormat, CultureInfo.InvariantCulture)));
+            _wrotePropertyName = false;
         }
 
         protected override void WriteDateTimeValueNoTimeZone(DateTime dateTimeValue)
         {
+            WritePropertyName(null);
             _writer.Append(Uri.EscapeDataString(dateTimeValue.ToString(DateTimeFormat, CultureInfo.InvariantCulture)));
+            _wrotePropertyName = false;
         }
 
         protected override void WriteDateValue(DateTime dateValue)
         {
             _writer.Append(Uri.EscapeDataString(dateValue.Date.ToString("o", CultureInfo.InvariantCulture).Substring(0, 10)));
+            _wrotePropertyName = false;
         }
 
         protected override void WriteNullValue()
         {
-            // Do nothing
+            WritePropertyName(null);
+            _wrotePropertyName = false;
         }
 
         protected override void WriteNumberValue(double numberValue)
         {
+            WritePropertyName(null);
             _writer.Append(numberValue);
+            _wrotePropertyName = false;
         }
 
         protected override void WriteDecimalValue(decimal decimalValue)
         {
+            WritePropertyName(null);
             _writer.Append(decimalValue);
+            _wrotePropertyName = false;
         }
 
         protected override void WritePropertyName(string name)
         {
-            AddSeparator();
-            var prefix = GetPrefix();
-
-            if (!string.IsNullOrEmpty(prefix))
+            if (!_wrotePropertyName)
             {
-                _writer.Append(Uri.EscapeDataString(prefix));
-                _writer.Append('.');
-            }
+                _wrotePropertyName = true;
+                AddSeparator();
+                var prefix = GetPrefix();
 
-            _writer.Append(Uri.EscapeDataString(name));
-            _writer.Append('=');
+                if (!string.IsNullOrEmpty(prefix))
+                {
+                    _writer.Append(prefix);
+
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        _writer.Append('.');
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(name))
+                {
+                    _writer.Append(Uri.EscapeDataString(name));
+                }
+
+                _writer.Append('=');
+            }
         }
 
         protected override void WriteStringValue(string stringValue)
         {
+            WritePropertyName(null);
             _writer.Append(Uri.EscapeDataString(stringValue));
+            _wrotePropertyName = false;
         }
 
         private void AddSeparator()
@@ -131,7 +150,8 @@ namespace Microsoft.PowerFx.Connectors.Execution
 
         private string GetPrefix()
         {
-            return string.Join(".", _stack.Where(e => !string.IsNullOrEmpty(e)));
+            // only return the indicators, not the array index [0], [1], ... as per current serialization standard
+            return string.Join(".", _stack.Select(e => e.Item1 ?? string.Empty).Where(s => !string.IsNullOrEmpty(s)));
         }
 
         internal override void StartSerialization(string refId)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiFormUrlEncoderTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiFormUrlEncoderTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 ["a"] = (SchemaArrayInteger, GetArray(Array.Empty<int>()))
             });
 
-            Assert.Equal("a=", str);
+            Assert.Equal(string.Empty, str);
         }
 
         [Fact]
@@ -257,12 +257,12 @@ namespace Microsoft.PowerFx.Connectors.Tests
         [Fact]
         public async Task UrlEncoderSerializer_Array_Record_Invalid()
         {
-            var ex = await Assert.ThrowsAsync<PowerFxConnectorException>(async () => await SerializeUrlEncoderAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
+            var str = await SerializeUrlEncoderAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
             {
                 ["a"] = (SchemaArrayObject, GetArray(GetRecord(("x", FormulaValue.New(1)))))
-            }));
+            });
 
-            Assert.Equal("Incompatible Table for supporting array, RecordValue doesn't have 'Value' column - propertyName a", ex.Message);
+            Assert.Equal("a.x=1", str);
         }
 
         [Fact]
@@ -279,12 +279,13 @@ namespace Microsoft.PowerFx.Connectors.Tests
         [Fact]
         public async Task UrlEncoderSerializer_Array_Invalid()
         {
-            var ex = await Assert.ThrowsAsync<PowerFxConnectorException>(async () => await SerializeUrlEncoderAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
+            var str = await SerializeUrlEncoderAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
             {
                 ["a"] = (SchemaArrayInteger, GetTable(GetRecord(("a", FormulaValue.New(1)), ("b", FormulaValue.New("foo")))))
-            }));
+            });
 
-            Assert.Equal("Incompatible Table for supporting array, RecordValue has more than one column - propertyName a, number of fields 2", ex.Message);
+            // Note: this is invalid form encoding
+            Assert.Equal("a.a=1&a.b=foo", str);
         }
 
         [Fact]

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiJsonSerializerTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiJsonSerializerTests.cs
@@ -282,12 +282,12 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async Task JsonSerializer_Array_Record_Invalid()
         {
-            var ex = await Assert.ThrowsAsync<PowerFxConnectorException>(async () => await SerializeJsonAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
+            var str = await SerializeJsonAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
             {
                 ["a"] = (SchemaArrayObject, GetArray(GetRecord(("x", FormulaValue.New(1)))))
-            }));
+            });
 
-            Assert.Equal("Incompatible Table for supporting array, RecordValue doesn't have 'Value' column - propertyName a", ex.Message);
+            Assert.Equal(@"{""a"":[{""x"":1}]}", str);
         }
 
         [Fact]
@@ -304,12 +304,12 @@ namespace Microsoft.PowerFx.Tests
         [Fact]
         public async Task JsonSerializer_Array_Invalid()
         {
-            var ex = await Assert.ThrowsAsync<PowerFxConnectorException>(async () => await SerializeJsonAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
+            var str = await SerializeJsonAsync(new Dictionary<string, (OpenApiSchema Schema, FormulaValue Value)>()
             {
                 ["a"] = (SchemaArrayInteger, GetTable(GetRecord(("a", FormulaValue.New(1)), ("b", FormulaValue.New("foo")))))
-            }));
+            });
 
-            Assert.Equal("Incompatible Table for supporting array, RecordValue has more than one column - propertyName a, number of fields 2", ex.Message);
+            Assert.Equal(@"{""a"":[{""a"":1,""b"":""foo""}]}", str);
         }
 
         [Fact]


### PR DESCRIPTION
_Today,_ if we have an unknown schema, it requires the record to have a single .Value property (as if it is a primitive).
If it is not, we throw.

_With this change,_ when we are encountering complex (unknown) schemas that arent all .Value, we gracefully write the full record instead of throwing.

Change required updates to the UriFormEncoder to better handle nested objects within arrays.