### PR TITLE
Fixes issue with OptionSet Naming.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -573,8 +573,7 @@ namespace Microsoft.PowerFx.Connectors
                         return new ConnectorType(schema, openApiParameter, ConnectorType.DefaultType);
                     }
 
-                    //ConnectorType arrayType = new OpenApiParameter() { Name = "Array", Required = true, Schema = schema.Items, Extensions = schema.Items.Extensions }.GetConnectorType(settings.Stack(itemIdentifier));
-                    ConnectorType arrayType = new SwaggerParameter("Array", true, schema.Items, schema.Items.Extensions).GetConnectorType(settings.Stack(itemIdentifier));
+                    ConnectorType arrayType = new SwaggerParameter(openApiParameter.Name, true, schema.Items, schema.Items.Extensions).GetConnectorType(settings.Stack(itemIdentifier));
 
                     settings.UnStack();
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
@@ -2262,7 +2262,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
             string ft = returnType.FormulaType.ToStringWithDisplayNames();
 
             string expected =
-               "!['@odata.nextLink'`'Next link':s, value:*[Array:!['@odata.id'`'OData Id':s, _createdby_value`'Created By (Value)':s, '_createdby_value@Microsoft.Dynamics.CRM.lookuplogicalname'`'Created " +
+               "!['@odata.nextLink'`'Next link':s, value:*[value:!['@odata.id'`'OData Id':s, _createdby_value`'Created By (Value)':s, '_createdby_value@Microsoft.Dynamics.CRM.lookuplogicalname'`'Created " +
                 "By (Type)':s, _createdbyexternalparty_value`'Created By (External Party) (Value)':s, '_createdbyexternalparty_value@Microsoft.Dynamics.CRM.lookuplogicalname'`'Created By (External Party) " +
                 "(Type)':s, _createdonbehalfby_value`'Created By (Delegate) (Value)':s, '_createdonbehalfby_value@Microsoft.Dynamics.CRM.lookuplogicalname'`'Created By (Delegate) (Type)':s, _defaultpricelevelid_value`'" +
                 "Price List (Value)':s, '_defaultpricelevelid_value@Microsoft.Dynamics.CRM.lookuplogicalname'`'Price List (Type)':s, _masterid_value`'Master ID (Value)':s, '_masterid_value@Microsoft.Dynamics.CRM.lookup" +

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformTabularTests.cs
@@ -932,7 +932,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 "Modified By ID'[User]:~User:s, LastModifiedDate`'Last Modified Date':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, MasterRecordId`'Master Record ID'[Account]:~Account:s, " +
                 "Name`'Account Name':s, NumberOfEmployees`Employees:w, OwnerId`'Owner ID'[User]:~User:s, ParentId`'Parent Account ID'[Account]:~Account:s, Phone`'Account Phone':s, PhotoUrl`'Photo URL':s, ShippingCity`'Shipping " +
                 "City':s, ShippingCountry`'Shipping Country':s, ShippingGeocodeAccuracy`'Shipping Geocode Accuracy':l, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping " +
-                "Zip/Postal Code':s, ShippingState`'Shipping State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s]",
+                "Zip/Postal Code':s, ShippingState`'Shipping State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s, picklist1`'Picklist 1':*[Value:l], picklist2`'Picklist 2':*[Value:l]]",
                 ((CdpRecordType)sfTable.RecordType).ToStringWithDisplayNames());
 
             Assert.Equal("Account", sfTable.RecordType.TableSymbolName);
@@ -1099,7 +1099,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 "Modified By ID':~User:s, LastModifiedDate`'Last Modified Date':d, LastReferencedDate`'Last Referenced Date':d, LastViewedDate`'Last Viewed Date':d, MasterRecordId`'Master Record ID':~Account:s, Name`'Account " +
                 "Name':s, NumberOfEmployees`Employees:w, OwnerId`'Owner ID':~User:s, ParentId`'Parent Account ID':~Account:s, Phone`'Account Phone':s, PhotoUrl`'Photo URL':s, ShippingCity`'Shipping City':s, ShippingCountry`'Shipping " +
                 "Country':s, ShippingGeocodeAccuracy`'Shipping Geocode Accuracy':l, ShippingLatitude`'Shipping Latitude':w, ShippingLongitude`'Shipping Longitude':w, ShippingPostalCode`'Shipping Zip/Postal Code':s, ShippingState`'Shipping " +
-                "State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s]", sfTable.Type.ToStringWithDisplayNames());
+                "State/Province':s, ShippingStreet`'Shipping Street':s, SicDesc`'SIC Description':s, SystemModstamp`'System Modstamp':d, Type`'Account Type':l, Website:s, picklist1`'Picklist 1':*[Value:l], picklist2`'Picklist 2':*[Value:l]]", sfTable.Type.ToStringWithDisplayNames());
 
             SymbolValues symbolValues = new SymbolValues().Add("Accounts", sfTable);
             RuntimeConfig rc = new RuntimeConfig(symbolValues).AddService<ConnectorLogger>(logger);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/SF GetSchema.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/SF GetSchema.json
@@ -801,6 +801,22 @@
           "calculated": false,
           "x-ms-capabilities": { "filterFunctions": [ "lt", "le", "eq", "ne", "gt", "ge", "and", "or", "not", "contains", "startswith", "endswith" ] },
           "x-ms-visibility": "advanced"
+        },
+        "picklist1": {
+          "title": "Picklist 1",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [ "abc", "def" ]
+          }
+        },
+        "picklist2": {
+          "title": "Picklist 2",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [ "123", "456" ]
+          }
         }
       }
     }


### PR DESCRIPTION
This pull request includes updates to improve type handling in connectors and expand test coverage by adding new fields and scenarios. The key changes include adjustments to how connector types are determined, updates to test cases to include new fields, and modifications to test data to support the expanded scenarios.

### Connector Type Handling:
* Updated the `GetConnectorType` method in `OpenApiExtensions.cs` to use the name of the `openApiParameter` instead of the hardcoded string "Array" when creating a `SwaggerParameter`. This ensures consistency and better alignment with the input parameter.

### Test Case Enhancements:
* Modified the `DVDynamicReturnType` test in `PowerPlatformConnectorTests.cs` to adjust the expected structure of the return type, reflecting updates to the connector schema.
* Updated the `SF_CdpTabular_GetTables` and `SF_CdpTabular` tests in `PowerPlatformTabularTests.cs` to include new fields `picklist1` and `picklist2` in the expected output, improving coverage for scenarios involving picklist arrays. [[1]](diffhunk://#diff-7b1be2cff9606912fdb9b09ff75af4e880829323c9e42a7252a1f93feb1ded67L935-R935) [[2]](diffhunk://#diff-7b1be2cff9606912fdb9b09ff75af4e880829323c9e42a7252a1f93feb1ded67L1102-R1102)

### Test Data Updates:
* Added `picklist1` and `picklist2` fields to the `SF GetSchema.json` test data. These fields are arrays of strings with predefined enumerations, supporting new test scenarios for picklist handling.