### PR TITLE
dont force raw output when override is set

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -858,8 +858,8 @@ namespace Microsoft.PowerFx.Connectors
             {
                 return ev;
             }
-
-            BaseRuntimeConnectorContext context = ReturnParameterType.Binary ? runtimeContext.WithRawResults() : runtimeContext;
+            
+            BaseRuntimeConnectorContext context = (ReturnParameterType.Binary && outputTypeOverride == null) ? runtimeContext.WithRawResults() : runtimeContext;
             ScopedHttpFunctionInvoker invoker = new ScopedHttpFunctionInvoker(DPath.Root.Append(DName.MakeValid(Namespace, out _)), Name, Namespace, new HttpFunctionInvoker(this, context), context.ThrowOnError);
             FormulaValue result = await invoker.InvokeAsync(arguments, context, outputTypeOverride, cancellationToken).ConfigureAwait(false);
             FormulaValue formulaValue = await PostProcessResultAsync(result, runtimeContext, invoker, cancellationToken).ConfigureAwait(false);

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
@@ -313,6 +313,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\TestConnector05.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\TestConnector12.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\TestConnectorDateTimeFormat.json" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\TestConnectorNoOutput.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\TestOpenAPI.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\TestSwagger1.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Swagger\ZenDesk.json" />

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Swagger/TestConnectorNoOutput.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Swagger/TestConnectorNoOutput.json
@@ -1,0 +1,88 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "v2.0",
+    "title": "Azure Cognitive Service for Language",
+    "description": "Azure Cognitive Service for Language, previously known as 'Text Analytics' connector detects language, sentiment and more of the text you provide.",
+    "contact": {
+      "name": "Microsoft",
+      "url": "https://gallery.cortanaanalytics.com/MachineLearningAPI/Text-Analytics-2",
+      "email": "mlapi@microsoft.com"
+    },
+    "x-ms-api-annotation": {
+      "status": "Production"
+    }
+  },
+  "host": "tip1-shared-002.azure-apim.net",
+  "basePath": "/apim/cognitiveservicestextanalytics",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/{connectionId}/language/analyze-conversations/jobs/": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "description": "Submit a collection of conversations for analysis. Specify one or more unique tasks to be executed..",
+        "operationId": "AnalyzeConversationTextSubmitJob",
+        "summary": "Async Conversation PII (text) (2022-05-15-preview)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Analysis job status and metadata.",
+          }
+        },
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/connectors/cognitiveservicestextanalytics/#async-conversation-pii-(text)-(2022-05-15-preview)"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ConversationalPIITextJobState": {
+      "type": "object",
+      "description": "Contains the status of the analyze conversations job submitted along with related statistics.",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "createdDateTime": {
+          "format": "date-time",
+          "description": "The date and time in the UTC time zone when the item was created.",
+          "type": "string",
+          "x-ms-summary": "Created Date"
+        }
+      },
+      "required": []
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "required": [
+        "error"
+      ],
+      "properties": {
+        "error": {}
+      }
+    }
+  },
+  "parameters": {},
+  "x-ms-connector-metadata": [
+    {
+      "propertyName": "Website",
+      "propertyValue": "https://azure.microsoft.com/services/cognitive-services/text-analytics/"
+    }
+  ],
+  "externalDocs": {
+    "url": "https://docs.microsoft.com/connectors/cognitiveservicestextanalytics"
+  }
+}


### PR DESCRIPTION
When the caller explicitly provides a type, we should honor it as such type, no matter the flags on the response type
Today, the override is completely skipped if there was no known output type.