### PR TITLE
Block Void type use in UDF argument type

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerFx.Core.Functions
                         errors.Add(new TexlError(arg.TypeIdent, DocumentErrorSeverity.Severe, TexlStrings.ErrUDF_UnknownType, arg.TypeIdent.Name));
                         isParamCheckSuccessful = false;
                     }
-                    else if (IsRestrictedType(parameterType))
+                    else if (IsRestrictedType(parameterType, UserDefinitions.RestrictedParameterTypes))
                     {
                         errors.Add(new TexlError(arg.TypeIdent, DocumentErrorSeverity.Severe, TexlStrings.ErrUDF_InvalidParamType, arg.TypeIdent.Name));
                         isParamCheckSuccessful = false;
@@ -347,7 +347,7 @@ namespace Microsoft.PowerFx.Core.Functions
                 return false;
             }
             
-            if (IsRestrictedType(returnTypeFormulaType))
+            if (IsRestrictedType(returnTypeFormulaType, UserDefinitions.RestrictedTypes))
             {
                 errors.Add(new TexlError(returnTypeToken, DocumentErrorSeverity.Severe, TexlStrings.ErrUDF_InvalidReturnType, returnTypeToken.Name));
                 returnType = DType.Invalid;
@@ -359,7 +359,7 @@ namespace Microsoft.PowerFx.Core.Functions
         }
 
         // To prevent aggregate types from containing restricted types
-        internal static bool IsRestrictedType(FormulaType ft)
+        internal static bool IsRestrictedType(FormulaType ft, ISet<DType> restrictedTypes)
         {
             Contracts.AssertValue(ft);
 
@@ -367,13 +367,13 @@ namespace Microsoft.PowerFx.Core.Functions
             // We can avoid calling this method on these types containing expand info.
             if (!ft._type.HasExpandInfo && ft is AggregateType aggType)
             {
-                if (aggType.GetFieldTypes().Any(ct => IsRestrictedType(ct.Type)))
+                if (aggType.GetFieldTypes().Any(ct => IsRestrictedType(ct.Type, restrictedTypes)))
                 {
                     return true;
                 }
             }
 
-            if (UserDefinitions.RestrictedTypes.Contains(ft._type))
+            if (restrictedTypes.Contains(ft._type))
             {
                 return true;
             }

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -30,7 +31,9 @@ namespace Microsoft.PowerFx.Syntax
         private readonly Features _features;
 
         // Exposing it so hosts can filter out the intellisense suggestions
-        public static readonly ISet<DType> RestrictedTypes = new HashSet<DType> { DType.DateTimeNoTimeZone, DType.ObjNull, DType.Decimal };
+        public static readonly ISet<DType> RestrictedTypes = ImmutableHashSet.Create(DType.DateTimeNoTimeZone, DType.ObjNull, DType.Decimal);
+
+        public static readonly ISet<DType> RestrictedParameterTypes = ImmutableHashSet.Create(DType.Void).Union(RestrictedTypes);
 
         private UserDefinitions(string script, ParserOptions parserOptions, Features features = null)
         {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -670,5 +670,24 @@ namespace Microsoft.PowerFx.Core.Tests
                 Assert.Contains(errors, x => x.MessageKey == "ErrUDF_UnknownType" || x.MessageKey == "ErrUDF_InvalidReturnType");
             }
         }
+
+        [Fact]
+        public void TestUDFRestrictedParameterTypes()
+        {
+            var parserOptions = new ParserOptions()
+            {
+                AllowsSideEffects = true,
+            };
+
+            foreach (var type in UserDefinitions.RestrictedParameterTypes)
+            {
+                var script = $"func(x: {type.GetKindString()}): Number = 42;";
+                var parseResult = UserDefinitions.Parse(script, parserOptions);
+                var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
+                errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
+
+                Assert.Contains(errors, x => x.MessageKey == "ErrUDF_UnknownType" || x.MessageKey == "ErrUDF_InvalidParamType");
+            }
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -655,10 +655,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestUDFRestrictedTypes()
         {
-            var parserOptions = new ParserOptions()
-            {
-                AllowsSideEffects = true,
-            };
+            var parserOptions = new ParserOptions();
 
             foreach (var type in FormulaType.PrimitiveTypes)
             {
@@ -676,10 +673,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [Fact]
         public void TestUDFRestrictedParameterTypes()
         {
-            var parserOptions = new ParserOptions()
-            {
-                AllowsSideEffects = true,
-            };
+            var parserOptions = new ParserOptions();
 
             foreach (var type in FormulaType.PrimitiveTypes)
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -660,14 +660,16 @@ namespace Microsoft.PowerFx.Core.Tests
                 AllowsSideEffects = true,
             };
 
-            foreach (var type in UserDefinitions.RestrictedTypes)
+            foreach (var type in FormulaType.PrimitiveTypes)
             {
-                var script = $"func():{type.GetKindString()} = Blank();";
-                var parseResult = UserDefinitions.Parse(script, parserOptions);
-                var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
-                errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
-
-                Assert.Contains(errors, x => x.MessageKey == "ErrUDF_UnknownType" || x.MessageKey == "ErrUDF_InvalidReturnType");
+                if (UserDefinitions.RestrictedTypes.Contains(type.Value._type))
+                {
+                    var script = $"func():{type.Key} = Blank();";
+                    var parseResult = UserDefinitions.Parse(script, parserOptions);
+                    var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
+                    errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
+                    Assert.Contains(errors, x => x.MessageKey == "ErrUDF_InvalidReturnType");
+                }
             }
         }
 
@@ -679,14 +681,16 @@ namespace Microsoft.PowerFx.Core.Tests
                 AllowsSideEffects = true,
             };
 
-            foreach (var type in UserDefinitions.RestrictedParameterTypes)
+            foreach (var type in FormulaType.PrimitiveTypes)
             {
-                var script = $"func(x: {type.GetKindString()}): Number = 42;";
-                var parseResult = UserDefinitions.Parse(script, parserOptions);
-                var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
-                errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
-
-                Assert.Contains(errors, x => x.MessageKey == "ErrUDF_UnknownType" || x.MessageKey == "ErrUDF_InvalidParamType");
+                if (UserDefinitions.RestrictedParameterTypes.Contains(type.Value._type))
+                {
+                    var script = $"func(x: {type.Key}): Number = 42;";
+                    var parseResult = UserDefinitions.Parse(script, parserOptions);
+                    var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
+                    errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
+                    Assert.Contains(errors, x => x.MessageKey == "ErrUDF_InvalidParamType");
+                }
             }
         }
     }


### PR DESCRIPTION
Today we allow Void type to be used as a valid type in UDF argument while it serves no real purpose. We do not want to allow this pattern and this PR blocks such usage.

![image](https://github.com/user-attachments/assets/53d3cb22-8687-46dd-baa0-d84571cfc693)
