### PR TITLE
{Draft] Rename UntypedObject to Dynamic at user level

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerFx.Types
             { new DName("Text"), String },
             { new DName("Hyperlink"), Hyperlink },
             { new DName("None"), Blank },
-            { new DName("UntypedObject"), UntypedObject },
+            { new DName("Dynamic"), UntypedObject },
             { new DName("Void"), Void },
         });
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
@@ -53,10 +53,10 @@ DateTime(1900,12,31,0,0,0,0)
 >> AsType(ParseJSON("""1900-12-31T00:00:00.000-08:00"""), DateTimeTZInd)
 DateTime(1900,12,31,8,0,0,0)
 
->> Value(AsType(ParseJSON("42"), UntypedObject))
+>> Value(AsType(ParseJSON("42"), Dynamic))
 42
 
->> Value(AsType(ParseJSON("true"), UntypedObject))
+>> Value(AsType(ParseJSON("true"), Dynamic))
 1
 
 >> If(AsType(ParseJSON("false"), Boolean), "MyFalse", "MyTrue")

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
@@ -9,10 +9,10 @@ DateTime(1900,12,31,15,59,59,999)
 >> AsType(ParseJSON("""1900-12-31T23:59:59.999-08:00"""), DateTime)
 DateTime(1900,12,31,23,59,59,999)
 
->> DateTimeValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), UntypedObject))
+>> DateTimeValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), Dynamic))
 DateTime(1900,12,30,16,0,0,0)
 
->> DateValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), UntypedObject))
+>> DateValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), Dynamic))
 Date(1900,12,30)
 
 >> AsType(ParseJSON("""1900-12-31T24:59:59.1002Z"""), DateTime)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
@@ -53,10 +53,10 @@ DateTime(1900,12,31,0,0,0,0)
 >> ParseJSON("""1900-12-31T00:00:00.000-08:00""", DateTimeTZInd)
 DateTime(1900,12,31,8,0,0,0)
 
->> Value(ParseJSON("42", UntypedObject))
+>> Value(ParseJSON("42", Dynamic))
 42
 
->> Value(ParseJSON("true", UntypedObject))
+>> Value(ParseJSON("true", Dynamic))
 1
 
 >> ParseJSON("true", Boolean)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
@@ -6,8 +6,8 @@ DateTime(2008,1,1,4,12,12,100)
 >> ParseJSON("""2008-01-01T12:12:12.100-08:00""", DateTime)
 DateTime(2008,1,1,12,12,12,100)
 
->> DateTimeValue(ParseJSON("""1900-12-31T00:00:00.000Z""", UntypedObject))
+>> DateTimeValue(ParseJSON("""1900-12-31T00:00:00.000Z""", Dynamic))
 DateTime(1900,12,30,16,0,0,0)
 
->> DateValue(ParseJSON("""1900-12-31T00:00:00.000Z""", UntypedObject))
+>> DateValue(ParseJSON("""1900-12-31T00:00:00.000Z""", Dynamic))
 Date(1900,12,30)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
@@ -648,7 +648,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [Theory]
         [InlineData("ParseJSON(\"42\", Nu|", "Number")]
         [InlineData("AsType(ParseJSON(\"42\"), Da|", "Date", "DateTime", "DateTimeTZInd")]
-        [InlineData("IsType(ParseJSON(\"42\"),|", "'My Type With Space'", "'Some \" DQuote'", "Boolean", "Date", "DateTime", "DateTimeTZInd", "Decimal", "GUID", "Hyperlink", "MyNewType", "Number", "Text", "Time", "UntypedObject")]
+        [InlineData("IsType(ParseJSON(\"42\"),|", "'My Type With Space'", "'Some \" DQuote'", "Boolean", "Date", "DateTime", "DateTimeTZInd", "Decimal", "Dynamic", "GUID", "Hyperlink", "MyNewType", "Number", "Text", "Time")]
         [InlineData("ParseJSON(\"42\", Voi|")]
         [InlineData("ParseJSON(\"42\", MyN|", "MyNewType")]
         [InlineData("ParseJSON(\"42\", Tim|", "DateTime", "DateTimeTZInd", "Time")]

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("A := Type(Blob); B := Type({x: Currency}); C := Type([DateTime]); D := Type(None)", 2)]
 
         // Have named formulas and udf in the script
-        [InlineData("NAlias := Type(Number);X := 5; ADDX(n:Number): Number = n + X; SomeType := Type(UntypedObject)", 2)]
+        [InlineData("NAlias := Type(Number);X := 5; ADDX(n:Number): Number = n + X; SomeType := Type(Dynamic)", 2)]
 
         // Have RecordOf with/ without errors
         [InlineData("Numbers := Type([Number]);T1 := Type(RecordOf([Number])); Num := Type(RecordOf(Numbers)); T2 := Type(Num);", 3)]

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/TypeSystemTests/JsonTypeSnapshots/SimplePrimitiveUntyped.json
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/TypeSystemTests/JsonTypeSnapshots/SimplePrimitiveUntyped.json
@@ -1,5 +1,5 @@
 {
   "Type": {
-    "Name": "UntypedObject"
+    "Name": "Dynamic"
   }
 }


### PR DESCRIPTION
Renames UntypedObject to Dynamic at end user perspective. Internal name UntypedObject stays the same