### PR TITLE
Introduce PowerPlatformConnectorClient2

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/IPowerPlatformConnectorClient2.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/IPowerPlatformConnectorClient2.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    /// <summary>
+    /// Delegate for providing a bearer token for authentication.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Token without "Bearer" scheme as the prefix.</returns>
+    public delegate Task<string> PowerPlatformConnectorClient2BearerTokenProvider(
+        CancellationToken cancellationToken);
+
+    public interface IPowerPlatformConnectorClient2
+    {
+        /// <summary>
+        /// Sends an HTTP request to the Power Platform connector.
+        /// </summary>
+        /// <param name="method">HTTP method.</param>
+        /// <param name="operationPathAndQuery">Operation path and query string.</param>
+        /// <param name="headers">Headers.</param>
+        /// <param name="content">Content.</param>
+        /// <param name="diagnosticOptions">Diagnostic options.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns><see cref="HttpResponseMessage"/>.</returns>
+        Task<HttpResponseMessage> SendAsync(
+            HttpMethod method,
+            string operationPathAndQuery,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers,
+            HttpContent content,
+            PowerPlatformConnectorClient2DiagnosticOptions diagnosticOptions,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -50,6 +50,17 @@ namespace Microsoft.PowerFx.Connectors
 
         private static string GetUriElement(this OpenApiDocument openApiDocument, Func<Uri, string> getElement, SupportsConnectorErrors errors)
         {
+            var uri = GetFirstServerUri(openApiDocument, errors);
+            if (uri is null)
+            {
+                return null;
+            }
+
+            return getElement(uri);
+        }
+
+        internal static Uri GetFirstServerUri(this OpenApiDocument openApiDocument, SupportsConnectorErrors errors)
+        {
             if (openApiDocument?.Servers == null)
             {
                 return null;
@@ -70,8 +81,7 @@ namespace Microsoft.PowerFx.Connectors
                     // This is a full URL that will pull in 'basePath' property from connectors.
                     // Extract BasePath back out from this.
                     var fullPath = openApiDocument.Servers[0].Url;
-                    var uri = new Uri(fullPath);
-                    return getElement(uri);
+                    return new Uri(fullPath);
 
                 default:
                     errors.AddError($"Multiple servers in OpenApiDocument is not supported");
@@ -520,7 +530,7 @@ namespace Microsoft.PowerFx.Connectors
                         case "currency":
                             return new ConnectorType(schema, openApiParameter, FormulaType.Decimal);
 
-                        default:                            
+                        default:
                             // ex: Format = "date" or "string"
                             return new ConnectorType($"Unsupported type of number: '{schema.Format}'", openApiParameter.Name, FormulaType.BindingError);
                     }
@@ -660,7 +670,7 @@ namespace Microsoft.PowerFx.Connectors
                                 return new ConnectorType(schema, openApiParameter, FormulaType.String, hiddenfields.ToRecordType());
                             }
 
-                            ConnectorType propertyType = new SwaggerParameter(propLogicalName, schema.Required.Contains(propLogicalName), kv.Value, kv.Value.Extensions).GetConnectorType(settings.Stack(schemaIdentifier));                            
+                            ConnectorType propertyType = new SwaggerParameter(propLogicalName, schema.Required.Contains(propLogicalName), kv.Value, kv.Value.Extensions).GetConnectorType(settings.Stack(schemaIdentifier));
 
                             settings.UnStack();
 
@@ -690,7 +700,7 @@ namespace Microsoft.PowerFx.Connectors
                 case "file":
                     return new ConnectorType(schema, openApiParameter, FormulaType.Blob);
 
-                default:                    
+                default:
                     // ex: type = "null" or "decimal"
                     return new ConnectorType($"Unsupported schema type '{schema.Type}'", openApiParameter.Name, FormulaType.BindingError);
             }
@@ -702,7 +712,7 @@ namespace Microsoft.PowerFx.Connectors
 
             if (settings.Settings.Compatibility.IsCDP() || schema.Format == "enum" || settings.Settings.SupportXMsEnumValues)
             {
-                // Try getting enum from 'x-ms-enum-values'                
+                // Try getting enum from 'x-ms-enum-values'
                 (IEnumerable<KeyValuePair<DName, DName>> list, bool isNumber) = openApiParameter.GetEnumValues();
 
                 if (list != null && list.Any())
@@ -758,7 +768,7 @@ namespace Microsoft.PowerFx.Connectors
                         return new ConnectorType("Unsupported enum type (int)", openApiParameter.Name, FormulaType.BindingError);
                     }
                     else
-                    {                        
+                    {
                         return new ConnectorType($"Unsupported enum type '{schema.Enum.GetType().Name}'", openApiParameter.Name, FormulaType.BindingError);
                     }
                 }
@@ -1192,7 +1202,7 @@ namespace Microsoft.PowerFx.Connectors
                 {
                     // https://github.com/microsoft/OpenAPI.NET/issues/533
                     // https://github.com/microsoft/Power-Fx/pull/1987 - https://github.com/microsoft/Power-Fx/issues/1982
-                    // api-version, x-ms-api-version, X-GitHub-Api-Version...                    
+                    // api-version, x-ms-api-version, X-GitHub-Api-Version...
                     if (prm.Key.EndsWith("api-version", StringComparison.OrdinalIgnoreCase))
                     {
                         fv = FormulaValue.New(dtv.GetConvertedValue(TimeZoneInfo.Utc).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));

--- a/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient2.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient2.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.PowerFx.Connectors
+{
+    /// <summary>
+    /// Client for invoking operations of Power Platform connectors.
+    /// </summary>
+    public class PowerPlatformConnectorClient2 : IPowerPlatformConnectorClient2
+    {
+        private readonly string _baseUrlStr;
+        private readonly HttpMessageInvoker _httpMessageInvoker;
+        private readonly PowerPlatformConnectorClient2BearerTokenProvider _tokenProvider;
+        private readonly string _environmentId;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerPlatformConnectorClient2"/> class.
+        /// </summary>
+        /// <param name="document">Document used for extracting the base URL.</param>
+        /// <param name="httpMessageInvoker">HTTP message invoker.</param>
+        /// <param name="tokenProvider">Bearer token provider.</param>
+        /// <param name="environmentId">Environment ID.</param>
+        public PowerPlatformConnectorClient2(
+            OpenApiDocument document,
+            HttpMessageInvoker httpMessageInvoker,
+            PowerPlatformConnectorClient2BearerTokenProvider tokenProvider,
+            string environmentId)
+            : this(GetBaseUrlFromOpenApiDocument(document), httpMessageInvoker, tokenProvider, environmentId)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerPlatformConnectorClient2"/> class.
+        /// </summary>
+        /// <param name="baseUrl">Base URL for requests.</param>
+        /// <param name="httpMessageInvoker">HTTP message invoker.</param>
+        /// <param name="tokenProvider">Bearer token provider.</param>
+        /// <param name="environmentId">Environment ID.</param>
+        public PowerPlatformConnectorClient2(
+            Uri baseUrl,
+            HttpMessageInvoker httpMessageInvoker,
+            PowerPlatformConnectorClient2BearerTokenProvider tokenProvider,
+            string environmentId)
+        {
+            this._baseUrlStr = GetBaseUrlStr(baseUrl ?? throw new ArgumentNullException(nameof(baseUrl)));
+            this._httpMessageInvoker = httpMessageInvoker ?? throw new ArgumentNullException(nameof(httpMessageInvoker));
+            this._tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+            this._environmentId = environmentId ?? throw new ArgumentNullException(nameof(environmentId));
+
+            static string GetBaseUrlStr(Uri uri)
+            {
+                var str = uri.GetLeftPart(UriPartial.Path);
+
+                // Note (shgogna): Ensure the base URL does NOT end with "/".
+                // This will allow us to concatenate the operation path to the base URL
+                // without worrying about the "/".
+                str = str.TrimEnd('/');
+                return str;
+            }
+        }
+
+        // <inheritdoc />
+        public Task<HttpResponseMessage> SendAsync(
+            HttpMethod method,
+            string operationPathAndQuery,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers,
+            HttpContent content,
+            CancellationToken cancellationToken)
+        {
+            return this.SendAsync(
+                method: method,
+                operationPathAndQuery: operationPathAndQuery,
+                headers: headers,
+                content: content,
+                diagnosticOptions: null,
+                cancellationToken: cancellationToken);
+        }
+
+        // <inheritdoc />
+        public async Task<HttpResponseMessage> SendAsync(
+            HttpMethod method,
+            string operationPathAndQuery,
+            IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers,
+            HttpContent content,
+            PowerPlatformConnectorClient2DiagnosticOptions diagnosticOptions,
+            CancellationToken cancellationToken)
+        {
+            if (operationPathAndQuery is null)
+            {
+                throw new ArgumentNullException(nameof(operationPathAndQuery));
+            }
+
+            var authToken = await this._tokenProvider(cancellationToken).ConfigureAwait(false);
+
+            var uri = this.CombineBaseUrlWithOperationPathAndQuery(operationPathAndQuery);
+            using (var req = new HttpRequestMessage(method, uri))
+            {
+                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
+
+                this.AddDiagnosticHeaders(diagnosticOptions, req);
+
+                foreach (var header in headers)
+                {
+                    req.Headers.Add(header.Key, header.Value);
+                }
+
+                req.Content = content;
+                return await this._httpMessageInvoker.SendAsync(req, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private Uri CombineBaseUrlWithOperationPathAndQuery(string operationPathAndQuery)
+        {
+            if (operationPathAndQuery.StartsWith("/", StringComparison.Ordinal))
+            {
+                return new Uri(this._baseUrlStr + operationPathAndQuery);
+            }
+            else
+            {
+                return new Uri(this._baseUrlStr + "/" + operationPathAndQuery);
+            }
+        }
+
+        private void AddDiagnosticHeaders(
+            PowerPlatformConnectorClient2DiagnosticOptions diagnosticOptions,
+            HttpRequestMessage req)
+        {
+            var userAgent = string.IsNullOrWhiteSpace(diagnosticOptions?.UserAgent)
+                ? $"PowerFx/{PowerPlatformConnectorClient.Version}"
+                : $"{diagnosticOptions.UserAgent} PowerFx/{PowerPlatformConnectorClient.Version}";
+
+            var clientRequestId = string.IsNullOrWhiteSpace(diagnosticOptions?.ClientRequestId)
+                ? Guid.NewGuid().ToString()
+                : diagnosticOptions.ClientRequestId;
+
+            // CorrelationID can be the same as ClientRequestID
+            var correlationId = string.IsNullOrWhiteSpace(diagnosticOptions?.CorrelationId)
+                ? clientRequestId
+                : diagnosticOptions.CorrelationId;
+
+            req.Headers.Add("User-Agent", userAgent);
+            req.Headers.Add("x-ms-user-agent", userAgent);
+            req.Headers.Add("x-ms-client-environment-id", $"/providers/Microsoft.PowerApps/environments/{this._environmentId}");
+            req.Headers.Add("x-ms-client-request-id", clientRequestId);
+            req.Headers.Add("x-ms-correlation-id", correlationId);
+
+            if (!string.IsNullOrWhiteSpace(diagnosticOptions?.ClientSessionId))
+            {
+                req.Headers.Add("x-ms-client-session-id", diagnosticOptions.ClientSessionId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(diagnosticOptions?.ClientTenantId))
+            {
+                req.Headers.Add("x-ms-client-tenant-id", diagnosticOptions.ClientTenantId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(diagnosticOptions?.ClientObjectId))
+            {
+                req.Headers.Add("x-ms-client-object-id", diagnosticOptions.ClientObjectId);
+            }
+        }
+
+        private static Uri GetBaseUrlFromOpenApiDocument(OpenApiDocument document)
+        {
+            ConnectorErrors errors = new ConnectorErrors();
+            Uri uri = document.GetFirstServerUri(errors);
+
+            if (uri is null)
+            {
+                errors.AddError("Swagger document doesn't contain an endpoint");
+            }
+
+            if (errors.HasErrors)
+            {
+                throw new PowerFxConnectorException(string.Join(", ", errors.Errors));
+            }
+
+            return uri;
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient2DiagnosticOptions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient2DiagnosticOptions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace Microsoft.PowerFx.Connectors
+{
+    public class PowerPlatformConnectorClient2DiagnosticOptions
+    {
+        public string ClientSessionId { get; set; }
+
+        public string ClientRequestId { get; set; }
+
+        public string ClientTenantId { get; set; }
+
+        public string ClientObjectId { get; set; }
+
+        public string CorrelationId { get; set; }
+
+        public string UserAgent { get; set; }
+    }
+}


### PR DESCRIPTION
This PR introduces a new version of `PowerPlatformConnectorClient` called `PowerPlatformConnectorClient2`. Naming for the new client is open for debate 😄

The differences include:
* An interface for testing/mocking: `IPowerPlatformConnectorClient2`
* A delegate for providing the bearer token: `PowerPlatformConnectorClient2BearerTokenProvider`
* POCO for diagnostic values: `PowerPlatformConnectorClient2DiagnosticOptions` which specifies values that are typically sent by clients
* Connector client takes specific parameters for `method`, `operationPathAndQuery`, `headers`, and `content` instead of reusing `HttpRequestMessage`. This was done to avoid client teams creating a dummy object that would not even get used.
* Connector client takes the full base URL (also known internally as the "primaryRuntimeUrl")
* Added `GetFirstServerUri` extension to `OpenApiExtensions`

Misc:
* Remove trailing whitespace from `OpenApiExtensions`

