### PR TITLE
Rename UntypedObject to Dynamic (UI side)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerFx.Types
             { new DName("Text"), String },
             { new DName("Hyperlink"), Hyperlink },
             { new DName("None"), Blank },
-            { new DName("UntypedObject"), UntypedObject },
+            { new DName("Dynamic"), UntypedObject },
             { new DName("Void"), Void },
         });
 

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Types/FormulaType.cs
@@ -74,7 +74,6 @@ namespace Microsoft.PowerFx.Types
             _type = type;
         }
 
-        // Primitive types - Keeping it same as PrimitiveTypeSymbolTable
         internal static readonly IReadOnlyDictionary<DName, FormulaType> PrimitiveTypes = ImmutableDictionary.CreateRange(new Dictionary<DName, FormulaType>()
         {
             { new DName("Boolean"), Boolean },

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using Microsoft.PowerFx.Core.App.ErrorContainers;

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using Microsoft.PowerFx.Core.App.ErrorContainers;
@@ -1045,6 +1046,11 @@ namespace Microsoft.PowerFx.Core.Types
             if (Kind == DKind._LimPrimitive)
             {
                 return "Control";
+            }
+
+            if (Kind == DKind.UntypedObject)
+            {
+                return "Dynamic";
             }
 
             if (IsLazyType)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
@@ -53,10 +53,10 @@ DateTime(1900,12,31,0,0,0,0)
 >> AsType(ParseJSON("""1900-12-31T00:00:00.000-08:00"""), DateTimeTZInd)
 DateTime(1900,12,31,8,0,0,0)
 
->> Value(AsType(ParseJSON("42"), UntypedObject))
+>> Value(AsType(ParseJSON("42"), Dynamic))
 42
 
->> Value(AsType(ParseJSON("true"), UntypedObject))
+>> Value(AsType(ParseJSON("true"), Dynamic))
 1
 
 >> If(AsType(ParseJSON("false"), Boolean), "MyFalse", "MyTrue")

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
@@ -9,10 +9,10 @@ DateTime(1900,12,31,15,59,59,999)
 >> AsType(ParseJSON("""1900-12-31T23:59:59.999-08:00"""), DateTime)
 DateTime(1900,12,31,23,59,59,999)
 
->> DateTimeValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), UntypedObject))
+>> DateTimeValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), Dynamic))
 DateTime(1900,12,30,16,0,0,0)
 
->> DateValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), UntypedObject))
+>> DateValue(AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), Dynamic))
 Date(1900,12,30)
 
 >> AsType(ParseJSON("""1900-12-31T24:59:59.1002Z"""), DateTime)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/BasicCoercion.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/BasicCoercion.txt
@@ -47,7 +47,7 @@ true
 
 // Erroneous Date -> Bool coercion
 >> Date(2000,1,2) && 1
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> If(Date(2000,1,1),1,2)
 Errors: Error 3-17: Invalid argument type (Date). Expecting a Boolean value instead.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/DecimalOps.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/DecimalOps.txt
@@ -298,7 +298,7 @@ false
 true
 
 >> ParseJSON("1.0000000000000000000000001") = ParseJSON("1.0000000000000000000000001")
-Errors: Error 41-42: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 41-42: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> 1.0000000000000000000000001 <> ParseJSON("1")
 true
@@ -310,7 +310,7 @@ true
 false
 
 >> ParseJSON("1.0000000000000000000000001") <> ParseJSON("1.0000000000000000000000001")
-Errors: Error 41-43: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 41-43: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> 1.0000000000000000000000001 > ParseJSON("1")
 true
@@ -322,7 +322,7 @@ true
 false
 
 >> ParseJSON("1.0000000000000000000000001") > ParseJSON("1.0000000000000000000000001")
-Errors: Error 41-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> 1.0000000000000000000000001 < ParseJSON("1")
 false
@@ -334,7 +334,7 @@ false
 false
 
 >> ParseJSON("1.0000000000000000000000001") < ParseJSON("1.0000000000000000000000001")
-Errors: Error 41-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> 1.0000000000000000000000001 >= ParseJSON("1")
 true
@@ -346,7 +346,7 @@ true
 true
 
 >> ParseJSON("1.0000000000000000000000001") >= ParseJSON("1.0000000000000000000000001")
-Errors: Error 41-43: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-43: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> 1.0000000000000000000000001 <= ParseJSON("1")
 false
@@ -358,7 +358,7 @@ false
 true
 
 >> ParseJSON("1.0000000000000000000000001") <= ParseJSON("1.0000000000000000000000001")
-Errors: Error 41-43: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-43: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2")%
 0.02

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/DecimalOps_DVDecimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/DecimalOps_DVDecimal.txt
@@ -298,7 +298,7 @@ true
 false
 
 >> ParseJSON("10000000000.0000000001") = ParseJSON("10000000000.0000000001")
-Errors: Error 36-37: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 36-37: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> 10000000000.0000000001 <> ParseJSON("1")
 true
@@ -310,7 +310,7 @@ true
 false
 
 >> ParseJSON("10000000000.0000000001") <> ParseJSON("10000000000.0000000001")
-Errors: Error 36-38: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 36-38: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> 10000000000.0000000001 > ParseJSON("1")
 true
@@ -322,7 +322,7 @@ true
 false
 
 >> ParseJSON("10000000000.0000000001") > ParseJSON("10000000000.0000000001")
-Errors: Error 36-37: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 36-37: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> 10000000000.0000000001 < ParseJSON("1")
 false
@@ -334,7 +334,7 @@ false
 false
 
 >> ParseJSON("10000000000.0000000001") < ParseJSON("10000000000.0000000001")
-Errors: Error 36-37: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 36-37: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> 10000000000.0000000001 >= ParseJSON("1")
 true
@@ -346,7 +346,7 @@ true
 true
 
 >> ParseJSON("10000000000.0000000001") >= ParseJSON("10000000000.0000000001")
-Errors: Error 36-38: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 36-38: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> 10000000000.0000000001 <= ParseJSON("1")
 false
@@ -358,7 +358,7 @@ false
 true
 
 >> ParseJSON("10000000000.0000000001") <= ParseJSON("10000000000.0000000001")
-Errors: Error 36-38: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 36-38: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2")%
 0.02

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/DecimalOverflow.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/DecimalOverflow.txt
@@ -8,7 +8,7 @@
 Errors: Error 0-29: Numeric value is too large.
 
 >> -79228162514264337593543950336
-Errors: Error 1-30: Numeric value is too large.|Error 1-30: Invalid argument type. Expecting one of the following: Decimal, Text, Boolean, UntypedObject.
+Errors: Error 1-30: Numeric value is too large.|Error 1-30: Invalid argument type. Expecting one of the following: Decimal, Text, Boolean, Dynamic.
 
 >> 79228162514264337593543950335.1
 79228162514264337593543950335
@@ -20,7 +20,7 @@ Errors: Error 1-30: Numeric value is too large.|Error 1-30: Invalid argument typ
 Errors: Error 0-31: Numeric value is too large.
 
 >> -79228162514264337593543950335.5
-Errors: Error 1-32: Numeric value is too large.|Error 1-32: Invalid argument type. Expecting one of the following: Decimal, Text, Boolean, UntypedObject.
+Errors: Error 1-32: Numeric value is too large.|Error 1-32: Invalid argument type. Expecting one of the following: Decimal, Text, Boolean, Dynamic.
 
 >> 79228162514264337593543950335 * 1
 79228162514264337593543950335

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/If_AllowsSideEffects.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/If_AllowsSideEffects.txt
@@ -70,13 +70,13 @@ If(true, {test:1}, "Void value (result of the expression can't be used).")
 Error({Kind:ErrorKind.Div0})
 
 >> If(1>0, 100, {x:3}) + 1
-Errors: Error 0-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 0-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If(1>0, 100; 30, {x:3}) + 1
-Errors: Error 0-23: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 0-23: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> Value(If(1>0, 100; 30, {x:3}) + 1)
-Errors: Error 6-29: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 6-29: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> Value(1 + If(1>0, 100; 30, {x:3}))
-Errors: Error 10-33: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 10-33: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Eq_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Eq_Decimal.txt
@@ -678,16 +678,16 @@ true
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") = ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-44: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 43-44: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") = ParseJSON("2")
-Errors: Error 40-41: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 40-41: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") = ParseJSON("2")
-Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") = ParseJSON("1e100")
-Errors: Error 41-42: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 41-42: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") = ParseJSON("1e100")
-Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Eq_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Eq_Float.txt
@@ -574,16 +574,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") = ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-44: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 43-44: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") = ParseJSON("2")
-Errors: Error 40-41: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 40-41: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") = ParseJSON("2")
-Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") = ParseJSON("1e100")
-Errors: Error 41-42: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 41-42: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") = ParseJSON("1e100")
-Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-20: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Exp_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Exp_Decimal.txt
@@ -63,13 +63,13 @@
 1
 
 >> Float(16)^Date(2000,1,1)
-Errors: Error 10-24: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 10-24: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Float(365265000)^DateTime(2000,1,1,12,0,0)
-Errors: Error 17-42: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 17-42: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Float(16)^Time(12,0,0)
-Errors: Error 10-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 10-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Float(16)^Decimal("2.00000000000000000000000002")
 256
@@ -143,13 +143,13 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> "32"^Date(2000,1,1)
-Errors: Error 5-19: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-19: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> "32"^DateTime(2000,1,1,12,0,0)
-Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> "16"^Time(12,0,0)
-Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> "16"^Decimal("2.000000000000000000000002")
 256
@@ -238,13 +238,13 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> true^Date(1927,5,18)
-Errors: Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> true^DateTime(1927,5,18,0,0,0)
-Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> true^Time(12,0,0)
-Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> true^Decimal("2.000000000000000000000002")
 1
@@ -285,13 +285,13 @@ Errors: Error 5-17: Invalid argument type. Expecting one of the following: Numbe
 1
 
 >> Blank()^Date(2000,1,1)
-Errors: Error 8-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 8-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Blank()^DateTime(2000,1,1,12,0,0)
-Errors: Error 8-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 8-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Blank()^Time(12,0,0)
-Errors: Error 8-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 8-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Blank()^Decimal("2.000000000000000000000002")
 0
@@ -305,119 +305,119 @@ Errors: Error 8-20: Invalid argument type. Expecting one of the following: Numbe
 // Date
 
 >> Date(2000,1,1)^Float(2)
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^"2"
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^true
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^Blank()
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(1954,10,3)^Date(1927,5,18)
-Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(1954,10,3)^Date(1900,1,1)
-Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(1954,10,3)^DateTime(1927,5,18,0,0,0)
-Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^Time(12,0,0)
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^Decimal("2.000000000000000000000002")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^ParseJSON("2")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^ParseJSON("1e100")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // DateTime
 
 >> DateTime(2000,1,1,12,0,0)^Float(2)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^"2"
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^true
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^Blank()
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^Date(1927,5,18)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^Date(1900,1,1)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^DateTime(1927,5,18,0,0,0)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^DateTime(1900,1,1,12,0,0)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^Time(12,0,0)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^Decimal("2.0000000000000000000002")
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^ParseJSON("2")
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^ParseJSON("1e100")
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // Time
 
 >> Time(9,0,0)^Float(0.125)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^"0.125"
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^true
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Blank()
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Time(6,0,0)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Date(1900,1,2)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> 1+(Time(9,0,0)^Date(1900,1,11)/1e20)
-Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Time(12,0,0)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> 1+(Time(9,0,0)^Time(12,0,0)/1e20)
-Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Decimal("0.125")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> 1+(Time(9,0,0)^Decimal("0.125")/1e20)
-Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Decimal("0.125000000000000000000001")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^ParseJSON("2")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^ParseJSON("1e100")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // Decimal
 
@@ -444,13 +444,13 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> Decimal("16.0000000000000000000001")^Date(1900,1,7)
-Errors: Error 37-51: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 37-51: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Decimal("16.0000000000000000000001")^DateTime(1900,1,1,12,0,0)
-Errors: Error 37-62: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 37-62: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Decimal("16.000000000000000000001")^Time(12,0,0)
-Errors: Error 36-48: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 36-48: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Decimal("16.000000000000000000000002")^Decimal("2.000000000000000000000001")
 256
@@ -503,22 +503,22 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> ParseJSON("16.0000000000000000000001")^Date(1900,1,7)
-Errors: Error 39-53: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 39-53: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("1e100")^Date(1900,1,7)
-Errors: Error 19-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("16.0000000000000000000001")^DateTime(1900,1,1,12,0,0)
-Errors: Error 39-64: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 39-64: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("1e100")^DateTime(1900,1,7,12,0,0)
-Errors: Error 19-44: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-44: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("16.000000000000000000001")^Time(12,0,0)
-Errors: Error 38-50: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 38-50: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("1e100")^Time(12,0,0)
-Errors: Error 19-31: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-31: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002")^Decimal("2.000000000000000000000000001")
 256

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Exp_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Exp_Float.txt
@@ -63,13 +63,13 @@
 1
 
 >> Value(16)^Date(2000,1,1)
-Errors: Error 10-24: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 10-24: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Value(365265000)^DateTime(2000,1,1,12,0,0)
-Errors: Error 17-42: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 17-42: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Value(16)^Time(12,0,0)
-Errors: Error 10-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 10-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Value(16)^ParseJSON("2")
 256
@@ -137,13 +137,13 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> "32"^Date(2000,1,1)
-Errors: Error 5-19: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-19: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> "32"^DateTime(2000,1,1,12,0,0)
-Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> "16"^Time(12,0,0)
-Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> "16"^ParseJSON("2")
 256
@@ -220,13 +220,13 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> true^Date(1927,5,18)
-Errors: Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> true^DateTime(1927,5,18,0,0,0)
-Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> true^Time(12,0,0)
-Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 5-17: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> true^ParseJSON("2")
 1
@@ -264,13 +264,13 @@ Errors: Error 5-17: Invalid argument type. Expecting one of the following: Numbe
 1
 
 >> Blank()^Date(2000,1,1)
-Errors: Error 8-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 8-22: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Blank()^DateTime(2000,1,1,12,0,0)
-Errors: Error 8-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 8-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Blank()^Time(12,0,0)
-Errors: Error 8-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 8-20: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Blank()^ParseJSON("2")
 0
@@ -278,104 +278,104 @@ Errors: Error 8-20: Invalid argument type. Expecting one of the following: Numbe
 // Date
 
 >> Date(2000,1,1)^Value(2)
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^"2"
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^true
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^Blank()
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(1954,10,3)^Date(1927,5,18)
-Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(1954,10,3)^Date(1900,1,1)
-Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(1954,10,3)^DateTime(1927,5,18,0,0,0)
-Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-15: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^Time(12,0,0)
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^ParseJSON("2")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Date(2000,1,1)^ParseJSON("1e100")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // DateTime
 
 >> DateTime(2000,1,1,12,0,0)^Value(2)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^"2"
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^true
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^Blank()
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^Date(1927,5,18)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^Date(1900,1,1)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^DateTime(1927,5,18,0,0,0)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(1954,10,3,0,0,0)^DateTime(1900,1,1,12,0,0)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^Time(12,0,0)
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^ParseJSON("2")
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^ParseJSON("1e100")
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // Time
 
 >> Time(9,0,0)^Value(0.125)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^"0.125"
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^true
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Blank()
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Time(6,0,0)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Date(1900,1,2)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> 1+(Time(9,0,0)^Date(1900,1,11)/1e20)
-Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Time(12,0,0)
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> 1+(Time(9,0,0)^Time(12,0,0)/1e20)
-Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^ParseJSON("2")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^ParseJSON("1e100")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // Untyped
 
@@ -410,22 +410,22 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> ParseJSON("16.0000000000000000000001")^Date(1900,1,7)
-Errors: Error 39-53: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 39-53: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("1e100")^Date(1900,1,7)
-Errors: Error 19-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-33: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("16.0000000000000000000001")^DateTime(1900,1,1,12,0,0)
-Errors: Error 39-64: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 39-64: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("1e100")^DateTime(1900,1,7,12,0,0)
-Errors: Error 19-44: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-44: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("16.000000000000000000001")^Time(12,0,0)
-Errors: Error 38-50: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 38-50: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("1e100")^Time(12,0,0)
-Errors: Error 19-31: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-31: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002")^ParseJSON("2")
 256

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Exp_Float_DecimalSupport.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Exp_Float_DecimalSupport.txt
@@ -30,19 +30,19 @@
 2
 
 >> Date(2000,1,1)^Decimal("2.000000000000000000000002")
-Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0)^Decimal("2.0000000000000000000002")
-Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-25: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Decimal("0.125")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> 1+(Time(9,0,0)^Decimal("0.125")/1e20)
-Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 3-14: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Time(9,0,0)^Decimal("0.125000000000000000000001")
-Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 0-11: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 // Decimal
 
@@ -69,13 +69,13 @@ Error({Kind:ErrorKind.Numeric})
 1
 
 >> Decimal("16.0000000000000000000001")^Date(1900,1,7)
-Errors: Error 37-51: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 37-51: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Decimal("16.0000000000000000000001")^DateTime(1900,1,1,12,0,0)
-Errors: Error 37-62: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 37-62: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Decimal("16.000000000000000000001")^Time(12,0,0)
-Errors: Error 36-48: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 36-48: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> Decimal("16.000000000000000000000002")^Decimal("2.000000000000000000000001")
 256

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Geq_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Geq_Decimal.txt
@@ -26,13 +26,13 @@ true
 
 // overflow error on decimal
 >> 1E100 >= 1E100
-Errors: Error 0-5: Numeric value is too large.|Error 9-14: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 9-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 9-14: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 9-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> 1E100 >= 1.1E100
-Errors: Error 0-5: Numeric value is too large.|Error 9-16: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 9-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 9-16: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 9-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> 1E100 >= 9.9E99
-Errors: Error 0-5: Numeric value is too large.|Error 9-15: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 9-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 9-15: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 9-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // underflow to zero on decimal
 >> 1E-100 >= 1E-100
@@ -59,40 +59,40 @@ false
 false
 
 >> Float(16) >= "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >= "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >= "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >= "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >= "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1e20) >= "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) >= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) >= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) >= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) >= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) >= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) >= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // >, <, <=, and >= comparisons between number and blank are done with numbers, with the blank being interpreted as a 0
 // = and <> comparisons are comparing the value against null, since a number can be a blank value.
@@ -171,232 +171,232 @@ true
 // Text - Text can only be compared with other text
 
 >> "16" >= Float(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Float(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Float(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= Float(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >= Float(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >= true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" >= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >= Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" >= Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" >= DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "2" >= Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >= ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >= ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >= ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >= ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true >= Float(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Float(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Float(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Float(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Float(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Float(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Float("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true >= "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -407,16 +407,16 @@ false
 false
 
 >> Blank() >= "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= Float(0)
 true
 
 >> Blank() >= "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= Blank()
 true
@@ -463,10 +463,10 @@ false
 true
 
 >> Date(1900,1,1) >= "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) >= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) >= Blank()
 true
@@ -537,13 +537,13 @@ true
 true
 
 >> DateTime(1900,1,1,12,0,0) >= "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >= true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) >= true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >= Blank()
 true
@@ -602,13 +602,13 @@ true
 true
 
 >> Time(9,0,0) >= "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) >= true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >= false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >= 0
 true
@@ -686,10 +686,10 @@ true
 true
 
 >> Decimal("16.000000000000000000000001") >= "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") >= true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") >= Blank()
 true
@@ -776,13 +776,13 @@ true
 true
 
 >> ParseJSON("16.00000000000000000000001") >= "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >= "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >=  "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >=  16 + ".00000000000000000000001"
 true
@@ -794,43 +794,43 @@ true
 false
 
 >> ParseJSON("16") >= "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >= "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >= true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") >= true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >= true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >= false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >= false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >= Blank()
 true
@@ -926,16 +926,16 @@ true
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") >= ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-45: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-45: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") >= ParseJSON("2")
-Errors: Error 40-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >= ParseJSON("2")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") >= ParseJSON("1e100")
-Errors: Error 41-43: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-43: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >= ParseJSON("1e100")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Geq_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Geq_Float.txt
@@ -62,40 +62,40 @@ false
 false
 
 >> Value(16) >= "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >= "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >= "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >= "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >= "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1e20) >= "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) >= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) >= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) >= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) >= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) >= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) >= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // >, <, <=, and >= comparisons between number and blank are done with numbers, with the blank being interpreted as a 0
 // = and <> comparisons are comparing the value against null, since a number can be a blank value.
@@ -164,208 +164,208 @@ true
 // Text - Text can only be compared with other text
 
 >> "16" >= Value(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Value(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Value(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= Value(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >= Value(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >= true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" >= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >= Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" >= Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" >= DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >= ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >= ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >= ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >= ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >= ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true >= Value(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Value(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Value(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Value(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Value(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Value(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Value("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true >= "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -376,16 +376,16 @@ false
 false
 
 >> Blank() >= "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= Value(0)
 true
 
 >> Blank() >= "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= Blank()
 true
@@ -426,10 +426,10 @@ false
 true
 
 >> Date(1900,1,1) >= "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) >= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) >= Blank()
 true
@@ -492,13 +492,13 @@ true
 true
 
 >> DateTime(1900,1,1,12,0,0) >= "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >= true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) >= true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >= Blank()
 true
@@ -549,13 +549,13 @@ true
 true
 
 >> Time(9,0,0) >= "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) >= true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >= false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >= 0
 true
@@ -613,13 +613,13 @@ true
 true
 
 >> ParseJSON("16.00000000000000000000001") >= "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >= "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >=  "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >=  16 + ".00000000000000000000001"
 true
@@ -632,43 +632,43 @@ true
 true
 
 >> ParseJSON("16") >= "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >= "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >= true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") >= true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >= true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >= false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >= false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >= Blank()
 true
@@ -758,16 +758,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") >= ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-45: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-45: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") >= ParseJSON("2")
-Errors: Error 40-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >= ParseJSON("2")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") >= ParseJSON("1e100")
-Errors: Error 41-43: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-43: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >= ParseJSON("1e100")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Geq_Float_DecimalSupport.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Geq_Float_DecimalSupport.txt
@@ -11,28 +11,28 @@ true
 true
 
 >> "2" >= Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >= Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >= Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >= Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >= Decimal("2.000000000000000000000002")
 false
@@ -87,10 +87,10 @@ true
 true
 
 >> Decimal("16.000000000000000000000001") >= "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") >= true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") >= Blank()
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Gt_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Gt_Decimal.txt
@@ -29,13 +29,13 @@ true
 
 // overflow error on decimal
 >> 1E100 > 1E100
-Errors: Error 0-5: Numeric value is too large.|Error 8-13: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 8-13: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> 1E100 > 1.1E100
-Errors: Error 0-5: Numeric value is too large.|Error 8-15: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 8-15: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> 1E100 > 9.9E99
-Errors: Error 0-5: Numeric value is too large.|Error 8-14: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 8-14: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // underflow to zero on decimal
 >> 1E-100 > 1E-100
@@ -62,40 +62,40 @@ false
 false
 
 >> Float(16) >  "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >  "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >  "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >  "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) >  "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1e20) >  "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) >  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) >  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) >  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) >  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) >  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) >  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) >  Blank()
 false
@@ -172,232 +172,232 @@ false
 // Text - Text can only be compared with other text
 
 >> "16" >  Float(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Float(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Float(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  Float(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >  Float(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >  true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" >  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >  Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" >  Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" >  DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "2" >  Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >  ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >  ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >  ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >  ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true >  Float(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Float(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Float(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Float(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Float(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Float(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Float("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true >  "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -408,16 +408,16 @@ false
 false
 
 >> Blank() >  "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  Float(0)
 false
 
 >> Blank() >  "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  Blank()
 false
@@ -464,10 +464,10 @@ false
 true
 
 >> Date(1900,1,1) >  "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) >  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) >  Blank()
 true
@@ -538,13 +538,13 @@ true
 true
 
 >> DateTime(1900,1,1,12,0,0) >  "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >  true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) >  true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >  Blank()
 true
@@ -603,13 +603,13 @@ true
 false
 
 >> Time(9,0,0) >  "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) >  true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >  false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >  0
 true
@@ -687,10 +687,10 @@ false
 true
 
 >> Decimal("16.000000000000000000000001") >  "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") >  true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") >  Blank()
 true
@@ -777,13 +777,13 @@ false
 true
 
 >> ParseJSON("16.00000000000000000000001") >  "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >  "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >   "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >   16 + ".00000000000000000000001"
 false
@@ -795,43 +795,43 @@ true
 false
 
 >> ParseJSON("16") >  "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >  "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >  true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") >  true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >  true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >  false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >  false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >  Blank()
 true
@@ -927,16 +927,16 @@ false
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") >  ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-44: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-44: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") >  ParseJSON("2")
-Errors: Error 40-41: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-41: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >  ParseJSON("2")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") >  ParseJSON("1e100")
-Errors: Error 41-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >  ParseJSON("1e100")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Gt_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Gt_Float.txt
@@ -62,40 +62,40 @@ false
 false
 
 >> Value(16) >  "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >  "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >  "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >  "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) >  "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1e20) >  "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) >  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) >  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) >  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) >  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) >  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) >  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) >  Blank()
 false
@@ -162,208 +162,208 @@ false
 // Text - Text can only be compared with other text
 
 >> "16" >  Value(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Value(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Value(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  Value(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >  Value(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >  true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" >  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" >  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" >  Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" >  Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" >  DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" >  ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >  ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" >  ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >  ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" >  ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true >  Value(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Value(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Value(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Value(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Value(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Value(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Value("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true >  "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -374,16 +374,16 @@ false
 false
 
 >> Blank() >  "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  Value(0)
 false
 
 >> Blank() >  "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  Blank()
 false
@@ -424,10 +424,10 @@ false
 true
 
 >> Date(1900,1,1) >  "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) >  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) >  Blank()
 true
@@ -489,13 +489,13 @@ true
 true
 
 >> DateTime(1900,1,1,12,0,0) >  "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >  true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) >  true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) >  Blank()
 true
@@ -545,13 +545,13 @@ true
 false
 
 >> Time(9,0,0) >  "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) >  true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >  false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) >  0
 true
@@ -608,13 +608,13 @@ false
 true
 
 >> ParseJSON("16.00000000000000000000001") >  "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >  "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >   "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") >   16 + ".00000000000000000000001"
 false
@@ -627,43 +627,43 @@ false
 false
 
 >> ParseJSON("16") >  "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >  "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >  true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") >  true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") >  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") >  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >  true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >  false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") >  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") >  false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") >  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") >  Blank()
 true
@@ -753,16 +753,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") >  ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-44: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-44: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") >  ParseJSON("2")
-Errors: Error 40-41: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-41: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >  ParseJSON("2")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") >  ParseJSON("1e100")
-Errors: Error 41-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") >  ParseJSON("1e100")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Gt_Float_DecimalSupport.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Gt_Float_DecimalSupport.txt
@@ -11,28 +11,28 @@ false
 true
 
 >> "2" >  Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" >  Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true >  Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false >  Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() >  Decimal("2.000000000000000000000002")
 false
@@ -86,10 +86,10 @@ false
 true
 
 >> Decimal("16.000000000000000000000001") >  "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") >  true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") >  Blank()
 true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Leq_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Leq_Decimal.txt
@@ -61,40 +61,40 @@ true
 true
 
 >> Float(16) <= "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <= "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <= "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <= "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <= "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1e20) <= "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) <= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) <= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) <= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) <= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) <= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) <= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) <= Blank()
 true
@@ -171,232 +171,232 @@ true
 // Text - Text can only be compared with other text
 
 >> "16" <= Float(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Float(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Float(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= Float(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <= Float(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <= true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" <= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <= Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" <= Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" <= DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "2" <= Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <= ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <= ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <= ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <= ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true <= Float(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Float(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Float(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Float(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Float(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Float(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Float("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true <= "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -407,16 +407,16 @@ true
 true
 
 >> Blank() <= "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= Float(0)
 true
 
 >> Blank() <= "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= Blank()
 true
@@ -463,10 +463,10 @@ true
 false
 
 >> Date(1900,1,1) <= "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) <= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) <= Blank()
 false
@@ -537,13 +537,13 @@ false
 false
 
 >> DateTime(1900,1,1,12,0,0) <= "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <= true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) <= true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <= Blank()
 false
@@ -602,13 +602,13 @@ false
 true
 
 >> Time(9,0,0) <= "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) <= true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <= false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <= 0
 false
@@ -686,10 +686,10 @@ true
 false
 
 >> Decimal("16.000000000000000000000001") <= "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") <= true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") <= Blank()
 false
@@ -776,13 +776,13 @@ true
 false
 
 >> ParseJSON("16.00000000000000000000001") <= "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <= "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <=  "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <=  16 + ".00000000000000000000001"
 true
@@ -794,43 +794,43 @@ false
 true
 
 >> ParseJSON("16") <= "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <= "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <= true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") <= true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <= true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <= false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <= false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <= Blank()
 false
@@ -927,16 +927,16 @@ true
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") <= ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-45: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-45: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") <= ParseJSON("2")
-Errors: Error 40-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <= ParseJSON("2")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") <= ParseJSON("1e100")
-Errors: Error 41-43: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-43: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <= ParseJSON("1e100")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Leq_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Leq_Float.txt
@@ -62,40 +62,40 @@ true
 true
 
 >> Value(16) <= "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <= "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <= "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <= "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <= "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1e20) <= "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) <= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) <= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) <= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) <= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) <= true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) <= false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) <= Blank()
 true
@@ -162,208 +162,208 @@ true
 // Text - Text can only be compared with other text
 
 >> "16" <= Value(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Value(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Value(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= Value(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <= Value(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <= true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" <= Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <= Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" <= Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" <= DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <= ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <= ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <= ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <= ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <= ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true <= Value(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Value(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Value(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Value(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Value(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Value(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Value("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true <= "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -374,16 +374,16 @@ true
 true
 
 >> Blank() <= "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= Value(0)
 true
 
 >> Blank() <= "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= Blank()
 true
@@ -424,10 +424,10 @@ true
 false
 
 >> Date(1900,1,1) <= "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) <= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) <= Blank()
 false
@@ -489,13 +489,13 @@ false
 false
 
 >> DateTime(1900,1,1,12,0,0) <= "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <= true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) <= true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <= Blank()
 false
@@ -545,13 +545,13 @@ false
 true
 
 >> Time(9,0,0) <= "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) <= true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <= false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <= 0
 false
@@ -608,13 +608,13 @@ true
 false
 
 >> ParseJSON("16.00000000000000000000001") <= "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <= "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <=  "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <=  16 + ".00000000000000000000001"
 true
@@ -627,43 +627,43 @@ true
 true
 
 >> ParseJSON("16") <= "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <= "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <= true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") <= true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <= true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <= false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <= true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <= false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <= false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <= true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <= Blank()
 false
@@ -753,16 +753,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") <= ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-45: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-45: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") <= ParseJSON("2")
-Errors: Error 40-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <= ParseJSON("2")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") <= ParseJSON("1e100")
-Errors: Error 41-43: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-43: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <= ParseJSON("1e100")
-Errors: Error 19-21: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-21: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Leq_Float_DecimalSupport.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Leq_Float_DecimalSupport.txt
@@ -11,28 +11,28 @@ true
 false
 
 >> "2" <= Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <= Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <= Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <= Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= Decimal("2.000000000000000000000002")
 true
@@ -86,10 +86,10 @@ true
 false
 
 >> Decimal("16.000000000000000000000001") <= "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") <= true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") <= Blank()
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Lt_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Lt_Decimal.txt
@@ -29,13 +29,13 @@ false
 
 // overflow error on decimal
 >> 1E100 < 1E100
-Errors: Error 0-5: Numeric value is too large.|Error 8-13: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 8-13: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> 1E100 < 1.1E100
-Errors: Error 0-5: Numeric value is too large.|Error 8-15: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 8-15: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> 1E100 < 9.9E99
-Errors: Error 0-5: Numeric value is too large.|Error 8-14: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Numeric value is too large.|Error 8-14: Numeric value is too large.|Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // underflow to zero on decimal
 >> 1E-100 < 1E-100
@@ -62,40 +62,40 @@ true
 true
 
 >> Float(16) <  "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <  "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <  "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <  "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(16) <  "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1e20) <  "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) <  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(1) <  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) <  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) <  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) <  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(2) <  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Float(0) <  Blank()
 false
@@ -172,232 +172,232 @@ false
 // Text - Text can only be compared with other text
 
 >> "16" <  Float(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Float(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Float(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  Float(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <  Float(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <  true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" <  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <  Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" <  Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" <  DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "2" <  Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <  ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <  ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <  ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <  ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true <  Float(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Float(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Float(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Float(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Float(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Float(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Float("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true <  "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -408,16 +408,16 @@ true
 true
 
 >> Blank() <  "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  Float(0)
 false
 
 >> Blank() <  "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  Blank()
 false
@@ -464,10 +464,10 @@ true
 false
 
 >> Date(1900,1,1) <  "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) <  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) <  Blank()
 false
@@ -538,13 +538,13 @@ false
 false
 
 >> DateTime(1900,1,1,12,0,0) <  "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <  true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) <  true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <  Blank()
 false
@@ -603,13 +603,13 @@ false
 false
 
 >> Time(9,0,0) <  "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) <  true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <  false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <  0
 false
@@ -687,10 +687,10 @@ false
 false
 
 >> Decimal("16.000000000000000000000001") <  "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") <  true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") <  Blank()
 false
@@ -777,13 +777,13 @@ false
 false
 
 >> ParseJSON("16.00000000000000000000001") <  "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <  "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <   "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <   16 + ".00000000000000000000001"
 false
@@ -795,43 +795,43 @@ false
 true
 
 >> ParseJSON("16") <  "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <  "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <  true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") <  true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <  true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <  false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <  false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <  Blank()
 false
@@ -927,16 +927,16 @@ false
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") <  ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-44: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-44: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") <  ParseJSON("2")
-Errors: Error 40-41: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-41: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <  ParseJSON("2")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") <  ParseJSON("1e100")
-Errors: Error 41-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <  ParseJSON("1e100")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Lt_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Lt_Float.txt
@@ -62,40 +62,40 @@ true
 true
 
 >> Value(16) <  "16"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <  "16.000000000000000000002"
-Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <  "14"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <  "18"
-Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(16) <  "1e20"
-Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 13-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1e20) <  "1e20"
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) <  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(1) <  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) <  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) <  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) <  true
-Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-16: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(2) <  false
-Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 12-17: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Value(0) <  Blank()
 false
@@ -162,208 +162,208 @@ false
 // Text - Text can only be compared with other text
 
 >> "16" <  Value(16)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Value(18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Value(14)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  Value(2)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <  Value(0)
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "16"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "18"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "14"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  "16.00000000000000000000000002"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 8-39: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  "2"
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <  true
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 7-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  true
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1" <  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "0" <  Blank()
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "" <  Blank()
-Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-2: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  Blank()
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526" <  Date(2000,1,1)
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "36526.5" <  DateTime(2000,1,1,12,0,0)
-Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("16")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("14")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("18")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("""16""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("""14""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "16" <  ParseJSON("""18""")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  ParseJSON("1e100")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <  ParseJSON("true")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "true" <  ParseJSON("false")
-Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-6: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <  ParseJSON("false")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "false" <  ParseJSON("true")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  ParseJSON("2")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Boolean
 
 >> true <  Value(2)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Value(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Value(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Value(2)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Value(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Value(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Value("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  "1"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  "0"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  "1"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  "1E+100"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // returns false in Excel
 >> true <  "true"
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  "false"
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  true
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  false
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Blank()
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Blank()
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Date(1927,5,18)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Time(12,0,0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Date(1927,5,18)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  DateTime(1927,5,18,0,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Time(12,0,0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("2")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("1")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("0")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("true")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("false")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("2")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("1")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("0")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("true")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("false")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  ParseJSON("1e100")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  ParseJSON("null")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Blank
 
@@ -374,16 +374,16 @@ true
 true
 
 >> Blank() <  "2"
-Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  Value(0)
 false
 
 >> Blank() <  "1e100"
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  true
-Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 11-15: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  Blank()
 false
@@ -424,10 +424,10 @@ true
 false
 
 >> Date(1900,1,1) <  "2"
-Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(1900,1,0) <  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Date(2000,1,1) <  Blank()
 false
@@ -489,13 +489,13 @@ false
 false
 
 >> DateTime(1900,1,1,12,0,0) <  "2.5"
-Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-34: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <  true
-Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,0,0,0,0) <  true
-Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTime(2000,1,1,12,0,0) <  Blank()
 false
@@ -545,13 +545,13 @@ false
 false
 
 >> Time(9,0,0) <  "0.375"
-Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(9,0,0) <  true
-Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 15-19: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <  false
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Time(24,0,0) <  0
 false
@@ -608,13 +608,13 @@ false
 false
 
 >> ParseJSON("16.00000000000000000000001") <  "2"
-Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <  "16"
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <   "16.00000000000000000000001"
-Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-72: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.00000000000000000000001") <   16 + ".00000000000000000000001"
 false
@@ -627,43 +627,43 @@ false
 false
 
 >> ParseJSON("16") <  "16"
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <  "2"
-Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <  true
-Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 44-48: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1.000000000000000000000001") <  true
-Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 43-47: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("0") <  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <  true
-Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-22: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1") <  false
-Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 18-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <  true
-Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <  false
-Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-27: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("false") <  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("true") <  false
-Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 21-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("1e100") <  true
-Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 22-26: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> ParseJSON("16.000000000000000000000001") <  Blank()
 false
@@ -753,16 +753,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") <  ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-44: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 43-44: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") <  ParseJSON("2")
-Errors: Error 40-41: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 40-41: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <  ParseJSON("2")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") <  ParseJSON("1e100")
-Errors: Error 41-42: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 41-42: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <  ParseJSON("1e100")
-Errors: Error 19-20: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 19-20: This operation isn't valid on these types: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Lt_Float_DecimalSupport.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Lt_Float_DecimalSupport.txt
@@ -11,28 +11,28 @@ false
 false
 
 >> "2" <  Decimal("2.000000000000000000000002")
-Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-3: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "1e100" <  Decimal("2.000000000000000000000002")
-Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-7: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Decimal("1.000000000000000000000002")
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Decimal(1)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> true <  Decimal(0)
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Decimal("1.000000000000000000000002")
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Decimal(1)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> false <  Decimal(0)
-Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-5: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <  Decimal("2.000000000000000000000002")
 true
@@ -87,10 +87,10 @@ false
 false
 
 >> Decimal("16.000000000000000000000001") <  "16"
-Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 42-46: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("1.000000000000000000000001") <  true
-Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 41-45: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Decimal("0.000000000000000000000001") <  Blank()
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Neq_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Neq_Decimal.txt
@@ -666,16 +666,16 @@ false
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") <> ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-45: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 43-45: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") <> ParseJSON("2")
-Errors: Error 40-42: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 40-42: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <> ParseJSON("2")
-Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") <> ParseJSON("1e100")
-Errors: Error 41-43: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 41-43: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <> ParseJSON("1e100")
-Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Neq_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Neq_Float.txt
@@ -573,16 +573,16 @@ Error({Kind:ErrorKind.InvalidArgument})
 Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("2.000000000000000000000000001") <> ParseJSON("2.000000000000000000000000001")
-Errors: Error 43-45: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 43-45: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("2.000000000000000000000002") <> ParseJSON("2")
-Errors: Error 40-42: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 40-42: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <> ParseJSON("2")
-Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("16.000000000000000000000002") <> ParseJSON("1e100")
-Errors: Error 41-43: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 41-43: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("1e100") <> ParseJSON("1e100")
-Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 19-21: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Unary_Decimal.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Unary_Decimal.txt
@@ -203,13 +203,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 true
 
 >> !Date(2000,1,1)
-Errors: Error 1-15: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 1-15: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !DateTime(2000,1,1,12,0,0)
-Errors: Error 1-26: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 1-26: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !Time(12,0,0)
-Errors: Error 1-13: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 1-13: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !Decimal("2.000000000000000000000002")
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Unary_Float.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/OpMatrix_Unary_Float.txt
@@ -191,13 +191,13 @@ Error({Kind:ErrorKind.InvalidArgument})
 true
 
 >> !Date(2000,1,1)
-Errors: Error 1-15: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 1-15: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !DateTime(2000,1,1,12,0,0)
-Errors: Error 1-26: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 1-26: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !Time(12,0,0)
-Errors: Error 1-13: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 1-13: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !ParseJSON("2")
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/ParseJson.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/ParseJson.txt
@@ -199,22 +199,22 @@ Errors: Error 29-37: Name isn't valid. 'ThisItem' isn't recognized.|Error 0-6: T
 1
 
 >> ParseJSON("5") = ParseJSON("5")
-Errors: Error 15-16: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 15-16: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("5") > ParseJSON("5")
-Errors: Error 15-16: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 15-16: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("5") < ParseJSON("5")
-Errors: Error 15-16: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 15-16: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("5") <> ParseJSON("5")
-Errors: Error 15-17: Incompatible types for comparison. These types can't be compared: UntypedObject, UntypedObject.
+Errors: Error 15-17: Incompatible types for comparison. These types can't be compared: Dynamic, Dynamic.
 
 >> ParseJSON("5") >= ParseJSON("5")
-Errors: Error 15-17: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 15-17: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> ParseJSON("5") <= ParseJSON("5")
-Errors: Error 15-17: This operation isn't valid on these types: UntypedObject, UntypedObject.
+Errors: Error 15-17: This operation isn't valid on these types: Dynamic, Dynamic.
 
 >> CountRows(ParseJSON("[1, 2, 3]"))
 3

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums.txt
@@ -295,46 +295,46 @@ Errors: Error 19-21: Unable to compare values of type Enum (StartOfWeek).
 //
 
 >> StartOfWeek.Tuesday + 3
-Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Tuesday + StartOfWeek.Thursday
-Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 33-42: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 33-42: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Tuesday * 2
-Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Tuesday * StartOfWeek.Thursday
-Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 33-42: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 33-42: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday + 2
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Tuesday + StartOfWeek.Wednesday
-Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 33-43: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-19: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 33-43: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday - 2
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday - StartOfWeek.Thursday
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday * 2
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday / 2
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday / StartOfWeek.Thursday
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Friday ^ 2
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> StartOfWeek.Friday ^ StartOfWeek.Thursday
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> StartOfWeek.Friday%
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Date, DateTime, DateTimeNoTimeZone, Time, Text, Boolean, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Date, DateTime, DateTimeNoTimeZone, Time, Text, Boolean, Dynamic.
 
 //===========================================================================================================
 //
@@ -921,10 +921,10 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 17-24: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 16-23: Invalid argument type (Enum (StartOfWeek)). Expecting a Decimal value instead.
 
 >> StartOfWeek.Sunday + 3
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> StartOfWeek.Sunday + StartOfWeek.Monday
-Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 32-39: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 11-18: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 32-39: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, 3, StartOfWeek.Sunday )  // first type rule
 If(true, {test:1}, "Void value (result of the expression can't be used).")
@@ -1027,10 +1027,10 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 14-20: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 13-19: Invalid argument type (Enum (TimeUnit)). Expecting a Decimal value instead.
 
 >> TimeUnit.Years + 3
-Errors: Error 8-14: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 8-14: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TimeUnit.Years + TimeUnit.Months
-Errors: Error 8-14: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 25-32: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 8-14: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 25-32: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, 3, TimeUnit.Years )  // first type rule
 If(true, {test:1}, "Void value (result of the expression can't be used).")
@@ -1145,10 +1145,10 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 11-15: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 10-14: Invalid argument type (Enum (Color)). Expecting a Decimal value instead.
 
 >> Color.Red + 3
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> Color.Red + Color.Red
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 17-21: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 17-21: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, RGBA(120,120,12,1), Color.Red )  // first type rule
 RGBA(255,0,0,1)
@@ -1382,7 +1382,7 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 20-29: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 19-28: Invalid argument type (Enum (DateTimeFormat)). Expecting a Decimal value instead.
 
 >> DateTimeFormat.LongDate + 3
-Errors: Error 14-23: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 14-23: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> DateTimeFormat.LongDate & "hi"
 "'longdate'hi"
@@ -1491,7 +1491,7 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 11-26: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 10-25: Invalid argument type (Enum (Match)). Expecting a Decimal value instead.
 
 >> Match.MultipleDigits + 3
-Errors: Error 5-20: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 5-20: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, "help", Match.MultipleDigits )  // first type rule
 "\d+"

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_BuiltInEnums_PreV1.txt
@@ -405,7 +405,7 @@ true
 false
 
 >> Match.Digit > "\d"
-Errors: Error 5-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 14-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-11: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 14-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> "\d" = Match.Digit
 true
@@ -414,7 +414,7 @@ true
 false
 
 >> "\d" > Match.Digit
-Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 12-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 0-4: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 12-18: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Most other enums do not, see section 1 above
 
@@ -769,25 +769,25 @@ false
 true
 
 >> Match.Letter < Blank()
-Errors: Error 5-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Match.Letter = Blank()
 false
 
 >> Blank() >= Match.Letter
-Errors: Error 16-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <> Match.Letter
 true
 
 >> Color.Gray < Blank()
-Errors: Error 5-10: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-10: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Color.Gray = Blank()
 false
 
 >> Blank() >= Color.Gray
-Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 16-21: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <> Color.Gray
 true
@@ -988,10 +988,10 @@ Error({Kind:ErrorKind.InvalidArgument})
 // Can't compare numerically (CanCompareNumeric = false)
 
 >> TimeUnit.Years < TimeUnit.Months
-Errors: Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 25-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 25-32: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> TimeUnit.Years >= TimeUnit.Months
-Errors: Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 26-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 8-14: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 26-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Can't concatenate strongly typed (CanConcatenateStronglyTyped = false)
 
@@ -1029,7 +1029,7 @@ true
 Errors: Error 0-4: The function 'Text' has some invalid arguments.|Error 11-15: Expected text or number. We expect text or a number at this point in the formula.
 
 >> "Option: " & Color.Yellow
-Errors: Error 18-25: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 18-25: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Len( Color.Yellow )
 Errors: Error 10-17: Invalid argument type (Color). Expecting a Text value instead.
@@ -1041,13 +1041,13 @@ Errors: Error 0-4: The function 'Left' has some invalid arguments.|Error 11-18: 
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 30-37: Invalid argument type (Color). Expecting a Text value instead.
 
 >> Color.Yellow & " banana"
-Errors: Error 5-12: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 5-12: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Concatenate( Color.Yellow, " banana" )
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 18-25: Invalid argument type (Color). Expecting a Text value instead.
 
 >> Color.Green & " bananas are riper than " & Color.Yellow & " bananas"
-Errors: Error 5-11: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.|Error 48-55: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 5-11: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.|Error 48-55: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Concatenate( Color.Green, " bananas are riper than ", Color.Yellow, " bananas" )
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 18-24: Invalid argument type (Color). Expecting a Text value instead.|Error 59-66: Invalid argument type (Color). Expecting a Text value instead.
@@ -1092,10 +1092,10 @@ Errors: Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 10-14: Invalid argument type (Color). Expecting a Decimal value instead.
 
 >> Color.Red + 3
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> Color.Red + Color.Red
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 17-21: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 17-21: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, RGBA(120,120,12,1), Color.Red )  // first type rule
 RGBA(255,0,0,1)
@@ -1103,18 +1103,18 @@ RGBA(255,0,0,1)
 // Can't compare numerically (CanCompareNumeric = false)
 
 >> Color.Red < Color.Yellow
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 17-24: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 17-24: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Color.Red >= Color.Yellow
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 18-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 18-25: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Color.Red >= SortOrder.Descending
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 22-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 22-33: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Can't concatenate strongly typed (CanConcatenateStronglyTyped = false)
 
 >> Color.Red & Color.Yellow
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.|Error 17-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.|Error 17-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 //===========================================================================================================
 //
@@ -1334,10 +1334,10 @@ Error({Kind:ErrorKind.InvalidArgument})
 // Can't compare numerically (CanCompareNumeric = false)
 
 >> DateTimeFormat.LongDate < DateTimeFormat.ShortDate
-Errors: Error 14-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 40-50: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 14-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 40-50: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> DateTimeFormat.LongDate >= DateTimeFormat.ShortDate
-Errors: Error 14-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 41-51: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 14-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 41-51: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Can't concatenate strongly typed (CanConcatenateStronglyTyped = false)
 
@@ -1437,10 +1437,10 @@ Error({Kind:ErrorKind.InvalidArgument})
 // Can't compare numerically (CanCompareNumeric = false)
 
 >> Match.MultipleDigits < Match.Digits
-Errors: Error 28-35: Name isn't valid. 'Digits' isn't recognized.|Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 28-35: Name isn't valid. 'Digits' isn't recognized.|Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Match.MultipleDigits >= Match.Digits
-Errors: Error 29-36: Name isn't valid. 'Digits' isn't recognized.|Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 29-36: Name isn't valid. 'Digits' isn't recognized.|Error 5-20: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Can concatenate strongly typed (CanConcatenateStronglyTyped = true)
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums.txt
@@ -144,28 +144,28 @@ Errors: Error 30-31: Incompatible types for comparison. These types can't be com
 // Booleans cannot be used in math expressions, even if they support coercion to backing kind
 
 >> TestBooleanNoCoerce.SuperFalse + 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse * 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse / 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse ^ 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> TestYesNo.Yes + 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.No * 2
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.Yes / 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.Yes ^ 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 //===========================================================================================================
 //
@@ -173,22 +173,22 @@ Errors: Error 9-13: Invalid argument type. Expecting one of the following: Numbe
 //
 
 >> TestYesNo.Yes && TestBooleanNoCoerce.SuperTrue
-Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestBooleanNoCoerce.SuperTrue && TestBooleanNoCoerce.SuperFalse
-Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.|Error 52-63: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.|Error 52-63: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestBooleanNoCoerce.SuperTrue && false
-Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !TestBooleanNoCoerce.SuperTrue
-Errors: Error 20-30: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 20-30: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestYesNo.Yes Or TestBooleanNoCoerce.SuperTrue
-Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> Not TestBooleanNoCoerce.SuperTrue And Not TestBooleanNoCoerce.SuperFalse
-Errors: Error 23-33: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.|Error 61-72: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 23-33: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.|Error 61-72: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestBooleanNoCoerce.SuperTrue
 TestBooleanNoCoerce.SuperTrue
@@ -782,10 +782,10 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 15-18: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 14-17: Invalid argument type (Enum (TestYesNo)). Expecting a Decimal value instead.
 
 >> TestYesNo.No + 3
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.No + TestYesNo.Yes
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 24-28: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 24-28: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, true, TestYesNo.No )  // first type rule
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums_AsOptionSets.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums_AsOptionSets.txt
@@ -146,28 +146,28 @@ Errors: Error 30-31: Incompatible types for comparison. These types can't be com
 // Booleans cannot be used in math expressions, even if they support coercion to backing kind
 
 >> TestBooleanNoCoerce.SuperFalse + 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse * 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse / 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse ^ 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> TestYesNo.Yes + 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.No * 2
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.Yes / 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.Yes ^ 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 //===========================================================================================================
 //
@@ -175,22 +175,22 @@ Errors: Error 9-13: Invalid argument type. Expecting one of the following: Numbe
 //
 
 >> TestYesNo.Yes && TestBooleanNoCoerce.SuperTrue
-Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestBooleanNoCoerce.SuperTrue && TestBooleanNoCoerce.SuperFalse
-Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.|Error 52-63: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.|Error 52-63: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestBooleanNoCoerce.SuperTrue && false
-Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 19-29: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> !TestBooleanNoCoerce.SuperTrue
-Errors: Error 20-30: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 20-30: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestYesNo.Yes Or TestBooleanNoCoerce.SuperTrue
-Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 36-46: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> Not TestBooleanNoCoerce.SuperTrue And Not TestBooleanNoCoerce.SuperFalse
-Errors: Error 23-33: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.|Error 61-72: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, UntypedObject.
+Errors: Error 23-33: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.|Error 61-72: Invalid argument type. Expecting one of the following: Boolean, Number, Decimal, Text, Dynamic.
 
 >> TestBooleanNoCoerce.SuperTrue
 TestBooleanNoCoerce.'1'
@@ -818,10 +818,10 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 15-18: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 14-17: Invalid argument type (OptionSetValue (TestYesNo)). Expecting a Decimal value instead.
 
 >> TestYesNo.No + 3
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.No + TestYesNo.Yes
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 24-28: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 24-28: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, true, TestYesNo.No )  // first type rule
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums_AsOptionSets_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums_AsOptionSets_PreV1.txt
@@ -145,28 +145,28 @@ true
 // Booleans cannot be used in math expressions, even if they support coercion to backing kind
 
 >> TestBooleanNoCoerce.SuperFalse + 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse * 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse / 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestBooleanNoCoerce.SuperFalse ^ 2
-Errors: Error 19-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 19-30: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 >> TestYesNo.Yes + 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.No * 2
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.Yes / 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.Yes ^ 2
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Text, Boolean, Dynamic.
 
 //===========================================================================================================
 //
@@ -813,10 +813,10 @@ Errors: Error 0-4: The function 'Sqrt' has some invalid arguments.|Error 15-18: 
 Errors: Error 0-3: The function 'Mod' has some invalid arguments.|Error 14-17: Invalid argument type (OptionSetValue (TestYesNo)). Expecting a Decimal value instead.
 
 >> TestYesNo.No + 3
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> TestYesNo.No + TestYesNo.Yes
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.|Error 24-28: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.|Error 24-28: Invalid argument type. Expecting one of the following: Decimal, Number, Text, Boolean, Date, Time, DateTimeNoTimeZone, DateTime, Dynamic.
 
 >> If( false, true, TestYesNo.No )  // first type rule
 false

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnum_TestEnums_PreV1.txt
@@ -482,19 +482,19 @@ false
 Errors: Error 0-4: The function 'Text' has some invalid arguments.|Error 18-25: Expected text or number. We expect text or a number at this point in the formula.
 
 >> "Label:" & TestBlueRamp.Blue50
-Errors: Error 23-30: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 23-30: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Concatenate( "Label:", TestBlueRamp.Blue50 )
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 35-42: Invalid argument type (Color). Expecting a Text value instead.
 
 >> TestBlueRamp.Blue50 & " is the sky"
-Errors: Error 12-19: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 12-19: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Concatenate( TestBlueRamp.Blue50, " is the sky")
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 25-32: Invalid argument type (Color). Expecting a Text value instead.
 
 >> "The sky is so very " & TestBlueRamp.Blue50 & " !!!"
-Errors: Error 36-43: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 36-43: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Concatenate( "The sky is so very ", TestBlueRamp.Blue50, " !!!")
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 48-55: Invalid argument type (Color). Expecting a Text value instead.
@@ -509,7 +509,7 @@ Errors: Error 17-24: Invalid argument type (Color). Expecting a Text value inste
 Errors: Error 0-4: The function 'Text' has some invalid arguments.|Error 17-23: Expected text or number. We expect text or a number at this point in the formula.
 
 >> "Label:" & TestRedRamp.Red25
-Errors: Error 22-28: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 22-28: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Mid( TestRedRamp.Red25, 2 )
 Errors: Error 0-3: The function 'Mid' has some invalid arguments.|Error 16-22: Invalid argument type (Color). Expecting a Text value instead.
@@ -518,22 +518,22 @@ Errors: Error 0-3: The function 'Mid' has some invalid arguments.|Error 16-22: I
 Errors: Error 16-22: Invalid argument type (Color). Expecting a Text value instead.
 
 >> true & TestRedRamp.Red25
-Errors: Error 18-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 18-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> 1 & TestRedRamp.Red25
-Errors: Error 15-21: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 15-21: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> "hi" & TestRedRamp.Red25
-Errors: Error 18-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 18-24: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> TestRedRamp.Red25 & true
-Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> TestRedRamp.Red25 & 1
-Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> TestRedRamp.Red25 & "hi"
-Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 11-17: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 >> Concatenate( true, TestRedRamp.Red25 )
 Errors: Error 0-11: The function 'Concatenate' has some invalid arguments.|Error 30-36: Invalid argument type (Color). Expecting a Text value instead.
@@ -601,16 +601,16 @@ true
 true
 
 >> TestYesNo.No >= Blank()
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> TestYesNo.No < Blank()
-Errors: Error 9-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 9-12: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() < TestYesNo.Yes
-Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 19-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> Blank() <= TestYesNo.Yes
-Errors: Error 20-24: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 20-24: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> TestNumberCompareNumeric.V2 < Blank()
 false
@@ -798,10 +798,10 @@ false
 // Can't compare numerically (CanCompareNumeric = false)
 
 >> TestYesNo.Yes < TestYesNo.No
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 25-28: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 25-28: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 >> TestYesNo.Yes >= TestYesNo.No
-Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 26-29: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 9-13: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 26-29: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Can't concatenate strongly typed (CanConcatenateStronglyTyped = false)
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnums_PreV1.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/StronglyTypedEnums_PreV1.txt
@@ -19,7 +19,7 @@ true
 RGBA(255,0,0,1)
 
 >> Color.Red < Color.Green
-Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.|Error 17-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, UntypedObject.
+Errors: Error 5-9: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.|Error 17-23: Invalid argument type. Expecting one of the following: Number, Decimal, Date, Time, DateTime, Dynamic.
 
 // Number backed enums support gt/lt/geq/leq, but enforce type checks
 >> With({ErrorKnd: ErrorKind.Div0}, ErrorKnd < ErrorKind.Custom) 
@@ -41,7 +41,7 @@ false
 // Non string-backed enums use the name when coerced to string
 // This might not be great, but it matches the CDS Option Set behavior.
 >> "Color: " & Color.Red
-Errors: Error 17-21: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, UntypedObject.
+Errors: Error 17-21: Invalid argument type. Expecting one of the following: Text, Number, Decimal, Date, Time, DateTimeNoTimeZone, DateTime, Boolean, ViewValue, Dynamic.
 
 // Functions can enforce expecting an enum type
 >> DateAdd(Date(2011,1,15), 100000000, "milliseconds")

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
@@ -53,10 +53,10 @@ DateTime(1900,12,31,0,0,0,0)
 >> ParseJSON("""1900-12-31T00:00:00.000-08:00""", DateTimeTZInd)
 DateTime(1900,12,31,8,0,0,0)
 
->> Value(ParseJSON("42", UntypedObject))
+>> Value(ParseJSON("42", Dynamic))
 42
 
->> Value(ParseJSON("true", UntypedObject))
+>> Value(ParseJSON("true", Dynamic))
 1
 
 >> ParseJSON("true", Boolean)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
@@ -6,8 +6,8 @@ DateTime(2008,1,1,4,12,12,100)
 >> ParseJSON("""2008-01-01T12:12:12.100-08:00""", DateTime)
 DateTime(2008,1,1,12,12,12,100)
 
->> DateTimeValue(ParseJSON("""1900-12-31T00:00:00.000Z""", UntypedObject))
+>> DateTimeValue(ParseJSON("""1900-12-31T00:00:00.000Z""", Dynamic))
 DateTime(1900,12,30,16,0,0,0)
 
->> DateValue(ParseJSON("""1900-12-31T00:00:00.000Z""", UntypedObject))
+>> DateValue(ParseJSON("""1900-12-31T00:00:00.000Z""", Dynamic))
 Date(1900,12,30)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
@@ -648,7 +648,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
         [Theory]
         [InlineData("ParseJSON(\"42\", Nu|", "Number")]
         [InlineData("AsType(ParseJSON(\"42\"), Da|", "Date", "DateTime", "DateTimeTZInd")]
-        [InlineData("IsType(ParseJSON(\"42\"),|", "'My Type With Space'", "'Some \" DQuote'", "Boolean", "Date", "DateTime", "DateTimeTZInd", "Decimal", "GUID", "Hyperlink", "MyNewType", "Number", "Text", "Time", "UntypedObject")]
+        [InlineData("IsType(ParseJSON(\"42\"),|", "'My Type With Space'", "'Some \" DQuote'", "Boolean", "Date", "DateTime", "DateTimeTZInd", "Decimal", "Dynamic", "GUID", "Hyperlink", "MyNewType", "Number", "Text", "Time")]
         [InlineData("ParseJSON(\"42\", Voi|")]
         [InlineData("ParseJSON(\"42\", MyN|", "MyNewType")]
         [InlineData("ParseJSON(\"42\", Tim|", "DateTime", "DateTimeTZInd", "Time")]

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("A := Type(Blob); B := Type({x: Currency}); C := Type([DateTime]); D := Type(None)", 2)]
 
         // Have named formulas and udf in the script
-        [InlineData("NAlias := Type(Number);X := 5; ADDX(n:Number): Number = n + X; SomeType := Type(UntypedObject)", 2)]
+        [InlineData("NAlias := Type(Number);X := 5; ADDX(n:Number): Number = n + X; SomeType := Type(Dynamic)", 2)]
 
         // Have RecordOf with/ without errors
         [InlineData("Numbers := Type([Number]);T1 := Type(RecordOf([Number])); Num := Type(RecordOf(Numbers)); T2 := Type(Num);", 3)]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/RecalcEngineTests.cs
@@ -2083,7 +2083,7 @@ namespace Microsoft.PowerFx.Tests
             "",
             false)]
         [InlineData(
-            "Account := Type(RecordOf(UntypedObject));",
+            "Account := Type(RecordOf(Dynamic));",
             "",
             false)]
 

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/TypeSystemTests/JsonTypeSnapshots/SimplePrimitiveUntyped.json
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/TypeSystemTests/JsonTypeSnapshots/SimplePrimitiveUntyped.json
@@ -1,5 +1,5 @@
 {
   "Type": {
-    "Name": "UntypedObject"
+    "Name": "Dynamic"
   }
 }


### PR DESCRIPTION
After discussion, it was decided to rename UntypedObject to Dynamic (what customers see). This PR makes that change.