### PR TITLE
Correct Blank handling for CDP Connectors.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.PowerFx.Connectors.Tabular;
 using Microsoft.PowerFx.Core.Entities;
 using Microsoft.PowerFx.Core.IR;
+using Microsoft.PowerFx.Functions;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
@@ -145,7 +146,7 @@ namespace Microsoft.PowerFx.Connectors
 
             if (value is BlankValue)
             {
-                return value;
+                return FormulaValue.NewBlank(expectedType);
             }
 
             if (expectedType == valueType)

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Tests;
+using Microsoft.PowerFx.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.PowerFx.Connectors.Tests
+{
+    public class CDPDelegationTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public CDPDelegationTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task CDPOdataExecutionTest()
+        {
+            using var testConnector = new LoggingTestServer(null /* no swagger */, _output);
+            var config = new PowerFxConfig(Features.PowerFxV1);
+            var engine = new RecalcEngine(config);
+
+            ConsoleLogger logger = new ConsoleLogger(_output);
+            using var httpClient = new HttpClient(testConnector);
+            string connectionId = "c1a4e9f52ec94d55bb82f319b3e33a6a";
+            string jwt = "eyJ0eXAiOiJKV1QiL...";
+            using var client = new PowerPlatformConnectorClient("firstrelease-003.azure-apihub.net", "49970107-0806-e5a7-be5e-7c60e2750f01", connectionId, () => jwt, httpClient) { SessionId = "8e67ebdc-d402-455a-b33a-304820832383" };
+
+            testConnector.SetResponseFromFile(@"Responses\SQL GetDatasetsMetadata.json");
+            DatasetMetadata dm = await CdpDataSource.GetDatasetsMetadataAsync(client, $"/apim/sql/{connectionId}", CancellationToken.None, logger);
+
+            Assert.NotNull(dm);
+            Assert.Null(dm.Blob);
+
+            Assert.Equal("{server},{database}", dm.DatasetFormat);
+            Assert.NotNull(dm.Tabular);
+            Assert.Equal("dataset", dm.Tabular.DisplayName);
+            Assert.Equal("mru", dm.Tabular.Source);
+            Assert.Equal("Table", dm.Tabular.TableDisplayName);
+            Assert.Equal("Tables", dm.Tabular.TablePluralName);
+            Assert.Equal("single", dm.Tabular.UrlEncoding);
+            Assert.NotNull(dm.Parameters);
+            Assert.Equal(2, dm.Parameters.Count);
+
+            Assert.Equal("Server name.", dm.Parameters.First().Description);
+            Assert.Equal("server", dm.Parameters.First().Name);
+            Assert.True(dm.Parameters.First().Required);
+            Assert.Equal("string", dm.Parameters.First().Type);
+            Assert.Equal("double", dm.Parameters.First().UrlEncoding);
+            Assert.Null(dm.Parameters.First().XMsDynamicValues);
+            Assert.Equal("Server name", dm.Parameters.First().XMsSummary);
+
+            Assert.Equal("Database name.", dm.Parameters.Skip(1).First().Description);
+            Assert.Equal("database", dm.Parameters.Skip(1).First().Name);
+            Assert.True(dm.Parameters.Skip(1).First().Required);
+            Assert.Equal("string", dm.Parameters.Skip(1).First().Type);
+            Assert.Equal("double", dm.Parameters.Skip(1).First().UrlEncoding);
+            Assert.NotNull(dm.Parameters.Skip(1).First().XMsDynamicValues);
+            Assert.Equal("/v2/databases?server={server}", dm.Parameters.Skip(1).First().XMsDynamicValues.Path);
+            Assert.Equal("value", dm.Parameters.Skip(1).First().XMsDynamicValues.ValueCollection);
+            Assert.Equal("Name", dm.Parameters.Skip(1).First().XMsDynamicValues.ValuePath);
+            Assert.Equal("DisplayName", dm.Parameters.Skip(1).First().XMsDynamicValues.ValueTitle);
+            Assert.Equal("Database name", dm.Parameters.Skip(1).First().XMsSummary);
+
+            CdpDataSource cds = new CdpDataSource("pfxdev-sql.database.windows.net,connectortest", ConnectorSettings.NewCDPConnectorSettings(maxRows: 101));
+
+            testConnector.SetResponseFromFiles(@"Responses\SQL GetDatasetsMetadata.json", @"Responses\SQL GetTables.json");
+            IEnumerable<CdpTable> tables = await cds.GetTablesAsync(client, $"/apim/sql/{connectionId}", CancellationToken.None, logger);
+
+            Assert.NotNull(tables);
+
+            CdpTable connectorTable = tables.First(t => t.DisplayName == "Customers");
+
+            Assert.False(connectorTable.IsInitialized);
+            Assert.Equal("Customers", connectorTable.DisplayName);
+
+            testConnector.SetResponseFromFiles(@"Responses\SQL Server Load Customers DB.json", @"Responses\SQL GetRelationships SampleDB.json");
+            await connectorTable.InitAsync(client, $"/apim/sql/{connectionId}", CancellationToken.None, logger);
+            Assert.True(connectorTable.IsInitialized);
+
+            CdpTableValue sqlTable = connectorTable.GetTableValue();
+
+            // Execute OData.
+            var responseFile = @"Responses\BlankTopLevelAggregation.json";
+            var oData = "$apply=aggregate%28Bonus%20with%20sum%20as%20result%29";
+            var delegationParam = new MockDelegationParameters(DelegationParameterFeatures.ApplyTopLevelAggregation, FormulaType.Decimal, oData);
+            testConnector.SetResponseFromFile(responseFile);
+            var result = await sqlTable.ExecuteQueryAsync(null, delegationParam, CancellationToken.None);
+            Assert.IsAssignableFrom<DecimalType>(result.Type);
+            Assert.IsAssignableFrom<BlankValue>(result);
+        }
+
+        private class MockDelegationParameters : DelegationParameters
+        {
+            private readonly DelegationParameterFeatures _features;
+
+            public override DelegationParameterFeatures Features => _features;
+
+            private readonly FormulaType _expectedType;
+
+            public override FormulaType ExpectedReturnType => _expectedType;
+
+            private readonly string _odata;
+
+            private readonly bool _returnTotalCount = false;
+
+            public MockDelegationParameters(DelegationParameterFeatures allowedFeatures, FormulaType expectedType, string oData, bool returnTotalCount = false)
+            {
+                _features = allowedFeatures;
+                _expectedType = expectedType;
+                _odata = oData;
+                _returnTotalCount = returnTotalCount;
+            }
+
+            public override string GetODataApply()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override string GetOdataFilter()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override string GetODataQueryString()
+            {
+                if (string.IsNullOrEmpty(_odata))
+                {
+                    throw new NotImplementedException("OData query string is not implemented.");
+                }
+
+                return _odata;
+            }
+
+            public override IReadOnlyCollection<(string, bool)> GetOrderBy()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool ReturnTotalCount()
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Microsoft.PowerFx.Connectors.Tests.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyProperties2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BaseConnectorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BasicRestTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CDPDelegationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CompatibilityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConnectorWizardTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DynamicTests.cs" />
@@ -48,6 +49,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\LoggingTestServer.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\BlankTopLevelAggregation.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\SQL Server Get First Customers_Aßþ.json" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Responses\SQL Server Load Customers_Aßþ.json" />
     <None Include="$(MSBuildThisFileDirectory)Owl.png">

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/BlankTopLevelAggregation.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/BlankTopLevelAggregation.json
@@ -1,0 +1,9 @@
+{
+  "@odata.context": "https://d5ecf3dd-b678-e86f-827c-07be75e98964.07.common.tip2.azure-apihub.net/apim/sql/b83da26628184be880d6b0ce5f69f289/$metadata#datasets('testconnector.database.windows.net%2Ctestconnector')/tables('%5Bdbo%5D.%5BEmployees%5D')/items",
+  "value": [
+    {
+      "@odata.etag": "",
+      "ItemInternalId": "3986130d-79eb-46ce-a0f8-2aff9be5da68"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `Microsoft.PowerFx.Connectors` library and its associated test suite. The changes include improvements to blank value handling, the addition of a comprehensive test class for CDP delegation, and updates to test resources and project files to support the new functionality.

### Library Enhancements:
* **Improved blank value handling**: Updated the `ConvertToExpectedType` method in `CdpTableValue.cs` to create a new blank value using the expected type instead of returning the original blank value. This ensures better type consistency.

### Test Suite Additions:
* **New CDP delegation test class**: Added `CDPDelegationTests.cs`, a detailed test class that validates CDP delegation functionality, including OData execution and table initialization. This class introduces mock delegation parameters and tests various scenarios for data source interaction.
* **Updated project files**: Included the new `CDPDelegationTests.cs` file in the project and added an embedded resource `BlankTopLevelAggregation.json` for testing OData aggregation responses. [[1]](diffhunk://#diff-bdf174ba6be83bc868dc2168d02bbcfe53b306f8d766f3187399a819e1be2531R15) [[2]](diffhunk://#diff-bdf174ba6be83bc868dc2168d02bbcfe53b306f8d766f3187399a819e1be2531R52)

### Test Resources:
* **New JSON test resource**: Added `BlankTopLevelAggregation.json` to simulate OData aggregation responses in tests. This resource ensures proper validation of data returned from the connector.