### PR TITLE
Update enhanced-connectors doc for $count support.md

### DIFF
--- a/docs/enhanced-connectors.md
+++ b/docs/enhanced-connectors.md
@@ -211,6 +211,8 @@ Defined in `x-ms-capabilities`
 | | IsReadOnly | ReadOnly table, when `x-ms-permission` is set to `read-only`<br> When a table is defining no primary column, it is also marked `read-only` and a fake primary key column is added to it ("KeyId", number)|
 | `sortRestrictions` | SortRestriction | Sort Restrictions |
 |  | IsSortable| When SortRestriction is not null |
+| `countRestrictions` | CountRestriction | Count Restrictions |
+|  | IsCountable | When `countRestrictions` is not null and `countable=true`, the table supports `$count` in OData queries |
 | `filterRestrictions` | FilterRestriction | Filter Restrictions |
 | `selectRestrictions`  | SelectionRestriction | Select Restrictions |
 |  | IsSelectable | When SelectionRestriction is not null && SelectionRestriction.IsSelectable |
@@ -300,6 +302,52 @@ OData optional parameters (in query string)
 - $count
 
 The supported runtime operations here should be consistent with the capabilities described in the metadata.
+
+#### Sample 200 Response (without `$count`)
+
+<details>
+<summary>Response</summary>
+
+
+```text
+HTTP/1.1 200 OK
+OData-Version: 4.0
+```
+```json
+{
+  "@odata.context": "[Organization URI]/api/data/v9.2/$metadata#accounts(accountid)",
+  "value": [
+    {
+      "@odata.etag": "W/\"81359849\"",
+      "accountid": "78914942-34cb-ed11-b596-0022481d68cd"
+    }
+    // ... more rows
+  ]
+}
+```
+</details>
+
+#### Sample 200 Response (with $count=true)
+<details> <summary>Response</summary>
+    
+```text
+HTTP/1.1 200 OK
+OData-Version: 4.0
+```
+```json
+{
+  "@odata.context": "[Organization URI]/api/data/v9.2/$metadata#accounts(accountid)",
+  "@odata.count": 9,
+  "value": [
+    {
+      "@odata.etag": "W/\"81359849\"",
+      "accountid": "78914942-34cb-ed11-b596-0022481d68cd"
+    }
+    // ... more rows
+  ]
+}
+```
+</details>
 
 ### DELETE /datasets/{datasetName}/tables/{tableName}/items/{id}
 Delete a row


### PR DESCRIPTION
This pull request updates the `docs/enhanced-connectors.md` file to add details about `countRestrictions` and provide examples of OData responses with and without `$count`. These changes enhance the documentation for better clarity and completeness.

Based on: https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/query/count-rows

### Documentation Enhancements:

* Added `countRestrictions` to the capabilities table, specifying that tables supporting `$count` in OData queries must have `countRestrictions` set to non-null and `countable=true`. (`[docs/enhanced-connectors.mdR214-R215](diffhunk://#diff-c5943549bf367bbd0775d7fd90401982f9983ad33f2b62e89bb1fda325919d24R214-R215)`)
* Included sample 200 responses for OData queries, demonstrating the difference between responses with and without `$count=true`. (`[docs/enhanced-connectors.mdR306-R351](diffhunk://#diff-c5943549bf367bbd0775d7fd90401982f9983ad33f2b62e89bb1fda325919d24R306-R351)`)