### PR TITLE
Adding Copilot generated /// comments for connector namespace …

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorConstants.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorConstants.cs
@@ -2,33 +2,114 @@
 // Licensed under the MIT license.
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Contains constant values for x-ms-* OpenAPI extensions used in connectors.
+    /// </summary>
     public static class Constants
     {
+        /// <summary>
+        /// The x-ms-ai-sensitivity extension name.
+        /// </summary>
         public const string XMsAiSensitivity = "x-ms-ai-sensitivity";
+        /// <summary>
+        /// The x-bodyName extension name.
+        /// </summary>
         public const string XMsBodyName = "x-bodyName";
+        /// <summary>
+        /// The x-ms-capabilities extension name.
+        /// </summary>
         public const string XMsCapabilities = "x-ms-capabilities";
+        /// <summary>
+        /// The x-ms-dynamic-list extension name.
+        /// </summary>
         public const string XMsDynamicList = "x-ms-dynamic-list";
+        /// <summary>
+        /// The x-ms-dynamic-properties extension name.
+        /// </summary>
         public const string XMsDynamicProperties = "x-ms-dynamic-properties";
+        /// <summary>
+        /// The x-ms-dynamic-schema extension name.
+        /// </summary>
         public const string XMsDynamicSchema = "x-ms-dynamic-schema";
+        /// <summary>
+        /// The x-ms-dynamic-values extension name.
+        /// </summary>
         public const string XMsDynamicValues = "x-ms-dynamic-values";
+        /// <summary>
+        /// The x-ms-enum extension name.
+        /// </summary>
         public const string XMsEnum = "x-ms-enum";
+        /// <summary>
+        /// The x-ms-enum-display-name extension name.
+        /// </summary>
         public const string XMsEnumDisplayName = "x-ms-enum-display-name";
+        /// <summary>
+        /// The x-ms-enum-values extension name.
+        /// </summary>
         public const string XMsEnumValues = "x-ms-enum-values";
+        /// <summary>
+        /// The x-ms-explicit-input extension name.
+        /// </summary>
         public const string XMsExplicitInput = "x-ms-explicit-input";
+        /// <summary>
+        /// The x-ms-keyOrder extension name.
+        /// </summary>
         public const string XMsKeyOrder = "x-ms-keyOrder";
+        /// <summary>
+        /// The x-ms-keyType extension name.
+        /// </summary>
         public const string XMsKeyType = "x-ms-keyType";
+        /// <summary>
+        /// The x-ms-media-kind extension name.
+        /// </summary>
         public const string XMsMediaKind = "x-ms-media-kind";
+        /// <summary>
+        /// The x-ms-notification-content extension name.
+        /// </summary>
         public const string XMsNotificationContent = "x-ms-notification-content";
+        /// <summary>
+        /// The x-ms-notification-url extension name.
+        /// </summary>
         public const string XMsNotificationUrl = "x-ms-notification-url";
+        /// <summary>
+        /// The x-ms-pageable extension name.
+        /// </summary>
         public const string XMsPageable = "x-ms-pageable";
+        /// <summary>
+        /// The x-ms-permission extension name.
+        /// </summary>
         public const string XMsPermission = "x-ms-permission";
+        /// <summary>
+        /// The x-ms-property-entity-type extension name.
+        /// </summary>
         public const string XMsPropertyEntityType = "x-ms-property-entity-type";
+        /// <summary>
+        /// The x-ms-relationships extension name.
+        /// </summary>
         public const string XMsRelationships = "x-ms-relationships";
+        /// <summary>
+        /// The x-ms-require-user-confirmation extension name.
+        /// </summary>
         public const string XMsRequireUserConfirmation = "x-ms-require-user-confirmation";
+        /// <summary>
+        /// The x-ms-sort extension name.
+        /// </summary>
         public const string XMsSort = "x-ms-sort";
+        /// <summary>
+        /// The x-ms-summary extension name.
+        /// </summary>
         public const string XMsSummary = "x-ms-summary";
+        /// <summary>
+        /// The x-ms-trigger extension name.
+        /// </summary>
         public const string XMsTrigger = "x-ms-trigger";
+        /// <summary>
+        /// The x-ms-url-encoding extension name.
+        /// </summary>
         public const string XMsUrlEncoding = "x-ms-url-encoding";
+        /// <summary>
+        /// The x-ms-visibility extension name.
+        /// </summary>
         public const string XMsVisibility = "x-ms-visibility";
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/AiSensitivity.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/AiSensitivity.cs
@@ -3,18 +3,29 @@
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// "x-ms-ai-sensitivity" enum.
+    /// </summary>
     public enum AiSensitivity : int
     {
-        // "x-ms-ai-sensitivity" is not corresponding to any valid value (normally, only "low", "high")
+        /// <summary>
+        /// "x-ms-ai-sensitivity" is not corresponding to any valid value (normally, only "low", "high")
+        /// </summary>
         Unknown = -1,
 
-        // "x-ms-ai-sensitivity" is not defined
+        /// <summary>
+        /// "x-ms-ai-sensitivity" is not defined
+        /// </summary>
         None = 0,
 
-        // "x-ms-ai-sensitivity" is "low"
+        /// <summary>
+        /// "x-ms-ai-sensitivity" is "low"
+        /// </summary>
         Low,
 
-        // "x-ms-ai-sensitivity" is "high"
+        /// <summary>
+        /// "x-ms-ai-sensitivity" is "high"
+        /// </summary>
         High
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/BaseRuntimeConnectorContext.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/BaseRuntimeConnectorContext.cs
@@ -6,12 +6,24 @@ using System.Net.Http;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Base class for runtime connector context.
+    /// </summary>
     public abstract class BaseRuntimeConnectorContext
     {
+        /// <summary>
+        /// Gets the HTTP message invoker for the specified namespace.
+        /// </summary>
         public abstract HttpMessageInvoker GetInvoker(string @namespace);
 
+        /// <summary>
+        /// Gets the time zone information.
+        /// </summary>
         public abstract TimeZoneInfo TimeZoneInfo { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether to throw on error.
+        /// </summary>
         public virtual bool ThrowOnError { get; } = false;        
 
         internal virtual bool ReturnRawResults { get; } = false;        
@@ -24,8 +36,14 @@ namespace Microsoft.PowerFx.Connectors
         }
     }
 
+    /// <summary>
+    /// Extension methods for runtime connector context.
+    /// </summary>
     public static class RuntimeConnectorContextExtensions
     {
+        /// <summary>
+        /// Adds a runtime context to the service provider.
+        /// </summary>
         public static BasicServiceProvider AddRuntimeContext(this BasicServiceProvider serviceProvider, BaseRuntimeConnectorContext context)
         {
             return serviceProvider.AddService(typeof(BaseRuntimeConnectorContext), context);

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpExtensions.cs
@@ -5,8 +5,14 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Extension methods for CDP-related types.
+    /// </summary>
     public static class CdpExtensions
     {
+        /// <summary>
+        /// Tries to get the external table name and foreign key for a field in a RecordType.
+        /// </summary>
         public static bool TryGetFieldExternalTableName(this RecordType recordType, string fieldName, out string tableName, out string foreignKey)
         {
             if (recordType is not CdpRecordType cdpRecordType)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/CdpTableValue.cs
@@ -15,10 +15,14 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
-    // Created by TabularService.GetTableValue
-    // Doesn't contain any ServiceProvider which is runtime only
+    /// <summary>
+    /// Represents a table value created by TabularService.GetTableValue. Does not contain any ServiceProvider which is runtime only.
+    /// </summary>
     public class CdpTableValue : TableValue, IRefreshable, IDelegatableTableValue
     {
+        /// <summary>
+        /// Gets a value indicating whether the table is delegable.
+        /// </summary>
         public bool IsDelegable => _tabularService.IsDelegable;
 
         protected internal readonly CdpService _tabularService;        
@@ -48,6 +52,9 @@ namespace Microsoft.PowerFx.Connectors
             _cachedRows = null;
         }
 
+        /// <summary>
+        /// Gets the rows of the table, fetching and caching them if necessary.
+        /// </summary>
         public override IEnumerable<DValue<RecordValue>> Rows
         {
             get
@@ -67,6 +74,9 @@ namespace Microsoft.PowerFx.Connectors
             }
         }
 
+        /// <summary>
+        /// Gets the supported delegation features for this table.
+        /// </summary>
         public DelegationParameterFeatures SupportedFeatures => DelegationParameterFeatures.Filter |
                 DelegationParameterFeatures.Top |
                 DelegationParameterFeatures.Columns | // $select
@@ -75,17 +85,26 @@ namespace Microsoft.PowerFx.Connectors
                 DelegationParameterFeatures.ApplyTopLevelAggregation |
                 DelegationParameterFeatures.Count;
 
+        /// <summary>
+        /// Asynchronously gets the rows of the table.
+        /// </summary>
         public async Task<IReadOnlyCollection<DValue<RecordValue>>> GetRowsAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel)
         {
             var rows = await _tabularService.GetItemsAsync(services, parameters, cancel).ConfigureAwait(false);
             return rows;
         }
 
+        /// <summary>
+        /// Refreshes the cached rows.
+        /// </summary>
         public void Refresh()
         {
             _cachedRows = null;
         }
 
+        /// <summary>
+        /// Asynchronously executes a query and returns the result as a FormulaValue.
+        /// </summary>
         public async Task<FormulaValue> ExecuteQueryAsync(IServiceProvider services, DelegationParameters parameters, CancellationToken cancel)
         {
             if (parameters == null)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorEnhancedSuggestions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorEnhancedSuggestions.cs
@@ -6,11 +6,19 @@ using Microsoft.PowerFx.Intellisense;
 
 namespace Microsoft.PowerFx.Connectors
 {
-    // Wraps ConnectorSuggestions (defined in PFx.Core) to add ConnectorType (Pfx.Connectors only)
+    /// <summary>
+    /// Wraps ConnectorSuggestions to add ConnectorType for enhanced suggestions.
+    /// </summary>
     public class ConnectorEnhancedSuggestions
     {
+        /// <summary>
+        /// Gets the connector type associated with the suggestions.
+        /// </summary>
         public ConnectorType ConnectorType { get; }
 
+        /// <summary>
+        /// Gets the connector suggestions.
+        /// </summary>
         public ConnectorSuggestions ConnectorSuggestions { get; }
 
         internal ConnectorEnhancedSuggestions(SuggestionMethod suggestionMethod, IReadOnlyList<ConnectorSuggestion> suggestions, ConnectorType connectorType = null)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorKeyType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorKeyType.cs
@@ -3,15 +3,24 @@
 
 namespace Microsoft.PowerFx.Connectors
 {
-    // x-ms-keyType
+    /// <summary>
+    /// Specifies the key type for a connector (x-ms-keyType).
+    /// </summary>
     public enum ConnectorKeyType
     {
+        /// <summary>
+        /// Undefined key type.
+        /// </summary>
         Undefined = -1,
 
-        // "primary"
+        /// <summary>
+        /// Primary key type.
+        /// </summary>
         Primary,
 
-        // "none"
+        /// <summary>
+        /// No key type.
+        /// </summary>
         None
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorLogger.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorLogger.cs
@@ -5,30 +5,48 @@ using System;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Logger for connector operations.
+    /// </summary>
     public abstract class ConnectorLogger
     {
         protected abstract void Log(ConnectorLog log);
 
+        /// <summary>
+        /// Logs an informational message.
+        /// </summary>
         public virtual void LogInformation(string message)
         {
             Log(new ConnectorLog(LogCategory.Information, message));
         }
 
+        /// <summary>
+        /// Logs a debug message.
+        /// </summary>
         public virtual void LogDebug(string message)
         {
             Log(new ConnectorLog(LogCategory.Debug, message));
         }
 
+        /// <summary>
+        /// Logs an error message.
+        /// </summary>
         public virtual void LogError(string message)
         {
             Log(new ConnectorLog(LogCategory.Error, message));
         }
 
+        /// <summary>
+        /// Logs a warning message.
+        /// </summary>
         public virtual void LogWarning(string message)
         {
             Log(new ConnectorLog(LogCategory.Warning, message));
         }
 
+        /// <summary>
+        /// Logs an exception with a message.
+        /// </summary>
         public virtual void LogException(Exception ex, string message)
         {
             Log(new ConnectorLog(LogCategory.Exception, message, ex));

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorParameter.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorParameter.cs
@@ -13,11 +13,19 @@ namespace Microsoft.PowerFx.Connectors
     [DebuggerDisplay("{Name} {ConnectorType}")]
     public class ConnectorParameter : ConnectorSchema
     {
+        /// <summary>
+        /// Gets the name of the parameter.
+        /// </summary>
         public string Name { get; private set; }
 
+        /// <summary>
+        /// Gets the description of the parameter.
+        /// </summary>
         public string Description { get; }
 
-        // Query, Header, Path or Cookie (not supported yet)
+        /// <summary>
+        /// Gets the location of the parameter (Query, Header, Path, or Cookie).
+        /// </summary>
         public ParameterLocation? Location { get; }
 
         internal bool IsBodyParameter = false;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorParameterWithSuggestions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorParameterWithSuggestions.cs
@@ -8,6 +8,9 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Represents a connector parameter with suggestions and values.
+    /// </summary>
     public class ConnectorParameterWithSuggestions : ConnectorParameter
     {
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorParameters.cs
@@ -3,6 +3,9 @@
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Represents a set of connector parameters.
+    /// </summary>
     public class ConnectorParameters
     {
         /// <summary>
@@ -10,6 +13,9 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         public bool IsCompleted { get; internal set; }
 
+        /// <summary>
+        /// Gets the parameters with suggestions.
+        /// </summary>
         public ConnectorParameterWithSuggestions[] ParametersWithSuggestions { get; internal set; }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorPermission.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorPermission.cs
@@ -3,14 +3,24 @@
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Defines permission levels for a connector.
+    /// </summary>
     public enum ConnectorPermission
     {
+        /// <summary>
+        /// Undefined permission.
+        /// </summary>
         Undefined = -1,
 
-        // "read-only"
+        /// <summary>
+        /// Read-only permission.
+        /// </summary>
         PermissionReadOnly,
 
-        // "read-write"
+        /// <summary>
+        /// Read-write permission.
+        /// </summary>
         PermissionReadWrite
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSchema.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSchema.cs
@@ -6,11 +6,20 @@ using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Represents the schema of a connector parameter or type.
+    /// </summary>
     [DebuggerDisplay("{ConnectorType}")]
     public class ConnectorSchema : SupportsConnectorErrors
     {
+        /// <summary>
+        /// Gets the connector type.
+        /// </summary>
         public ConnectorType ConnectorType { get; }
 
+        /// <summary>
+        /// Gets the default value for the parameter or type.
+        /// </summary>
         public FormulaValue DefaultValue { get; }
 
         internal ISwaggerSchema Schema { get; }
@@ -19,20 +28,41 @@ namespace Microsoft.PowerFx.Connectors
 
         private bool UseHiddenTypes { get; }
 
+        /// <summary>
+        /// Gets the title of the connector.
+        /// </summary>
         public string Title => Schema.Title;
 
+        /// <summary>
+        /// Gets the formula type, considering hidden types if applicable.
+        /// </summary>
         public FormulaType FormulaType => UseHiddenTypes ? ConnectorType.HiddenRecordType : ConnectorType.FormulaType;
 
         internal RecordType HiddenRecordType => ConnectorType.HiddenRecordType;
 
+        /// <summary>
+        /// Gets the summary of the connector.
+        /// </summary>
         public string Summary => ConnectorExtensions.Summary;
 
+        /// <summary>
+        /// Indicates whether dynamic intellisense is supported.
+        /// </summary>
         public bool SupportsDynamicIntellisense => ConnectorType.SupportsDynamicIntellisense;
 
+        /// <summary>
+        /// Gets the notification URL, if available.
+        /// </summary>
         public bool? NotificationUrl => ConnectorType.NotificationUrl;
 
+        /// <summary>
+        /// Gets the AI sensitivity level.
+        /// </summary>
         public AiSensitivity AiSensitivity => ConnectorType.AiSensitivity;
 
+        /// <summary>
+        /// Gets the property entity type.
+        /// </summary>
         public string PropertyEntityType => ConnectorType.PropertyEntityType;
 
         internal ConnectorSchema(ISwaggerParameter openApiParameter, ISwaggerExtensions bodyExtensions, bool useHiddenTypes, ConnectorSettings settings)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
@@ -16,6 +16,9 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         internal const int DefaultConnectorTop = 1000;
 
+        /// <summary>
+        /// Creates a new instance of ConnectorSettings for CDP connectors.
+        /// </summary>
         public static ConnectorSettings NewCDPConnectorSettings(bool extractSensitivityLabel = false, string purviewAccountName = null, int maxRows = DefaultConnectorTop)
         {
             var connectorSettings = new ConnectorSettings(null)
@@ -31,6 +34,9 @@ namespace Microsoft.PowerFx.Connectors
             return connectorSettings;
         }
         
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectorSettings"/> class.
+        /// </summary>
         public ConnectorSettings(string @namespace)
         {
             Namespace = @namespace;
@@ -126,8 +132,14 @@ namespace Microsoft.PowerFx.Connectors
         public ConnectorCompatibility Compatibility { get; init; } = ConnectorCompatibility.Default;
     }
 
+    /// <summary>
+    /// Specifies compatibility modes for connectors.
+    /// </summary>
     public enum ConnectorCompatibility
     {
+        /// <summary>
+        /// Default compatibility mode (PowerAppsCompatibility).
+        /// </summary>
         Default = PowerAppsCompatibility,
 
         // Power Apps Compatibility

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
@@ -16,90 +16,130 @@ using static Microsoft.PowerFx.Connectors.Constants;
 
 namespace Microsoft.PowerFx.Connectors
 {
-    // Wrapper class around FormulaType and ConnectorType
-    // FormulaType is used to represent the type of the parameter in the Power Fx expression as used in Power Apps
-    // ConnectorType contains more details information coming from the swagger file and extensions
+    /// <summary>
+    /// Wrapper class around FormulaType and ConnectorType. Contains detailed information from the swagger file and extensions.
+    /// </summary>
     [DebuggerDisplay("{FormulaType._type}")]
     public class ConnectorType : SupportsConnectorErrors
     {
-        // "name"
+        /// <summary>
+        /// Gets or sets the name of the connector type.
+        /// </summary>
         public string Name { get; internal set; }
 
-        // "x-ms-summary" or "title"
+        /// <summary>
+        /// Gets the display name ("x-ms-summary" or "title").
+        /// </summary>
         public string DisplayName { get; }
 
-        // "description"
+        /// <summary>
+        /// Gets the description.
+        /// </summary>
         public string Description { get; }
 
-        // "required"
+        /// <summary>
+        /// Gets or sets a value indicating whether the field is required.
+        /// </summary>
         public bool IsRequired { get; internal set; }
 
-        // Only used for RecordType and TableType
+        /// <summary>
+        /// Gets the fields for RecordType and TableType.
+        /// </summary>
         public ConnectorType[] Fields { get; }
 
-        internal ConnectorType[] HiddenFields { get; }
-
-        // FormulaType
+        /// <summary>
+        /// Gets the formula type.
+        /// </summary>
         public FormulaType FormulaType { get; private set; }
 
-        // "x-ms-explicit-input"
+        /// <summary>
+        /// Gets a value indicating whether the input is explicit ("x-ms-explicit-input").
+        /// </summary>
         public bool ExplicitInput { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this type is an enum.
+        /// </summary>
         public bool IsEnum { get; }
 
-        // Enumeration value, only defined if IsEnum is true
+        /// <summary>
+        /// Gets the enumeration values, only defined if IsEnum is true.
+        /// </summary>
         public FormulaValue[] EnumValues { get; }
 
-        // Enumeration display name ("x-ms-enum-display-name"), only defined if IsEnum is true
-        // If not defined, this array will be empty
+        /// <summary>
+        /// Gets the enumeration display names ("x-ms-enum-display-name"), only defined if IsEnum is true.
+        /// </summary>
         public string[] EnumDisplayNames { get; }
 
+        /// <summary>
+        /// Gets the enum dictionary.
+        /// </summary>
         public Dictionary<string, FormulaValue> Enum => GetEnum();
 
-        // Supports x-ms-visibility
+        /// <summary>
+        /// Gets the visibility (supports x-ms-visibility).
+        /// </summary>
         public Visibility Visibility { get; internal set; }
 
-        // Supports x-ms-capabilities
-        internal ColumnCapabilities Capabilities { get; }
-
-        // Supports x-ms-relationships
-        internal Dictionary<string, Relationship> Relationships { get; }
-
-        // Supports x-ms-keyType
+        /// <summary>
+        /// Gets the key type (supports x-ms-keyType).
+        /// </summary>
         public ConnectorKeyType KeyType { get; }
 
-        // Supports x-ms-keyOrder (only valid if KeyType = Primary)
+        /// <summary>
+        /// Gets the key order (supports x-ms-keyOrder, only valid if KeyType = Primary).
+        /// </summary>
         public double KeyOrder { get; }
 
+        /// <summary>
+        /// Gets the permission.
+        /// </summary>
         public ConnectorPermission Permission { get; }
 
-        // Supports x-ms-notification-url
+        /// <summary>
+        /// Gets a value indicating whether notification URL is supported (supports x-ms-notification-url).
+        /// </summary>
         public bool? NotificationUrl { get; }
 
-        // Supports x-ms-ai-sensitivity
+        /// <summary>
+        /// Gets the AI sensitivity (supports x-ms-ai-sensitivity).
+        /// </summary>
         public AiSensitivity AiSensitivity { get; }
 
-        // Supports x-ms-property-entity-type
+        /// <summary>
+        /// Gets the property entity type (supports x-ms-property-entity-type).
+        /// </summary>
         public string PropertyEntityType { get; }
 
-        internal RecordType HiddenRecordType { get; }
-
-        // Supports x-ms-dynamic-values or -list locally
+        /// <summary>
+        /// Gets a value indicating whether dynamic values or list are supported locally.
+        /// </summary>
         public bool SupportsDynamicValuesOrList => DynamicValues != null || DynamicList != null;
 
-        // Supports x-ms-dynamic-values or -list locally or anywhere in the tree
+        /// <summary>
+        /// Gets a value indicating whether dynamic values or list are supported locally or anywhere in the tree.
+        /// </summary>
         public bool ContainsDynamicValuesOrList => SupportsDynamicValuesOrList || (Fields != null && Fields.Any(f => f.ContainsDynamicValuesOrList));
 
-        // Supports x-ms-dynamic-schema or -property locally
+        /// <summary>
+        /// Gets a value indicating whether dynamic schema or property are supported locally.
+        /// </summary>
         public bool SupportsDynamicSchemaOrProperty => DynamicSchema != null || DynamicProperty != null;
 
-        // Supports x-ms-dynamic-schema or -property locally or anywhere in the tree
+        /// <summary>
+        /// Gets a value indicating whether dynamic schema or property are supported locally or anywhere in the tree.
+        /// </summary>
         public bool ContainsDynamicSchemaOrProperty => SupportsDynamicSchemaOrProperty || (Fields != null && Fields.Any(f => f.ContainsDynamicSchemaOrProperty));
 
-        // Supports x-ms-dynamic-values, -list, -schema, or -property locally
+        /// <summary>
+        /// Gets a value indicating whether dynamic intellisense is supported locally.
+        /// </summary>
         public bool SupportsDynamicIntellisense => SupportsDynamicValuesOrList || SupportsDynamicSchemaOrProperty;
 
-        // Supports x-ms-dynamic-values, -list, -schema, or -property locally or anywhere in the tree
+        /// <summary>
+        /// Gets a value indicating whether dynamic intellisense is supported locally or anywhere in the tree.
+        /// </summary>
         public bool ContainsDynamicIntellisense => ContainsDynamicValuesOrList || ContainsDynamicSchemaOrProperty;
 
         internal ConnectorDynamicSchema DynamicSchema { get; private set; }
@@ -112,7 +152,9 @@ namespace Microsoft.PowerFx.Connectors
 
         internal bool Binary { get; private set; }
 
-        // Supports x-ms-media-kind
+        /// <summary>
+        /// Gets the media kind (supports x-ms-media-kind).
+        /// </summary>
         internal MediaKind MediaKind { get; private set; }
 
         internal ISwaggerSchema Schema { get; private set; } = null;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ICDPAggregateMetadata.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ICDPAggregateMetadata.cs
@@ -7,8 +7,16 @@ using System.Text;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Interface for CDP aggregate metadata.
+    /// </summary>
     public interface ICDPAggregateMetadata
     {
+        /// <summary>
+        /// Tries to get sensitivity label information.
+        /// </summary>
+        /// <param name="cdpSensitivityLabelInfo">The sensitivity label info if available.</param>
+        /// <returns>True if sensitivity label info is available; otherwise, false.</returns>
         bool TryGetSensitivityLabelInfo(out IEnumerable<CDPSensitivityLabelInfo> cdpSensitivityLabelInfo);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/MediaKind.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/MediaKind.cs
@@ -8,22 +8,34 @@ namespace Microsoft.PowerFx.Connectors
     /// </summary>
     public enum MediaKind : int
     {
-        // "x-ms-media-kind" is not defined / dynamic intellisense, we use a string to store results while all others are byte[]
+        /// <summary>
+        /// Not a binary media kind (dynamic intellisense, string results).
+        /// </summary>
         NotBinary = -2,
 
-        // "x-ms-media-kind" is not corresponding to any valid value (normally, only "audio", "video" or "image")
+        /// <summary>
+        /// Unknown media kind.
+        /// </summary>
         Unknown = -1,
 
-        // "x-ms-media-kind" is not defined, defaulting to "File"
+        /// <summary>
+        /// File media kind (default).
+        /// </summary>
         File = 0,
 
-        // "x-ms-media-kind" is "audio"
+        /// <summary>
+        /// Audio media kind.
+        /// </summary>
         Audio,
 
-        // "x-ms-media-kind" is "video"
+        /// <summary>
+        /// Video media kind.
+        /// </summary>
         Video,
 
-        // "x-ms-media-kind" is "image"
+        /// <summary>
+        /// Image media kind.
+        /// </summary>
         Image
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/PowerFxConnectorException.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/PowerFxConnectorException.cs
@@ -8,24 +8,42 @@ using System.Runtime.Serialization;
 namespace Microsoft.PowerFx.Connectors
 {
     [Serializable]
+    /// <summary>
+    /// Represents errors that occur during Power Fx connector operations.
+    /// </summary>
     public class PowerFxConnectorException : Exception
     {
+        /// <summary>
+        /// Gets the status code associated with the exception.
+        /// </summary>
         public int StatusCode { get; init; } = 0;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerFxConnectorException"/> class.
+        /// </summary>
         public PowerFxConnectorException()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerFxConnectorException"/> class with a specified error message.
+        /// </summary>
         public PowerFxConnectorException(string message) 
             : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerFxConnectorException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
         public PowerFxConnectorException(string message, Exception innerException) 
             : base(message, innerException)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerFxConnectorException"/> class with serialized data.
+        /// </summary>
         protected PowerFxConnectorException(SerializationInfo info, StreamingContext context) 
             : base(info, context)
         {

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/SupportsConnectorErrors.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/SupportsConnectorErrors.cs
@@ -5,14 +5,29 @@ using System.Collections.Generic;
 
 namespace Microsoft.PowerFx.Connectors
 {
+    /// <summary>
+    /// Base class for supporting connector errors and warnings.
+    /// </summary>
     public class SupportsConnectorErrors
     {
+        /// <summary>
+        /// Gets a value indicating whether there are errors.
+        /// </summary>
         public bool HasErrors => _errors != null && _errors.Count != 0;
 
+        /// <summary>
+        /// Gets a value indicating whether there are warnings.
+        /// </summary>
         public bool HasWarnings => _warnings != null && _warnings.Count != 0;
 
+        /// <summary>
+        /// Gets the collection of errors.
+        /// </summary>
         public IReadOnlyCollection<string> Errors => _errors;
 
+        /// <summary>
+        /// Gets the collection of warnings.
+        /// </summary>
         public IReadOnlyCollection<ExpressionError> Warnings => _warnings;
 
         protected HashSet<string> _errors = null;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/Visibility.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/Visibility.cs
@@ -8,19 +8,29 @@ namespace Microsoft.PowerFx.Connectors
     /// </summary>
     public enum Visibility : int
     {
-        // "x-ms-visibility" is not corresponding to any valid value (normally, only "important", "advanced" or "internal")
+        /// <summary>
+        /// "x-ms-visibility" is not corresponding to any valid value (normally, only "important", "advanced" or "internal")
+        /// </summary>
         Unknown = -1,
 
-        // "x-ms-visibility" is not defined
+        /// <summary>
+        /// "x-ms-visibility" is not defined
+        /// </summary>
         None = 0,
 
-        // "x-ms-visibility" is "important"
+        /// <summary>
+        /// "x-ms-visibility" is "important"
+        /// </summary>
         Important,
 
-        // "x-ms-visibility" is "advanced"
+        /// <summary>
+        /// "x-ms-visibility" is "advanced"
+        /// </summary>
         Advanced,
 
-        // "x-ms-visibility" is "internal"
+        /// <summary>
+        /// "x-ms-visibility" is "internal"
+        /// </summary>
         Internal
     }
 }


### PR DESCRIPTION


I spent about an hour trying to see which descriptions could be updated using VSCode Copilot Agent mode with this prompt:

```
Please scan all .cs files in the current workspace. For each file:

1. Only process public interfaces, enumerations, classes, methods, properties, and fields.
2. Do not touch private, internal, or protected members.
3. If a public member already has a /// XML comment, leave it unchanged.
4. If a public member is missing a /// comment, add a basic XML summary comment.
5. Do not modify formatting or indentation.
This operation must be idempotent and safe to run multiple times.
```

And a little trial & error.

If these descriptions can be updated, then perhaps this reference documentation will be more valuable:
https://learn.microsoft.com/en-us/dotnet/api/microsoft.powerfx.connectors?view=powerfx-sdk-latest