### PR TITLE
Enable MIP Label via Metadata endpoint.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorConstants.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorConstants.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerFx.Connectors
         public const string XMsNotificationUrl = "x-ms-notification-url";
         public const string XMsPageable = "x-ms-pageable";
         public const string XMsPermission = "x-ms-permission";
+        public const string XMsContentSensitivityLabelInfo = "x-ms-content-sensitivityLabelInfo";
         public const string XMsPropertyEntityType = "x-ms-property-entity-type";
         public const string XMsRelationships = "x-ms-relationships";
         public const string XMsRequireUserConfirmation = "x-ms-require-user-confirmation";

--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1017,7 +1017,7 @@ namespace Microsoft.PowerFx.Connectors
 
         // Only called by ConnectorTable.GetSchema
         // Returns a FormulaType with AssociatedDataSources set (done in AddTabularDataSource)
-        internal static ConnectorType GetCdpTableType(ICdpTableResolver tableResolver, string connectorName, string tableName, string valuePath, StringValue stringValue, ConnectorSettings settings, string datasetName, CDPMetadataItem fieldMetadata,
+        internal static ConnectorType GetCdpTableType(ICdpTableResolver tableResolver, string connectorName, string tableName, string valuePath, StringValue stringValue, ConnectorSettings settings, string datasetName,
                                                       out TableDelegationInfo delegationInfo, out IEnumerable<OptionSet> optionSets)
         {
             // There are some errors when parsing this Json payload but that's not a problem here as we only need x-ms-capabilities parsing to work
@@ -1031,7 +1031,7 @@ namespace Microsoft.PowerFx.Connectors
             bool isTableReadOnly = tablePermission == ConnectorPermission.PermissionReadOnly;            
 
             SymbolTable symbolTable = new SymbolTable();
-            ConnectorType connectorType = new ConnectorType(jsonElement, tableName, symbolTable, settings, datasetName, name, displayName, connectorName, tableResolver, serviceCapabilities, isTableReadOnly, fieldMetadata);
+            ConnectorType connectorType = new ConnectorType(jsonElement, tableName, symbolTable, settings, datasetName, name, displayName, connectorName, tableResolver, serviceCapabilities, isTableReadOnly);
             delegationInfo = ((DataSourceInfo)connectorType.FormulaType._type.AssociatedDataSources.First()).DelegationInfo;
             optionSets = symbolTable.OptionSets.Select(kvp => kvp.Value);
 

--- a/src/libraries/Microsoft.PowerFx.Connectors/Internal/Wrappers/SwaggerJsonArray.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Internal/Wrappers/SwaggerJsonArray.cs
@@ -17,6 +17,8 @@ namespace Microsoft.PowerFx.Connectors
     {
         private readonly JsonElement _je;
 
+        internal JsonElement BackingJsonElement => _je;
+
         public SwaggerJsonArray(JsonElement je)
         {
             _je = je;

--- a/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -1067,6 +1068,16 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             return ConnectorPermission.Undefined;
+        }
+
+        internal static IEnumerable<CDPSensitivityLabelInfo> GetFieldMetadata(this ISwaggerExtensions param)
+        {
+            if (param.Extensions != null && param.Extensions.TryGetValue(XMsContentSensitivityLabelInfo, out var ext) && ext is SwaggerJsonArray apiArr && apiArr.Any())
+            {
+                return JsonSerializer.Deserialize<IEnumerable<CDPSensitivityLabelInfo>>(apiArr.BackingJsonElement);
+            }
+
+            return null;
         }
 
         internal static ServiceCapabilities GetTableCapabilities(this ISwaggerExtensions schema)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorType.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerFx.Connectors
 
         internal string ForeignKey { get; set; }
 
-        internal CDPMetadataItem FieldMetadata { get; }
+        internal IEnumerable<CDPSensitivityLabelInfo> FieldMetadata { get; }
 
         internal ConnectorType(ISwaggerSchema schema, ISwaggerParameter openApiParameter, FormulaType formulaType, ExpressionError warning = default, IEnumerable<KeyValuePair<DName, DName>> list = null, bool isNumber = false)
         {
@@ -150,6 +150,7 @@ namespace Microsoft.PowerFx.Connectors
             KeyType = schema.GetKeyType();
             KeyOrder = schema.GetKeyOrder();
             Permission = schema.GetPermission();
+            FieldMetadata = schema.GetFieldMetadata();
 
             // We only support one reference for now
             // SalesForce only
@@ -243,19 +244,17 @@ namespace Microsoft.PowerFx.Connectors
         }
 
         // Called by ConnectorFunction.GetCdpTableType
-        internal ConnectorType(JsonElement schema, string tableName, SymbolTable optionSets, ConnectorSettings settings, string datasetName, string name, string displayName, string connectorName, ICdpTableResolver resolver, ServiceCapabilities serviceCapabilities, bool isTableReadOnly, CDPMetadataItem fieldMetadata)
+        internal ConnectorType(JsonElement schema, string tableName, SymbolTable optionSets, ConnectorSettings settings, string datasetName, string name, string displayName, string connectorName, ICdpTableResolver resolver, ServiceCapabilities serviceCapabilities, bool isTableReadOnly)
             : this(SwaggerJsonSchema.New(schema), null, new SwaggerParameter(null, true, SwaggerJsonSchema.New(schema), null).GetConnectorType(tableName, optionSets, settings))
         {
             Name = name;
             DisplayName = displayName;
-            FieldMetadata = fieldMetadata;
-
             foreach (ConnectorType field in Fields.Where(f => f.Capabilities != null))
             {
                 serviceCapabilities.AddColumnCapability(field.Name, field.Capabilities);
             }
 
-            FormulaType = new CdpRecordType(this, resolver, ServiceCapabilities.ToDelegationInfo(serviceCapabilities, name, isTableReadOnly, this, datasetName), FieldMetadata);
+            FormulaType = new CdpRecordType(this, resolver, ServiceCapabilities.ToDelegationInfo(serviceCapabilities, name, isTableReadOnly, this, datasetName));
         }
 
         internal ConnectorType(ISwaggerSchema schema, ISwaggerParameter openApiParameter, ConnectorType connectorType)

--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ICDPAggregateMetadata.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ICDPAggregateMetadata.cs
@@ -10,5 +10,7 @@ namespace Microsoft.PowerFx.Connectors
     public interface ICDPAggregateMetadata
     {
         bool TryGetSensitivityLabelInfo(out IEnumerable<CDPSensitivityLabelInfo> cdpSensitivityLabelInfo);
+
+        bool TryGetMetadataItems(out IEnumerable<CDPMetadataItem> cdpMetadataItems);
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/CdpTableResolver.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/CdpTableResolver.cs
@@ -61,6 +61,15 @@ namespace Microsoft.PowerFx.Connectors
             string dataset = _doubleEncoding ? CdpServiceBase.DoubleEncode(_tabularTable.DatasetName) : CdpServiceBase.SingleEncode(_tabularTable.DatasetName);
             string uri = (_uriPrefix ?? string.Empty) + (UseV2(_uriPrefix) ? "/v2" : string.Empty) + $"/$metadata.json/datasets/{dataset}/tables/{CdpServiceBase.DoubleEncode(logicalName)}?api-version=2015-09-01";
 
+            if (_connectorSettings.ExtractSensitivityLabel)
+            {
+                uri += $"&extractSensitivityLabel=True";
+                if (!string.IsNullOrEmpty(_connectorSettings.PurviewAccountName))
+                {
+                    uri += $"&purviewAccountName={_connectorSettings.PurviewAccountName}";
+                }
+            }
+
             string text = await CdpServiceBase.GetObject(_httpClient, $"Get table metadata", uri, null, cancellationToken, Logger).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(text))
@@ -101,7 +110,7 @@ namespace Microsoft.PowerFx.Connectors
             var parts = _uriPrefix.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             string connectorName = (parts.Length > 1) ? parts[1] : string.Empty;
 
-            ConnectorType connectorType = ConnectorFunction.GetCdpTableType(this, connectorName, _tabularTable.TableName, "Schema/Items", FormulaValue.New(text), _connectorSettings, _tabularTable.DatasetName, _tabularTable._fieldMetadata,
+            ConnectorType connectorType = ConnectorFunction.GetCdpTableType(this, connectorName, _tabularTable.TableName, "Schema/Items", FormulaValue.New(text), _connectorSettings, _tabularTable.DatasetName,
                                                                             out TableDelegationInfo delegationInfo, out IEnumerable<OptionSet> optionSets);
 
             OptionSets = optionSets;

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
@@ -49,30 +49,27 @@ namespace Microsoft.PowerFx.Connectors
 
         private IReadOnlyDictionary<string, Relationship> _relationships;
 
-        // this can be null.
-        internal readonly CDPMetadataItem _fieldMetadata;
-
         private readonly ConnectorSettings _connectorSettings;
 
         public override ConnectorSettings ConnectorSettings => _connectorSettings;
 
-        internal CdpTable(string dataset, string table, IReadOnlyCollection<RawTable> tables, ConnectorSettings connectorSettings,  CDPMetadataItem fieldMetadata = null)
+        internal CdpTable(string dataset, string table, IReadOnlyCollection<RawTable> tables, ConnectorSettings connectorSettings)
         {
             DatasetName = dataset ?? throw new ArgumentNullException(nameof(dataset));
             TableName = table ?? throw new ArgumentNullException(nameof(table));
             Tables = tables;
             _connectorSettings = connectorSettings ?? ConnectorSettings.NewCDPConnectorSettings();
-            _fieldMetadata = fieldMetadata;
         }
 
-        internal CdpTable(string dataset, string table, DatasetMetadata datasetMetadata, IReadOnlyCollection<RawTable> tables, ConnectorSettings connectorSettings, CDPMetadataItem fieldMetadata)
-            : this(dataset, table, tables, connectorSettings, fieldMetadata)
+        internal CdpTable(string dataset, string table, DatasetMetadata datasetMetadata, IReadOnlyCollection<RawTable> tables, ConnectorSettings connectorSettings)
+            : this(dataset, table, tables, connectorSettings)
         {
             DatasetMetadata = datasetMetadata;
         }
 
         //// TABLE METADATA SERVICE
         // GET: /$metadata.json/datasets/{datasetName}/tables/{tableName}?api-version=2015-09-01        
+        // get MIP Data here.
         public virtual async Task InitAsync(HttpClient httpClient, string uriPrefix, CancellationToken cancellationToken, ConnectorLogger logger = null)
         {            
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/InternalObjects.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/InternalObjects.cs
@@ -11,9 +11,6 @@ namespace Microsoft.PowerFx.Connectors
     // Used by ConnectorDataSource.GetTablesAsync
     internal class GetTables : ISupportsPostProcessing
     {
-        [JsonPropertyName("@metadata")]
-        public List<CDPMetadataItem> Metadata { get; set; }
-
         [JsonPropertyName("value")]
         public List<RawTable> Value { get; set; }
 
@@ -28,7 +25,7 @@ namespace Microsoft.PowerFx.Connectors
         void PostProcess();
     }
 
-    internal class CDPMetadataItem
+    public class CDPMetadataItem
     {
         [JsonPropertyName("name")]
         public string Name { get; set; }
@@ -66,6 +63,9 @@ namespace Microsoft.PowerFx.Connectors
 
         [JsonPropertyName("isParent")]
         public bool IsParent { get; set; }
+
+        [JsonPropertyName("parentSensitivityLabelId")]
+        public string ParentSensitivityLabelId { get; set; }
     }
 
     internal class RawTable

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CompatibilityTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CompatibilityTests.cs
@@ -33,9 +33,9 @@ namespace Microsoft.PowerFx.Tests
 
             string text = (string)LoggingTestServer.GetFileText(@"Responses\Compatibility GetSchema.json");
 
-            ConnectorType ctCdp = ConnectorFunction.GetCdpTableType(tableResolver, "name", null, "schema/items", StringValue.New(text), new ConnectorSettings(null) { Compatibility = ConnectorCompatibility.CdpCompatibility }, "dataset", null, out _, out _);
-            ConnectorType ctPa = ConnectorFunction.GetCdpTableType(tableResolver, "name", null, "schema/items", StringValue.New(text), new ConnectorSettings(null) { Compatibility = ConnectorCompatibility.PowerAppsCompatibility }, "dataset", null, out _, out _);
-            ConnectorType ctSw = ConnectorFunction.GetCdpTableType(tableResolver, "name", null, "schema/items", StringValue.New(text), new ConnectorSettings(null) { Compatibility = ConnectorCompatibility.SwaggerCompatibility }, "dataset", null, out _, out _);
+            ConnectorType ctCdp = ConnectorFunction.GetCdpTableType(tableResolver, "name", null, "schema/items", StringValue.New(text), new ConnectorSettings(null) { Compatibility = ConnectorCompatibility.CdpCompatibility }, "dataset", out _, out _);
+            ConnectorType ctPa = ConnectorFunction.GetCdpTableType(tableResolver, "name", null, "schema/items", StringValue.New(text), new ConnectorSettings(null) { Compatibility = ConnectorCompatibility.PowerAppsCompatibility }, "dataset", out _, out _);
+            ConnectorType ctSw = ConnectorFunction.GetCdpTableType(tableResolver, "name", null, "schema/items", StringValue.New(text), new ConnectorSettings(null) { Compatibility = ConnectorCompatibility.SwaggerCompatibility }, "dataset", out _, out _);
 
             string cdp = ctCdp.FormulaType.ToStringWithDisplayNames();
             string pa = ctPa.FormulaType.ToStringWithDisplayNames();

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PublicSurfaceTests.cs
@@ -64,6 +64,7 @@ namespace Microsoft.PowerFx.Connector.Tests
               "Microsoft.PowerFx.Connectors.SupportsConnectorErrors",
               "Microsoft.PowerFx.Connectors.Visibility",
               "Microsoft.PowerFx.Connectors.CDPSensitivityLabelInfo",
+              "Microsoft.PowerFx.Connectors.CDPMetadataItem",
               "Microsoft.PowerFx.Connectors.ICDPAggregateMetadata"
             };
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/SQL GetSchema Products.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/SQL GetSchema Products.json
@@ -24,7 +24,21 @@
           "x-ms-keyOrder": 1,
           "x-ms-keyType": "primary",
           "x-ms-permission": "read-only",
-          "x-ms-sort": "none"
+          "x-ms-sort": "none",
+          "x-ms-content-sensitivityLabelInfo": [
+            {
+              "sensitivityLabelId": "34e4c2bf-bc71-4680-897b-bd559ad79cd2",
+              "name": "FTE Only",
+              "displayName": "FTE Only",
+              "tooltip": "FTE Only",
+              "priority": 65,
+              "color": "",
+              "isEncrypted": false,
+              "isEnabled": true,
+              "isParent": false,
+              "parentSensitivityLabelId": "ef85f0be-9819-46dd-b114-3d99fc96b702"
+            }
+          ]
         },
         "Name": {
           "title": "Name",

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/SQL GetTables SampleDB.json
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/Responses/SQL GetTables SampleDB.json
@@ -1,37 +1,6 @@
 {
   "@odata.context": "https://sql-wcus.azconn-wcus-001.p.azurewebsites.net/v2/$metadata#datasets('pfxdev-sql.database.windows.net%2CSampleDB')/tables",
-  "@metadata": [
-    {
-      "name": "[SalesLT].[Customer]",
-      "sensitivityLabelInfo": [
-        {
-          "sensitivityLabelId": "34e4c2bf-bc71-4680-897b-bd559ad79cd2",
-          "name": "FTE Only",
-          "displayName": "FTE Only",
-          "tooltip": "FTE Only",
-          "priority": 65,
-          "color": "",
-          "isEncrypted": false,
-          "isEnabled": true,
-          "isParent": false,
-          "parentSensitivityLabelId": "ef85f0be-9819-46dd-b114-3d99fc96b702"
-        },
-        {
-          "sensitivityLabelId": "7bb18415-09cf-41fc-afb8-316027661da0",
-          "name": "defa4170-0d19-0005-0000-bc88714345d2",
-          "displayName": "Personal",
-          "tooltip": "Non-business data, for personal use only.",
-          "priority": 68,
-          "color": "",
-          "isEncrypted": false,
-          "isEnabled": true,
-          "isParent": false,
-          "parentSensitivityLabelId": ""
-        }
-      ]
-    }
-  ],
-    "value": [
+  "value": [
         {
           "Name": "[dbo].[BuildVersion]",
           "DisplayName": "BuildVersion"


### PR DESCRIPTION
This pull request introduces support for handling sensitivity labels in the Microsoft PowerFx Connectors library. The changes include adding new constants, methods, and properties to manage sensitivity label metadata and improving the internal structure for caching and retrieving metadata. Below is a summary of the most significant changes:

### Sensitivity Label Support

* Added a new constant `XMsContentSensitivityLabelInfo` to `ConnectorConstants` for handling sensitivity label-related metadata. (`[src/libraries/Microsoft.PowerFx.Connectors/ConnectorConstants.csR25](diffhunk://#diff-f48903b696f5100da35ca9eb7593916ea62f5be930ddbd0299c8d7d78c947cc8R25)`)
* Introduced a new method `GetFieldMetadata` in `OpenApiExtensions` to deserialize sensitivity label metadata from Swagger extensions. (`[src/libraries/Microsoft.PowerFx.Connectors/OpenApiExtensions.csR1076-R1085](diffhunk://#diff-60186ac51285a0805530eefaf93a5c901b551442ee774d0aafb3303b6797ebafR1076-R1085)`)
* Updated `ConnectorType` to include a new property `FieldMetadata` for storing sensitivity label information and modified constructors to initialize this property. (`[[1]](diffhunk://#diff-e4ebc73bae6206482faf221906493b79ea4826cfdf350e21eef3fb54fc7462faL127-R127)`, `[[2]](diffhunk://#diff-e4ebc73bae6206482faf221906493b79ea4826cfdf350e21eef3fb54fc7462faR153)`, `[[3]](diffhunk://#diff-e4ebc73bae6206482faf221906493b79ea4826cfdf350e21eef3fb54fc7462faL246-R257)`)

### Metadata Caching and Retrieval

* Refactored `CdpRecordType` to use lazy initialization for caching metadata and sensitivity label information, improving performance and thread safety. Added methods `TryGetMetadataItems` and `TryGetSensitivityLabelInfo` for retrieving cached data. (`[[1]](diffhunk://#diff-9751178e22ee89ef2227406001a28b061731488539eacad1e04e59d013b65006L22-R67)`, `[[2]](diffhunk://#diff-9751178e22ee89ef2227406001a28b061731488539eacad1e04e59d013b65006R154-R178)`)
* Removed the `_fieldMetadata` property from `CdpTable` and updated related constructors to reflect this change. (`[src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.csL52-R72](diffhunk://#diff-47a46ec0a3c5decf575b64314c28ae39e3d266e42b4363c27b8c6804c2bfa76cL52-R72)`)

### API Enhancements

* Updated the `ResolveTableAsync` method in `CdpTableResolver` to include sensitivity label extraction parameters in the API request when enabled. (`[[1]](diffhunk://#diff-9af4b52ee3d527b4588ecff8ec2453a79b459ddb1615b2de74550858ec94ec03R64-R72)`, `[[2]](diffhunk://#diff-9af4b52ee3d527b4588ecff8ec2453a79b459ddb1615b2de74550858ec94ec03L104-R113)`)
* Simplified the `GetTablesAsync` method in `CdpDataSource` by removing sensitivity label-related logic, delegating it to `CdpTableResolver`. (`[src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpDataSource.csL46-R54](diffhunk://#diff-d3998531026cb41980cbf1a1cc768634d7d873d9f4569c253fcb4db62c5afc8bL46-R54)`)

### Internal Object Updates

* Added a new property `ParentSensitivityLabelId` to `CDPSensitivityLabelInfo` for hierarchical sensitivity label support. (`[src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/InternalObjects.csR66-R68](diffhunk://#diff-51b992d5d41bced70a79d446cc29ef62d8e5b59d3b017177ff35ba0d12d30aedR66-R68)`)
* Updated the `CDPMetadataItem` class to be public, allowing broader usage across the library. (`[src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/InternalObjects.csL31-R28](diffhunk://#diff-51b992d5d41bced70a79d446cc29ef62d8e5b59d3b017177ff35ba0d12d30aedL31-R28)`)