### PR TITLE
Include children when generating string interpolation call node

### DIFF
--- a/docs/enhanced-connectors.md
+++ b/docs/enhanced-connectors.md
@@ -211,6 +211,8 @@ Defined in `x-ms-capabilities`
 | | IsReadOnly | ReadOnly table, when `x-ms-permission` is set to `read-only`<br> When a table is defining no primary column, it is also marked `read-only` and a fake primary key column is added to it ("KeyId", number)|
 | `sortRestrictions` | SortRestriction | Sort Restrictions |
 |  | IsSortable| When SortRestriction is not null |
+| `countRestrictions` | CountRestriction | Count Restrictions |
+|  | IsCountable | When `countRestrictions` is not null and `countable=true`, the table supports `$count` in OData queries |
 | `filterRestrictions` | FilterRestriction | Filter Restrictions |
 | `selectRestrictions`  | SelectionRestriction | Select Restrictions |
 |  | IsSelectable | When SelectionRestriction is not null && SelectionRestriction.IsSelectable |
@@ -300,6 +302,52 @@ OData optional parameters (in query string)
 - $count
 
 The supported runtime operations here should be consistent with the capabilities described in the metadata.
+
+#### Sample 200 Response (without `$count`)
+
+<details>
+<summary>Response</summary>
+
+
+```text
+HTTP/1.1 200 OK
+OData-Version: 4.0
+```
+```json
+{
+  "@odata.context": "[Organization URI]/api/data/v9.2/$metadata#accounts(accountid)",
+  "value": [
+    {
+      "@odata.etag": "W/\"81359849\"",
+      "accountid": "78914942-34cb-ed11-b596-0022481d68cd"
+    }
+    // ... more rows
+  ]
+}
+```
+</details>
+
+#### Sample 200 Response (with $count=true)
+<details> <summary>Response</summary>
+    
+```text
+HTTP/1.1 200 OK
+OData-Version: 4.0
+```
+```json
+{
+  "@odata.context": "[Organization URI]/api/data/v9.2/$metadata#accounts(accountid)",
+  "@odata.count": 9,
+  "value": [
+    {
+      "@odata.etag": "W/\"81359849\"",
+      "accountid": "78914942-34cb-ed11-b596-0022481d68cd"
+    }
+    // ... more rows
+  ]
+}
+```
+</details>
 
 ### DELETE /datasets/{datasetName}/tables/{tableName}/items/{id}
 Delete a row

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2226,7 +2226,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 sourceList: node.SourceList,
                 head: new Identifier(ident),
                 headNode: null,
-                new ListNode(ref listNodeId, tok: node.Token, args: new TexlNode[0], delimiters: null, sourceList: node.SourceList),
+                new ListNode(ref listNodeId, tok: node.Token, args: node.Children.ToArray(), delimiters: null, sourceList: node.SourceList),
                 node.StrInterpEnd);
             _compilerGeneratedCallNodes[node.Id] = callNode;
             SetInfo(callNode, new CallInfo(func, callNode));

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -833,9 +833,7 @@ namespace Microsoft.PowerFx.Core.Functions
         public bool RequiresPagedDataForParam(CallNode callNode, int paramIndex, TexlBinding binding)
         {
             Contracts.AssertValue(callNode);
-
-            // ConcatenateFunction is a special case where we may not have any args on call node.
-            Contracts.Assert(this is ConcatenateFunction || callNode.Args.Count > 0);
+            Contracts.Assert(callNode.Args.Count > 0);
             Contracts.Assert(paramIndex >= 0 && paramIndex < callNode.Args.Children.Count());
             Contracts.AssertValue(binding);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/TexlFunction.cs
@@ -26,6 +26,7 @@ using Microsoft.PowerFx.Core.IR.Nodes;
 using Microsoft.PowerFx.Core.IR.Symbols;
 using Microsoft.PowerFx.Core.Localization;
 using Microsoft.PowerFx.Core.Logging.Trackers;
+using Microsoft.PowerFx.Core.Texl.Builtins;
 using Microsoft.PowerFx.Core.Types;
 using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
@@ -832,7 +833,9 @@ namespace Microsoft.PowerFx.Core.Functions
         public bool RequiresPagedDataForParam(CallNode callNode, int paramIndex, TexlBinding binding)
         {
             Contracts.AssertValue(callNode);
-            Contracts.AssertValue(callNode.Args);
+
+            // ConcatenateFunction is a special case where we may not have any args on call node.
+            Contracts.Assert(this is ConcatenateFunction || callNode.Args.Count > 0);
             Contracts.Assert(paramIndex >= 0 && paramIndex < callNode.Args.Children.Count());
             Contracts.AssertValue(binding);
 

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/VariadicBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/VariadicBase.cs
@@ -34,7 +34,11 @@ namespace Microsoft.PowerFx.Syntax
             foreach (var child in children)
             {
                 Contracts.AssertValue(child);
-                child.Parent = this;
+                if (child.Parent == null)
+                {
+                    child.Parent = this;
+                }
+
                 if (maxDepth < child.Depth)
                 {
                     maxDepth = child.Depth;

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/VariadicBase.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Nodes/VariadicBase.cs
@@ -34,6 +34,8 @@ namespace Microsoft.PowerFx.Syntax
             foreach (var child in children)
             {
                 Contracts.AssertValue(child);
+
+                // This may already be the parent node in case of Concatenate, so trying to set it again will fail the set assertion.
                 if (child.Parent == null)
                 {
                     child.Parent = this;

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -483,6 +483,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("x = $\"{\"1$\"}.{\"}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1, 0)]
         [InlineData("x = $\"{$\"{$\"{$\"{.12e4}\"}}\"}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1, 0)]
         [InlineData("x = $\"{$\"{$\"{$\"{.12e4}\"}\"}\"}{$\"Another nested}\";\r\nudf():Text = $\"{\"}\";\r\ny = 2;", 2, 1, 0)]
+        [InlineData("x = $\"{udf()} inside string interp\";\r\nudf():Text = $\"{\"}\";", 1, 1, 0)]
         public void TestUDF(string formula, int nfCount, int udfCount, int validUdfCount)
         {
             var parserOptions = new ParserOptions()


### PR DESCRIPTION
PA codegen throws an exception when calling TexlFunction.RequiresPagedDataForParam() because string interpolation nodes were created with an empty list of args. This led to an issue with UDFs that were dependent on a pageable datasource throwing an assert failure when called inside string interpolation.