### PR TITLE
Restrict void return type in non-behavior UDF

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Data;
 using System.Linq;
-using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.PowerFx.Core.App;
 using Microsoft.PowerFx.Core.App.Controls;

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Data;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -850,6 +850,7 @@ namespace Microsoft.PowerFx.Core.Localization
         public static ErrorResourceKey ErrUDF_InvalidReturnType = new ErrorResourceKey("ErrUDF_InvalidReturnType");
         public static ErrorResourceKey ErrUDF_InvalidParamType = new ErrorResourceKey("ErrUDF_InvalidParamType");
         public static ErrorResourceKey WrnUDF_ShadowingBuiltInFunction = new ErrorResourceKey("WrnUDF_ShadowingBuiltInFunction");
+        public static ErrorResourceKey ErrUDF_NonImperativeVoidType = new ErrorResourceKey("ErrUDF_NonImperativeVoidType");
 
         public static ErrorResourceKey ErrTypeFunction_InvalidTypeExpression = new ErrorResourceKey("ErrTypeFunction_InvalidTypeExpression");
         public static ErrorResourceKey ErrTypeFunction_UnsupportedUsage = new ErrorResourceKey("ErrTypeFunction_UnsupportedUsage");

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/DTypeVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/Visitors/DTypeVisitor.cs
@@ -68,7 +68,8 @@ namespace Microsoft.PowerFx.Core.Syntax.Visitors
                 }
 
                 var ty = cNode.Accept(this, context);
-                if (ty == DType.Invalid)
+
+                if (ty == DType.Invalid || ty.IsVoid)
                 {
                     return DType.Invalid;
                 }
@@ -92,7 +93,7 @@ namespace Microsoft.PowerFx.Core.Syntax.Visitors
             var childNode = node.ChildNodes.First();
             var ty = childNode.Accept(this, context);
 
-            if (ty == DType.Invalid)
+            if (ty == DType.Invalid || ty.IsVoid)
             {
                 return DType.Invalid;
             }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -4233,6 +4233,10 @@
     <value>Function name {0} is restricted.</value>
     <comment>This error message shows up when user tries to define a function with a restricted name.</comment>
   </data>
+  <data name="ErrUDF_NonImperativeVoidType" xml:space="preserve">
+    <value>Void return type is only supported with behavior user-defined functions.</value>
+    <comment>This error message shows up when user tries to use Void return type in non-behavior user-defined function.</comment>
+  </data>
   <data name="ErrUDF_DuplicateParameter" xml:space="preserve">
     <value>Parameter {0} is a duplicate.</value>
     <comment>This error message shows up when user-defined function has a duplicate parameter</comment>

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -691,6 +691,7 @@ namespace Microsoft.PowerFx.Core.Tests
         [Theory]
         [InlineData("F():Void = 5;")]
         [InlineData("F():Void = Set(x,5);")]
+        [InlineData("F(x: Text):Void = x;")]
         public void TestNonBehaviorUDFReturnsVoid(string expression)
         {
             var parserOptions = new ParserOptions();
@@ -699,7 +700,6 @@ namespace Microsoft.PowerFx.Core.Tests
                                             .SetBindingInfo(_primitiveTypes);
             var errors = checkResult.ApplyErrors();
             Assert.Contains(errors, e => e.MessageKey.Contains("ErrUDF_NonImperativeVoidType"));
-
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -687,5 +687,19 @@ namespace Microsoft.PowerFx.Core.Tests
                 }
             }
         }
+
+        [Theory]
+        [InlineData("F():Void = 5;")]
+        [InlineData("F():Void = Set(x,5);")]
+        public void TestNonBehaviorUDFReturnsVoid(string expression)
+        {
+            var parserOptions = new ParserOptions();
+            var checkResult = new DefinitionsCheckResult()
+                                            .SetText(expression)
+                                            .SetBindingInfo(_primitiveTypes);
+            var errors = checkResult.ApplyErrors();
+            Assert.Contains(errors, e => e.MessageKey.Contains("ErrUDF_NonImperativeVoidType"));
+
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerFx.Core.Tests
 
         // Type alias
         [InlineData("DTNZ := Type(DateTimeTZInd)", "Z", true)]
+        [InlineData("MyVoid := Type(Void)", "-", true)]
 
         // Nested record types
         [InlineData("Nested := Type({a: {b: DateTime, c: {d: GUID, e: Hyperlink}}, x: Time})", "![a:![b:d, c:![d:g, e:h]], x:T]", true)]
@@ -124,6 +125,9 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("Currency := Type({x: Text}); Record := Type([DateTime]); D := Type(None);", 2, "ErrNamedType_InvalidTypeName")]
         [InlineData("A = 5;C :=; B := Type(Number);", 1, "ErrNamedType_MissingTypeExpression")]
         [InlineData("C := 5; D := [1,2,3];", 2, "ErrNamedType_MissingTypeExpression")]
+        [InlineData("T := Type([{a: {b: Void}}]);", 1, "ErrNamedType_InvalidTypeDeclaration")]
+        [InlineData("T := Type([Void]);", 1, "ErrNamedType_InvalidTypeDeclaration")]
+        [InlineData("T := Type({a: Void});", 1, "ErrNamedType_InvalidTypeDeclaration")]
         public void TestUDTErrors(string typeDefinition, int expectedErrorCount, string expectedMessageKey)
         {
             var checkResult = new DefinitionsCheckResult()

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
@@ -94,7 +94,8 @@ namespace Microsoft.PowerFx.Json.Tests
             // Negative Tests
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5}\"", "Type({a: Text})", obj1, isValid: false);
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5, \"\"b\"\": 6}\"", "Type({a: Number})", obj1, false);
-            CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type({a: Void})", TexlStrings.ErrUnsupportedTypeInTypeArgument.Key);
+            CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type({a: Void})", TexlStrings.ErrTypeFunction_InvalidTypeExpression.Key);
+            CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type({a: Color})", TexlStrings.ErrUnsupportedTypeInTypeArgument.Key);
             CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type(RecordOf(T))", TexlStrings.ErrTypeFunction_InvalidTypeExpression.Key);
         }
 


### PR DESCRIPTION
Restrict void return type from being used in non-behavior UDF. Also blocks Void to be used in aggregate types in UDTs. 

![image](https://github.com/user-attachments/assets/3c84ea1d-669f-4924-b8ce-1520486a3211)
