### PR TITLE
Adds header that enables column selection.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient.cs
@@ -194,6 +194,7 @@ namespace Microsoft.PowerFx.Connectors
             req.Headers.Add("x-ms-client-environment-id", "/providers/Microsoft.PowerApps/environments/" + EnvironmentId);
             req.Headers.Add("x-ms-user-agent", UserAgent);
             req.Headers.Add("x-ms-request-url", url);
+            req.Headers.Add("x-ms-enable-selects", "true");
 
             // might be needed for tabular connectors
             //req.Headers.Add("X-Ms-Protocol-Semantics", "cdp");

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/IntellisenseTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/IntellisenseTests.cs
@@ -105,6 +105,7 @@ $@"POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/{queryPart}
  x-ms-user-agent: PowerFx/{PowerPlatformConnectorClient.Version}
@@ -172,6 +173,7 @@ $@"POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/v2/$metadata.json/datasets/default,default/procedures/sp_{responseIndex}
  x-ms-user-agent: PowerFx/{PowerPlatformConnectorClient.Version}
@@ -303,6 +305,7 @@ $@"POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/v2/$metadata.json/datasets/default,default/procedures/sp_{responseIndex}
  x-ms-user-agent: PowerFx/{PowerPlatformConnectorClient.Version}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs
@@ -500,6 +500,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/aaa373836ffd4915bf6eefd63d164adc
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/cognitiveservicestextanalytics/16e7c181-2f8d-4cae-b1f0-179c5c4e4d8b/language/:analyze-conversations?api-version=2022-05-01
  x-ms-user-agent: PowerFx/{version}
@@ -1178,6 +1179,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/ddadf2c7-ebdd-ec01-a5d1-502dc07f04b4
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/4bf9a87fc9054b6db3a4d07a1c1f5a5b/v2/datasets/pfxdev-sql.database.windows.net,connectortest/procedures
  x-ms-user-agent: PowerFx/{version}
@@ -1188,6 +1190,7 @@ POST https://tip1002-002.azure-apihub.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/ddadf2c7-ebdd-ec01-a5d1-502dc07f04b4
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/4bf9a87fc9054b6db3a4d07a1c1f5a5b/v2/$metadata.json/datasets/pfxdev-sql.database.windows.net,connectortest/procedures/sp_1
  x-ms-user-agent: PowerFx/{version}
@@ -1198,6 +1201,7 @@ POST https://tip1002-002.azure-apihub.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/ddadf2c7-ebdd-ec01-a5d1-502dc07f04b4
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/4bf9a87fc9054b6db3a4d07a1c1f5a5b/v2/$metadata.json/datasets/pfxdev-sql.database.windows.net,connectortest/procedures/sp_1
  x-ms-user-agent: PowerFx/{version}
@@ -1262,6 +1266,7 @@ POST https://tip1002-002.azure-apihub.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/Default-9f6be790-4a16-4dd6-9850-44a0d2649aef
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/commondataserviceforapps/461a30624723445c9ba87313d8bbefa3/v1.0/$metadata.json/GetEntityListEnum/GetEntitiesWithOrganization
  x-ms-user-agent: PowerFx/{version}
@@ -1273,6 +1278,7 @@ POST https://tip1-shared.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/Default-9f6be790-4a16-4dd6-9850-44a0d2649aef
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/commondataserviceforapps/461a30624723445c9ba87313d8bbefa3/v1.0/$metadata.json/entities/accounts/postitem
  x-ms-user-agent: PowerFx/{version}
@@ -1281,7 +1287,7 @@ POST https://tip1-shared.azure-apim.net/invoke
             // Normalize CRLF ==> LF
             expected = expected.Replace("\r", string.Empty);
             input = input.Replace("\r", string.Empty);
-            Assert.Equal(expected, input);
+            Assert.Equal<object>(expected, input);
         }
 
         [Theory]
@@ -1339,6 +1345,7 @@ POST https://tip1-shared.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/7592282b-e371-e3f6-8e04-e8f23e64227c
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/cardsforpowerapps/shared-cardsforpower-eafc4fa0-c560-4eba-a5b2-3e1ebc63193a/cards/cards/card/instances
  x-ms-user-agent: PowerFx/{PowerPlatformConnectorClient.Version}

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorClientTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorClientTests.cs
@@ -112,6 +112,9 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                     case "x-ms-request-url":
                         Assert.Equal($"/{TestConnectionId}/test/someUri", header.Value.First());
                         break;
+                    case "x-ms-enable-selects":
+                        Assert.Equal("true", header.Value.First());
+                        break;
                     default:
                         Assert.True(request.Headers.Contains(header.Key), $"Missing {header.Key} header");
                         var reqHeaderValues = request.Headers.First(h => h.Key == header.Key).Value;
@@ -122,7 +125,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 }
             }
 
-            Assert.Equal(request.Headers.Count() + 9, transformedRequest.Headers.Count());
+            Assert.Equal(request.Headers.Count() + 10, transformedRequest.Headers.Count());
         }
     }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
@@ -289,6 +289,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/839eace6-59ab-4243-97ec-a5b8fcc104e4
  x-ms-client-session-id: MySessionId
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/msnweather/shared-msnweather-8d08e763-937a-45bf-a2ea-c5ed-ecc70ca4/current/Redmond?units=Imperial
  x-ms-user-agent: PowerFx/{version}
@@ -338,6 +339,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/49970107-0806-e5a7-be5e-7c60e2750f01
  x-ms-client-session-id: MySessionId
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/msnweather/480a676ab6e64b168cfa41506014e45d/current/Orl%C3%A9ans?units=C
  x-ms-user-agent: PowerFx/{version}
@@ -521,6 +523,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/0a1a8d62-0453-e710-b774-446dc6634a89
  x-ms-client-session-id: ccccbff3-9d2c-44b2-bee6-cf24aab10b7e
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/azureblob/1f18a56da7574c1f8b66a1ea42c23805/datasets/default/files?folderPath=container&name=01.txt&queryParametersSingleEncoded=True
  x-ms-user-agent: PowerFx/{version}
@@ -599,6 +602,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/0a1a8d62-0453-e710-b774-446dc6634a89
  x-ms-client-session-id: ccccbff3-9d2c-44b2-bee6-cf24aab10b7e
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/azureblob/6d228109794849049ce8116e5d4ffaf8/v2/datasets/pfxdevstgaccount1/files?folderPath=container&name=001.jpg&queryParametersSingleEncoded=True
  x-ms-user-agent: PowerFx/{version}
@@ -1075,6 +1079,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/v2/Mail?folderPath=Inbox&importance=Any&fetchOnlyWithAttachment=False&fetchOnlyUnread=True&fetchOnlyFlagged=False&includeAttachments=False&top=10
  x-ms-user-agent: PowerFx/{version}
@@ -1131,6 +1136,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/datasets/calendars/v4/tables/Calendar/items
  x-ms-user-agent: PowerFx/{version}
@@ -1178,6 +1184,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/codeless/beta/me/messages/AAMkAGJiMDkyY2NkLTg1NGItNDg1ZC04MjMxLTc5NzQ1YTUwYmNkNgBGAAAAAACivZtRsXzPEaP8AIBfULPVBwCDi7i2pr6zRbiq9q8hHM-iAAAFMQAZAABDuyuwiYTvQLeL0nv55lGwAAVHeZkhAAA%3D/$value
  x-ms-user-agent: PowerFx/{version}
@@ -1223,6 +1230,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/codeless/beta/me/findMeetingTimes
  x-ms-user-agent: PowerFx/{version}
@@ -1270,6 +1278,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: PATCH
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/codeless/v1.0/me/messages/AAMkAGJiMDkyY2NkLTg1NGItNDg1ZC04MjMxLTc5NzQ1YTUwYmNkNgBGAAAAAACivZtRsXzPEaP8AIBfULPVBwBBHsoKDHXPEaP6AIBfULPVAAAABp8rAABDuyuwiYTvQLeL0nv55lGwAAVHeWXcAAA%3D/flag
  x-ms-user-agent: PowerFx/{version}
@@ -1317,6 +1326,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/codeless/v1.0/me/getMailTips
  x-ms-user-agent: PowerFx/{version}
@@ -1367,6 +1377,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/office365/785da26033fe4f3f8604273d25f209d5/codeless/beta/me/findRoomLists
  x-ms-user-agent: PowerFx/{version}
@@ -1452,6 +1463,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/839eace6-59ab-4243-97ec-a5b8fcc104e4
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/office365/c112a9268f2a419bb0ced71f5e48ece9/codeless/beta/me/findRooms
  x-ms-user-agent: PowerFx/{version}
@@ -1500,6 +1512,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b60ed9ea-c17c-e39a-8682-e33a20d51e14
  x-ms-client-session-id: ce55fe97-6e74-4f56-b8cf-529e275b253f
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/bingmaps/9ab2342eaecc4800a5c327290abf4a1f/V3/REST/V1/Routes/Driving?wp.0=47%2C396846%2C%20-0%2C499967&wp.1=47%2C395142%2C%20-0%2C480142&avoid_highways=False&avoid_tolls=False&avoid_ferry=False&avoid_minimizeHighways=False&avoid_minimizeTolls=False&avoid_borderCrossing=False
  x-ms-user-agent: PowerFx/{version}
@@ -1549,6 +1562,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/v2/datasets/pfxdev-sql.database.windows.net,connectortest/procedures
  x-ms-user-agent: PowerFx/{version}
@@ -1619,6 +1633,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/4d4a8e81-17a4-4a92-9bfe-8d12e607fb7f
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/sql/53f515b50c3e4925803ec1f0945e799f/v2/datasets/pfxdev-sql.database.windows.net,SampleDB/query/sql
  x-ms-user-agent: PowerFx/{PowerPlatformConnectorClient.Version}
@@ -1706,6 +1721,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/v2/datasets/pfxdev-sql.database.windows.net,connectortest/procedures/sp_1
  x-ms-user-agent: PowerFx/{version}
@@ -1760,6 +1776,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/v2/datasets/pfxdev-sql.database.windows.net,connectortest/procedures/sp_1
  x-ms-user-agent: MyProduct/v1.2 PowerFx/{version}
@@ -1912,6 +1929,7 @@ namespace Microsoft.PowerFx.Tests
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/2f0cc19d-893e-e765-b15d-2906e3231c09
  x-ms-client-session-id: 547d471f-c04c-4c4a-b3af-337ab0637a0d
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sharepointonline/6fb0a1a8e2f5487eafbe306821d8377e/datasets
  x-ms-user-agent: PowerFx/{version}
@@ -1922,6 +1940,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/2f0cc19d-893e-e765-b15d-2906e3231c09
  x-ms-client-session-id: 547d471f-c04c-4c4a-b3af-337ab0637a0d
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sharepointonline/6fb0a1a8e2f5487eafbe306821d8377e/$metadata.json/datasets
  x-ms-user-agent: PowerFx/{version}
@@ -1932,6 +1951,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/2f0cc19d-893e-e765-b15d-2906e3231c09
  x-ms-client-session-id: 547d471f-c04c-4c4a-b3af-337ab0637a0d
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sharepointonline/6fb0a1a8e2f5487eafbe306821d8377e/datasets/https%253A%252F%252Fauroraprojopsintegration01.sharepoint.com%252Fsites%252FSite17/alltables
  x-ms-user-agent: PowerFx/{version}
@@ -1942,6 +1962,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/2f0cc19d-893e-e765-b15d-2906e3231c09
  x-ms-client-session-id: 547d471f-c04c-4c4a-b3af-337ab0637a0d
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sharepointonline/6fb0a1a8e2f5487eafbe306821d8377e/datasets/https%253A%252F%252Fauroraprojopsintegration01.sharepoint.com%252Fsites%252FSite17/tables/3756de7d-cb20-4014-bab8-6ea7e5264b97/views
  x-ms-user-agent: PowerFx/{version}
@@ -1952,6 +1973,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/2f0cc19d-893e-e765-b15d-2906e3231c09
  x-ms-client-session-id: 547d471f-c04c-4c4a-b3af-337ab0637a0d
+ x-ms-enable-selects: true
  x-ms-request-method: GET
  x-ms-request-url: /apim/sharepointonline/6fb0a1a8e2f5487eafbe306821d8377e/datasets/https%253A%252F%252Fauroraprojopsintegration01.sharepoint.com%252Fsites%252FSite17/tables/3756de7d-cb20-4014-bab8-6ea7e5264b97/items?$top=4
  x-ms-user-agent: PowerFx/{version}
@@ -2172,6 +2194,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/b29c41cf-173b-e469-830b-4f00163d296b
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/commondataserviceforapps/82728ddb6bfa461ea3e50e17da8ab164/v1.0/$metadata.json/GetActionListEnum/GetBoundActionsWithOrganization
  x-ms-user-agent: PowerFx/{version}
@@ -2414,6 +2437,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/a2df3fb8-e4a4-e5e6-905c-e3dff9f93b46
  x-ms-client-session-id: 8e67ebdc-d402-455a-b33a-304820832383
+ x-ms-enable-selects: true
  x-ms-request-method: POST
  x-ms-request-url: /apim/sql/5f57ec83acef477b8ccc769e52fa22cc/v2/datasets/pfxdev-sql.database.windows.net,connectortest/procedures/sp_1
  x-ms-user-agent: PowerFx/{version}
@@ -2506,6 +2530,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/49970107-0806-e5a7-be5e-7c60e2750f01
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: PATCH
  x-ms-request-url: /apim/excelonlinebusiness/e24a1ac719284479a4817a0c5bb6ef58/drives/b%21IbvdIRe4LEGypNQpzV_eHMlG3PtubVREtOzk7doKeFvkIs8VRqloT4mtkIOb6aTB/files/013DZ3QDGY2Y23HOQN5BC2HUMJWD7G4UPL/tables/%7BE5A21CC6-3B17-48DE-84D7-0326A06B38F4%7D/items/035fd7a2-34d6-4a6f-a885-a646b1398012?source=me&idColumn=__PowerAppsId__
  x-ms-user-agent: PowerFx/{version}
@@ -2519,6 +2544,7 @@ POST https://tip1-shared-002.azure-apim.net/invoke
  scheme: https
  x-ms-client-environment-id: /providers/Microsoft.PowerApps/environments/49970107-0806-e5a7-be5e-7c60e2750f01
  x-ms-client-session-id: a41bd03b-6c3c-4509-a844-e8c51b61f878
+ x-ms-enable-selects: true
  x-ms-request-method: PATCH
  x-ms-request-url: /apim/excelonlinebusiness/e24a1ac719284479a4817a0c5bb6ef58/drives/b%21IbvdIRe4LEGypNQpzV_eHMlG3PtubVREtOzk7doKeFvkIs8VRqloT4mtkIOb6aTB/files/013DZ3QDGY2Y23HOQN5BC2HUMJWD7G4UPL/tables/%7BE5A21CC6-3B17-48DE-84D7-0326A06B38F4%7D/items/035fd7a2-34d6-4a6f-a885-a646b1398012?source=me&idColumn=__PowerAppsId__
  x-ms-user-agent: PowerFx/{version}


### PR DESCRIPTION
This pull request introduces a new HTTP header, `x-ms-enable-selects`, to enable additional functionality in requests, and updates related test cases to validate its inclusion. The changes ensure consistent application of the header across various connectors and enhance testing coverage.

### Header Addition in Request Handling:

* Added the `x-ms-enable-selects` header with a value of `"true"` in the `Transform` method of `PowerPlatformConnectorClient` to support additional query capabilities. (`src/libraries/Microsoft.PowerFx.Connectors/PowerPlatformConnectorClient.cs`)

### Updates to Test Cases:

#### Intellisense Tests:
* Added `x-ms-enable-selects` header to requests in multiple test methods, including `ConnectorIntellisenseTest`, `ConnectorIntellisenseTest2`, and `ConnectorIntellisenseTestLSP`. (`src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/IntellisenseTests.cs`) [[1]](diffhunk://#diff-6c0a9057c264e0736844c944dc7566295f62bb444bb659a8cf7d109d4aff26a6R108) [[2]](diffhunk://#diff-6c0a9057c264e0736844c944dc7566295f62bb444bb659a8cf7d109d4aff26a6R176) [[3]](diffhunk://#diff-6c0a9057c264e0736844c944dc7566295f62bb444bb659a8cf7d109d4aff26a6R308)

#### OpenAPI Parser Tests:
* Updated test methods, such as `DirectIntellisenseTest`, `DataverseTest`, and `CardsForPowerApps_Invoke`, to include the new header in request validation. (`src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/OpenApiParserTests.cs`) [[1]](diffhunk://#diff-d82eba4a87da4e8a8163968b82e782add03b56abaf760b205fa83daeda7ac2d6R1182) [[2]](diffhunk://#diff-d82eba4a87da4e8a8163968b82e782add03b56abaf760b205fa83daeda7ac2d6R1269) [[3]](diffhunk://#diff-d82eba4a87da4e8a8163968b82e782add03b56abaf760b205fa83daeda7ac2d6R1348)
* Adjusted an assertion in `DataverseTest` to use `Assert.Equal<object>` for better type compatibility.

#### PowerPlatform Connector Client Tests:
* Added validation for the `x-ms-enable-selects` header in the `ValidateHeaders` method and adjusted the header count assertion accordingly. (`src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorClientTests.cs`) [[1]](diffhunk://#diff-ea0147413c416fcdcc165c02893cdb61e57190cea2c03286b0460a912e7b23b2R115-R117) [[2]](diffhunk://#diff-ea0147413c416fcdcc165c02893cdb61e57190cea2c03286b0460a912e7b23b2L125-R128)

#### Other Connector Tests:
* Incorporated the new header in various connector test methods, such as `MSNWeatherConnector_CurrentWeather`, `AzureBlobConnector_UploadFile`, and `Office365Outlook_GetEmailsV2`. (`src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs`) [[1]](diffhunk://#diff-3a6561745a1d247c0fd58d6ca872407048b2df855eb6923700cec59988e7080eR292) [[2]](diffhunk://#diff-3a6561745a1d247c0fd58d6ca872407048b2df855eb6923700cec59988e7080eR526) [[3]](diffhunk://#diff-3a6561745a1d247c0fd58d6ca872407048b2df855eb6923700cec59988e7080eR1082)