### PR TITLE
Allow additional fields in Dynamic to Strongly typed conversion functions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -22,7 +22,6 @@ namespace Microsoft.PowerFx.Types
 
         // JSON value input of type object may contain fields with values that not present in the target schema.
         // This attribute controls if the result such conversion should be valid or an error.
-        // This is false (i.e we dont allow additional field in input) when used for functions like AsType_UO, IsType_UO and TypedParseJSON
         public bool AllowUnknownRecordFields { get; init; } = true;
 
         public TimeZoneInfo ResultTimeZone { get; init; } = TimeZoneInfo.Utc;

--- a/src/libraries/Microsoft.PowerFx.Json/Functions/JSONFunctionUtils.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/Functions/JSONFunctionUtils.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerFx.Core.Utils
             var uo = untypedObjectValue.Impl;
             var jsElement = ((JsonUntypedObject)uo)._element;
 
-            var settings = new FormulaValueJsonSerializerSettings { AllowUnknownRecordFields = false, ResultTimeZone = timeZoneInfo };
+            var settings = new FormulaValueJsonSerializerSettings { AllowUnknownRecordFields = true, ResultTimeZone = timeZoneInfo };
 
             return FormulaValueJSON.FromJson(jsElement, settings, FormulaType.Build(dtype));
         }
@@ -69,7 +69,7 @@ namespace Microsoft.PowerFx.Core.Utils
             }
 
             var json = ((StringValue)input).Value;
-            var settings = new FormulaValueJsonSerializerSettings { AllowUnknownRecordFields = false, ResultTimeZone = timeZoneInfo };
+            var settings = new FormulaValueJsonSerializerSettings { AllowUnknownRecordFields = true, ResultTimeZone = timeZoneInfo };
 
             return FormulaValueJSON.FromJson(json, settings, FormulaType.Build(dtype));
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
@@ -76,6 +76,9 @@ true
 >> AsType(ParseJSON("{""Name"": ""SpongeBob"", ""Age"": 1}"), Type({Name: Text, Age: Number, Aquatic: Boolean})).Name
 "SpongeBob"
 
+>> AsType(ParseJSON("{""a"": 5, ""b"":true}"), Type({a: Number}))
+{a:5}
+
 // Deeply nested record with table
 >> AsType(ParseJSON("{""a"": {""b"" : { ""c"" : [1, 2, 3, 4]}}}"), Type({a: {b: {c: [Number]}}}))
 {a:{b:{c:Table({Value:1},{Value:2},{Value:3},{Value:4})}}}
@@ -111,9 +114,6 @@ Error({Kind:ErrorKind.InvalidJSON})
 
 >> AsType(ParseJSON("true"), Void)
 Errors: Error 26-30: Unsupported type 'Void' in type argument.
-
->> AsType(ParseJSON("{""a"": 5, ""b"":true}"), Type({a: Number}))
-Error({Kind:ErrorKind.InvalidArgument})
 
 >> AsType(ParseJSON("{""a"": 5}"), Type({a: Number}), "Hello")
 Errors: Error 0-59: Invalid number of arguments: received 3, expected 2.

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
@@ -63,7 +63,7 @@ true
 
 // record with additional field
 >> IsType(ParseJSON("{""a"": 5, ""b"":true}"), Type({a: Number}))
-false
+true
 
 // record with incorrect field type
 >> IsType(ParseJSON("{""a"": 5}"), Type({a: Text}))

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
@@ -82,6 +82,9 @@ false
 >> ParseJSON("{""Name"": ""SpongeBob"", ""Age"": 1}", Type({Name: Text, Age: Number, Aquatic: Boolean})).Name
 "SpongeBob"
 
+>> ParseJSON("{""a"": 5, ""b"":true}", Type({a: Number}))
+{a:5}
+
 // Deeply nested record with table
 >> ParseJSON("{""a"": {""b"" : { ""c"" : [1, 2, 3, 4]}}}", Type({a: {b: {c: [Number]}}}))
 {a:{b:{c:Table({Value:1},{Value:2},{Value:3},{Value:4})}}}
@@ -120,9 +123,6 @@ Error({Kind:ErrorKind.InvalidJSON})
 
 >> ParseJSON("true", Void)
 Errors: Error 18-22: Unsupported type 'Void' in type argument.
-
->> ParseJSON("{""a"": 5, ""b"":true}", Type({a: Number}))
-Error({Kind:ErrorKind.InvalidArgument})
 
 >> ParseJSON("{""a"": 5}", Type({a: Number}), "Hello")
 Errors: Error 0-51: Invalid number of arguments: received 3, expected 2.

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
@@ -90,10 +90,10 @@ namespace Microsoft.PowerFx.Json.Tests
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5}\"", "Type({a: Number})", obj1);
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": { \"\"b\"\": {\"\"c\"\":  false}}}\"", "Type({a: {b: {c: Boolean }}})", obj2);
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": [1, 2, 3, 4]}\"", "Type({a: [Decimal]})", obj3);
+            CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5, \"\"b\"\": 6}\"", "Type({a: Number})", obj1);
 
             // Negative Tests
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5}\"", "Type({a: Text})", obj1, isValid: false);
-            CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5, \"\"b\"\": 6}\"", "Type({a: Number})", obj1, false);
             CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type({a: Void})", TexlStrings.ErrTypeFunction_InvalidTypeExpression.Key);
             CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type({a: Color})", TexlStrings.ErrUnsupportedTypeInTypeArgument.Key);
             CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"{\"\"a\"\": \"\"foo/bar/uri\"\"}\"", "Type(RecordOf(T))", TexlStrings.ErrTypeFunction_InvalidTypeExpression.Key);
@@ -120,9 +120,9 @@ namespace Microsoft.PowerFx.Json.Tests
             CheckIsTypeAsTypeParseJSON(engine, "\"{\"\"a\"\": 5}\"", "Type(RecordOf(T))", obj1);
             CheckIsTypeAsTypeParseJSON(engine, "\"[{\"\"a\"\": [true, true, false, true]}]\"", "Type([{a: [Boolean]}])", t3);
             CheckIsTypeAsTypeParseJSON(engine, "\"[1, 2, 3, 4]\"", "Type([Decimal])", t2);
+            CheckIsTypeAsTypeParseJSON(engine, "\"[{\"\"a\"\": 5, \"\"b\"\": 6}]\"", "Type([{a: Number}])", t1);
 
             // Negative tests
-            CheckIsTypeAsTypeParseJSON(engine, "\"[{\"\"a\"\": 5, \"\"b\"\": 6}]\"", "Type([{a: Number}])", t1, false);
             CheckIsTypeAsTypeParseJSON(engine, "\"[1, 2, 3, 4]\"", "Type([Text])", t2, false);
             CheckIsTypeAsTypeParseJSONCompileErrors(engine, "\"[\"\"foo/bar/uri\"\"]\"", "Type([Color])", TexlStrings.ErrUnsupportedTypeInTypeArgument.Key);
         }


### PR DESCRIPTION
Allows additional fields to be part of the input string in Untyped Object conversion functions.