### PR TITLE
Add manifest file to define the scope of the new loc process

### DIFF
--- a/localize/LocProject.json
+++ b/localize/LocProject.json
@@ -14,13 +14,13 @@
           "SourceFile": "src\\strings\\PowerFxResources.en-US.resx",
           "CopyOption": "UsePlaceholders",
           "OutputPath": "src\\strings\\PowerFxResources.{Lang}.resx",
-          "_OutputPath.comment": "For instance, for ko-KR (Korean), OutputPath resolves to src\\strings\\PowerFxConnectorResources.ko-KR.resx"
+          "_OutputPath.comment": "For instance, for ko-KR (Korean), OutputPath resolves to src\\strings\\PowerFxResources.ko-KR.resx"
         },
         {
           "SourceFile": "src\\strings\\PowerFxRuntimeResources.en-US.resx",
           "CopyOption": "UsePlaceholders",
           "OutputPath": "src\\strings\\PowerFxRuntimeResources.{Lang}.resx",
-          "_OutputPath.comment": "For instance, for ko-KR (Korean), OutputPath resolves to src\\strings\\PowerFxConnectorResources.ko-KR.resx"
+          "_OutputPath.comment": "For instance, for ko-KR (Korean), OutputPath resolves to src\\strings\\PowerFxRuntimeResources.ko-KR.resx"
         }
       ]
     }


### PR DESCRIPTION
Add the manifest file to define the scope of the new loc process. Please refer to https://eng.ms/docs/cloud-ai-platform/azure-core/azure-experiences-and-ecosystems/cme-international-customer-exp/software-localization-onelocbuild/onelocbuild/onboarding/localizationproject for the schema of the manifest file.