### PR TITLE
Remove logging of error message, move responsibility to caller

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1822,4 +1822,3 @@ namespace Microsoft.PowerFx.Connectors
         }
     }
 }
-


### PR DESCRIPTION
Since we don't know what is inside this error message, move the responsibility of logging this to the caller where there is more context on the call itself.