### PR TITLE
Prevent non-imperative UDFs from calling imperative UDFs

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BindingConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BindingConfig.cs
@@ -36,5 +36,16 @@ namespace Microsoft.PowerFx.Core.Binding
             MarkAsAsyncOnLazilyLoadedControlRef = markAsAsyncOnLazilyLoadedControlRef;
             UserDefinitionsMode = userDefinitionsMode;
         }
+
+        public BindingConfig Clone(bool allowsSideEffects)
+        {
+            return new BindingConfig(
+                allowsSideEffects: allowsSideEffects, // overrides value in object
+                useThisRecordForRuleScope: this.UseThisRecordForRuleScope,
+                numberIsFloat: this.NumberIsFloat,
+                analysisMode: this.AnalysisMode,
+                markAsAsyncOnLazilyLoadedControlRef: this.MarkAsAsyncOnLazilyLoadedControlRef,
+                userDefinitionsMode: this.UserDefinitionsMode);
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Functions/UserDefinedFunction.cs
@@ -191,7 +191,7 @@ namespace Microsoft.PowerFx.Core.Functions
                 throw new InvalidOperationException($"Body should only get bound once: {this.Name}");
             }
 
-            bindingConfig = bindingConfig ?? new BindingConfig(this._isImperative, userDefinitionsMode: true);
+            bindingConfig = bindingConfig == null ? new BindingConfig(this._isImperative, userDefinitionsMode: true) : bindingConfig.Clone(allowsSideEffects: this._isImperative);
             _binding = TexlBinding.Run(documentBinderGlue, UdfBody, GetUDFNameResolver(nameResolver), bindingConfig, features: features, rule: rule, updateDisplayNames: updateDisplayNames);
 
             CheckTypesOnDeclaration(_binding.CheckTypesContext, _binding.ResultType, _binding);

--- a/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
+++ b/src/libraries/Microsoft.PowerFx.Repl/Repl.cs
@@ -510,7 +510,7 @@ namespace Microsoft.PowerFx
 
                 if (this.AllowUserDefinedFunctions && definitionsCheckResult.IsSuccess && definitionsCheckResult.ContainsUDF)
                 {
-                    var defCheckResult = this.Engine.AddUserDefinedFunction(expression, this.ParserOptions.Culture, extraSymbolTable);
+                    var defCheckResult = this.Engine.AddUserDefinedFunction(expression, this.ParserOptions.Culture, extraSymbolTable, allowSideEffects: true);
 
                     if (!defCheckResult.IsSuccess)
                     {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -701,5 +701,21 @@ namespace Microsoft.PowerFx.Core.Tests
             var errors = checkResult.ApplyErrors();
             Assert.Contains(errors, e => e.MessageKey.Contains("ErrUDF_NonImperativeVoidType"));
         }
+
+        [Theory]
+        [InlineData("F():Number = 5;", true)]
+        [InlineData("F():Number = {5};", true)]
+        [InlineData("F():Number = {5}; G():Number = F();", false)]
+        [InlineData("F():Number = 5;   G():Number = F();", true)]
+        [InlineData("F():Number = {5}; G():Number = {F()};", true)]
+        public void TestBehaviorFuncsInNonBehaviorFuncs(string expression, bool valid)
+        {
+            var parserOptions = new ParserOptions() { AllowsSideEffects = true };
+            var checkResult = new DefinitionsCheckResult()
+                                            .SetText(expression, parserOptions)
+                                            .SetBindingInfo(_primitiveTypes);
+            var errors = checkResult.ApplyErrors();
+            Assert.True((valid && !errors.Any()) || (!valid && errors.Any()));
+        }
     }
 }


### PR DESCRIPTION
Currently, a single binding context is used for all UDFs to be added. The `AllowsSideEffects` for each UDF needs to be different since some UDFs are defined to be imperative (with curly braces) and some are not. As a result we currently allow `F():Number = {5}; G():Number = F();` which we should not.  

Canvas currently blocks this, presumably somewhere in PA Client. But Power Fx core should block it as a compile time error.