### PR TITLE
Plumbing Features settings down to UDF Body processing

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -229,10 +229,10 @@ namespace Microsoft.PowerFx
         /// <param name="symbolTable">Extra symbols to bind UDF. Commonly coming from Engine.</param>
         /// <param name="extraSymbolTable">Additional symbols to bind UDF.</param>
         /// <param name="allowSideEffects">Allow for curly brace parsing.</param>
-        internal DefinitionsCheckResult AddUserDefinedFunction(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, ReadOnlySymbolTable extraSymbolTable = null, bool allowSideEffects = false)
+        internal DefinitionsCheckResult AddUserDefinedFunction(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, ReadOnlySymbolTable extraSymbolTable = null, bool allowSideEffects = false, Features features = null)
         {
             var composedSymbolTable = ReadOnlySymbolTable.Compose(this, symbolTable, extraSymbolTable);
-            var checkResult = GetDefinitionsCheckResult(script, parseCulture, composedSymbolTable, allowSideEffects);
+            var checkResult = GetDefinitionsCheckResult(script, parseCulture, composedSymbolTable, allowSideEffects, features);
 
             var udfs = checkResult.ApplyCreateUserDefinedFunctions();
 
@@ -246,10 +246,10 @@ namespace Microsoft.PowerFx
             return checkResult;
         }
 
-        internal static DefinitionsCheckResult GetDefinitionsCheckResult(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, bool allowSideEffects = false)
+        internal static DefinitionsCheckResult GetDefinitionsCheckResult(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, bool allowSideEffects = false, Features features = null)
         {
             var options = GetUDFParserOptions(parseCulture, allowSideEffects);
-            var checkResult = new DefinitionsCheckResult();
+            var checkResult = new DefinitionsCheckResult(features);
             return checkResult.SetText(script, options)
                 .SetBindingInfo(symbolTable);
         }

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/SymbolTable.cs
@@ -229,6 +229,7 @@ namespace Microsoft.PowerFx
         /// <param name="symbolTable">Extra symbols to bind UDF. Commonly coming from Engine.</param>
         /// <param name="extraSymbolTable">Additional symbols to bind UDF.</param>
         /// <param name="allowSideEffects">Allow for curly brace parsing.</param>
+        /// <param name="features">Features in effect for processing the body of the UDF.</param>
         internal DefinitionsCheckResult AddUserDefinedFunction(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, ReadOnlySymbolTable extraSymbolTable = null, bool allowSideEffects = false, Features features = null)
         {
             var composedSymbolTable = ReadOnlySymbolTable.Compose(this, symbolTable, extraSymbolTable);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/DefinitionsCheckResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/DefinitionsCheckResult.cs
@@ -184,10 +184,8 @@ namespace Microsoft.PowerFx
 
                 foreach (var udf in partialUDFs)
                 {
-                    var binding = udf.BindBody(UDFBindingSymbols, new Glue2DocumentBinderGlue(), UDFBindingConfig);
-                    
-                    List<TexlError> bindErrors = new List<TexlError>();
-
+                    var binding = udf.BindBody(UDFBindingSymbols, new Glue2DocumentBinderGlue(), UDFBindingConfig, _features);
+ 
                     if (binding.ErrorContainer.GetErrors().Any(error => error.Severity > DocumentErrorSeverity.Warning))
                     {
                         _errors.AddRange(ExpressionError.New(binding.ErrorContainer.GetErrors(), _defaultErrorCulture));

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Engine.cs
@@ -566,13 +566,13 @@ namespace Microsoft.PowerFx
 
         public DefinitionsCheckResult AddUserDefinedFunction(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, bool allowSideEffects = false)
         {
-            return Config.SymbolTable.AddUserDefinedFunction(script, parseCulture, UDFDefaultBindingSymbols, symbolTable, allowSideEffects);
+            return Config.SymbolTable.AddUserDefinedFunction(script, parseCulture, UDFDefaultBindingSymbols, symbolTable, allowSideEffects, Config.Features);
         }
 
         public ReadOnlySymbolTable GetUserDefinedFunctionSymbol(string script, CultureInfo parseCulture = null, ReadOnlySymbolTable symbolTable = null, bool allowSideEffects = false)
         {
             var resultSymbols = new SymbolTable();
-            resultSymbols.AddUserDefinedFunction(script, parseCulture, UDFDefaultBindingSymbols, symbolTable, allowSideEffects);
+            resultSymbols.AddUserDefinedFunction(script, parseCulture, UDFDefaultBindingSymbols, symbolTable, allowSideEffects, Config.Features);
             return resultSymbols;
         }
     }

--- a/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Types/DType.cs
@@ -3354,9 +3354,10 @@ namespace Microsoft.PowerFx.Core.Types
             {
                 foreach (var typedName in GetNames(DPath.Root))
                 {
-                    if (!typeDest.TryGetType(typedName.Name, out var diffType))
+                    if (!typeDest.TryGetType(typedName.Name, out var _))
                     {
-                        schemaDifference = new KeyValuePair<string, DType>(typedName.Name, diffType);
+                        // return DType.Unknown so that the caller knows it was a missing field
+                        schemaDifference = new KeyValuePair<string, DType>(typedName.Name, DType.Unknown);
                         return false;
                     }
                 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/IntellisenseTests/SuggestTest.cs
@@ -642,7 +642,7 @@ namespace Microsoft.PowerFx.Tests.IntellisenseTests
             var suggestions = SuggestStrings(expression, config, null, lazyInstance);
 
             // Just check that the execution didn't stack overflow.
-            Assert.True(suggestions.Any());
+            Assert.NotEmpty(suggestions);
         }
 
         [Theory]

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -701,5 +701,23 @@ namespace Microsoft.PowerFx.Core.Tests
             var errors = checkResult.ApplyErrors();
             Assert.Contains(errors, e => e.MessageKey.Contains("ErrUDF_NonImperativeVoidType"));
         }
+
+        [Theory]
+        [InlineData("f(x:GUID):Boolean = x+1 And true;")] // PowerFXV1CompatibilityRules doesn't support GUID+1
+        public void TestUDFBodyFeaturesSupport(string expression)
+        {
+            var checkResultV1 = new DefinitionsCheckResult(Features.PowerFxV1)
+                                            .SetText(expression)
+                                            .SetBindingInfo(_primitiveTypes);
+            var errorsV1 = checkResultV1.ApplyErrors();
+            Assert.True(errorsV1.Any());
+
+            // test inverse, that an error occurs with the opposite features setting
+            var checkResultNone = new DefinitionsCheckResult(Features.None)
+                                            .SetText(expression)
+                                            .SetBindingInfo(_primitiveTypes);
+            var errorsNone = checkResultNone.ApplyErrors();
+            Assert.True(!errorsNone.Any());
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -715,14 +715,14 @@ namespace Microsoft.PowerFx.Core.Tests
                                             .SetText(expression)
                                             .SetBindingInfo(nameResolver);
             var errorsV1 = checkResultV1.ApplyErrors();
-            Assert.True(errorsV1.Any());
+            Assert.NotEmpty(errorsV1);
 
             // test inverse, that there is no error if no features used, that in fact the features setting is having an impact
             var checkResultNone = new DefinitionsCheckResult(Features.None)
                                             .SetText(expression)
                                             .SetBindingInfo(nameResolver);
             var errorsNone = checkResultNone.ApplyErrors();
-            Assert.True(!errorsNone.Any());
+            Assert.Empty(errorsNone);
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -712,7 +712,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var errorsV1 = checkResultV1.ApplyErrors();
             Assert.True(errorsV1.Any());
 
-            // test inverse, that an error occurs with the opposite features setting
+            // test inverse, that there is no error if no features used, that in fact the features setting is having an impact
             var checkResultNone = new DefinitionsCheckResult(Features.None)
                                             .SetText(expression)
                                             .SetBindingInfo(_primitiveTypes);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedFunctionTests.cs
@@ -704,18 +704,23 @@ namespace Microsoft.PowerFx.Core.Tests
 
         [Theory]
         [InlineData("f(x:GUID):Boolean = x+1 And true;")] // PowerFXV1CompatibilityRules doesn't support GUID+1
+        [InlineData("f():Number = ShowColumns({a:1}, \"a\").a;")] // SupportColumnNamesAsIdentifiers
+        [InlineData("f():Number = First([{a:1}]).Value.a;")] // TableSyntaxDoesntWrapRecords
+        [InlineData("f():Number = First(Mod([1,2,3],1)).Result;")] // ConsistentOneColumnTableResult
         public void TestUDFBodyFeaturesSupport(string expression)
         {
+            var nameResolver = ReadOnlySymbolTable.NewDefault(BuiltinFunctionsCore._library, FormulaType.PrimitiveTypes);
+
             var checkResultV1 = new DefinitionsCheckResult(Features.PowerFxV1)
                                             .SetText(expression)
-                                            .SetBindingInfo(_primitiveTypes);
+                                            .SetBindingInfo(nameResolver);
             var errorsV1 = checkResultV1.ApplyErrors();
             Assert.True(errorsV1.Any());
 
             // test inverse, that there is no error if no features used, that in fact the features setting is having an impact
             var checkResultNone = new DefinitionsCheckResult(Features.None)
                                             .SetText(expression)
-                                            .SetBindingInfo(_primitiveTypes);
+                                            .SetBindingInfo(nameResolver);
             var errorsNone = checkResultNone.ApplyErrors();
             Assert.True(!errorsNone.Any());
         }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -168,8 +168,8 @@ namespace Microsoft.PowerFx.Core.Tests
         [InlineData("f(x:T):Number = x.n; T := Type({n: Number}); g(): Number = f({n: 5, m: 5});", "ErrBadSchema_AdditionalField")]
         [InlineData("f():T = [{x: 5}]; T := Type([{x: Number}]);", null)]
         [InlineData("f(x:T):T = x; T := Type([{n: Number}]); g(): T = f([{n: 5, m: 5}]);", "ErrBadSchema_AdditionalField")]
-        [InlineData("f(x:T):T = {n: \"Foo\"}; T := Type({n: GUID});", null)]
-        [InlineData("f():GUID = \"Foo\";", null)]
+        [InlineData("f(x:T):T = {n: \"Foo\"}; T := Type({n: GUID});", null)] // returns an error with PreV1
+        [InlineData("f():GUID = \"Foo\";", null)] // returns an error with PreV1
         public void TestAggregateTypeErrors(string typeDefinition, string expectedMessageKey)
         {
             // with number is float

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -160,13 +160,12 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Contains(errors, e => e.MessageKey.Contains(expectedMessageKey));
         }
 
-        // needs fixing in UserDefinedFunctions.cs CheckTypesOnDeclaration
-        // [InlineData("f():T = [{x: 5, y: 5}]; T := Type([{x: Number}]);", "ErrUDF_ReturnTypeSchemaAdditionalFields")]
-
         [Theory]
         [InlineData("f():T = {x: true, y: 1}; T := Type({x: Boolean});", "ErrUDF_ReturnTypeSchemaAdditionalFields")]
         [InlineData("f(x:T):Number = x.n; T := Type({n: Number}); g(): Number = f({n: 5, m: 5});", "ErrBadSchema_AdditionalField")]
         [InlineData("f():T = [{x: 5}]; T := Type([{x: Number}]);", null)]
+        [InlineData("f():T = [{x: 5}]; T := Type([{x: GUID}]);", "ErrUDF_ReturnTypeSchemaIncompatible")]
+        [InlineData("f():T = [{x: 5, y: 5}]; T := Type([{x: Number}]);", "ErrUDF_ReturnTypeSchemaAdditionalFields")]
         [InlineData("f(x:T):T = x; T := Type([{n: Number}]); g(): T = f([{n: 5, m: 5}]);", "ErrBadSchema_AdditionalField")]
         [InlineData("f(x:T):T = {n: \"Foo\"}; T := Type({n: GUID});", null)] // returns an error with PreV1
         [InlineData("f():GUID = \"Foo\";", null)] // returns an error with PreV1

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var errors = checkResult.ApplyErrors();
             if (expectedMessageKey == null)
             {
-                Assert.True(!errors.Any());
+                Assert.Empty(errors);
             }
             else
             {
@@ -196,7 +196,7 @@ namespace Microsoft.PowerFx.Core.Tests
             var errorsDecimal = checkResultDecimal.ApplyErrors();
             if (expectedMessageKey == null)
             {
-                Assert.True(!errorsDecimal.Any());
+                Assert.Empty(errorsDecimal);
             }
             else
             {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/UserDefinedTypeTests.cs
@@ -160,19 +160,49 @@ namespace Microsoft.PowerFx.Core.Tests
             Assert.Contains(errors, e => e.MessageKey.Contains(expectedMessageKey));
         }
 
+        // needs fixing in UserDefinedFunctions.cs CheckTypesOnDeclaration
+        // [InlineData("f():T = [{x: 5, y: 5}]; T := Type([{x: Number}]);", "ErrUDF_ReturnTypeSchemaAdditionalFields")]
+
         [Theory]
         [InlineData("f():T = {x: true, y: 1}; T := Type({x: Boolean});", "ErrUDF_ReturnTypeSchemaAdditionalFields")]
         [InlineData("f(x:T):Number = x.n; T := Type({n: Number}); g(): Number = f({n: 5, m: 5});", "ErrBadSchema_AdditionalField")]
-        [InlineData("f():T = [{x: 5, y: 5}]; T := Type([{x: Number}]);", "ErrUDF_ReturnTypeSchemaAdditionalFields")]
+        [InlineData("f():T = [{x: 5}]; T := Type([{x: Number}]);", null)]
         [InlineData("f(x:T):T = x; T := Type([{n: Number}]); g(): T = f([{n: 5, m: 5}]);", "ErrBadSchema_AdditionalField")]
-        [InlineData("f(x:T):T = {n: \"Foo\"}; T := Type({n: GUID});", "ErrUDF_ReturnTypeSchemaIncompatible")]
+        [InlineData("f(x:T):T = {n: \"Foo\"}; T := Type({n: GUID});", null)]
+        [InlineData("f():GUID = \"Foo\";", null)]
         public void TestAggregateTypeErrors(string typeDefinition, string expectedMessageKey)
         {
-            var checkResult = new DefinitionsCheckResult()
-                                            .SetText(typeDefinition)
+            // with number is float
+
+            var parserOptions = new ParserOptions() { NumberIsFloat = true };
+            var checkResult = new DefinitionsCheckResult(Features.PowerFxV1)
+                                            .SetText(typeDefinition, parserOptions)
                                             .SetBindingInfo(_primitiveTypes);
             var errors = checkResult.ApplyErrors();
-            Assert.Contains(errors, e => e.MessageKey.Contains(expectedMessageKey));
+            if (expectedMessageKey == null)
+            {
+                Assert.True(!errors.Any());
+            }
+            else
+            {
+                Assert.Contains(errors, e => e.MessageKey.Contains(expectedMessageKey));
+            }
+
+            // without number is float, oddly this has given different results for some cases in the past
+
+            var parserOptionsDecimal = new ParserOptions() { NumberIsFloat = false };
+            var checkResultDecimal = new DefinitionsCheckResult(Features.PowerFxV1)
+                                            .SetText(typeDefinition, parserOptionsDecimal)
+                                            .SetBindingInfo(_primitiveTypes);
+            var errorsDecimal = checkResultDecimal.ApplyErrors();
+            if (expectedMessageKey == null)
+            {
+                Assert.True(!errorsDecimal.Any());
+            }
+            else
+            {
+                Assert.Contains(errorsDecimal, e => e.MessageKey.Contains(expectedMessageKey));
+            }
         }
 
         [Theory]

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/UserDefinedTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/UserDefinedTests.cs
@@ -227,5 +227,22 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 Assert.False(udf.IsAsync);
             }
         }
+
+        [Theory]
+        [InlineData("f():Number = First(ShowColumns([1,2,3], Value)).Value;", "f()", true, 1)] // SupportColumnNamesAsIdentifiers
+        [InlineData("f():Number = First(ShowColumns([1,2,3], \"Value\")).Value;", "f()", false, 1)] // SupportColumnNamesAsIdentifiers
+        public void UDFBodyUsesFeatures(string script, string eval, bool powerFxV1, double expected)
+        {
+            var configWorks = new PowerFxConfig(powerFxV1 ? Features.PowerFxV1 : Features.None);
+            var engineWorks = new RecalcEngine(configWorks);
+
+            engineWorks.AddUserDefinitions(script);
+
+            var checkEvalWorks = engineWorks.Check(eval);
+            Assert.True(checkEvalWorks.IsSuccess);
+
+            var resultWorks = (NumberValue)checkEvalWorks.GetEvaluator().Eval();
+            Assert.Equal(expected, resultWorks.Value);
+        }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/UserDefinedTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/UserDefinedTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.PowerFx.Core.App.Controls;
 using Microsoft.PowerFx.Core.Binding;
 using Microsoft.PowerFx.Core.Binding.BindInfo;
@@ -231,8 +232,12 @@ namespace Microsoft.PowerFx.Interpreter.Tests
         [Theory]
         [InlineData("f():Number = First(ShowColumns([1,2,3], Value)).Value;", "f()", true, 1)] // SupportColumnNamesAsIdentifiers
         [InlineData("f():Number = First(ShowColumns([1,2,3], \"Value\")).Value;", "f()", false, 1)] // SupportColumnNamesAsIdentifiers
+        [InlineData("f():Number = First([{a:1}]).a;", "f()", true, 1)] // TableSyntaxDoesntWrapRecords
+        [InlineData("f():Number = First([{a:1}]).Value.a;", "f()", false, 1)] // TableSyntaxDoesntWrapRecords
         public void UDFBodyUsesFeatures(string script, string eval, bool powerFxV1, double expected)
         {
+            // easy way
+
             var configWorks = new PowerFxConfig(powerFxV1 ? Features.PowerFxV1 : Features.None);
             var engineWorks = new RecalcEngine(configWorks);
 
@@ -243,6 +248,32 @@ namespace Microsoft.PowerFx.Interpreter.Tests
 
             var resultWorks = (NumberValue)checkEvalWorks.GetEvaluator().Eval();
             Assert.Equal(expected, resultWorks.Value);
+
+            // harder way, using DefinitionCheckResult, that passes through a different UDF body path than above
+
+            var configDCR = new PowerFxConfig(powerFxV1 ? Features.PowerFxV1 : Features.None);
+            var engineDCR = new RecalcEngine(configDCR);
+
+            var addDCR = engineDCR.AddUserDefinedFunction(script);
+            var errorsDCR = addDCR.ApplyErrors();
+
+            Assert.False(errorsDCR.Any());
+
+            var checkEvalDCR = engineDCR.Check(eval);
+            Assert.True(checkEvalDCR.IsSuccess);
+
+            var resultDCR = (NumberValue)checkEvalDCR.GetEvaluator().Eval();
+            Assert.Equal(expected, resultDCR.Value);
+
+            // harder way, using DefinitionCheckResult, inverted Features setting
+
+            var configDCRNot = new PowerFxConfig(powerFxV1 ? Features.None : Features.PowerFxV1);
+            var engineDCRNot = new RecalcEngine(configDCRNot);
+
+            var addDCRNot = engineDCRNot.AddUserDefinedFunction(script);
+            var errorsDCRNot = addDCRNot.ApplyErrors();
+
+            Assert.True(errorsDCRNot.Any());
         }
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/UserDefinedTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/UserDefinedTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.False(errors.Any());
+            Assert.Empty(errors);
         }
 
         [Theory]
@@ -73,7 +73,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.False(errors.Any());
+            Assert.Empty(errors);
         }
 
         [Theory]
@@ -89,7 +89,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.True(errors.Any());
+            Assert.NotEmpty(errors);
         }
 
         [Theory]
@@ -106,7 +106,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.True(errors.Any());
+            Assert.NotEmpty(errors);
             Assert.Equal(udfCount, parseResult.UDFs.Count());
             Assert.Equal(validUdfCount, udfs.Count());
             Assert.Equal(nfCount, parseResult.NamedFormulas.Count());
@@ -126,7 +126,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out var errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.True(errors.Any());
+            Assert.NotEmpty(errors);
 
             options = new ParserOptions()
             {
@@ -137,7 +137,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             udfs = UserDefinedFunction.CreateFunctions(parseResult.UDFs.Where(udf => udf.IsParseValid), _primitiveTypes, out errors);
             errors.AddRange(parseResult.Errors ?? Enumerable.Empty<TexlError>());
 
-            Assert.False(errors.Any());
+            Assert.Empty(errors);
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var addDCR = engineDCR.AddUserDefinedFunction(script);
             var errorsDCR = addDCR.ApplyErrors();
 
-            Assert.False(errorsDCR.Any());
+            Assert.Empty(errorsDCR);
 
             var checkEvalDCR = engineDCR.Check(eval);
             Assert.True(checkEvalDCR.IsSuccess);
@@ -273,7 +273,7 @@ namespace Microsoft.PowerFx.Interpreter.Tests
             var addDCRNot = engineDCRNot.AddUserDefinedFunction(script);
             var errorsDCRNot = addDCRNot.ApplyErrors();
 
-            Assert.True(errorsDCRNot.Any());
+            Assert.NotEmpty(errorsDCRNot);
         }
     }
 }


### PR DESCRIPTION
The body of UDFs is interpreted without the current engine features in place, the flags are not passed down and a default of Features.None ends up being used. In this example, the REPL is in V1 mode, and yet ShowColumns isn't using ColumnNamesAsIdentifiers, a part of V1:
```
>> f():Number = First( ShowColumns( [1,2,3], Value ) ).Value;
Error 42-47: Name isn't valid. 'Value' isn't recognized.
Error 20-31: The function 'ShowColumns' has some invalid arguments.
Error 51-57: Name isn't valid. 'Value' isn't recognized.

>> f():Number = First( ShowColumns( [1,2,3], "Value" ) ).Value;

>>
```

Fixing this exposed another bug where error messages could become confused: an extra field, which should be an error, would be reported as a type incompatibility in another parameter, despite coercion handling it if the extra field was not there. 

Consider this correct error message:

<img width="1328" height="133" alt="image" src="https://github.com/user-attachments/assets/32170b1b-aa31-45b8-a6b2-98537eb13dfb" />

If instead the 1 is replaced with Now(), which Coerces to a number, but is not Accepted by a number, then an incorrect error message is displayed, masking the additional field error:

<img width="1328" height="133" alt="image" src="https://github.com/user-attachments/assets/1b820658-1ed1-4a0f-886f-2024b9b44a3a" />

Removing the additional field and there is no longer any error, somehow the Coercion logic kicks in:

<img width="1328" height="133" alt="image" src="https://github.com/user-attachments/assets/f762144c-2c52-44b6-9656-665c1e09ac2d" />

I believe the culprit is in UserDefinedFunction.cs. CheckTypesOnDeclaration does an Accepts check which does fall back to a CoercesTo check, but somehow it isn't encoding this properly for AddAggregateTypeErrors to interpret, which stops first at the supposed type difference before displaying the additional field error.

This second problem has also been fixed.
