### PR TITLE
Fix reassembly of link URLs on error resources

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/StringResources.cs
@@ -332,7 +332,7 @@ namespace Microsoft.PowerFx.Core.Localization
                                 members.Add(ErrorResource.LinkTagUrlTag, linkKeys);
                             }
 
-                            linkKeys.Add(i, member);
+                            linkKeys.Add(i, link);
                         }
                     }
                 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ResourceValidationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ResourceValidationTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.PowerFx.Tests
             Assert.Equal("This is sample message #2 long version", er.GetSingleValue(ErrorResource.LongMessageTag));
             Assert.Equal("This is sample message #2 how to fix", er.GetSingleValue(ErrorResource.HowToFixTag));
             Assert.Equal("This is sample message #2 link", er.HelpLinks[0].DisplayText);
+            Assert.Equal("https://go.microsoft.com/fwlink/?linkid=99999999", er.HelpLinks[0].Url);
 
             // This is the correct way to get this resource here as it's really an ErrorResourceKey
             ErrorResource er2 = StringResources.GetErrorResource(TexlStrings.OpNotSupportedByColumnSuggestionMessage_OpNotSupportedByColumn);


### PR DESCRIPTION
The assembly of the error resources is incorrectly placing the link description in the URL field. This fixes it.