### PR TITLE
Remove IsLookUpReductionDelegationEnabled

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/Features.cs
@@ -73,11 +73,6 @@ namespace Microsoft.PowerFx
         internal bool JsonFunctionAcceptsLazyTypes { get; init; }
 
         /// <summary>
-        /// Enables more robust lookup reduction delegation.
-        /// </summary>
-        internal bool IsLookUpReductionDelegationEnabled { get; init; }
-
-        /// <summary>
         /// Enables User-defined types functionality.
         /// </summary>
         internal bool IsUserDefinedTypesEnabled { get; init; } = false;
@@ -123,7 +118,6 @@ namespace Microsoft.PowerFx
             IsUserDefinedTypesEnabled = other.IsUserDefinedTypesEnabled;
             AsTypeLegacyCheck = other.AsTypeLegacyCheck;
             JsonFunctionAcceptsLazyTypes = other.JsonFunctionAcceptsLazyTypes;
-            IsLookUpReductionDelegationEnabled = other.IsLookUpReductionDelegationEnabled;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Lookup.cs
@@ -88,14 +88,6 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             }
 
             var args = callNode.Args.Children.VerifyValue();
-
-            // Without lookup reduction delegation, follow the legacy logic to determine if the function call is delegatable
-            // NOTE that with the reduction delegation enabled, the reduction node can only make a LookUp not delegatable if it is used inside another filter
-            if (!binding.Features.IsLookUpReductionDelegationEnabled && args.Count > 2 && binding.IsDelegatable(args[2]))
-            {
-                SuggestDelegationHint(args[2], binding);
-                return false;
-            }
             
             if (args.Count < 2)
             {
@@ -166,9 +158,8 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var function = binding.GetInfo(node)?.Function;
             var args = node.Args.Children.VerifyValue();          
 
-            // if enabled, only for Lookup functions, verify if the reduction formula is valid for delegation
-            if (binding.Features.IsLookUpReductionDelegationEnabled &&
-                function is LookUpFunction lookup && args.Count > 2 && 
+            // Only for Lookup function calls with a reduction formula, verify it is valid for delegation
+            if (function is LookUpFunction lookup && args.Count > 2 && 
                 !lookup.IsValidDelegatableReductionNode(node, args[2], binding))
             {
                 this.SuggestDelegationHint(args[2], binding);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TestRunnerTests/InternalSetup.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/TestRunnerTests/InternalSetup.cs
@@ -45,9 +45,6 @@ namespace Microsoft.PowerFx.Core.Tests
                 case "FirstLastNRequiresSecondArguments":
                     this.Features = new Features(this.Features) { FirstLastNRequiresSecondArguments = featureValue };
                     return true;
-                case "IsLookUpReductionDelegationEnabled":
-                    this.Features = new Features(this.Features) { IsLookUpReductionDelegationEnabled = featureValue };
-                    return true;
                 case "IsUserDefinedTypesEnabled":
                     this.Features = new Features(this.Features) { IsUserDefinedTypesEnabled = featureValue };
                     return true;


### PR DESCRIPTION
Remove the Canvas feature IsLookUpReductionDelegationEnabled and always use the updated logic when determining if a LookUp reduction formula can be delegated.