### PR TITLE
Fixes SPO connector encoding.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
@@ -26,7 +27,14 @@ namespace Microsoft.PowerFx.Connectors
         /// </summary>
         internal const int DefaultConnectorTop = 1000;
 
-        public static ConnectorSettings NewCDPConnectorSettings(bool extractSensitivityLabel = false, string purviewAccountName = null, int maxRows = DefaultConnectorTop)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="extractSensitivityLabel"></param>
+        /// <param name="purviewAccountName"></param>
+        /// <param name="maxRows"></param>
+        /// <param name="queryMarshallerSettings"> Must be passed for SalesForce.</param>
+        public static ConnectorSettings NewCDPConnectorSettings(bool extractSensitivityLabel = false, string purviewAccountName = null, int maxRows = DefaultConnectorTop, QueryMarshallerSettings queryMarshallerSettings = null)
         {
             var connectorSettings = new ConnectorSettings(null)
             {
@@ -35,7 +43,8 @@ namespace Microsoft.PowerFx.Connectors
                 ReturnEnumsAsPrimitive = false,
                 MaxRows = maxRows,
                 ExtractSensitivityLabel = extractSensitivityLabel,
-                PurviewAccountName = purviewAccountName
+                PurviewAccountName = purviewAccountName,
+                QueryMarshallerSettings = queryMarshallerSettings ?? new QueryMarshallerSettings()
             };
 
             return connectorSettings;
@@ -134,6 +143,8 @@ namespace Microsoft.PowerFx.Connectors
         public bool UseItemDynamicPropertiesSpecialHandling { get; init; } = false;
         
         public ConnectorCompatibility Compatibility { get; init; } = ConnectorCompatibility.Default;
+
+        public QueryMarshallerSettings QueryMarshallerSettings { get; init; } = new QueryMarshallerSettings();
     }
 
     public enum ConnectorCompatibility

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/DefaultCDPDelegationParameter.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/DefaultCDPDelegationParameter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Connectors.Tabular
             return string.Empty;
         }
 
-        public override string GetODataQueryString()
+        public override string GetODataQueryString(QueryMarshallerSettings queryMarshallerSettings)
         {
             var sb = new StringBuilder();
             sb.Append($"$top={_maxRows}");

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerFx.Connectors
             cancellationToken.ThrowIfCancellationRequested();
             ConnectorLogger executionLogger = serviceProvider?.GetService<ConnectorLogger>();
             parameters ??= new DefaultCDPDelegationParameter(ConnnectorType.FormulaType, _connectorSettings.MaxRows);
-            string queryParams = parameters.GetODataQueryString();
+            string queryParams = parameters.GetODataQueryString(_connectorSettings.QueryMarshallerSettings);
             if (!string.IsNullOrEmpty(queryParams))
             {
                 queryParams = "&" + queryParams;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
@@ -100,9 +100,26 @@ namespace Microsoft.PowerFx.Types
         /// Returns OData query string which has all parameter like $filter, $apply, etc.
         /// </summary>
         /// <returns></returns>
-        public abstract string GetODataQueryString();
+        public abstract string GetODataQueryString(QueryMarshallerSettings queryMarshallerSettings);
 
         public int? Top { get; set; }
+    }
+
+    public class QueryMarshallerSettings
+    {
+        /// <summary>
+        /// OData boolean values are true/false. Sharepoint needs 1/0.
+        /// </summary>
+        public bool EncodeBooleanAsInteger { get; init; } = false;
+
+        /// <summary>
+        /// Gets a value indicating whether dates should be encoded as strings. Sharepoint needs this.
+        /// </summary>
+        public bool EncodeDateAsString { get; init; } = false;
+
+        public QueryMarshallerSettings()
+        {
+        }
     }
 
     /// <summary>

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetODataQueryString()
+            public override string GetODataQueryString(QueryMarshallerSettings queryMarshallerOptions)
             {
                 if (string.IsNullOrEmpty(_odata))
                 {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
@@ -152,6 +152,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Types.OptionSetValueType",
                 "Microsoft.PowerFx.Types.PrimitiveValue`1",
                 "Microsoft.PowerFx.Types.PrimitiveValueConversions",
+                "Microsoft.PowerFx.Types.QueryMarshallerSettings",
                 "Microsoft.PowerFx.Types.RecordType",
                 "Microsoft.PowerFx.Types.RecordValue",
                 "Microsoft.PowerFx.Types.SpecialFieldKind",


### PR DESCRIPTION
This pull request introduces support for customizing OData query string encoding through a new `QueryMarshallerSettings` class. The changes allow for more flexible handling of boolean and date encodings, which is especially relevant for connectors like SharePoint and Salesforce. The `ConnectorSettings` class and related methods are updated to accept and propagate these settings throughout the query-building process.

### Query marshalling enhancements

* Added the `QueryMarshallerSettings` class, allowing configuration of boolean and date encoding in OData queries (e.g., encoding booleans as integers and dates as strings for SharePoint compatibility) (`src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs`).
* Updated the abstract method `GetODataQueryString` in `DelegationParameters` and its overrides to accept a `QueryMarshallerSettings` parameter, enabling customized query string generation (`src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs`, `src/libraries/Microsoft.PowerFx.Connectors/Tabular/DefaultCDPDelegationParameter.cs`, `src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs`) [[1]](diffhunk://#diff-7d0c7991f2b0cafe204ca1ce9c4aafaa8424ef742874060d7dfb322de4a8c457L103-R124) [[2]](diffhunk://#diff-72ba6d3f24874b72c7e5c51f66d5cb717562126cb40f8553ed4bad28d7fdad7cL37-R37) [[3]](diffhunk://#diff-b0eb9c4e67b4874fcf250f6921bb1840d600967de8abdec7242f65d39242dc69L177-R177).

### Connector settings improvements

* Extended `ConnectorSettings` with a new `QueryMarshallerSettings` property, defaulting to a new instance, and updated the `NewCDPConnectorSettings` factory method to accept and initialize this property (including documentation updates) (`src/libraries/Microsoft.PowerFx.Connectors/Public/ConnectorSettings.cs`) [[1]](diffhunk://#diff-5b668106d359b647dc2d970cc4c94e742319a83eea6389adb346c39ac208f4b3L29-R37) [[2]](diffhunk://#diff-5b668106d359b647dc2d970cc4c94e742319a83eea6389adb346c39ac208f4b3L38-R47) [[3]](diffhunk://#diff-5b668106d359b647dc2d970cc4c94e742319a83eea6389adb346c39ac208f4b3R146-R147).
* Modified query construction in `CdpTable` to pass the `QueryMarshallerSettings` from `ConnectorSettings` when building OData queries (`src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs`).

### Public API exposure

* Added `QueryMarshallerSettings` to the public surface area, making it accessible for consumers of the library (`src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs`).