### PR TITLE
Support for more functions that take type arguments

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4421,23 +4421,15 @@ namespace Microsoft.PowerFx.Core.Binding
 
                     if (overloadsWithTypeArgs.Any() && node.Args.Count > 1)
                     {
-                        var nodeInp = node.Args.Children[0];
-                        nodeInp.Accept(this);
-
                         Contracts.Assert(overloadsWithTypeArgs.Count() == 1);
 
                         var functionWithTypeArg = overloadsWithTypeArgs.First();
 
-                        if (MatchOverloadWithUntypedOrJSONConversionFunctions(node, functionWithTypeArg))
+                        // Either one of the untyped JSON conversion functions,
+                        // or other functions where the last argument is a type
+                        if (MatchOverloadWithUntypedOrJSONConversionFunctions(node, functionWithTypeArg) ||
+                            functionWithTypeArg.ArgIsType(node.Args.Count - 1))
                         {
-                            PreVisitTypeArgAndProccesCallNode(node, functionWithTypeArg);
-                            FinalizeCall(node);
-                            return false;
-                        }
-
-                        if (functionWithTypeArg.ArgIsType(node.Args.Count - 1))
-                        {
-                            // Other functions where the type argument is the last one
                             PreVisitTypeArgAndProccesCallNode(node, functionWithTypeArg);
                             FinalizeCall(node);
                             return false;
@@ -5215,7 +5207,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // Process other non-type arguments
-                for (var i = 1; i < args.Length - 1; i++)
+                for (var i = 0; i < args.Length - 1; i++)
                 {
                     args[i].Accept(this);
                 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -4432,6 +4432,11 @@ namespace Microsoft.PowerFx.Core.Binding
                     {
                         Contracts.Assert(overloadsWithTypeArgs.Count() == 1);
 
+                        // Evaluates the first argument; required for the call to
+                        // MatchOverloadWithUntypedOrJSONConversionFunctions
+                        var firstArg = node.Args.Children[0];
+                        firstArg.Accept(this);
+
                         var functionWithTypeArg = overloadsWithTypeArgs.First();
 
                         // Either one of the untyped JSON conversion functions,
@@ -5221,7 +5226,7 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
 
                 // Process other non-type arguments
-                for (var i = 0; i < args.Length - 1; i++)
+                for (var i = 1; i < args.Length - 1; i++)
                 {
                     args[i].Accept(this);
                 }


### PR DESCRIPTION
Currently the support for user-defined type arguments is hardcoded to specific functions. This makes the support more generic, allowing new functions to be created that receive UDTs as arguments.