### PR TITLE
QueryMarshallerSettings - c#8 init support

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
@@ -120,6 +120,12 @@ namespace Microsoft.PowerFx.Types
         public QueryMarshallerSettings()
         {
         }
+
+        public QueryMarshallerSettings(bool encodeDateAsString = false, bool encodeBooleanAsInteger = false)
+        {
+            EncodeDateAsString = encodeDateAsString;
+            EncodeBooleanAsInteger = encodeBooleanAsInteger;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Add constructor support for QueryMarshallerSettings to enable initialization in C# versions prior to 9.0