### PR TITLE
Fixes issue with TimeZone in OData queries.

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/DefaultCDPDelegationParameter.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/DefaultCDPDelegationParameter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerFx.Connectors.Tabular
             return string.Empty;
         }
 
-        public override string GetODataQueryString(QueryMarshallerSettings queryMarshallerSettings)
+        public override string GetODataQueryString(DelegationRuntimeConfig delegationRuntimeConfig)
         {
             var sb = new StringBuilder();
             sb.Append($"$top={_maxRows}");

--- a/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Tabular/Services/CdpTable.cs
@@ -139,7 +139,8 @@ namespace Microsoft.PowerFx.Connectors
             cancellationToken.ThrowIfCancellationRequested();
             ConnectorLogger executionLogger = serviceProvider?.GetService<ConnectorLogger>();
             parameters ??= new DefaultCDPDelegationParameter(ConnnectorType.FormulaType, _connectorSettings.MaxRows);
-            string queryParams = parameters.GetODataQueryString(_connectorSettings.QueryMarshallerSettings);
+            var delegationRuntimeConfig = new DelegationRuntimeConfig(_connectorSettings.QueryMarshallerSettings, serviceProvider);
+            string queryParams = parameters.GetODataQueryString(delegationRuntimeConfig);
             if (!string.IsNullOrEmpty(queryParams))
             {
                 queryParams = "&" + queryParams;

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/DelegationParameters.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerFx.Types
         /// Returns OData query string which has all parameter like $filter, $apply, etc.
         /// </summary>
         /// <returns></returns>
-        public abstract string GetODataQueryString(QueryMarshallerSettings queryMarshallerSettings);
+        public abstract string GetODataQueryString(DelegationRuntimeConfig delegationRuntimeConfig);
 
         public int? Top { get; set; }
     }
@@ -110,14 +110,15 @@ namespace Microsoft.PowerFx.Types
         /// <summary>
         /// OData boolean values are true/false. Sharepoint needs 1/0.
         /// </summary>
-        public bool EncodeBooleanAsInteger { get; init; } = false;
+        public bool EncodeBooleanAsInteger { get; init; }
 
         /// <summary>
         /// Gets a value indicating whether dates should be encoded as strings. Sharepoint needs this.
         /// </summary>
-        public bool EncodeDateAsString { get; init; } = false;
+        public bool EncodeDateAsString { get; init; }
 
         public QueryMarshallerSettings()
+            : this(false, false)
         {
         }
 
@@ -125,6 +126,22 @@ namespace Microsoft.PowerFx.Types
         {
             EncodeDateAsString = encodeDateAsString;
             EncodeBooleanAsInteger = encodeBooleanAsInteger;
+        }
+    }
+
+    /// <summary>
+    /// Represents the configuration settings required for delegation runtime operations.
+    /// </summary>
+    public class DelegationRuntimeConfig
+    {
+        public QueryMarshallerSettings QueryMarshallerSettings { get; init; }
+
+        public IServiceProvider ServiceProvider { get; init; }
+
+        public DelegationRuntimeConfig(QueryMarshallerSettings queryMarshallerSettings, IServiceProvider serviceProvider)
+        {
+            QueryMarshallerSettings = queryMarshallerSettings;
+            ServiceProvider = serviceProvider;
         }
     }
 

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/CDPDelegationTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.PowerFx.Connectors.Tests
                 throw new NotImplementedException();
             }
 
-            public override string GetODataQueryString(QueryMarshallerSettings queryMarshallerOptions)
+            public override string GetODataQueryString(DelegationRuntimeConfig delegationRuntimeConfig)
             {
                 if (string.IsNullOrEmpty(_odata))
                 {

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/PublicSurfaceTests.cs
@@ -130,6 +130,7 @@ namespace Microsoft.PowerFx.Core.Tests
                 "Microsoft.PowerFx.Types.DeferredType",
                 "Microsoft.PowerFx.Types.DelegationParameters",
                 "Microsoft.PowerFx.Types.DelegationParameterFeatures",
+                "Microsoft.PowerFx.Types.DelegationRuntimeConfig",
                 "Microsoft.PowerFx.Types.DValue`1",
                 "Microsoft.PowerFx.Types.ErrorValue",
                 "Microsoft.PowerFx.Types.ExternalType",


### PR DESCRIPTION
This pull request introduces a new configuration class, `DelegationRuntimeConfig`, to encapsulate both `QueryMarshallerSettings` and `IServiceProvider` for delegation runtime operations. The change updates method signatures and usages throughout the codebase to accept this new configuration object, improving extensibility and clarity around delegation-related settings.

### API and Method Signature Updates

* Changed the signature of the abstract method `GetODataQueryString` in `DelegationParameters` and all its overrides to accept a `DelegationRuntimeConfig` object instead of a `QueryMarshallerSettings` parameter. [[1]](diffhunk://#diff-7d0c7991f2b0cafe204ca1ce9c4aafaa8424ef742874060d7dfb322de4a8c457L103-R103) [[2]](diffhunk://#diff-72ba6d3f24874b72c7e5c51f66d5cb717562126cb40f8553ed4bad28d7fdad7cL37-R37) [[3]](diffhunk://#diff-b0eb9c4e67b4874fcf250f6921bb1840d600967de8abdec7242f65d39242dc69L177-R177)

* Updated the invocation of `GetODataQueryString` in `CdpTable.Query` to construct and pass a `DelegationRuntimeConfig` instance, ensuring both settings and service provider are available for delegation queries.

### Configuration and Public Surface Changes

* Introduced the `DelegationRuntimeConfig` class, which holds `QueryMarshallerSettings` and `IServiceProvider`, centralizing delegation runtime configuration.

* Added `DelegationRuntimeConfig` to the public API surface list in `PublicSurface_Tests`, making it a part of the library’s public types.

### Minor Adjustments

* Removed default values from the `EncodeBooleanAsInteger` and `EncodeDateAsString` properties in `QueryMarshallerSettings` and updated the constructor to explicitly set defaults, improving clarity and initialization control.