### PR TITLE
Return null from GetConnectorType on empty/missing schema payload

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
+++ b/src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs
@@ -1007,6 +1007,12 @@ namespace Microsoft.PowerFx.Connectors
 
             ConnectorType connectorType = GetConnectorType(cds.ValuePath, sv, ConnectorSettings);
 
+            if (connectorType == null)
+            {
+                runtimeContext.ExecutionLogger?.LogWarning($"Exiting {this.LogFunction(nameof(GetConnectorSuggestionsFromDynamicSchemaAsync))}, no schema at valuePath '{cds.ValuePath}'");
+                return null;
+            }
+
             if (connectorType.HasErrors)
             {
                 runtimeContext.ExecutionLogger?.LogError($"Exiting {this.LogFunction(nameof(GetConnectorSuggestionsFromDynamicSchemaAsync))}, with {LogConnectorType(connectorType)}");
@@ -1022,6 +1028,19 @@ namespace Microsoft.PowerFx.Connectors
         internal static ConnectorType GetConnectorType(string valuePath, StringValue sv, ConnectorSettings settings)
         {
             JsonElement je = ExtractFromJson(sv, valuePath);
+
+            // ExtractFromJson returns default(JsonElement) (ValueKind == Undefined) when
+            // 'sv' is empty or the 'valuePath' doesn't resolve in the JSON body. Forwarding
+            // that default value to GetConnectorTypeInternal makes OpenApiStringReader parse
+            // an empty string, which fails deep inside Microsoft.OpenApi.Readers with
+            // InvalidOperationException("Sequence contains no elements") from
+            // YamlStream.Documents.First(). Return null so callers can fall back to the
+            // static schema instead of propagating a misleading LINQ exception.
+            if (je.ValueKind == JsonValueKind.Undefined || je.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+
             return GetConnectorTypeInternal(settings, je);
         }
 
@@ -1257,6 +1276,12 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             ConnectorType connectorType = GetConnectorType(cdp.ItemValuePath, sv, ConnectorSettings);
+
+            if (connectorType == null)
+            {
+                runtimeContext.ExecutionLogger?.LogWarning($"Exiting {this.LogFunction(nameof(GetConnectorSuggestionsFromDynamicPropertyAsync))}, no schema at itemValuePath '{cdp.ItemValuePath}'");
+                return null;
+            }
 
             if (connectorType.HasErrors)
             {

--- a/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
+++ b/src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs
@@ -2626,6 +2626,59 @@ POST https://tip1-shared-002.azure-apim.net/invoke
             Assert.True(patchItemParam.ConnectorType.SupportsDynamicSchemaOrProperty);
         }
 
+        // Regression tests for the "Sequence contains no elements" LINQ exception that
+        // escaped from a dynamic-schema resolution when the sub-call's response body had
+        // an empty or missing value at the configured valuePath (e.g. Azure DevOps'
+        // GetQueryResultWorkItemSchema returning a body without Fields populated). Passing
+        // the default JsonElement through to OpenApiStringReader.ReadFragment caused
+        // Microsoft.OpenApi.Readers.OpenApiTextReaderReader.LoadYamlDocument to call
+        // YamlStream.Documents.First() on an empty stream and throw. The fix returns null
+        // from GetConnectorType so the caller can fall back to the static schema.
+
+        [Fact]
+        public void GetConnectorType_MissingValuePath_ReturnsNull()
+        {
+            StringValue sv = (StringValue)FormulaValue.New("{\"otherProperty\":\"value\"}");
+            ConnectorSettings settings = new ConnectorSettings("test");
+
+            ConnectorType result = ConnectorFunction.GetConnectorType("Fields", sv, settings);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetConnectorType_EmptyStringValue_ReturnsNull()
+        {
+            StringValue sv = (StringValue)FormulaValue.New(string.Empty);
+            ConnectorSettings settings = new ConnectorSettings("test");
+
+            ConnectorType result = ConnectorFunction.GetConnectorType("Fields", sv, settings);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetConnectorType_ValuePathResolvesToNull_ReturnsNull()
+        {
+            StringValue sv = (StringValue)FormulaValue.New("{\"Fields\":null}");
+            ConnectorSettings settings = new ConnectorSettings("test");
+
+            ConnectorType result = ConnectorFunction.GetConnectorType("Fields", sv, settings);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetConnectorType_ValidSchemaAtValuePath_ReturnsConnectorType()
+        {
+            StringValue sv = (StringValue)FormulaValue.New("{\"Fields\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}}}}");
+            ConnectorSettings settings = new ConnectorSettings("test");
+
+            ConnectorType result = ConnectorFunction.GetConnectorType("Fields", sv, settings);
+
+            Assert.NotNull(result);
+        }
+
         public class HttpLogger : HttpClient
         {
             private readonly ITestOutputHelper _console;


### PR DESCRIPTION
When a connector's x-ms-dynamic-schema or x-ms-dynamic-properties sub-call returns a 200 OK response whose body is empty or whose valuePath doesn't resolve, ExtractFromJson yields default(JsonElement) (ValueKind == Undefined). GetConnectorType then forwarded that default value to GetConnectorTypeInternal, which called je.ToString() (producing "") and passed it to OpenApiStringReader.ReadFragment<OpenApiSchema>. Deep inside Microsoft.OpenApi.Readers.OpenApiTextReaderReader.LoadYamlDocument, YamlStream.Documents.First() was invoked on an empty document stream and threw InvalidOperationException("Sequence contains no elements"). The exception surfaced out of GetConnectorReturnTypeAsync / GetConnectorTypeAsync as an opaque LINQ failure with no hint that the real cause was a dynamic-schema payload that didn't contain the expected property.

Real-world repro: Azure DevOps GetQueryResultsV2 declares its items as x-ms-dynamic-properties with operationId=GetQueryResultWorkItemSchema and itemValuePath=Fields. For some valid query shapes (e.g. queries whose saved columnOptions don't map to populated Fields), the sub-call returns 200 OK with a body that has no usable value at Fields. The static 5-layer recursion through GetConnectorTypeInternalAsync then hit LoadYamlDocument and failed with "Sequence contains no elements" instead of simply falling back to the static return type.

# Fix

File: src/libraries/Microsoft.PowerFx.Connectors/ConnectorFunction.cs

GetConnectorType now checks JsonElement.ValueKind against Undefined / Null before delegating to GetConnectorTypeInternal and returns null when the extracted element is not usable. The two async callers (GetConnectorSuggestionsFromDynamicSchemaAsync and GetConnectorSuggestionsFromDynamicPropertyAsync) recognize the new null return, log a warning identifying the offending valuePath / itemValuePath, and return null themselves. The rest of the recursion already treats null as "no dynamic extension resolved" (see GetConnectorTypeInternalAsync line 683), so null propagates cleanly all the way back to GetConnectorReturnTypeAsync callers that can then fall back to the static ReturnParameterType.

# Test

File: src/tests/Microsoft.PowerFx.Connectors.Tests.Shared/PowerPlatformConnectorTests.cs

Added four direct unit tests for GetConnectorType:
- GetConnectorType_MissingValuePath_ReturnsNull — exact AzDO repro shape ({"otherProperty":"value"} with valuePath="Fields").
- GetConnectorType_EmptyStringValue_ReturnsNull — empty StringValue.
- GetConnectorType_ValuePathResolvesToNull_ReturnsNull — {"Fields":null}.
- GetConnectorType_ValidSchemaAtValuePath_ReturnsConnectorType — happy path, guards against the early-return swallowing valid schemas.

All four pass. Pre-existing GetConnectorType_* and dynamic-schema tests (DVDynamicReturnType, ServiceNowOutputType_GetRecord, ExcelOnlineAddRowV2_ItemParamHasDynamicSchema) continue to pass unchanged.