### PR TITLE
Fix #2997: PrettyPrint preserves trailing comment

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseUserDefinitionResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseUserDefinitionResult.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.PowerFx.Core.Errors;
 using Microsoft.PowerFx.Syntax;
+using Microsoft.PowerFx.Syntax.SourceInformation;
 
 namespace Microsoft.PowerFx.Core.Parser
 {
@@ -23,6 +24,10 @@ namespace Microsoft.PowerFx.Core.Parser
         // This is used to preserve the order of user definitions and all their source trivia (like comments), to be used by Pretty Print and other similar operations.
         internal IEnumerable<UserDefinitionSourceInfo> UserDefinitionSourceInfos { get; }
 
+        // Trivia consumed after the terminating semicolon of the last user definition (whitespace and/or comments).
+        // Preserved so pretty printing can emit a trailing comment like "MyNF = Pi()/2; // Half PI".
+        internal ITexlSource TrailingTrivia { get; }
+
         internal bool HasErrors { get; }
 
         // There is a good chance that the script contained user definitions.
@@ -30,7 +35,7 @@ namespace Microsoft.PowerFx.Core.Parser
         // This determination is not definitive, but if true, user definition errors should be returned instead of standard parse errors.
         internal bool DefinitionsLikely { get; }
 
-        public ParseUserDefinitionResult(IEnumerable<NamedFormula> namedFormulas, IEnumerable<UDF> uDFs, IEnumerable<DefinedType> definedTypes, IEnumerable<TexlError> errors, IEnumerable<CommentToken> comments, IEnumerable<UserDefinitionSourceInfo> userDefinitionSourceInfos, bool definitionsLikely)
+        public ParseUserDefinitionResult(IEnumerable<NamedFormula> namedFormulas, IEnumerable<UDF> uDFs, IEnumerable<DefinedType> definedTypes, IEnumerable<TexlError> errors, IEnumerable<CommentToken> comments, IEnumerable<UserDefinitionSourceInfo> userDefinitionSourceInfos, bool definitionsLikely, ITexlSource trailingTrivia = null)
         {
             NamedFormulas = namedFormulas;
             UDFs = uDFs;
@@ -38,6 +43,7 @@ namespace Microsoft.PowerFx.Core.Parser
             Comments = comments;
             UserDefinitionSourceInfos = userDefinitionSourceInfos;
             DefinitionsLikely = definitionsLikely;
+            TrailingTrivia = trailingTrivia;
 
             if (errors?.Any() ?? false)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -283,6 +283,13 @@ namespace Microsoft.PowerFx.Core.Parser
             var definitionBeforeTrivia = new List<ITexlSource>();
             var declarationStart = 0;
             var index = 0;
+
+            // Trivia after the last terminating semicolon; captured so FormatUserDefinitions
+            // can emit trailing comments (issue #2997). Overwritten on each iteration so only
+            // the final post-semicolon ParseTrivia survives — by construction that is the
+            // trivia between the last ";" and EOF.
+            ITexlSource trailingTrivia = null;
+
             ParseTrivia();
 
             while (_curs.TokCur.Kind != TokKind.Eof)
@@ -358,7 +365,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                     declarationStart = _curs.TokCur.Span.Lim;
                     _curs.TokMove();
-                    ParseTrivia();
+                    trailingTrivia = ParseTrivia();
                 }
                 else if (_curs.TidCur == TokKind.Equ)
                 {
@@ -410,7 +417,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                     declarationStart = _curs.TokCur.Span.Lim;
                     _curs.TokMove();
-                    ParseTrivia();
+                    trailingTrivia = ParseTrivia();
                 }
                 else if (_curs.TidCur == TokKind.ParenOpen)
                 {
@@ -529,7 +536,7 @@ namespace Microsoft.PowerFx.Core.Parser
                         break;
                     }
 
-                    ParseTrivia();
+                    trailingTrivia = ParseTrivia();
                 }
                 else
                 {
@@ -539,12 +546,25 @@ namespace Microsoft.PowerFx.Core.Parser
                 }
             }
 
-            return new ParseUserDefinitionResult(namedFormulas, udfs, definedTypes, _errors, _comments, userDefinitionSourceInfos: userDefinitionSourceInfos, definitionsLikely);
+            return new ParseUserDefinitionResult(namedFormulas, udfs, definedTypes, _errors, _comments, userDefinitionSourceInfos: userDefinitionSourceInfos, definitionsLikely, trailingTrivia: trailingTrivia);
         }
 
         private SourceList GetExtraTriviaSourceList()
         {
-            return _extraTrivia != null ? new SourceList(new List<ITexlSource> { _extraTrivia }) : null;
+            if (_extraTrivia == null)
+            {
+                return null;
+            }
+
+            // Transfer ownership of _extraTrivia into the returned SourceList. The original
+            // caller (UserDefinitionSourceInfo.After) is now the authoritative holder of these
+            // comment/whitespace tokens. Clearing here prevents the next post-semicolon
+            // ParseTrivia() from re-consuming them as trailing trivia (issue #2997).
+            // This matches prior effective semantics: previously the next ParseTrivia would
+            // drain _extraTrivia and then discard the returned sources.
+            var result = new SourceList(new List<ITexlSource> { _extraTrivia });
+            _extraTrivia = null;
+            return result;
         }
 
         // Look ahead to check if the upcoming token sequence is a record

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/TexlPretty.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/TexlPretty.cs
@@ -547,8 +547,23 @@ namespace Microsoft.PowerFx.Syntax
                 }
             }
 
-            return string.Join($"{TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorChainingSeparator}\n", definitions) +
+            var output = string.Join($"{TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorChainingSeparator}\n", definitions) +
                 TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorChainingSeparator;
+
+            // Issue #2997: trailing comments after the final ";" (e.g. "MyNF = Pi()/2; // Half PI")
+            // are held on ParseUserDefinitionResult.TrailingTrivia because no subsequent definition
+            // consumes them. Emit them here so pretty print is idempotent on inputs with a trailing
+            // comment on the last user definition.
+            if (result.TrailingTrivia != null && definitions.Count > 0)
+            {
+                var trailingComments = visitor.CommentsOf(new SourceList(result.TrailingTrivia));
+                if (trailingComments.Any())
+                {
+                    output += " " + string.Concat(trailingComments);
+                }
+            }
+
+            return output;
         }
 
         private LazyList<string> CommentsOf(SourceList list)

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerFx.Syntax
                         firstAttribute));
             }
 
-            return new ParseUserDefinitionResult(newFormulas, parsed.UDFs, parsed.DefinedTypes, errors, parsed.Comments, parsed.UserDefinitionSourceInfos, parsed.DefinitionsLikely);
+            return new ParseUserDefinitionResult(newFormulas, parsed.UDFs, parsed.DefinedTypes, errors, parsed.Comments, parsed.UserDefinitionSourceInfos, parsed.DefinitionsLikely, trailingTrivia: parsed.TrailingTrivia);
         }
 
         private Formula GetPartialCombinedFormula(string name, PartialAttribute.AttributeOperationKind operationKind, IList<NamedFormula> formulas)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
@@ -324,6 +324,13 @@ namespace Microsoft.PowerFx.Tests
         [InlineData(
             "// Math\nAdd(x:Number,y:Number):Number= /*c1*/ x+y;\n// Trig\nCosine(x:Number):Number=Cos(x);\n",
             "// Math\nAdd(x:Number,y:Number):Number = /*c1*/x + y;\n// Trig\nCosine(x:Number):Number = Cos(x);")]
+
+        // Issue #2997: trailing comment on the last user definition must be preserved.
+        [InlineData("MyNF=Pi()/2; // Half PI", "MyNF = Pi() / 2; // Half PI")]
+        [InlineData("MyNF=Pi()/2; /* Half PI */", "MyNF = Pi() / 2; /* Half PI */")]
+        [InlineData("a=1; b=2; // last", "a = 1;\nb = 2; // last")]
+        [InlineData("F(x:Number):Number=x; // Identity", "F(x:Number):Number = x; // Identity")]
+        [InlineData("T := Type(Number); // the type", "T := Type(Number); // the type")]
         public void TestUserDefinitionsPrettyPrint(string script, string expected)
         {
             var parserOptions = new ParserOptions()


### PR DESCRIPTION
Issue https://github.com/microsoft/Power-Fx/issues/2997

The formatter dropped any comment that appeared after the terminating ";" of the last user definition (e.g. "MyNF=Pi()/2; // Half PI" lost "// Half PI"). Comments between definitions survived because FormatUserDefinitions picks them up via the declaration substring of the following definition, but the final comment has no follower to claim it.

Capture trailing trivia in ParseUserDefinitionResult.TrailingTrivia, set it from the post-semicolon ParseTrivia() in ParseUDFsAndNamedFormulas (the overwriting-each-iteration local naturally ends up holding only the trivia between the last ";" and EOF), and emit any contained comment tokens with a single leading space after the final ";".

Also clear _extraTrivia inside GetExtraTriviaSourceList once its contents are transferred to UserDefinitionSourceInfo.After. Previously the next ParseTrivia() call drained and discarded _extraTrivia; with trailing-trivia capture that same drain would re-emit pre-semicolon comments (e.g. "y = 3/* test */;" rendered as "y = 3/* test */; /* test */"). Clearing on transfer keeps the prior effective behavior while preventing the double-emit.

Adds five InlineData rows to TestUserDefinitionsPrettyPrint covering the issue repro (line comment), a block-comment variant, a multi-definition case that proves only the truly-trailing comment is appended, and UDF / DefinedType variants. The existing test body already re-formats the output to assert idempotence.