### PR TITLE
Fix PrettyPrint corruption when user-definition header has a trailing…

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/TexlPretty.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/TexlPretty.cs
@@ -518,6 +518,9 @@ namespace Microsoft.PowerFx.Syntax
             foreach (var info in result.UserDefinitionSourceInfos)
             {
                 var declaration = info.Declaration.Trim();
+
+                // If a // line comment is the last thing in the declaration, Trim() ate the newline that terminated it — emit a line break before '=' so the operator doesn't land inside the comment.
+                var preAssignSeparator = EndsInsideLineComment(declaration) ? "\n    " : " ";
                 var name = info.Name;
                 var before = info.Before;
                 var after = info.After;
@@ -526,7 +529,7 @@ namespace Microsoft.PowerFx.Syntax
                     case UserDefinitionType.NamedFormula:
                         var nf = result.NamedFormulas.First(nf => nf.Ident == name);
 
-                        definitions.Add(declaration + $" {(nf.ColonEqual ? TexlLexer.PunctuatorColonEqual : TexlLexer.PunctuatorEqual)} " + string.Concat(visitor.CommentsOf(before).With(nf.Formula.ParseTree.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after)))));
+                        definitions.Add(declaration + $"{preAssignSeparator}{(nf.ColonEqual ? TexlLexer.PunctuatorColonEqual : TexlLexer.PunctuatorEqual)} " + string.Concat(visitor.CommentsOf(before).With(nf.Formula.ParseTree.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after)))));
                         break;
                     case UserDefinitionType.UDF:
                         var udf = result.UDFs.First(udf => udf.Ident == name);
@@ -535,12 +538,12 @@ namespace Microsoft.PowerFx.Syntax
                             $"\n{{\n\t{string.Concat(visitor.CommentsOf(before).With(udf.Body.Accept(visitor, new Context(1)).With(visitor.CommentsOf(after)))).Trim()}\n}}" :
                             string.Concat(visitor.CommentsOf(before).With(udf.Body.Accept(visitor, new Context(0)).With(visitor.CommentsOf(after))));
 
-                        definitions.Add(declaration + $" {TexlLexer.PunctuatorEqual} " + udfBody);
+                        definitions.Add(declaration + $"{preAssignSeparator}{TexlLexer.PunctuatorEqual} " + udfBody);
                         break;
                     case UserDefinitionType.DefinedType:
                         var type = result.DefinedTypes.First(type => type.Ident == name);
 
-                        definitions.Add(declaration + $" {TexlLexer.PunctuatorColonEqual} " + string.Concat(visitor.CommentsOf(before).With(type.Type.Accept(visitor, new Context(0))).With(visitor.CommentsOf(after))));
+                        definitions.Add(declaration + $"{preAssignSeparator}{TexlLexer.PunctuatorColonEqual} " + string.Concat(visitor.CommentsOf(before).With(type.Type.Accept(visitor, new Context(0))).With(visitor.CommentsOf(after))));
                         break;
                     default:
                         continue;
@@ -549,6 +552,52 @@ namespace Microsoft.PowerFx.Syntax
 
             return string.Join($"{TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorChainingSeparator}\n", definitions) +
                 TexlLexer.GetLocalizedInstance(CultureInfo.CurrentCulture).LocalizedPunctuatorChainingSeparator;
+        }
+
+        private static bool EndsInsideLineComment(string text)
+        {
+            var inLineComment = false;
+            var inBlockComment = false;
+            for (var i = 0; i < text.Length; i++)
+            {
+                var c = text[i];
+                if (inLineComment)
+                {
+                    if (c == '\n')
+                    {
+                        inLineComment = false;
+                    }
+
+                    continue;
+                }
+
+                if (inBlockComment)
+                {
+                    if (c == '*' && i + 1 < text.Length && text[i + 1] == '/')
+                    {
+                        inBlockComment = false;
+                        i++;
+                    }
+
+                    continue;
+                }
+
+                if (c == '/' && i + 1 < text.Length)
+                {
+                    if (text[i + 1] == '/')
+                    {
+                        inLineComment = true;
+                        i++;
+                    }
+                    else if (text[i + 1] == '*')
+                    {
+                        inBlockComment = true;
+                        i++;
+                    }
+                }
+            }
+
+            return inLineComment;
         }
 
         private LazyList<string> CommentsOf(SourceList list)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
@@ -324,6 +324,16 @@ namespace Microsoft.PowerFx.Tests
         [InlineData(
             "// Math\nAdd(x:Number,y:Number):Number= /*c1*/ x+y;\n// Trig\nCosine(x:Number):Number=Cos(x);\n",
             "// Math\nAdd(x:Number,y:Number):Number = /*c1*/x + y;\n// Trig\nCosine(x:Number):Number = Cos(x);")]
+
+        // Trailing // line comment on the header line must not be merged with the '=' body (issue #2998).
+        [InlineData(
+            "MyNF // My Named Formula\n    = Pi()/2;",
+            "MyNF // My Named Formula\n    = Pi() / 2;")]
+
+        // Mixing /*..*/ block and // line comments in a UDF declaration must also preserve the line break.
+        [InlineData(
+            "Add(x:Number,y:Number):Number /* rt */ // trailing\n  = x+y;",
+            "Add(x:Number,y:Number):Number /* rt */ // trailing\n    = x + y;")]
         public void TestUserDefinitionsPrettyPrint(string script, string expected)
         {
             var parserOptions = new ParserOptions()

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/FormatterTests.cs
@@ -334,6 +334,7 @@ namespace Microsoft.PowerFx.Tests
         [InlineData(
             "Add(x:Number,y:Number):Number /* rt */ // trailing\n  = x+y;",
             "Add(x:Number,y:Number):Number /* rt */ // trailing\n    = x + y;")]
+            
         // Issue #2997: trailing comment on the last user definition must be preserved.
         [InlineData("MyNF=Pi()/2; // Half PI", "MyNF = Pi() / 2; // Half PI")]
         [InlineData("MyNF=Pi()/2; /* Half PI */", "MyNF = Pi() / 2; /* Half PI */")]


### PR DESCRIPTION
… // comment

PrettyPrintVisitor.FormatUserDefinitions joined the trimmed declaration with the assignment operator using a single-space separator. When the original source placed a // line comment on the header line and the '=' body on the next line, Trim() stripped the newline that terminated the comment, and the subsequent " = " pushed the operator inside the // comment, corrupting the output so it could no longer be parsed back.

Detect when the trimmed declaration ends inside an unterminated // line comment (tracking /*..*/ nesting so a // inside a block comment is ignored) and, in that case, insert a newline + 4-space indent before the operator. Applied uniformly to NamedFormula, UDF, and DefinedType branches.

Adds two xUnit InlineData cases in TestUserDefinitionsPrettyPrint: the exact repro from the issue and a mixed /*..*/ + // UDF header that covers the generalization named in the issue title.

Issue: https://github.com/microsoft/Power-Fx/issues/2998