### PR TITLE
Remove PowerFxConfig.AdditionalFunctions

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Config/PowerFxConfig.cs
@@ -52,9 +52,6 @@ namespace Microsoft.PowerFx
             set => _symbolTable = value;
         }
 
-        // Remove this: https://github.com/microsoft/Power-Fx/issues/2821
-        internal readonly Dictionary<TexlFunction, IAsyncTexlFunction> AdditionalFunctions = new ();
-
         [Obsolete("Use Config.EnumStore or symboltable directly")]
         internal EnumStoreBuilder EnumStoreBuilder => InternalConfigSymbols.EnumStoreBuilder;
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -67,15 +67,14 @@ namespace Microsoft.PowerFx
         {
             RegexTypeCache regexTypeCache = new (regexCacheSize);
 
-            foreach (KeyValuePair<TexlFunction, IAsyncTexlFunction> func in Library.RegexFunctions(regExTimeout, regexTypeCache))
+            foreach (TexlFunction func in Library.RegexFunctions(regExTimeout, regexTypeCache))
             {
-                if (config.ComposedConfigSymbols.Functions.AnyWithName(func.Key.Name))
+                if (config.ComposedConfigSymbols.Functions.AnyWithName(func.Name))
                 {
                     throw new InvalidOperationException("Cannot add RegEx functions more than once.");
                 }
 
-                config.InternalConfigSymbols.AddFunction(func.Key);
-                config.AdditionalFunctions.Add(func.Key, func.Value);
+                config.InternalConfigSymbols.AddFunction(func);
             }
         }
 

--- a/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/EvalVisitor.cs
@@ -404,9 +404,6 @@ namespace Microsoft.PowerFx
 
             FormulaValue result;
 
-            // Remove this: https://github.com/microsoft/Power-Fx/issues/2821
-            IReadOnlyDictionary<TexlFunction, IAsyncTexlFunction> extraFunctions = _services.GetService<IReadOnlyDictionary<TexlFunction, IAsyncTexlFunction>>();
-
             try
             {
                 IFunctionInvoker invoker = GetInvoker(func);
@@ -427,10 +424,6 @@ namespace Microsoft.PowerFx
                     result = await invoker.InvokeAsync(invokeInfo, _cancellationToken).ConfigureAwait(false);
                 }
                 else if (func is IAsyncTexlFunction asyncFunc)
-                {
-                    result = await asyncFunc.InvokeAsync(args, _cancellationToken).ConfigureAwait(false);
-                }
-                else if (extraFunctions?.TryGetValue(func, out asyncFunc) == true)
                 {
                     result = await asyncFunc.InvokeAsync(args, _cancellationToken).ConfigureAwait(false);
                 }

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryRegEx.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryRegEx.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerFx.Functions
         /// <param name="regexTimeout">Timeout duration for regular expression execution. Default is 1 second.</param>
         /// <param name="regexCache">Regular expression type cache.</param>        
         /// <returns></returns>
-        internal static Dictionary<TexlFunction, IAsyncTexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache)
+        internal static IEnumerable<TexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache)
         {
             if (regexTimeout == TimeSpan.Zero)
             {
@@ -43,12 +43,45 @@ namespace Microsoft.PowerFx.Functions
                 throw new ArgumentOutOfRangeException(nameof(regexTimeout), "Timeout duration for regular expression execution must be positive.");
             }
 
-            return new Dictionary<TexlFunction, IAsyncTexlFunction>()
+            return new TexlFunction[]
             {
-                { new IsMatchFunction(regexCache), new IsMatchImplementation(regexTimeout) },
-                { new MatchFunction(regexCache), new MatchImplementation(regexTimeout) },
-                { new MatchAllFunction(regexCache), new MatchAllImplementation(regexTimeout) }
+                new IsMatchImpl(regexCache, new IsMatchImplementation(regexTimeout)),
+                new MatchImpl(regexCache, new MatchImplementation(regexTimeout)),
+                new MatchAllImpl(regexCache, new MatchAllImplementation(regexTimeout)),
             };
+        }
+
+        internal sealed class IsMatchImpl : IsMatchFunction, IAsyncTexlFunction
+        {
+            private readonly IAsyncTexlFunction _inner;
+
+            public IsMatchImpl(RegexTypeCache regexCache, IAsyncTexlFunction inner)
+                : base(regexCache) => _inner = inner;
+
+            public Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancellationToken)
+                => _inner.InvokeAsync(args, cancellationToken);
+        }
+
+        internal sealed class MatchImpl : MatchFunction, IAsyncTexlFunction
+        {
+            private readonly IAsyncTexlFunction _inner;
+
+            public MatchImpl(RegexTypeCache regexCache, IAsyncTexlFunction inner)
+                : base(regexCache) => _inner = inner;
+
+            public Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancellationToken)
+                => _inner.InvokeAsync(args, cancellationToken);
+        }
+
+        internal sealed class MatchAllImpl : MatchAllFunction, IAsyncTexlFunction
+        {
+            private readonly IAsyncTexlFunction _inner;
+
+            public MatchAllImpl(RegexTypeCache regexCache, IAsyncTexlFunction inner)
+                : base(regexCache) => _inner = inner;
+
+            public Task<FormulaValue> InvokeAsync(FormulaValue[] args, CancellationToken cancellationToken)
+                => _inner.InvokeAsync(args, cancellationToken);
         }
 
         internal class IsMatchImplementation : RegexCommonImplementation

--- a/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/ParsedExpression.cs
@@ -86,7 +86,6 @@ namespace Microsoft.PowerFx
                 _globals = globals,
                 _allSymbols = result.Symbols,
                 _parameterSymbolTable = result.Parameters,
-                _additionalFunctions = result.Engine.Config.AdditionalFunctions
             };
 
             return expr;
@@ -126,7 +125,6 @@ namespace Microsoft.PowerFx
         internal ReadOnlySymbolValues _globals;
         internal ReadOnlySymbolTable _allSymbols;
         internal ReadOnlySymbolTable _parameterSymbolTable;
-        internal IReadOnlyDictionary<TexlFunction, IAsyncTexlFunction> _additionalFunctions;
 
         internal ParsedExpression(IntermediateNode irnode, ScopeSymbol topScope, StackDepthCounter stackMarker, CultureInfo cultureInfo = null)
         {
@@ -147,12 +145,6 @@ namespace Microsoft.PowerFx
             if (_cultureInfo != null)
             {
                 innerServices.AddService(_cultureInfo);
-                hasInnerServices = true;
-            }
-
-            if (_additionalFunctions != null && _additionalFunctions.Any())
-            {
-                innerServices.AddService(_additionalFunctions);
                 hasInnerServices = true;
             }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/LibraryRegEx_Compare.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/LibraryRegEx_Compare.cs
@@ -25,19 +25,18 @@ namespace Microsoft.PowerFx.Functions
         {
             RegexTypeCache regexTypeCache = new (regexCacheSize);
 
-            foreach (KeyValuePair<TexlFunction, IAsyncTexlFunction> func in RegexFunctions(regExTimeout, regexTypeCache, includeDotNet, includeNode, includePCRE2))
+            foreach (TexlFunction func in RegexFunctions(regExTimeout, regexTypeCache, includeDotNet, includeNode, includePCRE2))
             {
-                if (config.ComposedConfigSymbols.Functions.AnyWithName(func.Key.Name))
+                if (config.ComposedConfigSymbols.Functions.AnyWithName(func.Name))
                 {
                     throw new InvalidOperationException("Cannot add RegEx functions more than once.");
                 }
 
-                config.InternalConfigSymbols.AddFunction(func.Key);
-                config.AdditionalFunctions.Add(func.Key, func.Value);
+                config.InternalConfigSymbols.AddFunction(func);
             }
         }
 
-        internal static Dictionary<TexlFunction, IAsyncTexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache, bool includeDotNet, bool includeNode, bool includePCRE2)
+        internal static IEnumerable<TexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache, bool includeDotNet, bool includeNode, bool includePCRE2)
         {
             if (regexTimeout == TimeSpan.Zero)
             {
@@ -49,11 +48,11 @@ namespace Microsoft.PowerFx.Functions
                 throw new ArgumentOutOfRangeException(nameof(regexTimeout), "Timeout duration for regular expression execution must be positive.");
             }
 
-            return new Dictionary<TexlFunction, IAsyncTexlFunction>()
+            return new TexlFunction[]
             {
-                { new IsMatchFunction(regexCache), new Compare_IsMatchImplementation(regexTimeout, includeDotNet, includeNode, includePCRE2) },
-                { new MatchFunction(regexCache), new Compare_MatchImplementation(regexTimeout, includeDotNet, includeNode, includePCRE2) },
-                { new MatchAllFunction(regexCache), new Compare_MatchAllImplementation(regexTimeout, includeDotNet, includeNode, includePCRE2) }
+                new Library.IsMatchImpl(regexCache, new Compare_IsMatchImplementation(regexTimeout, includeDotNet, includeNode, includePCRE2)),
+                new Library.MatchImpl(regexCache, new Compare_MatchImplementation(regexTimeout, includeDotNet, includeNode, includePCRE2)),
+                new Library.MatchAllImpl(regexCache, new Compare_MatchAllImplementation(regexTimeout, includeDotNet, includeNode, includePCRE2)),
             };
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/LibraryRegEx_NodeJS.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/LibraryRegEx_NodeJS.cs
@@ -242,19 +242,18 @@ namespace Microsoft.PowerFx.Functions
         {
             RegexTypeCache regexTypeCache = new (regexCacheSize);
 
-            foreach (KeyValuePair<TexlFunction, IAsyncTexlFunction> func in RegexFunctions(regExTimeout, regexTypeCache))
+            foreach (TexlFunction func in RegexFunctions(regExTimeout, regexTypeCache))
             {
-                if (config.SymbolTable.Functions.AnyWithName(func.Key.Name))
+                if (config.SymbolTable.Functions.AnyWithName(func.Name))
                 {
                     throw new InvalidOperationException("Cannot add RegEx functions more than once.");
                 }
 
-                config.SymbolTable.AddFunction(func.Key);
-                config.AdditionalFunctions.Add(func.Key, func.Value);
+                config.SymbolTable.AddFunction(func);
             }
         }
 
-        internal static Dictionary<TexlFunction, IAsyncTexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache)
+        internal static IEnumerable<TexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache)
         {
             if (regexTimeout == TimeSpan.Zero)
             {
@@ -266,11 +265,11 @@ namespace Microsoft.PowerFx.Functions
                 throw new ArgumentOutOfRangeException(nameof(regexTimeout), "Timeout duration for regular expression execution must be positive.");
             }
 
-            return new Dictionary<TexlFunction, IAsyncTexlFunction>()
+            return new TexlFunction[]
             {
-                { new IsMatchFunction(regexCache), new NodeJS_IsMatchImplementation(regexTimeout) },
-                { new MatchFunction(regexCache), new NodeJS_MatchImplementation(regexTimeout) },
-                { new MatchAllFunction(regexCache), new NodeJS_MatchAllImplementation(regexTimeout) }
+                new Library.IsMatchImpl(regexCache, new NodeJS_IsMatchImplementation(regexTimeout)),
+                new Library.MatchImpl(regexCache, new NodeJS_MatchImplementation(regexTimeout)),
+                new Library.MatchAllImpl(regexCache, new NodeJS_MatchAllImplementation(regexTimeout)),
             };
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/LibraryRegEx_PCRE2.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/Helpers/LibraryRegEx_PCRE2.cs
@@ -437,19 +437,18 @@ namespace Microsoft.PowerFx.Functions
         {
             RegexTypeCache regexTypeCache = new (regexCacheSize);
 
-            foreach (KeyValuePair<TexlFunction, IAsyncTexlFunction> func in RegexFunctions(regExTimeout, regexTypeCache))
+            foreach (TexlFunction func in RegexFunctions(regExTimeout, regexTypeCache))
             {
-                if (config.SymbolTable.Functions.AnyWithName(func.Key.Name))
+                if (config.SymbolTable.Functions.AnyWithName(func.Name))
                 {
                     throw new InvalidOperationException("Cannot add RegEx functions more than once.");
                 }
 
-                config.SymbolTable.AddFunction(func.Key);
-                config.AdditionalFunctions.Add(func.Key, func.Value);
+                config.SymbolTable.AddFunction(func);
             }
         }
 
-        internal static Dictionary<TexlFunction, IAsyncTexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache)
+        internal static IEnumerable<TexlFunction> RegexFunctions(TimeSpan regexTimeout, RegexTypeCache regexCache)
         {
             if (regexTimeout == TimeSpan.Zero)
             {
@@ -461,11 +460,11 @@ namespace Microsoft.PowerFx.Functions
                 throw new ArgumentOutOfRangeException(nameof(regexTimeout), "Timeout duration for regular expression execution must be positive.");
             }
 
-            return new Dictionary<TexlFunction, IAsyncTexlFunction>()
+            return new TexlFunction[]
             {
-                { new IsMatchFunction(regexCache), new PCRE2_IsMatchImplementation(regexTimeout) },
-                { new MatchFunction(regexCache), new PCRE2_MatchImplementation(regexTimeout) },
-                { new MatchAllFunction(regexCache), new PCRE2_MatchAllImplementation(regexTimeout) }
+                new Library.IsMatchImpl(regexCache, new PCRE2_IsMatchImplementation(regexTimeout)),
+                new Library.MatchImpl(regexCache, new PCRE2_MatchImplementation(regexTimeout)),
+                new Library.MatchAllImpl(regexCache, new PCRE2_MatchAllImplementation(regexTimeout)),
             };
         }
 

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/TextTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/TextTests.cs
@@ -35,7 +35,6 @@ namespace Microsoft.PowerFx.Interpreter.Tests
                 _allSymbols = symbols,
                 _parameterSymbolTable = symbols,
                 _globals = values,
-                _additionalFunctions = new Dictionary<TexlFunction, IAsyncTexlFunction>(),
             };
 
             // This test 


### PR DESCRIPTION
Issue https://github.com/microsoft/Power-Fx/issues/2821

The AdditionalFunctions dictionary on PowerFxConfig (in Fx.Core) mapped TexlFunction keys to IAsyncTexlFunction implementations from the Interpreter, a layering violation since Core should not reference Interpreter implementation types.

Migrate the single producer (EnableRegExFunctions) to the same pattern already used by Join, Patch, and Set: a class that derives from the Core TexlFunction base and also implements the interpreter interface. Three thin wrapper classes (IsMatchImpl, MatchImpl, MatchAllImpl) in LibraryRegEx.cs inherit IsMatchFunction/MatchFunction/MatchAllFunction and delegate InvokeAsync to the existing Implementation classes.

With that, registration is a plain symbolTable.AddFunction call and the EvalVisitor `func is IAsyncTexlFunction` branch handles dispatch. The field, its plumbing through ParsedExpression and EvalVisitor, and the matching test helpers for NodeJS/PCRE2/Compare are all removed.

No public API change. All 64,946 interpreter tests pass.