### PR TITLE
fix: make TestNl2FxIsCanceledCorrectly deterministic (#2755)

### DIFF
--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/CancellationTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/CancellationTests.cs
@@ -12,8 +12,6 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 {
     public partial class LanguageServerTestBase
     {
-        // Fix this: https://github.com/microsoft/Power-Fx/issues/2755
-#if false
         [Fact]
         public async Task TestNl2FxIsCanceledCorrectly()
         {
@@ -27,19 +25,31 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
             Init(new InitParams(scopeFactory: scopeFactory));
             var nl2FxHandler = CreateAndConfigureNl2FxHandler();
             nl2FxHandler.ThrowOnCancellation = true;
-            nl2FxHandler.Nl2FxDelayTime = 800;
+            nl2FxHandler.Nl2FxDelayTime = 500;
+
+            // Use a semaphore to synchronize cancellation: the token is cancelled only after
+            // the NL2Fx handler has demonstrably entered NL2FxAsync, eliminating the
+            // wall-clock race that made the original CancelAfter(500) approach flaky.
+            using var handlerEntered = new SemaphoreSlim(0, 1);
+            nl2FxHandler.NL2FxEnteredSemaphore = handlerEntered;
+
             var payload = NL2FxMessageJson(documentUri);
             using var source = new CancellationTokenSource();
-            source.CancelAfter(500);  <-- flaky 
 
-            // Act
-            var rawResponse = await TestServer.OnDataReceivedAsync(payload.payload, source.Token);
+            // Start the server call without awaiting — it will run concurrently.
+            var responseTask = TestServer.OnDataReceivedAsync(payload.payload, source.Token);
+
+            // Wait until the handler body has started, then cancel.
+            await handlerEntered.WaitAsync();
+            source.Cancel();
+
+            // Act — now await the response with cancellation already signalled.
+            var rawResponse = await responseTask;
 
             // Assert
             AssertErrorPayload(rawResponse, payload.id, JsonRpcHelper.ErrorCode.RequestCancelled);
             Assert.NotEmpty(TestServer.UnhandledExceptions);
             Assert.Equal(1, nl2FxHandler.PreHandleNl2FxCallCount);
         }
-#endif 
     }
 }

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/LanguageServiceProtocol/RedesignedLanguageServerTests/Nl2FxTests.cs
@@ -40,12 +40,23 @@ namespace Microsoft.PowerFx.Tests.LanguageServiceProtocol
 
         public int PreHandleNl2FxCallCount { get; set; } = 0;
 
+        /// <summary>
+        /// When set, Released once NL2FxAsync has been entered. Allows tests to synchronize
+        /// cancellation to a point after the handler has demonstrably started, avoiding
+        /// wall-clock races.
+        /// </summary>
+        public SemaphoreSlim NL2FxEnteredSemaphore { get; set; }
+
         public TestNL2FxHandler()
         {
         }
 
         public override async Task<CustomNL2FxResult> NL2FxAsync(NL2FxParameters request, CancellationToken cancel)
         {
+            // Signal to any waiting test that the handler body has been entered.
+            // This must happen before any delay so callers can cancel deterministically.
+            NL2FxEnteredSemaphore?.Release();
+
             if (Nl2FxDelayTime.HasValue)
             {
                 await Task.Delay(Nl2FxDelayTime.Value, CancellationToken.None);


### PR DESCRIPTION
## Summary

Fixes #2755. `TestNl2FxIsCanceledCorrectly` was flaky in CI because it relied on three overlapping timing assumptions:

1. `CancelAfter(500)` could fire before the NL2Fx handler body was entered (scheduler delay on loaded CI)
2. `Task.Delay(800, CancellationToken.None)` silently ignored cancellation, creating a dead window
3. `ThrowIfCancellationRequested()` only ran after the full 800ms delay — drift caused the assertion to see the wrong error code

**Fix:** Replace the time-based trigger with a `SemaphoreSlim` signal:
- `TestNL2FxHandler` releases `NL2FxEnteredSemaphore` at the very start of `NL2FxAsync` (proving the handler is entered)
- The test awaits `handlerEntered.WaitAsync()` before calling `Cancel()`, guaranteeing the token is cancelled only after the operation has genuinely started
- All three original assertions are preserved

Test-only change. No production code touched. Passes 3/3 consecutive runs at ~750ms each.

## Files changed

- `CancellationTests.cs` — replaced `CancelAfter(500)` with deterministic semaphore-based cancel
- `Nl2FxTests.cs` — added `NL2FxEnteredSemaphore` property to `TestNL2FxHandler` (null-safe, unaffected by other tests)

## Test results

```
Passed: TestNl2FxIsCanceledCorrectly (run 1)  ~1s
Passed: TestNl2FxIsCanceledCorrectly (run 2)  774ms
Passed: TestNl2FxIsCanceledCorrectly (run 3)  743ms
```

## A-TEAM pipeline confidence: 7 / 10

**Reason:** Root cause is well understood and the `SemaphoreSlim` signal pattern is correct. The fix is surgical (test-only, zero production risk) and eliminated flakiness across 3 consecutive local runs. Two items prevent a higher score: (1) `WaitAsync()` is called without a timeout — if the NL2Fx handler never fires due to a future refactor, the test will hang indefinitely rather than fail with a clear assertion; a bounded `WaitAsync(TimeSpan)` would make failure mode cleaner. (2) 3 consecutive passes is a reasonable smoke test but not statistical proof for a test reported as flaky in CI — the real validation is sustained green CI runs.

## Notes

- The `.Net7.0` test project `TargetFramework` was temporarily changed to `net8.0` for local testing (net7 runtime absent on this machine) and **reverted to `net7.0`** before committing — verify the committed state is correct.
- `net462` build path not validated locally; `SemaphoreSlim` is available in .NET 4.6.2 BCL so no compatibility issue expected.

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via A-TEAM pipeline