### PR TITLE
Update conversion from untyped (dynamic) values to date to assume local time without time zone information

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -101,7 +101,7 @@ namespace Microsoft.PowerFx.Types
             // offset-bearing values to UTC, so the resulting instance does not depend on the host's
             // local timezone. Also accepts non-strict ISO 8601 forms emitted by connectors (e.g.
             // "+0000" instead of "+00:00") that element.GetDateTime() would reject.
-            if (!DateTimeOffset.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dto))
+            if (!DateTimeOffset.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dto))
             {
                 return new ErrorValue(IRContext.NotInSource(targetType), new ExpressionError()
                 {
@@ -111,7 +111,7 @@ namespace Microsoft.PowerFx.Types
                 });
             }
 
-            return funcParse(dto.UtcDateTime);
+            return funcParse(dto.DateTime);
         }
 
         internal static FormulaValue FromJson(JsonElement element, FormulaValueJsonSerializerSettings settings, FormulaValueJsonSerializerWorkingData data, FormulaType formulaType = null)

--- a/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/FormulaValueJSON.cs
@@ -96,11 +96,10 @@ namespace Microsoft.PowerFx.Types
                 return FormulaValue.NewBlank(targetType);
             }
 
-            // Use DateTimeOffset.TryParse for consistent, machine-independent parsing that matches
-            // Power Automate / Logic Apps behavior. Treats offset-less values as UTC and normalizes
-            // offset-bearing values to UTC, so the resulting instance does not depend on the host's
-            // local timezone. Also accepts non-strict ISO 8601 forms emitted by connectors (e.g.
-            // "+0000" instead of "+00:00") that element.GetDateTime() would reject.
+            // Use DateTimeOffset.TryParse for consistent, machine-independent parsing. Explicit
+            // offsets are normalized to UTC, while offset-less values are treated as local to match
+            // DateTimeValue semantics. This also accepts non-strict ISO 8601 forms emitted by
+            // connectors (e.g. "+0000" instead of "+00:00") that element.GetDateTime() would reject.
             if (!DateTimeOffset.TryParse(strValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dto))
             {
                 return new ErrorValue(IRContext.NotInSource(targetType), new ExpressionError()
@@ -111,7 +110,23 @@ namespace Microsoft.PowerFx.Types
                 });
             }
 
-            return funcParse(dto.DateTime);
+            return funcParse(HasExplicitTimeZone(strValue) ? dto.UtcDateTime : dto.LocalDateTime);
+        }
+
+        private static bool HasExplicitTimeZone(string value)
+        {
+            if (value.EndsWith("Z", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var timeSeparator = Math.Max(value.LastIndexOf('T'), value.LastIndexOf(' '));
+            if (timeSeparator < 0)
+            {
+                return false;
+            }
+
+            return value.LastIndexOf('+') > timeSeparator || value.LastIndexOf('-') > timeSeparator;
         }
 
         internal static FormulaValue FromJson(JsonElement element, FormulaValueJsonSerializerSettings settings, FormulaValueJsonSerializerWorkingData data, FormulaType formulaType = null)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO.txt
@@ -29,10 +29,13 @@ Date(1900,12,31)
 >> AsType(ParseJSON("""1900-12-31T00:00:00.000Z"""), Date)
 Date(1900,12,31)
 
->> AsType(ParseJSON("""1900-12-31T23:59:59.999"""), DateTime) = DateTimeValue("1900-12-31T23:59:59.999Z")
+>> AsType(ParseJSON("""1900-12-31T23:59:59.999"""), DateTime) = DateTimeValue("1900-12-31T23:59:59.999")
 true
 
->> AsType(ParseJSON("""1900-12-31"""), DateTime) = DateTimeValue("1900-12-31T00:00:00Z")
+>> AsType(ParseJSON("""1900-12-31T23:59:59.999Z"""), DateTime) = DateTimeValue("1900-12-31T23:59:59.999Z")
+true
+
+>> AsType(ParseJSON("""1900-12-31"""), DateTime) = DateTimeValue("1900-12-31T00:00:00")
 true
 
 >> AsType(ParseJSON("""11:59:59.999"""), Time)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
@@ -17,3 +17,9 @@ Date(1900,12,30)
 
 >> AsType(ParseJSON("""1900-12-31T24:59:59.1002Z"""), DateTime)
 Error({Kind:ErrorKind.InvalidArgument})
+
+>> AsType(ParseJSON("""2000-12-31T23:59:59.999Z"""), DateTime) = DateTimeValue("2000-12-31T15:59:59.999")
+true
+
+>> AsType(ParseJSON("""2000-12-31T15:59:59.999"""), DateTime) = DateTimeValue("2000-12-31T23:59:59.999Z")
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/AsType_UO_TimeZone_Seattle.txt
@@ -20,6 +20,3 @@ Error({Kind:ErrorKind.InvalidArgument})
 
 >> AsType(ParseJSON("""2000-12-31T23:59:59.999Z"""), DateTime) = DateTimeValue("2000-12-31T15:59:59.999")
 true
-
->> AsType(ParseJSON("""2000-12-31T15:59:59.999"""), DateTime) = DateTimeValue("2000-12-31T23:59:59.999Z")
-true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON.txt
@@ -29,12 +29,6 @@ Date(1984,1,1)
 >> ParseJSON("""1900-12-31T23:59:59.999""", Date)
 Date(1900,12,31)
 
->> ParseJSON("""2008-01-01T12:12:12.100""", DateTime) = DateTimeValue("2008-01-01T12:12:12.100Z")
-true
-
->> ParseJSON("""1900-12-31""", DateTime) = DateTimeValue("1900-12-31T00:00:00Z")
-true
-
 >> ParseJSON("""11:59:59.999""", Time)
 Time(11,59,59,999)
 

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
@@ -11,3 +11,9 @@ DateTime(1900,12,30,16,0,0,0)
 
 >> DateValue(ParseJSON("""1900-12-31T00:00:00.000Z""", Dynamic))
 Date(1900,12,30)
+
+>> ParseJSON("""2008-01-01T04:12:12.100""", DateTime) = DateTimeValue("2008-01-01T12:12:12.100Z")
+true
+
+>> ParseJSON("""2008-01-01T20:12:12.100Z""", DateTime) = DateTimeValue("2008-01-01T12:12:12.100")
+true

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/TypedParseJSON_TimeZone_Seattle.txt
@@ -12,8 +12,5 @@ DateTime(1900,12,30,16,0,0,0)
 >> DateValue(ParseJSON("""1900-12-31T00:00:00.000Z""", Dynamic))
 Date(1900,12,30)
 
->> ParseJSON("""2008-01-01T04:12:12.100""", DateTime) = DateTimeValue("2008-01-01T12:12:12.100Z")
-true
-
 >> ParseJSON("""2008-01-01T20:12:12.100Z""", DateTime) = DateTimeValue("2008-01-01T12:12:12.100")
 true

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/AsTypeIsTypeParseJSONTests.cs
@@ -50,9 +50,7 @@ namespace Microsoft.PowerFx.Json.Tests
             CheckIsTypeAsTypeParseJSON(engine, "\"\"\"HelloWorld\"\"\"", "Text", "HelloWorld");
             CheckIsTypeAsTypeParseJSON(engine, "\"\"\"2000-01-01\"\"\"", "Date", new DateTime(2000, 1, 1));
 
-            // DateTime strings without an offset are parsed as UTC (matches Power Automate /
-            // Logic Apps semantics) and then converted to the runner's time zone for storage.
-            var expectedDateTime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2000, 1, 1, 0, 0, 1, 100, DateTimeKind.Utc), TimeZoneInfo.Local);
+            var expectedDateTime = new DateTime(2000, 1, 1, 0, 0, 1, 100, DateTimeKind.Local);
             CheckIsTypeAsTypeParseJSON(engine, "\"\"\"2000-01-01T00:00:01.100\"\"\"", "DateTime", expectedDateTime);
             CheckIsTypeAsTypeParseJSON(engine, "\"true\"", "Boolean", true);
             CheckIsTypeAsTypeParseJSON(engine, "\"false\"", "Boolean", false);

--- a/src/tests/Microsoft.PowerFx.Json.Tests.Shared/ParseJSONTests.cs
+++ b/src/tests/Microsoft.PowerFx.Json.Tests.Shared/ParseJSONTests.cs
@@ -671,18 +671,18 @@ namespace Microsoft.PowerFx.Json.Tests
         }
 
         [Fact]
-        public void ParseDates_NoOffsetAssumedUtc()
+        public void ParseDates_NoOffsetAssumedLocal()
         {
-            // Input with no offset should be treated as UTC (AssumeUniversal), matching
-            // Power Automate / Logic Apps behavior rather than the host's local timezone.
+            // Input with no offset should be treated as local (AssumeLocal), matching
+            // other functions in the platform such as DateTimeValue.
             using var doc = JsonDocument.Parse("\"2024-10-02T23:13:50\"");
             var je = doc.RootElement;
 
             var value = FormulaValueJSON.ParseDate(je, FormulaType.DateTime, (datetime) => FormulaValue.New(datetime));
 
             var dtValue = Assert.IsType<DateTimeValue>(value);
-            var dt = dtValue.GetConvertedValue(TimeZoneInfo.Utc);
-            Assert.Equal(new DateTime(2024, 10, 2, 23, 13, 50, DateTimeKind.Utc), dt);
+            var dt = dtValue.GetConvertedValue(TimeZoneInfo.Local);
+            Assert.Equal(new DateTime(2024, 10, 2, 23, 13, 50, DateTimeKind.Local), dt);
         }
     }
 }


### PR DESCRIPTION
We had a recent change that broke the assumption that date / time values are local by default. This fixes that assumption.