### PR TITLE
Fix IsType function to not return error for valid untyped input

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Json/Functions/IsTypeFunction_UOImpl.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/Functions/IsTypeFunction_UOImpl.cs
@@ -21,17 +21,32 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             var irContext = IRContext.NotInSource(FormulaType.UntypedObject);
             var typeString = (StringValue)args[1];
 
-            try 
+            if (args[0] is ErrorValue)
+            {
+                return args[0];
+            }
+
+            if (args[0] is BlankValue)
+            {
+                // Blank is not of the given type
+                return BooleanValue.New(false);
+            }
+
+            try
             {
                 var fv = JSONFunctionUtils.ConvertUntypedObjectToFormulaValue(irContext, args[0], typeString, timezoneInfo);
-                if (fv is BlankValue || fv is ErrorValue)
+
+                if (fv is ErrorValue)
+                {
+                    return BooleanValue.New(false);
+                }
+
+                if (fv is BlankValue)
                 {
                     return fv;
                 }
-                else
-                {
-                    return BooleanValue.New(true);
-                }
+
+                return BooleanValue.New(true);
             }
             catch
             {

--- a/src/libraries/Microsoft.PowerFx.Json/Functions/IsTypeFunction_UOImpl.cs
+++ b/src/libraries/Microsoft.PowerFx.Json/Functions/IsTypeFunction_UOImpl.cs
@@ -26,24 +26,13 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
                 return args[0];
             }
 
-            if (args[0] is BlankValue)
-            {
-                // Blank is not of the given type
-                return BooleanValue.New(false);
-            }
-
             try
             {
                 var fv = JSONFunctionUtils.ConvertUntypedObjectToFormulaValue(irContext, args[0], typeString, timezoneInfo);
 
-                if (fv is ErrorValue)
+                if (fv is ErrorValue || fv is BlankValue)
                 {
                     return BooleanValue.New(false);
-                }
-
-                if (fv is BlankValue)
-                {
-                    return fv;
                 }
 
                 return BooleanValue.New(true);

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/ExpressionTestCases/IsType_UO.txt
@@ -88,7 +88,7 @@ false
 true
 
 >> IsType(ParseJSON("""1900-12-31T24:59:59.1002Z"""), DateTime)
-Error({Kind:ErrorKind.InvalidArgument})
+false
 
 >> IsType(ParseJSON("""24:59:59.12345678"""), Time)
 false
@@ -120,8 +120,27 @@ Errors: Error 28-29: Unsupported type 'Color' in type argument.
 >> IsType(If(1/0 > 1, ParseJSON("42")), Number)
 Error({Kind:ErrorKind.Div0})
 
+// IsType(blank, type) should always return false for any valid type, since the first argument is not a valid value of any type.
 >> IsType(ParseJSON(Blank()), Number)
-Blank()
+false
+
+>> IsType(If(1<0, ParseJSON("42")), Number)
+false
+
+>> IsType(If(1<0, ParseJSON("true")), Boolean)
+false
+
+>> IsType(If(1<0, ParseJSON("""Hello""")), Text)
+false
+
+>> IsType(If(1<0, ParseJSON("""2026-01-01""")), Date)
+false
+
+>> IsType(If(1<0, ParseJSON("""2026-01-01T12:34:56Z""")), DateTime)
+false
+
+>> IsType(If(1<0, ParseJSON("{""a"": 5}")), Type({a: Number}))
+false
 
 >> IsType(ParseJSON("42"), Blank())
 Errors: Error 24-31: Invalid argument 'Blank()'. Expected valid type name or inline type expression.


### PR DESCRIPTION
A recent change made an update on the untyped version of the IsType function where it can return an error for a valid untyped (dynamic) input. If given a non-blank, non-error dynamic input and a valid type, IsType should only return true or false. This fixes it.