### PR TITLE
Preserve incomplete attributes for IntelliSense

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Parser/Attribute.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/Attribute.cs
@@ -17,12 +17,24 @@ namespace Microsoft.PowerFx.Core.Parser
 
         public readonly Token OpenBracket;
 
-        public Attribute(IdentToken name, IReadOnlyList<Token> argumentTokens, Token openBracket)
+        // Argument-list and closing tokens, when present. Preserved so consumers (such as
+        // IntelliSense) can locate attribute regions even when the argument list is empty or
+        // the closing delimiters have not been typed yet.
+        public readonly Token OpenParen;
+
+        public readonly Token CloseParen;
+
+        public readonly Token CloseBracket;
+
+        public Attribute(IdentToken name, IReadOnlyList<Token> argumentTokens, Token openBracket, Token openParen = null, Token closeParen = null, Token closeBracket = null)
         {
             Name = name;
             Arguments = argumentTokens.Select(t => t is IdentToken ident ? ident.Name.Value : t.As<StrLitToken>().Value).ToList();
             ArgumentTokens = argumentTokens;
             OpenBracket = openBracket;
+            OpenParen = openParen;
+            CloseParen = closeParen;
+            CloseBracket = closeBracket;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseUserDefinitionResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseUserDefinitionResult.cs
@@ -35,9 +35,10 @@ namespace Microsoft.PowerFx.Core.Parser
         // This determination is not definitive, but if true, user definition errors should be returned instead of standard parse errors.
         internal bool DefinitionsLikely { get; }
 
-        // Attributes that were parsed but not attached to any UDF or named formula because no
-        // definition name followed them (e.g. the maker is still typing "[RecordLink("). Exposed
-        // so IntelliSense can offer suggestions for the attribute and its arguments.
+        // Attributes that were parsed but not attached to any UDF or named formula because the
+        // attribute group is incomplete, or no definition name followed it (e.g. the maker is
+        // still typing "[RecordLink("). Exposed so IntelliSense can offer suggestions for the
+        // attribute and its arguments.
         internal IEnumerable<Attribute> IncompleteAttributes { get; }
 
         public ParseUserDefinitionResult(IEnumerable<NamedFormula> namedFormulas, IEnumerable<UDF> uDFs, IEnumerable<DefinedType> definedTypes, IEnumerable<TexlError> errors, IEnumerable<CommentToken> comments, IEnumerable<UserDefinitionSourceInfo> userDefinitionSourceInfos, bool definitionsLikely, ITexlSource trailingTrivia = null, IEnumerable<Attribute> incompleteAttributes = null)

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/ParseUserDefinitionResult.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/ParseUserDefinitionResult.cs
@@ -35,7 +35,12 @@ namespace Microsoft.PowerFx.Core.Parser
         // This determination is not definitive, but if true, user definition errors should be returned instead of standard parse errors.
         internal bool DefinitionsLikely { get; }
 
-        public ParseUserDefinitionResult(IEnumerable<NamedFormula> namedFormulas, IEnumerable<UDF> uDFs, IEnumerable<DefinedType> definedTypes, IEnumerable<TexlError> errors, IEnumerable<CommentToken> comments, IEnumerable<UserDefinitionSourceInfo> userDefinitionSourceInfos, bool definitionsLikely, ITexlSource trailingTrivia = null)
+        // Attributes that were parsed but not attached to any UDF or named formula because no
+        // definition name followed them (e.g. the maker is still typing "[RecordLink("). Exposed
+        // so IntelliSense can offer suggestions for the attribute and its arguments.
+        internal IEnumerable<Attribute> IncompleteAttributes { get; }
+
+        public ParseUserDefinitionResult(IEnumerable<NamedFormula> namedFormulas, IEnumerable<UDF> uDFs, IEnumerable<DefinedType> definedTypes, IEnumerable<TexlError> errors, IEnumerable<CommentToken> comments, IEnumerable<UserDefinitionSourceInfo> userDefinitionSourceInfos, bool definitionsLikely, ITexlSource trailingTrivia = null, IEnumerable<Attribute> incompleteAttributes = null)
         {
             NamedFormulas = namedFormulas;
             UDFs = uDFs;
@@ -44,6 +49,7 @@ namespace Microsoft.PowerFx.Core.Parser
             UserDefinitionSourceInfos = userDefinitionSourceInfos;
             DefinitionsLikely = definitionsLikely;
             TrailingTrivia = trailingTrivia;
+            IncompleteAttributes = incompleteAttributes ?? Enumerable.Empty<Attribute>();
 
             if (errors?.Any() ?? false)
             {

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -227,7 +227,7 @@ namespace Microsoft.PowerFx.Core.Parser
             return new TypeLiteralNode(ref _idNext, parenOpen, expr, new SourceList(sourceList));
         }
 
-        private IReadOnlyList<Attribute> MaybeParseAttributes()
+        private IReadOnlyList<Attribute> MaybeParseAttributes(List<Attribute> incompleteAttributes)
         {
             var attributes = new List<Attribute>();
 
@@ -267,6 +267,10 @@ namespace Microsoft.PowerFx.Core.Parser
                         {
                             _curs.TokMove();
                             ParseTrivia();
+                            if (!CanConsumeAttributeArgumentAfterComma())
+                            {
+                                break;
+                            }
                         }
                         else
                         {
@@ -281,10 +285,30 @@ namespace Microsoft.PowerFx.Core.Parser
                 var closeBracket = TokEat(TokKind.BracketClose);
                 ParseTrivia();
 
-                attributes.Add(new Attribute(annotationName.As<IdentToken>(), argumentTokens, openBracket, openParen, closeParen, closeBracket));
+                var attribute = new Attribute(annotationName.As<IdentToken>(), argumentTokens, openBracket, openParen, closeParen, closeBracket);
+                attributes.Add(attribute);
+
+                if (closeBracket == null)
+                {
+                    PreserveIncompleteAttributes(attributes, incompleteAttributes);
+                    attributes.Clear();
+                    break;
+                }
             }
 
             return attributes;
+        }
+
+        private bool CanConsumeAttributeArgumentAfterComma()
+        {
+            if (_curs.TidCur != TokKind.StrLit && _curs.TidCur != TokKind.Ident)
+            {
+                return false;
+            }
+
+            var nextToken = _curs.TidPeek(PeekSkipTrivia(1));
+            return nextToken == TokKind.Comma ||
+                nextToken == TokKind.ParenClose;
         }
 
         private static void PreserveIncompleteAttributes(IReadOnlyList<Attribute> attributes, List<Attribute> incompleteAttributes)
@@ -307,10 +331,10 @@ namespace Microsoft.PowerFx.Core.Parser
             var declarationStart = 0;
             var index = 0;
 
-            // Attributes that were parsed but never attached to a definition because no UDF or
-            // named-formula name followed them. This happens while the maker is mid-typing
-            // (e.g. "[RecordLink("). Preserving them lets IntelliSense offer attribute/argument
-            // suggestions even though the statement is not yet a complete definition.
+            // Attributes that were parsed but never attached to a definition because the
+            // attribute group is incomplete, or no UDF or named-formula name followed them.
+            // Preserving them lets IntelliSense offer attribute/argument suggestions even
+            // though the statement is not yet a complete definition.
             var incompleteAttributes = new List<Attribute>();
 
             // Trivia after the last terminating semicolon; captured so FormatUserDefinitions
@@ -326,7 +350,7 @@ namespace Microsoft.PowerFx.Core.Parser
                 IReadOnlyList<Attribute> attributes = null;
                 if (_flagsMode.Peek().HasFlag(Flags.AllowAttributes))
                 {
-                    attributes = MaybeParseAttributes();
+                    attributes = MaybeParseAttributes(incompleteAttributes);
                 }
 
                 var thisIdentifier = TokEat(TokKind.Ident);
@@ -402,7 +426,7 @@ namespace Microsoft.PowerFx.Core.Parser
                 else if (_curs.TidCur == TokKind.Equ)
                 {
                     var equalToken = _curs.TokCur;
-                    
+
                     var declaration = script.Substring(declarationStart, _curs.TokCur.Span.Min - declarationStart);
                     _curs.TokMove();
                     definitionBeforeTrivia.Add(ParseTrivia());
@@ -431,8 +455,8 @@ namespace Microsoft.PowerFx.Core.Parser
                             CreateError(equalToken, TexlStrings.ErrNamedFormulaColonEqualRequired);
                             continue;
                         }
-                      
-                        definitionsLikely = true;                      
+
+                        definitionsLikely = true;
 
                         namedFormulas.Add(new NamedFormula(thisIdentifier.As<IdentToken>(), new Formula(result.GetCompleteSpan().GetFragment(script), result), _startingIndex, colonEqual: false, attributes));
                         userDefinitionSourceInfos.Add(new UserDefinitionSourceInfo(index++, UserDefinitionType.NamedFormula, thisIdentifier.As<IdentToken>(), declaration, new SourceList(definitionBeforeTrivia), GetExtraTriviaSourceList()));

--- a/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Parser/TexlParser.cs
@@ -248,9 +248,12 @@ namespace Microsoft.PowerFx.Core.Parser
                 ParseTrivia();
 
                 var argumentTokens = new List<Token>();
+                Token openParen = null;
+                Token closeParen = null;
 
                 if (_curs.TidCur == TokKind.ParenOpen)
                 {
+                    openParen = _curs.TokCur;
                     _curs.TokMove();
                     ParseTrivia();
 
@@ -271,17 +274,25 @@ namespace Microsoft.PowerFx.Core.Parser
                         }
                     }
 
-                    TokEat(TokKind.ParenClose);
+                    closeParen = TokEat(TokKind.ParenClose);
                     ParseTrivia();
                 }
 
-                TokEat(TokKind.BracketClose);
+                var closeBracket = TokEat(TokKind.BracketClose);
                 ParseTrivia();
 
-                attributes.Add(new Attribute(annotationName.As<IdentToken>(), argumentTokens, openBracket));
+                attributes.Add(new Attribute(annotationName.As<IdentToken>(), argumentTokens, openBracket, openParen, closeParen, closeBracket));
             }
 
             return attributes;
+        }
+
+        private static void PreserveIncompleteAttributes(IReadOnlyList<Attribute> attributes, List<Attribute> incompleteAttributes)
+        {
+            if (attributes != null && attributes.Count > 0)
+            {
+                incompleteAttributes.AddRange(attributes);
+            }
         }
 
         private ParseUserDefinitionResult ParseUDFsAndNamedFormulas(string script, ParserOptions parserOptions)
@@ -295,6 +306,12 @@ namespace Microsoft.PowerFx.Core.Parser
             var definitionBeforeTrivia = new List<ITexlSource>();
             var declarationStart = 0;
             var index = 0;
+
+            // Attributes that were parsed but never attached to a definition because no UDF or
+            // named-formula name followed them. This happens while the maker is mid-typing
+            // (e.g. "[RecordLink("). Preserving them lets IntelliSense offer attribute/argument
+            // suggestions even though the statement is not yet a complete definition.
+            var incompleteAttributes = new List<Attribute>();
 
             // Trivia after the last terminating semicolon; captured so FormatUserDefinitions
             // can emit trailing comments (issue #2997). Overwritten on each iteration so only
@@ -315,6 +332,7 @@ namespace Microsoft.PowerFx.Core.Parser
                 var thisIdentifier = TokEat(TokKind.Ident);
                 if (thisIdentifier == null)
                 {
+                    PreserveIncompleteAttributes(attributes, incompleteAttributes);
                     CreateError(_curs.TokCur, TexlStrings.ErrNamedFormula_MissingValue);
                     _curs.TokMove();
                     continue;
@@ -325,6 +343,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                 if (_curs.TidCur == TokKind.Semicolon)
                 {
+                    PreserveIncompleteAttributes(attributes, incompleteAttributes);
                     CreateError(thisIdentifier, TexlStrings.ErrNamedFormula_MissingValue);
                     _curs.TokMove();
                     continue;
@@ -339,6 +358,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                     if (_curs.TidCur == TokKind.Semicolon || _curs.TidCur == TokKind.Eof)
                     {
+                        PreserveIncompleteAttributes(attributes, incompleteAttributes);
                         CreateError(thisIdentifier, TexlStrings.ErrNamedType_MissingTypeExpression);
                     }
 
@@ -389,6 +409,7 @@ namespace Microsoft.PowerFx.Core.Parser
 
                     if (_curs.TidCur == TokKind.Semicolon || _curs.TidCur == TokKind.Eof)
                     {
+                        PreserveIncompleteAttributes(attributes, incompleteAttributes);
                         CreateError(thisIdentifier, TexlStrings.ErrNamedFormula_MissingValue);
                     }
 
@@ -447,6 +468,7 @@ namespace Microsoft.PowerFx.Core.Parser
                     var colonToken = TokEat(TokKind.Colon, addError: false);
                     if (colonToken == null)
                     {
+                        PreserveIncompleteAttributes(attributes, incompleteAttributes);
                         CreateError(_curs.TokCur, TexlStrings.ErrUDF_MissingReturnType);
                         userDefinitionSourceInfos.Add(new UserDefinitionSourceInfo(index++, UserDefinitionType.UDF, thisIdentifier.As<IdentToken>(), script.Substring(declarationStart, _curs.TokCur.Span.Min - declarationStart), new SourceList(definitionBeforeTrivia), GetExtraTriviaSourceList()));
                         _curs.TokMove();
@@ -553,12 +575,13 @@ namespace Microsoft.PowerFx.Core.Parser
                 else
                 {
                     // = or ( expected here
+                    PreserveIncompleteAttributes(attributes, incompleteAttributes);
                     ErrorTid(_curs.TokCur, TokKind.Equ);
                     MoveToNextUserDefinition();
                 }
             }
 
-            return new ParseUserDefinitionResult(namedFormulas, udfs, definedTypes, _errors, _comments, userDefinitionSourceInfos: userDefinitionSourceInfos, definitionsLikely, trailingTrivia: trailingTrivia);
+            return new ParseUserDefinitionResult(namedFormulas, udfs, definedTypes, _errors, _comments, userDefinitionSourceInfos: userDefinitionSourceInfos, definitionsLikely, trailingTrivia: trailingTrivia, incompleteAttributes: incompleteAttributes);
         }
 
         private SourceList GetExtraTriviaSourceList()

--- a/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Syntax/UserDefinitions.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerFx.Syntax
                         nameGroup.First().Attributes));
             }
 
-            return new ParseUserDefinitionResult(newFormulas, parsed.UDFs, parsed.DefinedTypes, errors, parsed.Comments, parsed.UserDefinitionSourceInfos, parsed.DefinitionsLikely, trailingTrivia: parsed.TrailingTrivia);
+            return new ParseUserDefinitionResult(newFormulas, parsed.UDFs, parsed.DefinedTypes, errors, parsed.Comments, parsed.UserDefinitionSourceInfos, parsed.DefinitionsLikely, trailingTrivia: parsed.TrailingTrivia, incompleteAttributes: parsed.IncompleteAttributes);
         }
 
         private Formula GetPartialCombinedFormula(string name, PartialOperationKind operationKind, IList<NamedFormula> formulas)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AttributeParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AttributeParserTests.cs
@@ -124,6 +124,129 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TestAnnotationDelimiterTokensCaptured()
+        {
+            var result = UserDefinitions.Parse(
+            @"
+                [MyAttr(someIdent)]
+                MyFunc(): Number = 1;
+            ", _parseOptions);
+
+            Assert.False(result.HasErrors);
+
+            var attribute = result.UDFs.First().Attributes[0];
+            Assert.NotNull(attribute.OpenParen);
+            Assert.Equal(TokKind.ParenOpen, attribute.OpenParen.Kind);
+            Assert.NotNull(attribute.CloseParen);
+            Assert.Equal(TokKind.ParenClose, attribute.CloseParen.Kind);
+            Assert.NotNull(attribute.CloseBracket);
+            Assert.Equal(TokKind.BracketClose, attribute.CloseBracket.Kind);
+        }
+
+        [Fact]
+        public void TestAnnotationWithoutArgsHasNoParenTokens()
+        {
+            var result = UserDefinitions.Parse(
+            @"
+                [SomeName]
+                Foo = 123;
+            ", _parseOptions);
+
+            Assert.False(result.HasErrors);
+            var attribute = result.NamedFormulas.First().Attributes[0];
+            Assert.Null(attribute.OpenParen);
+            Assert.Null(attribute.CloseParen);
+            Assert.NotNull(attribute.CloseBracket);
+        }
+
+        // While the maker is mid-typing an attribute (e.g. "[RecordLink(") no definition name
+        // follows, so the parser previously discarded the attribute entirely. It is now surfaced
+        // through ParseUserDefinitionResult.IncompleteAttributes so IntelliSense can react.
+        [Fact]
+        public void TestIncompleteAttribute_OpenArgList()
+        {
+            var result = UserDefinitions.Parse("[RecordLink(", _parseOptions);
+
+            Assert.Empty(result.UDFs);
+            Assert.Empty(result.NamedFormulas);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("RecordLink", attribute.Name.Name.Value);
+            Assert.NotNull(attribute.OpenParen);
+            Assert.Equal(TokKind.ParenOpen, attribute.OpenParen.Kind);
+            Assert.Null(attribute.CloseParen);
+            Assert.Null(attribute.CloseBracket);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_EmptyArgList()
+        {
+            var result = UserDefinitions.Parse("[RecordLink()]", _parseOptions);
+
+            Assert.Empty(result.UDFs);
+            Assert.Empty(result.NamedFormulas);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("RecordLink", attribute.Name.Name.Value);
+            Assert.Empty(attribute.Arguments);
+            Assert.NotNull(attribute.OpenParen);
+            Assert.NotNull(attribute.CloseParen);
+            Assert.NotNull(attribute.CloseBracket);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_NameOnly()
+        {
+            var result = UserDefinitions.Parse("[RecordLink", _parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("RecordLink", attribute.Name.Name.Value);
+            Assert.Null(attribute.OpenParen);
+            Assert.Null(attribute.CloseParen);
+            Assert.Null(attribute.CloseBracket);
+        }
+
+        [Theory]
+        [InlineData("[RecordLink()] OpenAccount")]
+        [InlineData("[RecordLink()] OpenAccount()")]
+        [InlineData("[RecordLink()] Foo =")]
+        [InlineData("[RecordLink()] Foo :=")]
+        [InlineData("[RecordLink()] Foo;")]
+        public void TestIncompleteAttribute_IncompleteDefinitionShape(string script)
+        {
+            var result = UserDefinitions.Parse(script, _parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("RecordLink", attribute.Name.Name.Value);
+            Assert.NotNull(attribute.OpenParen);
+            Assert.NotNull(attribute.CloseParen);
+            Assert.NotNull(attribute.CloseBracket);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_MultipleAttributes()
+        {
+            var result = UserDefinitions.Parse("[A][RecordLink()] OpenAccount", _parseOptions);
+
+            var attributes = result.IncompleteAttributes.ToList();
+            Assert.Equal(2, attributes.Count);
+            Assert.Equal("A", attributes[0].Name.Name.Value);
+            Assert.Equal("RecordLink", attributes[1].Name.Name.Value);
+        }
+
+        [Fact]
+        public void TestCompleteDefinitionHasNoIncompleteAttributes()
+        {
+            var result = UserDefinitions.Parse(
+            @"
+                [MyAttr(someIdent)]
+                MyFunc(): Number = 1;
+            ", _parseOptions);
+            Assert.False(result.HasErrors);
+            Assert.Empty(result.IncompleteAttributes);
+        }
+
+        [Fact]
         public void TestNFAttributeSingleKeyAnd()
         {
             var result = UserDefinitions.Parse(

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AttributeParserTests.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AttributeParserTests.cs
@@ -235,6 +235,210 @@ namespace Microsoft.PowerFx.Core.Tests
         }
 
         [Fact]
+        public void TestIncompleteAttribute_ResumesAtNextDefinition()
+        {
+            var parseOptions = new ParserOptions() { AllowAttributes = true, AllowEqualOnlyNamedFormulas = true, AllowsSideEffects = true };
+            var result = UserDefinitions.Parse(
+            @"
+                Foo = 123;
+
+                [Record
+                Bar(): Void = { Notify(""Abc"") };
+
+                Baz = ""Valid?"";
+            ", parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("Record", attribute.Name.Name.Value);
+            Assert.Null(attribute.CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+
+            var udf = Assert.Single(result.UDFs);
+            Assert.Equal("Bar", udf.Ident.Name.Value);
+            Assert.Empty(udf.Attributes);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_ResumesBeforeDefinitionWithBracketedBody()
+        {
+            var parseOptions = new ParserOptions() { AllowAttributes = true, AllowEqualOnlyNamedFormulas = true, AllowsSideEffects = true };
+            var result = UserDefinitions.Parse(
+            @"
+                Foo = 123;
+
+                [Record
+                Bar(): Void = { Notify(""Abc""); CountRows([1, 2]) };
+
+                Baz = ""Valid?"";
+            ", parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("Record", attribute.Name.Name.Value);
+            Assert.Null(attribute.CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+
+            var udf = Assert.Single(result.UDFs);
+            Assert.Equal("Bar", udf.Ident.Name.Value);
+            Assert.Empty(udf.Attributes);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_ResumesAtNextNamedFormula()
+        {
+            var result = UserDefinitions.Parse(
+            @"
+                Foo = 123;
+
+                [Record
+                Baz = ""Valid?"";
+            ", _parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("Record", attribute.Name.Name.Value);
+            Assert.Null(attribute.CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+            Assert.Empty(formulas[1].Attributes);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_MissingCloseBracketAfterClosedArgsResumesAtNextDefinition()
+        {
+            var parseOptions = new ParserOptions() { AllowAttributes = true, AllowEqualOnlyNamedFormulas = true, AllowsSideEffects = true };
+            var result = UserDefinitions.Parse(
+            @"
+                Foo = 123;
+
+                [RecordLink()
+                Bar(): Void = { Notify(""Abc"") };
+
+                Baz = ""Valid?"";
+            ", parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("RecordLink", attribute.Name.Name.Value);
+            Assert.NotNull(attribute.OpenParen);
+            Assert.NotNull(attribute.CloseParen);
+            Assert.Null(attribute.CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+
+            var udf = Assert.Single(result.UDFs);
+            Assert.Equal("Bar", udf.Ident.Name.Value);
+            Assert.Empty(udf.Attributes);
+        }
+
+        [Theory]
+        [InlineData("[RecordLink(foo")]
+        [InlineData("[RecordLink(foo,")]
+        public void TestIncompleteAttribute_PartialArgsResumeAtNextDefinition(string incompleteAttribute)
+        {
+            var parseOptions = new ParserOptions() { AllowAttributes = true, AllowEqualOnlyNamedFormulas = true, AllowsSideEffects = true };
+            var result = UserDefinitions.Parse(
+            $@"
+                Foo = 123;
+
+                {incompleteAttribute}
+                Bar(): Void = {{ Notify(""Abc"") }};
+
+                Baz = ""Valid?"";
+            ", parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("RecordLink", attribute.Name.Name.Value);
+            var argument = Assert.Single(attribute.Arguments);
+            Assert.Equal("foo", argument);
+            Assert.NotNull(attribute.OpenParen);
+            Assert.Null(attribute.CloseParen);
+            Assert.Null(attribute.CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+
+            var udf = Assert.Single(result.UDFs);
+            Assert.Equal("Bar", udf.Ident.Name.Value);
+            Assert.Empty(udf.Attributes);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_LaterIncompleteAttributeDoesNotAttachEarlierAttributeToNextDefinition()
+        {
+            var parseOptions = new ParserOptions() { AllowAttributes = true, AllowEqualOnlyNamedFormulas = true, AllowsSideEffects = true };
+            var result = UserDefinitions.Parse(
+            @"
+                Foo = 123;
+
+                [A(""arg"")][Record
+                Bar(): Void = { Notify(""Abc"") };
+
+                Baz = ""Valid?"";
+            ", parseOptions);
+
+            var attributes = result.IncompleteAttributes.ToList();
+            Assert.Equal(2, attributes.Count);
+            Assert.Equal("A", attributes[0].Name.Name.Value);
+            var firstAttributeArgument = Assert.Single(attributes[0].Arguments);
+            Assert.Equal("arg", firstAttributeArgument);
+            Assert.NotNull(attributes[0].CloseBracket);
+            Assert.Equal("Record", attributes[1].Name.Name.Value);
+            Assert.Null(attributes[1].CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+
+            var udf = Assert.Single(result.UDFs);
+            Assert.Equal("Bar", udf.Ident.Name.Value);
+            Assert.Empty(udf.Attributes);
+        }
+
+        [Fact]
+        public void TestIncompleteAttribute_ResumesBeforeDefinitionWithBracketedStringsAndCommentsInBody()
+        {
+            var parseOptions = new ParserOptions() { AllowAttributes = true, AllowEqualOnlyNamedFormulas = true, AllowsSideEffects = true };
+            var result = UserDefinitions.Parse(
+            @"
+                Foo = 123;
+
+                [Record
+                Bar(): Void = { Notify(""[""); // ]
+                    Notify(""]"") };
+
+                Baz = ""Valid?"";
+            ", parseOptions);
+
+            var attribute = Assert.Single(result.IncompleteAttributes);
+            Assert.Equal("Record", attribute.Name.Name.Value);
+            Assert.Null(attribute.CloseBracket);
+
+            var formulas = result.NamedFormulas.ToList();
+            Assert.Equal(2, formulas.Count);
+            Assert.Equal("Foo", formulas[0].Ident.Name.Value);
+            Assert.Equal("Baz", formulas[1].Ident.Name.Value);
+
+            var udf = Assert.Single(result.UDFs);
+            Assert.Equal("Bar", udf.Ident.Name.Value);
+            Assert.Empty(udf.Attributes);
+        }
+
+        [Fact]
         public void TestCompleteDefinitionHasNoIncompleteAttributes()
         {
             var result = UserDefinitions.Parse(


### PR DESCRIPTION
## Summary
- Preserve parsed attributes that are not yet attached to a UDF or named formula so hosts can provide IntelliSense while makers are mid-typing attribute arguments, e.g. `[RecordLink(`.
- Capture attribute delimiter tokens (`OpenParen`, `CloseParen`, `CloseBracket`) so consumers can compute parser-backed replacement spans for `[RecordLink(` and `[RecordLink()]` without raw script scanning.
- Preserve `IncompleteAttributes` through Partial-attribute post-processing.


## Validation
- `dotnet test tests\.Net7.0\Microsoft.PowerFx.Core.Tests\Microsoft.PowerFx.Core.Tests.csproj --filter "FullyQualifiedName~AttributeParserTests" --nologo -v minimal`