### PR TITLE
Mark data-backed record variables async

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BindInfo/NameLookupInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BindInfo/NameLookupInfo.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Binding.BindInfo
             DisplayName = displayName;
 
             // Any connectedDataSourceInfo or option set or view needs to be accessed asynchronously to allow data to be loaded.
-            IsAsync = Data is IExternalTabularDataSource || Kind == BindKind.OptionSet || Kind == BindKind.View || isAsync || TypeRequiresAsync(kind, type, data);
+            IsAsync = Data is IExternalTabularDataSource || Kind == BindKind.OptionSet || Kind == BindKind.View || isAsync;
         }
 
         public bool TryToSymbolEntry(out SymbolEntry x)
@@ -52,7 +52,7 @@ namespace Microsoft.PowerFx.Core.Binding.BindInfo
                 x = new SymbolEntry
                 {
                     Name = ns.Name,
-                    DisplayName = this.DisplayName,                
+                    DisplayName = this.DisplayName,
                     Properties = ns.Props,
                     Type = FormulaType.Build(this.Type),
                     Slot = ns
@@ -62,46 +62,6 @@ namespace Microsoft.PowerFx.Core.Binding.BindInfo
 
             x = null;
             return false;
-        }
-
-        private static bool TypeRequiresAsync(BindKind kind, DType type, object data)
-        {
-            Contracts.AssertValid(type);
-
-            if (!IsVariableBinding(kind, data))
-            {
-                return false;
-            }
-
-            if (!type.IsRecord)
-            {
-                return false;
-            }
-
-            foreach (var dataSource in type.AssociatedDataSources)
-            {
-                if (dataSource.RequiresAsync)
-                {
-                    return true;
-                }
-            }
-
-            return type.HasExpandInfo && type.ExpandInfo?.ParentDataSource?.RequiresAsync == true;
-        }
-
-        private static bool IsVariableBinding(BindKind kind, object data)
-        {
-            if (kind == BindKind.ScopeVariable)
-            {
-                return true;
-            }
-
-            if (kind != BindKind.PowerFxResolvedObject || data is not NameSymbol nameSymbol)
-            {
-                return false;
-            }
-
-            return nameSymbol.Owner is not Microsoft.PowerFx.SymbolTableOverRecordType;
         }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/BindInfo/NameLookupInfo.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/BindInfo/NameLookupInfo.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerFx.Core.Binding.BindInfo
             DisplayName = displayName;
 
             // Any connectedDataSourceInfo or option set or view needs to be accessed asynchronously to allow data to be loaded.
-            IsAsync = Data is IExternalTabularDataSource || Kind == BindKind.OptionSet || Kind == BindKind.View || isAsync;
+            IsAsync = Data is IExternalTabularDataSource || Kind == BindKind.OptionSet || Kind == BindKind.View || isAsync || TypeRequiresAsync(kind, type, data);
         }
 
         public bool TryToSymbolEntry(out SymbolEntry x)
@@ -62,6 +62,46 @@ namespace Microsoft.PowerFx.Core.Binding.BindInfo
 
             x = null;
             return false;
-        }            
+        }
+
+        private static bool TypeRequiresAsync(BindKind kind, DType type, object data)
+        {
+            Contracts.AssertValid(type);
+
+            if (!IsVariableBinding(kind, data))
+            {
+                return false;
+            }
+
+            if (!type.IsRecord)
+            {
+                return false;
+            }
+
+            foreach (var dataSource in type.AssociatedDataSources)
+            {
+                if (dataSource.RequiresAsync)
+                {
+                    return true;
+                }
+            }
+
+            return type.HasExpandInfo && type.ExpandInfo?.ParentDataSource?.RequiresAsync == true;
+        }
+
+        private static bool IsVariableBinding(BindKind kind, object data)
+        {
+            if (kind == BindKind.ScopeVariable)
+            {
+                return true;
+            }
+
+            if (kind != BindKind.PowerFxResolvedObject || data is not NameSymbol nameSymbol)
+            {
+                return false;
+            }
+
+            return nameSymbol.Owner is not Microsoft.PowerFx.SymbolTableOverRecordType;
+        }
     }
 }

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -2584,12 +2584,12 @@ namespace Microsoft.PowerFx.Core.Binding
 
             // Binding TypeLiteralNode from anywhere other than valid type context should be an error.
             // This ensures that binding of unintended use of TypeLiteralNode eg: "If(Type(Boolean), 1, 2)" will result in an error.
-            // VisitType method is used to resolve the type of TypeLiteralNode from valid context. 
+            // VisitType method is used to resolve the type of TypeLiteralNode from valid context.
             public override void Visit(TypeLiteralNode node)
             {
                 AssertValid();
                 Contracts.AssertValue(node);
-                
+
                 _txb.SetType(node, DType.Error);
                 _txb.ErrorContainer.Error(node, TexlStrings.ErrTypeFunction_UnsupportedUsage);
             }
@@ -2898,7 +2898,7 @@ namespace Microsoft.PowerFx.Core.Binding
                     return;
                 }
 
-                // We have an allowlist of kinds permitted in simple expressions, all of which should be Sync. 
+                // We have an allowlist of kinds permitted in simple expressions, all of which should be Sync.
                 // The IsAsync check is just to be sure we're not introducing async
                 // if things are added to the set of valid kinds in the future.
                 // As the main point of the "Simple Expression" constraint is to ensure certain expressions are sync
@@ -3055,8 +3055,8 @@ namespace Microsoft.PowerFx.Core.Binding
                     }
                 }
 
-                if (_txb.BindingConfig.MarkAsAsyncOnLazilyLoadedControlRef && 
-                    lookupType.IsControl && 
+                if (_txb.BindingConfig.MarkAsAsyncOnLazilyLoadedControlRef &&
+                    lookupType.IsControl &&
                     lookupInfo.Data is IExternalControl control &&
                     !control.IsAppGlobalControl)
                 {
@@ -3788,12 +3788,9 @@ namespace Microsoft.PowerFx.Core.Binding
                 _txb.SetIsUnliftable(node, _txb.IsUnliftable(node.Left));
             }
 
-            /*
-             * If Rhs is accessing optionset, data source should be accessed async...
-             */
-
             private bool ShouldFlagDottedOptionSetAccessAsAsync(DottedNameNode node, DType typeRhs)
             {
+                // Data-backed option-set fields can require async loading when accessed from a record producer that can cross the data-source boundary.
                 if (typeRhs.Kind != DKind.OptionSetValue ||
                     !typeRhs.AssociatedDataSources.Any(ds => ds.RequiresAsync))
                 {
@@ -3802,9 +3799,6 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 return IsAsyncRecordProducer(node.Left);
             }
-
-            /*
-             * ... but check this isn't a constant, ThisRecord, As,              */
 
             private bool IsAsyncRecordProducer(TexlNode node)
             {
@@ -3918,9 +3912,9 @@ namespace Microsoft.PowerFx.Core.Binding
                 {
                     // Expands reached via a different path should have a different relatedentitypath.
                     // If we found an expand in the cache but it's not accessed via the same relationship
-                    // we need to create a different expand info but with the same type. 
+                    // we need to create a different expand info but with the same type.
                     // DType.Clone doesn't clone expand info, so we force that with CopyExpandInfo,
-                    // because that sadly mutates expand info on what should otherwise be an immutable dtype. 
+                    // because that sadly mutates expand info on what should otherwise be an immutable dtype.
                     type = DType.CopyExpandInfo(type.Clone(), type);
                     type.ExpandInfo.UpdateEntityInfo(expandEntityInfo.ParentDataSource, relatedEntityPath);
                 }
@@ -4204,9 +4198,9 @@ namespace Microsoft.PowerFx.Core.Binding
                         // Behavior only component properties should be treated as stateful.
                         hasSideEffects |= infoTexlFunction.IsBehaviorOnly;
 
-                        // At the moment, we're going to treat all invocations of component scoped property functions as stateful. 
+                        // At the moment, we're going to treat all invocations of component scoped property functions as stateful.
                         // This ensures that we don't lift these function invocations in loops, and that they are re-evaluated every time they are called,
-                        // which is always correct, although less efficient in some cases. 
+                        // which is always correct, although less efficient in some cases.
                         isStateFul |= true;
                     }
                     else

--- a/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Binding/Binder.cs
@@ -3711,6 +3711,11 @@ namespace Microsoft.PowerFx.Core.Binding
                 }
                 else if (leftType.IsRecord)
                 {
+                    if (ShouldFlagDottedOptionSetAccessAsAsync(node, typeRhs))
+                    {
+                        _txb.FlagPathAsAsync(node);
+                    }
+
                     // ![id:type, ...] . id --> type
                     _txb.SetType(node, typeRhs);
                 }
@@ -3781,6 +3786,61 @@ namespace Microsoft.PowerFx.Core.Binding
 
                 _txb.AddVolatileVariables(node, _txb.GetVolatileVariables(node.Left));
                 _txb.SetIsUnliftable(node, _txb.IsUnliftable(node.Left));
+            }
+
+            /*
+             * If Rhs is accessing optionset, data source should be accessed async...
+             */
+
+            private bool ShouldFlagDottedOptionSetAccessAsAsync(DottedNameNode node, DType typeRhs)
+            {
+                if (typeRhs.Kind != DKind.OptionSetValue ||
+                    !typeRhs.AssociatedDataSources.Any(ds => ds.RequiresAsync))
+                {
+                    return false;
+                }
+
+                return IsAsyncRecordProducer(node.Left);
+            }
+
+            /*
+             * ... but check this isn't a constant, ThisRecord, As,              */
+
+            private bool IsAsyncRecordProducer(TexlNode node)
+            {
+                if (_txb.IsAsync(node))
+                {
+                    return true;
+                }
+
+                if (node is FirstNameNode firstNameNode)
+                {
+                    return IsVariableBackedRecord(_txb.GetInfo(firstNameNode));
+                }
+
+                if (node is DottedNameNode dottedNameNode)
+                {
+                    return IsAsyncRecordProducer(dottedNameNode.Left);
+                }
+
+                if (node is CallNode callNode)
+                {
+                    foreach (var child in callNode.Args.Children)
+                    {
+                        if (_txb.GetType(child).IsRecord && IsAsyncRecordProducer(child))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            private static bool IsVariableBackedRecord(FirstNameInfo firstNameInfo)
+            {
+                return firstNameInfo?.Kind == BindKind.ScopeVariable ||
+                    (firstNameInfo?.Kind == BindKind.PowerFxResolvedObject && firstNameInfo.Data is NameSymbol);
             }
 
             private (IExternalControl controlInfo, bool isIndirectPropertyUsage) GetLHSControlInfo(DottedNameNode node)

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDVEntity.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDVEntity.cs
@@ -69,7 +69,8 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
                 accountsType, 
                 keyColumns: new[] { "accountid" },
                 selectableColumns: new[] { "name", "address1_city", "accountid", "address1_country", "address1_line1" },
-                hasCachedCountRows: hasCachedCountRows);
+                hasCachedCountRows: hasCachedCountRows,
+                requiresAsync: true);
             var displayNameMapping = dataSource.DisplayNameMapping;            
             displayNameMapping.Add("name", "Account Name");
             displayNameMapping.Add("address1_city", "Address 1: City");

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -160,13 +160,27 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         [InlineData("varAccount.donotallowemails", true)]
         [InlineData("Coalesce(varAccount.donotallowemails, DoNotAllowEmailsOptions.No)", true)]
         [InlineData("Coalesce(varAccount.donotallowemails, false)", true)]
+        [InlineData("varAccount.numericoption", true)]
+        [InlineData("Coalesce(varAccount.numericoption, NumericOptions.One)", true)]
+        [InlineData("Int(varAccount.numericoption)", true)]
+        [InlineData("varAccount.stringoption", true)]
+        [InlineData("Coalesce(varAccount.stringoption, StringOptions.Alpha)", true)]
+        [InlineData("Concatenate(varAccount.stringoption, \" suffix\")", true)]
         [InlineData("DoNotAllowEmailsOptions.No", false)]
         [InlineData("Coalesce(DoNotAllowEmailsOptions.No, false)", false)]
         [InlineData("plainAccount.donotallowemails", false)]
         [InlineData("Coalesce(plainAccount.donotallowemails, false)", false)]
+        [InlineData("plainAccount.numericoption", false)]
+        [InlineData("Int(plainAccount.numericoption)", false)]
+        [InlineData("plainAccount.stringoption", false)]
+        [InlineData("Concatenate(plainAccount.stringoption, \" suffix\")", false)]
         [InlineData("varAccountCopy.donotallowemails", true)]
+        [InlineData("varAccountCopy.numericoption", true)]
+        [InlineData("varAccountCopy.stringoption", true)]
         [InlineData("If(true, varAccountCopy, varAccount).donotallowemails", true)]
         [InlineData("Coalesce(If(true, varAccountCopy, varAccount).donotallowemails, false)", true)]
+        [InlineData("If(true, varAccountCopy, varAccount).numericoption", true)]
+        [InlineData("If(true, varAccountCopy, varAccount).stringoption", true)]
         public void DataBackedRecordOptionSetField(string expression, bool expectedIsAsync)
         {
             var boolOptionSet = new EnumSymbol(
@@ -180,8 +194,30 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
                 canCoerceFromBackingKind: true,
                 canCoerceToBackingKind: true);
 
+            var numericOptionSet = new EnumSymbol(
+                new DName("NumericOptions"),
+                DType.Number,
+                new Dictionary<string, object>
+                {
+                   { "One", 1 },
+                   { "Two", 2 },
+                },
+                canCoerceToBackingKind: true);
+
+            var stringOptionSet = new EnumSymbol(
+                new DName("StringOptions"),
+                DType.String,
+                new Dictionary<string, object>
+                {
+                   { "Alpha", "alpha" },
+                   { "Beta", "beta" },
+                },
+                canCoerceToBackingKind: true);
+
             var accountsType = AccountsTypeHelper.GetDType()
-                .Add(new TypedName(boolOptionSet.FormulaType._type, new DName("donotallowemails")));
+                .Add(new TypedName(boolOptionSet.FormulaType._type, new DName("donotallowemails")))
+                .Add(new TypedName(numericOptionSet.FormulaType._type, new DName("numericoption")))
+                .Add(new TypedName(stringOptionSet.FormulaType._type, new DName("stringoption")));
 
             var dataSource = new TestDataSource("Accounts", accountsType, requiresAsync: true);
             var dataBackedAccountsType = dataSource.Type;
@@ -193,6 +229,8 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
 
             var enumStoreBuilder = new EnumStoreBuilder();
             enumStoreBuilder.TestOnly_WithCustomEnum(boolOptionSet);
+            enumStoreBuilder.TestOnly_WithCustomEnum(numericOptionSet, append: true);
+            enumStoreBuilder.TestOnly_WithCustomEnum(stringOptionSet, append: true);
 
             var config = PowerFxConfig.BuildWithEnumStore(enumStoreBuilder, Features.PowerFxV1);
             config.SymbolTable = symbolTable;

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -12,6 +12,7 @@ using Microsoft.PowerFx.Core.Functions.Delegation;
 using Microsoft.PowerFx.Core.Tests.Helpers;
 using Microsoft.PowerFx.Core.Texl;
 using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Types.Enums;
 using Microsoft.PowerFx.Core.Utils;
 using Microsoft.PowerFx.Types;
 using Xunit;
@@ -154,13 +155,64 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         }
 
         [Theory]
-        [InlineData("Coalesce(varAccount.name, \"fallback\")")]
-        [InlineData("varAccount.name = \"Contoso\"")]
-        public void TestDataSourceBackedRecordVariablesAreAsync(string expression)
+        [InlineData("varAccount.'Account Name'", false)]
+        [InlineData("Coalesce(varAccount.'Account Name', \"fallback\")", false)]
+        [InlineData("varAccount.donotallowemails", true)]
+        [InlineData("Coalesce(varAccount.donotallowemails, DoNotAllowEmailsOptions.No)", true)]
+        [InlineData("Coalesce(varAccount.donotallowemails, false)", true)]
+        [InlineData("DoNotAllowEmailsOptions.No", false)]
+        [InlineData("Coalesce(DoNotAllowEmailsOptions.No, false)", false)]
+        [InlineData("plainAccount.donotallowemails", false)]
+        [InlineData("Coalesce(plainAccount.donotallowemails, false)", false)]
+        [InlineData("varAccountCopy.donotallowemails", true)]
+        [InlineData("If(true, varAccountCopy, varAccount).donotallowemails", true)]
+        [InlineData("Coalesce(If(true, varAccountCopy, varAccount).donotallowemails, false)", true)]
+        public void DataBackedRecordOptionSetField(string expression, bool expectedIsAsync)
+        {
+            var boolOptionSet = new EnumSymbol(
+                new DName("DoNotAllowEmailsOptions"),
+                DType.Boolean,
+                new Dictionary<string, object>
+                {
+                   { "Yes", true },
+                   { "No", false },
+                },
+                canCoerceFromBackingKind: true,
+                canCoerceToBackingKind: true);
+
+            var accountsType = AccountsTypeHelper.GetDType()
+                .Add(new TypedName(boolOptionSet.FormulaType._type, new DName("donotallowemails")));
+
+            var dataSource = new TestDataSource("Accounts", accountsType, requiresAsync: true);
+            var dataBackedAccountsType = dataSource.Type;
+
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddVariable("plainAccount", FormulaType.Build(accountsType.ToRecord()));
+            symbolTable.AddVariable("varAccount", FormulaType.Build(dataBackedAccountsType.ToRecord()));
+            symbolTable.AddVariable("varAccountCopy", FormulaType.Build(dataBackedAccountsType.ToRecord()));
+
+            var enumStoreBuilder = new EnumStoreBuilder();
+            enumStoreBuilder.TestOnly_WithCustomEnum(boolOptionSet);
+
+            var config = PowerFxConfig.BuildWithEnumStore(enumStoreBuilder, Features.PowerFxV1);
+            config.SymbolTable = symbolTable;
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+
+            Assert.True(result.IsSuccess);
+            Assert.Empty(result.Errors);
+            Assert.Equal(expectedIsAsync, result.Binding.IsAsync(result.Binding.Top));
+        }
+
+        [Theory]
+        [InlineData("varAccount.'Account Name'", false)]
+        [InlineData("Coalesce(varAccount.'Account Name', \"fallback\")", false)]
+        [InlineData("varAccount.address1_addresstypecode", true)]
+        public void DataBackedRecordExistingOptionSetField(string expression, bool expectedIsAsync)
         {
             var symbolTable = new DelegatableSymbolTable();
-            var accountRecordType = AccountsTypeHelper.GetDType().ToRecord();
-            symbolTable.AddVariable("varAccount", FormulaType.Build(accountRecordType));
+            symbolTable.AddVariable("varAccount", FormulaType.Build(AccountsTypeHelper.GetDType().ToRecord()));
 
             var config = new PowerFxConfig(Features.PowerFxV1)
             {
@@ -171,7 +223,8 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             var result = engine.Check(expression);
 
             Assert.True(result.IsSuccess);
-            Assert.True(result.Binding.IsAsync(result.Binding.Top));
+            Assert.Empty(result.Errors);
+            Assert.Equal(expectedIsAsync, result.Binding.IsAsync(result.Binding.Top));
         }
 
         [Fact]
@@ -210,6 +263,26 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             Assert.False(result.Binding.IsAsync(result.Binding.Top));
         }
 
+        [Theory]
+        [InlineData("Filter(localAccounts, IsBlank(ThisRecord.address1_addresstypecode))")]
+        [InlineData("Filter(localAccounts As account, IsBlank(account.address1_addresstypecode))")]
+        public void TestDataSourceBackedTableVariableRowScopeOptionSetFieldsRemainSync(string expression)
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddVariable("localAccounts", FormulaType.Build(AccountsTypeHelper.GetDType()));
+
+            var config = new PowerFxConfig(Features.PowerFxV1)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.Binding.IsAsync(result.Binding.Top));
+        }
+
         [Fact]
         public void TestExpandedDataSourceBackedTableVariablesRemainSync()
         {
@@ -235,9 +308,13 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
         }
 
         [Theory]
-        [InlineData("constAccount.name")]
-        [InlineData("hostAccount.name")]
-        public void TestDataSourceBackedResolvedObjectsRemainSyncUnlessVariables(string expression)
+        [InlineData("constAccount.'Account Name'")]
+        [InlineData("constAccount.address1_addresstypecode")]
+        [InlineData("hostAccount.'Account Name'")]
+        [InlineData("hostAccount.address1_addresstypecode")]
+        [InlineData("If(true, constAccount, constAccount).address1_addresstypecode")]
+        [InlineData("If(true, hostAccount, hostAccount).address1_addresstypecode")]
+        public void TestDataSourceBackedResolvedObjectsRemainSync(string expression)
         {
             var accountRecordType = (RecordType)FormulaType.Build(AccountsTypeHelper.GetDType().ToRecord());
             var accountRecordValue = FormulaValue.NewRecordFromFields(
@@ -256,8 +333,8 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             var result = engine.Check(expression);
 
             Assert.True(result.IsSuccess);
+            Assert.Empty(result.Errors);
             Assert.False(result.Binding.IsAsync(result.Binding.Top));
         }
-
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDelegationValidation.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/AssociatedDataSourcesTests/TestDelegationValidation.cs
@@ -152,5 +152,112 @@ namespace Microsoft.PowerFx.Core.Tests.AssociatedDataSourcesTests
             Assert.True(result.IsSuccess);
             Assert.Empty(result.Errors);
         }
+
+        [Theory]
+        [InlineData("Coalesce(varAccount.name, \"fallback\")")]
+        [InlineData("varAccount.name = \"Contoso\"")]
+        public void TestDataSourceBackedRecordVariablesAreAsync(string expression)
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            var accountRecordType = AccountsTypeHelper.GetDType().ToRecord();
+            symbolTable.AddVariable("varAccount", FormulaType.Build(accountRecordType));
+
+            var config = new PowerFxConfig(Features.PowerFxV1)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+
+            Assert.True(result.IsSuccess);
+            Assert.True(result.Binding.IsAsync(result.Binding.Top));
+        }
+
+        [Fact]
+        public void TestDataSourceBackedTableVariablesRemainSync()
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddVariable("localAccounts", FormulaType.Build(AccountsTypeHelper.GetDType()));
+
+            var config = new PowerFxConfig(Features.PowerFxV1)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check("CountRows(localAccounts)");
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.Binding.IsAsync(result.Binding.Top));
+        }
+
+        [Fact]
+        public void TestDataSourceBackedTableVariableRowScopeFieldsRemainSync()
+        {
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddVariable("localAccounts", FormulaType.Build(AccountsTypeHelper.GetDType()));
+
+            var config = new PowerFxConfig(Features.PowerFxV1)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check("Filter(localAccounts, name = \"Contoso\")");
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.Binding.IsAsync(result.Binding.Top));
+        }
+
+        [Fact]
+        public void TestExpandedDataSourceBackedTableVariablesRemainSync()
+        {
+            var accountsType = AccountsTypeHelper.GetDType();
+            var expandInfo = new TestExpandInfo(accountsType)
+            {
+                DataSource = new TestDataSource("Accounts", accountsType, requiresAsync: true)
+            };
+            var expandedAccountsTableType = DType.CopyExpandInfo(accountsType, DType.CreateExpandType(expandInfo));
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddVariable("expandedAccounts", FormulaType.Build(expandedAccountsTableType));
+
+            var config = new PowerFxConfig(Features.PowerFxV1)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check("CountRows(expandedAccounts)");
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.Binding.IsAsync(result.Binding.Top));
+        }
+
+        [Theory]
+        [InlineData("constAccount.name")]
+        [InlineData("hostAccount.name")]
+        public void TestDataSourceBackedResolvedObjectsRemainSyncUnlessVariables(string expression)
+        {
+            var accountRecordType = (RecordType)FormulaType.Build(AccountsTypeHelper.GetDType().ToRecord());
+            var accountRecordValue = FormulaValue.NewRecordFromFields(
+                accountRecordType,
+                new NamedValue("name", FormulaValue.New("Contoso")));
+            var symbolTable = new DelegatableSymbolTable();
+            symbolTable.AddConstant("constAccount", accountRecordValue);
+            symbolTable.AddHostObject("hostAccount", accountRecordType, _ => accountRecordValue);
+
+            var config = new PowerFxConfig(Features.PowerFxV1)
+            {
+                SymbolTable = symbolTable
+            };
+
+            var engine = new Engine(config);
+            var result = engine.Check(expression);
+
+            Assert.True(result.IsSuccess);
+            Assert.False(result.Binding.IsAsync(result.Binding.Top));
+        }
+
     }
 }

--- a/src/tests/Microsoft.PowerFx.Core.Tests.Shared/Helpers/TestTabularDataSource.cs
+++ b/src/tests/Microsoft.PowerFx.Core.Tests.Shared/Helpers/TestTabularDataSource.cs
@@ -176,8 +176,9 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
         private readonly HashSet<string> _selectableColumns;
         private readonly TabularDataQueryOptions _tabularDataQueryOptions;
         private readonly bool _hasCachedCountRows;
+        private readonly bool _requiresAsync;
 
-        internal TestDataSource(string name, DType schema, string[] keyColumns = null, IEnumerable<string> selectableColumns = null, bool hasCachedCountRows = false)
+        internal TestDataSource(string name, DType schema, string[] keyColumns = null, IEnumerable<string> selectableColumns = null, bool hasCachedCountRows = false, bool requiresAsync = false)
         {
             ExternalDataEntityMetadataProvider = new ExternalDataEntityMetadataProvider();
             Type = DType.AttachDataSourceInfo(schema, this);
@@ -187,6 +188,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
             _selectableColumns = new HashSet<string>(selectableColumns ?? Enumerable.Empty<string>());
             _tabularDataQueryOptions = new TabularDataQueryOptions(this);
             _hasCachedCountRows = hasCachedCountRows;
+            _requiresAsync = requiresAsync;
         }
 
         public string Name { get; }
@@ -197,7 +199,7 @@ namespace Microsoft.PowerFx.Core.Tests.Helpers
 
         public virtual bool IsDelegatable => throw new NotImplementedException();
 
-        public bool RequiresAsync => throw new NotImplementedException();
+        public bool RequiresAsync => _requiresAsync;
 
         public IExternalDataEntityMetadataProvider DataEntityMetadataProvider => ExternalDataEntityMetadataProvider;
 


### PR DESCRIPTION
Assume a case where
App.OnStart= Set(varAccount, First(Accounts)
Toggle1.Default=Coalesce(varAccount.'Option set', false)

The emitted `Rule.IsAsync` was false because pfx interpreted `varAccount.'Option set'` as a synchronous variable lookup, which depends on the datasource `Accounts`. As line 44 in NameLookupInfo.cs states, they should have been accessed async, hence Rule.IsAsync should have been true. 

This caused issues in Powerapps. Emitted rule had `IsAsync: False`, so it translated that as synchronous js code. But the argument was actually async, which meant we were passing a `Promise` to a sync js function. 
