### PR TITLE
Implement Update function (Issue #1000)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Localization/Strings.cs
@@ -531,6 +531,12 @@ namespace Microsoft.PowerFx.Core.Localization
         public static StringGetter RemoveDataSourceArg = (b) => StringResources.Get("RemoveDataSourceArg", b);
         public static StringGetter RemoveRecordsArg = (b) => StringResources.Get("RemoveRecordsArg", b);
 
+        public static StringGetter AboutUpdate = (b) => StringResources.Get("AboutUpdate", b);
+        public static StringGetter UpdateArg_Source = (b) => StringResources.Get("UpdateArg_Source", b);
+        public static StringGetter UpdateArg_Record = (b) => StringResources.Get("UpdateArg_Record", b);
+        public static StringGetter UpdateArg_Update = (b) => StringResources.Get("UpdateArg_Update", b);
+        public static StringGetter UpdateArg_RemoveFlags = (b) => StringResources.Get("UpdateArg_RemoveFlags", b);
+
         public static StringGetter AboutDec2Hex = (b) => StringResources.Get("AboutDec2Hex", b);
         public static StringGetter Dec2HexArg1 = (b) => StringResources.Get("Dec2HexArg1", b);
         public static StringGetter Dec2HexArg2 = (b) => StringResources.Get("Dec2HexArg2", b);

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/CollectionTableValue.cs
@@ -255,6 +255,44 @@ namespace Microsoft.PowerFx.Types
             }
         }
 
+        protected override async Task<DValue<RecordValue>> UpdateCoreAsync(RecordValue baseRecord, RecordValue newRecord, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_sourceList == null)
+            {
+                return await base.UpdateCoreAsync(baseRecord, newRecord, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (CanShallowCopy)
+            {
+                for (int index = 0; index < _sourceList.Count; index++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    RecordValue record = Marshal(_sourceIndex[index]).Value;
+
+                    if (await MatchesAsync(record, baseRecord, cancellationToken).ConfigureAwait(false))
+                    {
+                        var item = MarshalInverse(newRecord);
+                        _sourceMutableIndex[index] = item;
+                        return DValue<RecordValue>.Of(newRecord);
+                    }
+                }
+            }
+            else
+            {
+                foreach (var current in Rows)
+                {
+                    if (await MatchesAsync(current.Value, baseRecord, cancellationToken).ConfigureAwait(false))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return DValue<RecordValue>.Of(FormulaValue.NewError(new ExpressionError() { Message = "The specified record was not found.", Kind = ErrorKind.NotFound }));
+        }
+
         /// <summary>
         /// Execute a linear search for the matching record.
         /// </summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Public/Values/TableValue.cs
@@ -262,6 +262,14 @@ namespace Microsoft.PowerFx.Types
         }
 
         /// <summary>
+        /// Update implementation for derived classes.
+        /// </summary>
+        protected virtual async Task<DValue<RecordValue>> UpdateCoreAsync(RecordValue baseRecord, RecordValue newRecord, CancellationToken cancellationToken)
+        {
+            return DValue<RecordValue>.Of(NotImplementedError(IRContext));
+        }
+
+        /// <summary>
         /// Patch single record implementation for derived classes.
         /// </summary>
         /// <returns></returns>
@@ -292,6 +300,19 @@ namespace Microsoft.PowerFx.Types
             // IR has already resolved to logical names because of 
             // RequiresDataSourceScope, ArgMatchesDatasourceType on function.
             return await PatchCoreAsync(baseRecord, changeRecord, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Replaces one record in a data source.
+        /// </summary>
+        /// <param name="baseRecord">A record to replace.</param>
+        /// <param name="newRecord">The replacement record.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The updated record.</returns>
+        public async Task<DValue<RecordValue>> UpdateAsync(RecordValue baseRecord, RecordValue newRecord, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await UpdateCoreAsync(baseRecord, newRecord, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/BuiltinFunctionsCore.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerFx.Core.Texl
             "Assert", "Back", "Choices", "ClearData", "Concurrent", "Confirm", "Copy", "DataSourceInfo", "Defaults", "Disable", "Distinct", "Download", "EditForm", "Enable", "Errors", "Exit",
             "GroupBy", "HashTags", "IsMatch", "IsType", "Join", "JSON", "Launch", "LoadData", "Match", "MatchAll", "Navigate", "NewForm", "Notify", "PDF", "Param", "Pending", "Print", "ReadNFC",
             "RecordInfo", "Relate", "RemoveAll", "RemoveIf", "RequestHide", "Reset", "ResetForm", "Revert", "SaveData", "ScanBarcode", "Select", "SetFocus",
-            "SetProperty", "ShowColumns", "State", "SubmitForm", "TraceValue", "Ungroup", "Unrelate", "Update", "UpdateContext", "UpdateIf", "User", "Validate", "ValidateRecord", "ViewForm",
+            "SetProperty", "ShowColumns", "State", "SubmitForm", "TraceValue", "Ungroup", "Unrelate", "UpdateContext", "UpdateIf", "User", "Validate", "ValidateRecord", "ViewForm",
             "Collect", "Clear", "Patch", "Remove", "ClearCollect", "Set"
         };
 
@@ -247,6 +247,7 @@ namespace Microsoft.PowerFx.Core.Texl
         public static readonly TexlFunction UniCharT = _library.Add(new UniCharTFunction());
         public static readonly TexlFunction Upper = _library.Add(new LowerUpperFunction(isLower: false));
         public static readonly TexlFunction UpperT = _library.Add(new LowerUpperTFunction(isLower: false));
+        public static readonly TexlFunction Update = _library.Add(new UpdateFunction());
         public static readonly TexlFunction Value = _library.Add(new ValueFunction());
         public static readonly TexlFunction Value_UO = _library.Add(new ValueFunction_UO());
         public static readonly TexlFunction VarP = _library.Add(new VarPFunction());

--- a/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Update.cs
+++ b/src/libraries/Microsoft.PowerFx.Core/Texl/Builtins/Update.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.PowerFx.Core.App.ErrorContainers;
+using Microsoft.PowerFx.Core.Binding;
+using Microsoft.PowerFx.Core.Errors;
+using Microsoft.PowerFx.Core.Functions;
+using Microsoft.PowerFx.Core.Localization;
+using Microsoft.PowerFx.Core.Types;
+using Microsoft.PowerFx.Core.Utils;
+using Microsoft.PowerFx.Syntax;
+
+namespace Microsoft.PowerFx.Core.Texl.Builtins
+{
+    // Update(DataSource, OldRecord, NewRecord, [RemoveFlags])
+    internal class UpdateFunction : BuiltinFunction
+    {
+        public override bool ManipulatesCollections => true;
+
+        public override bool ModifiesValues => true;
+
+        public override bool IsSelfContained => false;
+
+        public override bool AllowedWithinNondeterministicOperationOrder => false;
+
+        public override bool SupportsParamCoercion => true;
+
+        public override bool MutatesArg(int argIndex, TexlNode arg) => argIndex == 0;
+
+        public UpdateFunction()
+            : base("Update", TexlStrings.AboutUpdate, FunctionCategories.Behavior | FunctionCategories.Table, DType.EmptyRecord, 0, 3, 4, DType.EmptyTable, DType.EmptyRecord, DType.EmptyRecord, DType.String)
+        {
+        }
+
+        public override IEnumerable<TexlStrings.StringGetter[]> GetSignatures()
+        {
+            yield return new[] { TexlStrings.UpdateArg_Source, TexlStrings.UpdateArg_Record, TexlStrings.UpdateArg_Update };
+            yield return new[] { TexlStrings.UpdateArg_Source, TexlStrings.UpdateArg_Record, TexlStrings.UpdateArg_Update, TexlStrings.UpdateArg_RemoveFlags };
+        }
+
+        public override bool CheckTypes(CheckTypesContext context, TexlNode[] args, DType[] argTypes, IErrorContainer errors, out DType returnType, out Dictionary<TexlNode, DType> nodeToCoercedTypeMap)
+        {
+            Contracts.AssertValue(args);
+            Contracts.AssertAllValues(args);
+            Contracts.AssertValue(argTypes);
+            Contracts.Assert(args.Length == argTypes.Length);
+            Contracts.AssertValue(errors);
+            Contracts.Assert(MinArity <= args.Length && args.Length <= MaxArity);
+
+            var fValid = base.CheckTypes(context, args, argTypes, errors, out returnType, out nodeToCoercedTypeMap);
+
+            DType collectionType = argTypes[0];
+            if (!collectionType.IsTable)
+            {
+                errors.EnsureError(args[0], TexlStrings.ErrNeedTable_Func, Name);
+                fValid = false;
+            }
+
+            // Verify OldRecord type (arg 1)
+            DType oldRecordType = argTypes[1];
+            if (!oldRecordType.IsRecord)
+            {
+                errors.EnsureError(args[1], TexlStrings.ErrNeedRecord_Arg, args[1]);
+                fValid = false;
+            }
+            else
+            {
+                if (!collectionType.Accepts(oldRecordType.ToTable(), exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
+                {
+                    errors.EnsureError(DocumentErrorSeverity.Severe, args[1], TexlStrings.ErrTableDoesNotAcceptThisType);
+                    fValid = false;
+                }
+            }
+
+            // Verify NewRecord type (arg 2)
+            DType newRecordType = argTypes[2];
+            if (!newRecordType.IsRecord)
+            {
+                errors.EnsureError(args[2], TexlStrings.ErrNeedRecord_Arg, args[2]);
+                fValid = false;
+            }
+            else
+            {
+                if (!collectionType.Accepts(newRecordType.ToTable(), exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
+                {
+                    errors.EnsureError(DocumentErrorSeverity.Severe, args[2], TexlStrings.ErrTableDoesNotAcceptThisType);
+                    fValid = false;
+                }
+            }
+
+            // Verify RemoveFlags (arg 3, if present)
+            if (args.Length == 4)
+            {
+                DType removeFlagsType = argTypes[3];
+                if (!DType.String.Accepts(removeFlagsType, exact: true, useLegacyDateTimeAccepts: false, usePowerFxV1CompatibilityRules: context.Features.PowerFxV1CompatibilityRules))
+                {
+                    errors.EnsureError(args[3], TexlStrings.ErrRemoveAllArg, args[3]);
+                    fValid = false;
+                }
+                else if (args[3] is StrLitNode strNode)
+                {
+                    if (strNode.Value.ToUpperInvariant() != "ALL")
+                    {
+                        errors.EnsureError(args[3], TexlStrings.ErrRemoveAllArg, args[3]);
+                        fValid = false;
+                    }
+                }
+            }
+
+            returnType = context.Features.PowerFxV1CompatibilityRules ? DType.Void : collectionType.ToRecord();
+
+            return fValid;
+        }
+
+        public override void CheckSemantics(TexlBinding binding, TexlNode[] args, DType[] argTypes, IErrorContainer errors)
+        {
+            base.CheckSemantics(binding, args, argTypes, errors);
+            base.ValidateArgumentIsMutable(binding, args[0], errors);
+        }
+    }
+}

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Environment/PowerFxConfigExtensions.cs
@@ -55,6 +55,7 @@ namespace Microsoft.PowerFx
             symbolTable.AddFunction(new ClearCollectScalarImpl());
             symbolTable.AddFunction(new CollectImpl());
             symbolTable.AddFunction(new CollectScalarImpl());
+            symbolTable.AddFunction(new UpdateImpl());
         }
 
         [Obsolete("FileFunctions are still in preview.")]

--- a/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMutation.cs
+++ b/src/libraries/Microsoft.PowerFx.Interpreter/Functions/LibraryMutation.cs
@@ -423,4 +423,39 @@ namespace Microsoft.PowerFx.Core.Texl.Builtins
             return await new ClearCollectImpl().InvokeAsync(invokeInfo, cancellationToken).ConfigureAwait(false);
         }
     }
+
+    // Update(dataSource, oldRecord, newRecord)
+    internal class UpdateImpl : UpdateFunction, IFunctionInvoker
+    {
+        public async Task<FormulaValue> InvokeAsync(FunctionInvokeInfo invokeInfo, CancellationToken cancellationToken)
+        {
+            var args = invokeInfo.Args;
+
+            var arg0 = args[0];
+
+            if (args[0] is LambdaFormulaValue arg0lazy)
+            {
+                arg0 = await arg0lazy.EvalAsync().ConfigureAwait(false);
+            }
+
+            if (arg0 is not TableValue tableValue)
+            {
+                return arg0;
+            }
+
+            if (args[1] is not RecordValue oldRecord)
+            {
+                return args[1];
+            }
+
+            if (args[2] is not RecordValue newRecord)
+            {
+                return args[2];
+            }
+
+            var result = await tableValue.UpdateAsync(oldRecord, newRecord, cancellationToken).ConfigureAwait(false);
+
+            return result.ToFormulaValue();
+        }
+    }
 }

--- a/src/strings/PowerFxResources.en-US.resx
+++ b/src/strings/PowerFxResources.en-US.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -5247,5 +5247,20 @@
   <data name="ErrJoinDottedNameleft" xml:space="preserve">
     <value>The '{0}' value is invalid in this context. It should be a reference to either '{1}' or '{2}' scope name.</value>
     <comment>{Locked='RightRecord'}</comment>
+  </data>
+  <data name="AboutUpdate" xml:space="preserve">
+    <value>Replaces a record in a data source with a new record.</value>
+  </data>
+  <data name="UpdateArg_Source" xml:space="preserve">
+    <value>datasource</value>
+  </data>
+  <data name="UpdateArg_Record" xml:space="preserve">
+    <value>old_record</value>
+  </data>
+  <data name="UpdateArg_Update" xml:space="preserve">
+    <value>new_record</value>
+  </data>
+  <data name="UpdateArg_RemoveFlags" xml:space="preserve">
+    <value>remove_flags</value>
   </data>
 </root>

--- a/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/Update_V1Compat.txt
+++ b/src/tests/Microsoft.PowerFx.Interpreter.Tests.Shared/MutationScripts/Update_V1Compat.txt
@@ -1,0 +1,54 @@
+#SETUP: DecimalSupport
+#SETUP: PowerFxV1CompatibilityRules
+
+// Basic Update - replace a record entirely
+
+>> Set(t1, [{a:1, b:"hello"}, {a:2, b:"world"}, {a:3, b:"test"}])
+Table({a:1,b:"hello"},{a:2,b:"world"},{a:3,b:"test"})
+
+>> Update(t1, LookUp(t1, a=2), {a:20, b:"updated"})
+{a:20,b:"updated"}
+
+>> 0;t1
+Table({a:1,b:"hello"},{a:20,b:"updated"},{a:3,b:"test"})
+
+// Update with First
+
+>> Update(t1, First(t1), {a:10, b:"first_updated"})
+{a:10,b:"first_updated"}
+
+>> 1;t1
+Table({a:10,b:"first_updated"},{a:20,b:"updated"},{a:3,b:"test"})
+
+// Update with Index
+
+>> Update(t1, Index(t1, 3), {a:30, b:"third_updated"})
+{a:30,b:"third_updated"}
+
+>> 2;t1
+Table({a:10,b:"first_updated"},{a:20,b:"updated"},{a:30,b:"third_updated"})
+
+// Update with non-existent record returns error
+
+>> Update(t1, {a:999, b:"nonexistent"}, {a:0, b:"should_fail"})
+Error({Kind:ErrorKind.NotFound})
+
+// Table should not have changed after failed update
+
+>> 3;t1
+Table({a:10,b:"first_updated"},{a:20,b:"updated"},{a:30,b:"third_updated"})
+
+// Update with wrong argument count
+
+>> Update(t1, {a:1, b:"hello"})
+Errors: Error 0-28: Invalid number of arguments: received 2, expected 3-4.
+
+// Update with non-table first argument
+
+>> Update("not_a_table", {a:1}, {a:2})
+Errors: Error 7-20: Invalid argument type (Text). Expecting a Table value instead.|Error 0-6: The function 'Update' has some invalid arguments.
+
+// Update with non-record second argument
+
+>> Update(t1, "not_a_record", {a:2, b:"test"})
+Errors: Error 11-25: Invalid argument type (Text). Expecting a Record value instead.|Error 11-25: Cannot use a non-record value in this context: '"not_a_record"'.|Error 0-6: The function 'Update' has some invalid arguments.


### PR DESCRIPTION
This PR implements the Excel-like Update function in Power-Fx, addressing issue #1000.

### Changes
- Created Update.cs to define the Update builtin function metadata and arguments verification.
- Registered the Update function inside BuiltinFunctionsCore.cs.
- Added localized string getters and resource values in English for functional validation error messages.
- Implemented UpdateAsync and UpdateCoreAsync in TableValue and CollectionTableValue to perform record substitution at the core/collection level.
- Registered UpdateImpl in PowerFxConfigExtensions and implemented interpreter evaluation logic in LibraryMutation.
- Added comprehensive mutation test coverage under Update_V1Compat.txt to cover basic scenarios, nested parameters coercion check, invalid arguments check, and error states.