### PR TITLE
Bump Microsoft.OpenApi.Readers to 1.6.31 to remediate SharpYaml DoS advisory (MVS-2026-hqm8-ggjx)

### DIFF
--- a/src/libraries/Microsoft.PowerFx.Connectors/Microsoft.PowerFx.Connectors.csproj
+++ b/src/libraries/Microsoft.PowerFx.Connectors/Microsoft.PowerFx.Connectors.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />   
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.31" />   
     <PackageReference Include="System.Text.Json" Version="6.0.10" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/src/tests/.Net7.0/Microsoft.PowerFx.TexlFunctionExporter/Microsoft.PowerFx.TexlFunctionExporter.csproj
+++ b/src/tests/.Net7.0/Microsoft.PowerFx.TexlFunctionExporter/Microsoft.PowerFx.TexlFunctionExporter.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.11" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.31" />
     <PackageReference Include="YamlDotNet" Version="13.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Bumps `Microsoft.OpenApi.Readers` from **1.6.11** to **1.6.31** to remediate a Component Governance security alert on the transitive dependency `SharpYaml`.

Filed as CG alert [19024728](https://dev.azure.com/msazure/OneAgile/_componentGovernance/Power%20Fx/alert/19024728?typeId=14504431&pipelinesTrackingFilter=0) against the `Power Fx-Official` pipeline.

## The vulnerability

[MVS-2026-hqm8-ggjx](https://eng.ms/docs/microsoft-security/digital-security-and-resilience/sr-assurance/cspa/sdl-home/sdl-home/ossadvisories/MVS-2026-hqm8-ggjx) (severity: medium) — SharpYaml versions before 3.4.0 are vulnerable to denial-of-service when processing deeply nested YAML. The advisory requires **2.1.5+** on the 2.x line.

`SharpYaml` is not referenced directly anywhere in this repo. It arrives purely transitively:

```
Microsoft.PowerFx.Connectors
  └─ Microsoft.OpenApi.Readers 1.6.11
       └─ SharpYaml 2.1.0   ← vulnerable
```

## Why 1.6.31 specifically

Walking the nuspec dependency of each 1.6.x release:

| Microsoft.OpenApi.Readers | SharpYaml |
|---|---|
| 1.6.11 (current) | 2.1.0 ❌ |
| 1.6.14 – 1.6.28 | 2.1.1 ❌ |
| **1.6.31** | **2.1.5** ✅ |

1.6.31 is the first 1.6.x release that satisfies the advisory. Bumping the reader avoids adding a direct `SharpYaml` pin to the dependency surface of the shipped `Microsoft.PowerFx.Connectors` package, and stays on the 1.6.x line (2.x is still preview and has breaking API changes).

## Changes

- `Microsoft.PowerFx.Connectors.csproj` — 1.6.11 → 1.6.31
- `Microsoft.PowerFx.TexlFunctionExporter.csproj` — 1.6.11 → 1.6.31

Both were bumped together so the exporter does not silently downgrade the resolved graph.

## Validation

- Full solution restore clean
- `SharpYaml` now resolves to **2.1.5** in all three affected projects (`Microsoft.PowerFx.Connectors`, `Microsoft.PowerFx.Connectors.Tests`, `Microsoft.PowerFx.TexlFunctionExporter`), verified via `project.assets.json`
- `Microsoft.PowerFx.Connectors` and `Microsoft.PowerFx.TexlFunctionExporter` build clean — 0 warnings, 0 errors
- `Microsoft.PowerFx.Connectors.Tests`: **549 passed, 0 failed, 20 skipped**

## Downstream impact

`Microsoft.PowerFx.Connectors` declares `Microsoft.OpenApi.Readers` as a nuspec dependency, so consumers inherit this fix once they pick up a build containing it. This also clears the same SharpYaml advisory on the internal `bic/power-fx-internal` repo (CG alert 19025149), which consumes `Microsoft.PowerFx.Connectors` as a package rather than referencing SharpYaml itself.
